### PR TITLE
docs: 补充三人 Agent 流程架构

### DIFF
--- a/docs/architecture/成员A-主持编排Agent流程架构.md
+++ b/docs/architecture/成员A-主持编排Agent流程架构.md
@@ -1,0 +1,386 @@
+# 成员 A：主持编排 Agent 流程架构
+
+> 文档状态：MVP 实施基线  
+> 主责成员：成员 A  
+> 核心产出：从玩家输入到玩家可见回复的完整运行时链路  
+> 术语说明：本文的“成员 A”指团队分工；“机制 A”特指规则引擎的 `refuse_ops` 拒绝机制，二者无关。
+
+## 1. 目标与系统定位
+
+成员 A 负责运行时主持 Agent、回合编排和服务端 WebSocket 接线。它位于玩家与确定性规则引擎之间：先把玩家自然语言转换为结构化 `Intent`，再调用成员 B 提供的 `ActionExecutor` 获得权威 `ActionResult`，最后只依据玩家可见事实生成叙事。
+
+成员 A 的核心目标不是“替代真人主持人自由裁决”，而是保证下面这条链路稳定、可追踪、不会越权：
+
+```text
+玩家输入
+→ 身份与协议校验
+→ 玩家视角投影
+→ 意图理解
+→ 确定性引擎裁决
+→ 结果脱敏
+→ 忠实叙事
+→ WebSocket 定向发送
+```
+
+架构语义以最新版《数据模型设计》为准；《协作修改建议》用于修正旧团队计划中的 `ActionPlan`、`ConfirmedOutcome` 和 Event 写入顺序。下载目录中的后端代码只用于映射当前实现，不反向定义架构。
+
+### 1.1 编排框架决策
+
+**主持编排层的流程语义独立于具体框架。** MVP 先使用普通 Python `Orchestrator` 跑通纵向闭环；当异常分支、暂停/恢复和多阶段状态管理明显增多时，再采用 LangGraph 实现 `State / Node / Edge` 编排。无论是否引入 LangGraph，`Intent`、`ActionExecutor`、`ActionResult` 及其与确定性规则引擎的接口保持不变；LangGraph 只属于成员 A 的内部运行时实现，不进入跨模块数据契约。
+
+技术栈职责固定为：
+
+| 技术或接口 | 职责定位 |
+| --- | --- |
+| Pydantic | 数据契约和结构校验，是跨模块 Schema 的单一事实源 |
+| LangGraph | 可选的运行时工作流编排实现；MVP 不依赖，复杂度达到触发条件后再引入 |
+| `ActionExecutor` | 独立、确定性的规则引擎接口，不依赖普通 Orchestrator 或 LangGraph |
+
+## 2. 输入、输出与上下游
+
+| 方向 | 数据或服务 | 提供方 | 成员 A 如何使用 |
+| --- | --- | --- | --- |
+| 输入 | `action.submit` | 玩家客户端 | 接收本回合自然语言和输入模式 |
+| 输入 | 已认证会话 | WebSocket Gateway | 取得可信 `room_id`、`player_id`、`actor_id` |
+| 输入 | `ModuleContent` | 成员 C | 读取场景、实体、Checkpoint 和玩家可见内容 |
+| 输入 | `PlayerView`、`SceneActionMenu` | ViewProjector | 为 IntentParser 提供脱敏上下文和安全候选菜单 |
+| 输入 | `ActionResult` | 成员 B | 作为本回合已经确认的唯一事实边界 |
+| 输出 | `Intent` | 成员 A | 交给成员 B 的 `ActionExecutor` 复核和执行 |
+| 输出 | `NarrationOutput` | 成员 A | 生成忠于裁决结果的玩家可见文本 |
+| 输出 | `narration.push`、`view.private` | WebSocket Gateway | 分别发送场景叙事和玩家私有视图 |
+
+三人之间的接口关系：
+
+```text
+成员 C ── ModuleContent ──→ 成员 A
+成员 A ── Intent ──→ 成员 B
+成员 B ── ActionResult ──→ 成员 A
+成员 A ── NarrationOutput / WebSocketEvent ──→ 玩家
+```
+
+## 3. 主流程架构图
+
+```mermaid
+flowchart TB
+    subgraph ENTRY["入口与身份边界"]
+        PLAYER["玩家发送 action.submit"]
+        GATEWAY["WebSocket Gateway<br/>解析统一事件信封"]
+        AUTH{"连接是否已绑定<br/>room / player / actor"}
+        REJECT["拒绝消息<br/>不调用 Agent、不修改状态"]
+    end
+
+    subgraph HOST["成员 A：主持编排 Agent"]
+        PROJECT["读取 PlayerView<br/>与 SceneActionMenu"]
+        PARSER["IntentParser<br/>OpenAI Provider Adapter"]
+        INTENT_OK{"Intent 是否通过<br/>严格 Schema 校验"}
+        CLARIFY["返回澄清提示或 unknown<br/>不得产生状态变更"]
+        EXECUTOR["调用 ActionExecutor<br/>传入可信 room_id / player_id"]
+        REFRESH["裁决后重新投影 PlayerView"]
+        CONTEXT["构造脱敏 NarrationContext<br/>移除秘密和内部求值信息"]
+        NARRATOR["Narrator<br/>生成结构化 NarrationOutput"]
+        NARRATION_OK{"叙事是否通过<br/>结构与事实校验"}
+        FALLBACK["确定性降级文本<br/>直接复述 ActionResult 可见事实"]
+    end
+
+    subgraph ENGINE["成员 B：确定性规则边界"]
+        RULES["校验 Intent、执行规则<br/>写 Event 与状态视图"]
+        RESULT["ActionResult<br/>已确认事实与可见信息"]
+    end
+
+    subgraph OUTPUT["玩家可见输出"]
+        PUSH["narration.push<br/>按 scene 定向发送"]
+        PRIVATE["view.private<br/>仅发送给当前玩家"]
+    end
+
+    PLAYER --> GATEWAY --> AUTH
+    AUTH -->|"否"| REJECT
+    AUTH -->|"是"| PROJECT --> PARSER --> INTENT_OK
+    INTENT_OK -->|"否"| CLARIFY
+    INTENT_OK -->|"是"| EXECUTOR --> RULES --> RESULT
+    RESULT --> REFRESH
+    RESULT --> CONTEXT
+    REFRESH --> CONTEXT --> NARRATOR --> NARRATION_OK
+    NARRATION_OK -->|"否"| FALLBACK --> PUSH
+    NARRATION_OK -->|"是"| PUSH
+    REFRESH --> PRIVATE
+
+    classDef agent fill:#dbeafe,stroke:#2563eb,color:#172554,stroke-width:2px;
+    classDef deterministic fill:#1f2937,stroke:#111827,color:#ffffff,stroke-width:2px;
+    classDef engine fill:#ffedd5,stroke:#ea580c,color:#7c2d12,stroke-width:2px;
+    classDef output fill:#dcfce7,stroke:#16a34a,color:#14532d,stroke-width:2px;
+    classDef failure fill:#fee2e2,stroke:#dc2626,color:#7f1d1d,stroke-width:2px;
+
+    class PARSER,NARRATOR agent;
+    class GATEWAY,AUTH,PROJECT,INTENT_OK,EXECUTOR,REFRESH,CONTEXT,NARRATION_OK deterministic;
+    class RULES engine;
+    class RESULT,PUSH,PRIVATE output;
+    class REJECT,CLARIFY,FALLBACK failure;
+```
+
+颜色约定：蓝色为 Agent/LLM，深色为确定性代码或校验器，橙色为规则引擎，绿色为已确认输出，红色为拒绝或降级路径。
+
+## 4. 主流程逐步说明
+
+### 4.1 接收并绑定可信身份
+
+1. Gateway 接收统一事件信封并校验 `id`、`ts`、`roomId`、`type` 和 `payload`。
+2. `room_id`、`player_id`、`actor_id` 必须来自已经认证并加入房间的连接上下文。
+3. 客户端正文即使携带同名字段，也只能作为无效冗余字段忽略或拒绝，不能覆盖连接身份。
+4. 身份、房间、阶段或协议无效时，链路在 Gateway 终止，不调用 LLM 和规则引擎。
+
+### 4.2 投影安全上下文
+
+1. 按 `room_id` 加载当前状态，但不把完整 `GameState` 交给 Agent。
+2. `ViewProjector` 为当前玩家生成 `PlayerView`，隐藏未发现实体、秘密、暗骰和其他玩家私有信息。
+3. 同时生成 `SceneActionMenu`，只暴露当前场景允许被模型引用的实体、NPC、出口、技能和动作提示。
+4. IntentParser 只能在 `PlayerView + SceneActionMenu` 的边界内做软匹配。
+
+### 4.3 解析并校验 Intent
+
+1. IntentParser 通过 OpenAI Provider Adapter 调用模型，使用严格结构化输出。
+2. 输出采用判别式 `Intent`；无法匹配时显式返回 `unknown`，不能伪造目标 ID。
+3. `CheckProposal.route` 统一为：
+   - `none`：动作不主动要求检定；
+   - `module`：提议使用当前场景中的模组 Checkpoint；
+   - `default`：提议使用 World 默认检定。
+4. Parser 可以提议 `checkpoint_id`、`proposed_skills` 和 `narrative_intent`，但不能确定最终技能、难度、成功线、骰点或分支结果。
+5. 即使 `route="none"`，动作也必须进入统一 `ActionExecutor`，以便引擎复核身份、执行机制 A/B/C/D、记录 Event 和保证回放一致性。
+
+### 4.4 调用确定性规则引擎
+
+成员 A 只依赖稳定端口，不直接操纵 `RulesEngine`、`GameStateRepo` 或 `EventLog`：
+
+```python
+async def execute(
+    room_id: str,
+    player_id: str,
+    intent: Intent,
+) -> ActionResult:
+    ...
+```
+
+`ActionExecutor` 内部由成员 B 负责加载房间状态、复核场景和角色、执行 auto 检定、写 Event、更新状态视图并返回 `ActionResult`。成员 A 不在引擎调用之后额外执行 `GameStateRepo.save(state)`。
+
+### 4.5 重新投影并构造叙事上下文
+
+1. 引擎提交事务后，重新投影 `PlayerView`，不得复用裁决前的旧视图。
+2. 用 `ActionResult` 和新 `PlayerView` 构造专门的 `NarrationContext`。
+3. `NarrationContext` 只包含玩家可以知道的事实、叙事约束、说话角色和建议动作。
+4. `ActionResult` 中用于审计或规则调试的隐藏字段不能直接进入 Narrator 提示词。
+
+### 4.6 输出叙事与私有视图
+
+1. Narrator 输出结构化 `NarrationOutput`，至少包含文本和事实引用。
+2. 校验器检查叙事是否违背 `ActionResult`：失败不能写成成功，未发生的状态变化不能写成已发生。
+3. MVP 先发送完整非流式消息：`streaming=false`、`seq=0`、`done=true`。
+4. `narration.push` 只发给同一场景内有权看到或听到该事件的连接；`view.private` 只发给当前玩家。
+5. Narrator 不可用时，用确定性模板根据 `player_visible_information` 和 `narration_constraints` 生成降级回复。
+
+## 5. 模块职责与禁止事项
+
+### 5.1 成员 A 负责
+
+- 运行时主持 Agent 的提示词、Provider 适配和模型调用策略。
+- 玩家上下文组装、`PlayerView` 与 `SceneActionMenu` 消费。
+- 自然语言到判别式 `Intent` 的解析和结构校验。
+- Checkpoint、技能和动作类型的软提议。
+- 回合编排、`ActionExecutor` 调用和裁决后重新投影。
+- `NarrationContext` 脱敏、最终旁白和 NPC 对话生成。
+- `action.submit`、`narration.push`、`view.private` 的服务端接线。
+- 模型超时、非法输出和叙事失败的降级策略。
+- Intent、Narration 和完整回合链路的评测。
+
+### 5.2 成员 A 不负责
+
+- 不直接修改 `GameState` 或物化状态表。
+- 不直接追加权威 Event。
+- 不决定最终技能、难度、成功线、骰点和检定结果。
+- 不执行 `Rule.when`、`Op`、`refuse_ops`、invariant 或 `WinCondition`。
+- 不信任客户端或模型提供的 `player_id`、`actor_id`、`room_id`。
+- 不把引擎失败改写为成功，也不为叙事效果补造状态变化。
+- 不把完整 God View、秘密或暗骰结果传给 Narrator。
+
+## 6. 核心接口与数据契约
+
+### 6.1 `PlayerActionInput`
+
+| 字段 | 含义 | 信任级别 |
+| --- | --- | --- |
+| `utterance` | 玩家自然语言 | 不可信输入，必须限制长度并校验 |
+| `input_mode` | `text` 或 `voice` | 客户端元数据；MVP 只实现 text |
+| `client_action_id` | 客户端幂等标识 | 用于防止断线重发重复执行 |
+| `room_id/player_id/actor_id` | 执行上下文 | 只能由已认证连接注入 |
+
+### 6.2 `Intent` 与 `CheckProposal`
+
+`Intent` 保留现有后端的判别式联合结构，并为交互行为和检定提议增加统一字段。示例：
+
+```json
+{
+  "kind": "interact",
+  "action": "open",
+  "target": { "matched": true, "id": "cabinet" },
+  "check": {
+    "route": "module",
+    "checkpoint_id": "open_cabinet",
+    "proposed_skills": ["locksmith"]
+  },
+  "narrative_intent": "尝试打开书房柜子"
+}
+```
+
+约束：
+
+- 模型不输出可信 `actor_id`；执行者由 `ActionExecutor` 根据 `player_id` 绑定。
+- `checkpoint_id` 只是候选，成员 B 必须验证它属于当前 Scene。
+- `proposed_skills` 只是软判据，成员 B 必须与 Checkpoint 和角色技能求交集。
+- 模型无法把目标匹配到安全菜单时使用 `RefUnmatched`，不得猜测内部 ID。
+
+### 6.3 `ActionResult`
+
+成员 A 至少消费以下语义字段：
+
+| 字段 | 用途 |
+| --- | --- |
+| `success` | 本次规则解析是否成功完成，不等同于所有后果都是好结果 |
+| `resolution` | `checkpoint/direct/improvised/blocked/unrecognized` 等解析类型 |
+| `confirmed_facts` | 已经由引擎确认、可供编排器使用的事实 |
+| `player_visible_information` | 允许进入 Narrator 的信息 |
+| `state_changes` | `path/from/to/cause`，用于事实核对而非由 A 再次执行 |
+| `narration_constraints` | 必须表达或禁止表达的内容 |
+| `next_required_action` | 需要澄清或等待的下一步；MVP 不返回 `PendingCheck` |
+
+### 6.4 `NarrationContext` 与 `NarrationOutput`
+
+```json
+{
+  "context": {
+    "scene": "书房",
+    "visible_facts": ["柜门已经打开", "里面的文件被砸坏"],
+    "constraints": ["不得称文件完好", "不得泄露管家下一回合出现"]
+  },
+  "output": {
+    "text": "柜门终于在撞击中弹开，但纸页也被震裂、撕碎。",
+    "claimed_fact_ids": ["cabinet.opened", "document.destroyed"],
+    "suggested_actions": []
+  }
+}
+```
+
+### 6.5 `WebSocketEvent`
+
+统一事件信封：
+
+```json
+{
+  "id": "evt_01",
+  "ts": 0,
+  "roomId": "room_01",
+  "type": "narration.push",
+  "payload": {
+    "sceneId": "study",
+    "text": "……",
+    "streaming": false,
+    "seq": 0,
+    "done": true
+  }
+}
+```
+
+## 7. 异常与降级路径
+
+| 异常 | 行为 | 状态影响 |
+| --- | --- | --- |
+| 会话未认证、房间不匹配 | Gateway 拒绝并返回协议错误 | 无 Event、无状态变化 |
+| 消息 Schema 无效 | 拒绝消息，记录技术日志 | 无 Event、无状态变化 |
+| Intent JSON 无效 | 重试一次结构化输出；仍失败则返回 `unknown` | 无状态变化 |
+| 目标无法匹配 | 返回澄清问题，不猜测实体 ID | 无状态变化 |
+| 引擎拒绝动作 | 使用 `ActionResult` 的失败事实生成叙事 | 只保留引擎明确记录的 Event |
+| Narrator 超时或不可用 | 使用确定性降级文本 | 不重试引擎，不重复执行动作 |
+| NarrationOutput 违背事实 | 丢弃模型文本，使用降级文本 | 已提交的引擎结果不回滚 |
+| 推送失败或断线 | 按事件 ID 补发视图/叙事 | 不重复调用 ActionExecutor |
+
+## 8. 当前后端实现映射
+
+当前参考代码位于 `/Users/jiahao/Downloads/TRPG-master-LWC-1-Folder`：
+
+| 目标能力 | 当前模块 | 当前状态与差距 |
+| --- | --- | --- |
+| Intent 解析 | `packages/core/ai/intent.py` | 已有判别式 Intent 和 `unknown` 保底；当前使用兼容 OpenAI SDK 的 Chat Completions/JSON 模式，尚未采用严格结构化输出和统一 `CheckProposal` |
+| 玩家视角与安全菜单 | `packages/core/view/` | 已有 `PlayerView` 和 `SceneActionMenu` 投影入口，可作为 Agent 的唯一上下文来源 |
+| 回合编排 | `packages/core/orchestrator/orchestrator.py` | 主链已存在；当前直接调用 `RulesEngine` 后执行 `GameStateRepo.save`，需改为单一 `ActionExecutor` 事务边界 |
+| Narrator | `packages/core/ai/narrator.py` | 已有流式文本接口；当前直接消费 `ActionResult`，需增加脱敏 `NarrationContext` 和结构化事实校验 |
+| WebSocket | `packages/server/ws/gateway.py` | 已接通 `action.submit`、`narration.push`、`view.private`；当前仍信任信封中的玩家标识、整房广播并缓冲叙事，需要连接身份绑定、场景定向和统一事件信封 |
+
+这些差距描述用于指导适配，不表示要保留下载目录当前实现中的错误边界。
+
+## 9. 与其他成员的协作接口
+
+### 9.1 成员 A → 成员 B
+
+- 提供已通过 Schema 校验的 `Intent`。
+- 传递可信 `room_id`、`player_id`，不传递可被模型伪造的身份。
+- 不要求 B 信任 `checkpoint_id` 或技能提议。
+- 使用统一 `ActionExecutor.execute(...) -> ActionResult`，测试期间由 FakeActionExecutor 保持并行开发。
+
+### 9.2 成员 B → 成员 A
+
+- 返回稳定、可叙述的 `ActionResult`。
+- 明确失败、拒绝、坏后果和玩家可见信息。
+- 保证函数返回时 Event 与状态视图事务已经提交，A 可以安全重新投影。
+
+### 9.3 成员 C → 成员 A
+
+- 提供通过审查的 `ModuleContent`、稳定实体 ID、Scene、Checkpoint 和可见内容。
+- 提供 Demo 输入、预期 Intent 和叙事约束，供 Intent/Narration 评测使用。
+
+## 10. MVP 交付顺序
+
+1. 冻结 `Intent`、`CheckProposal`、`ActionResult` 和 WebSocket 事件 Schema。
+2. 用 FakeActionExecutor 打通 `action.submit → Intent → ActionResult → NarrationOutput`。
+3. 接入 OpenAI Provider Adapter 和严格结构化 Intent 输出。
+4. 建立 `NarrationContext` 脱敏和事实忠实度校验。
+5. 接入成员 B 的真实 ActionExecutor，移除编排层直接保存状态的路径。
+6. 修复 WebSocket 身份绑定、场景定向和幂等处理。
+7. 接入成员 C 的书房 Demo，运行三人共同验收案例。
+
+第二阶段再实现：`PendingCheck`、玩家手动掷骰、暗骰扩展、真正的 token 流式推送、语音输入和运行时单 Agent 拆分。
+
+## 11. 测试与验收标准
+
+### 11.1 Intent 测试
+
+- 调查书架生成合法 `investigate` Intent 并匹配书架。
+- 打开、砸坏、使用物品等交互动作生成合法判别式 Intent。
+- 模型提出不存在的实体时输出 unmatched/unknown，不伪造 ID。
+- `none/module/default` 三条检定提议能被稳定解析。
+- 模型不能注入可信 `actor_id`、难度或骰点。
+
+### 11.2 编排测试
+
+- 每个合法动作只调用一次 ActionExecutor。
+- `route="none"` 也不会绕过引擎。
+- 编排器不调用 `GameStateRepo.save`，不直接追加 Event。
+- 引擎返回后重新投影视图，再生成叙事。
+- Narrator 失败不会导致同一动作再次执行。
+
+### 11.3 叙事测试
+
+- 无钥匙开柜被拒绝时，旁白明确柜子未打开。
+- 砸柜成功但文件损毁时，同时表达动作成功和坏结果。
+- 不泄露秘密、隐藏骰点、未发现实体和未来 Hook。
+- 模型文本违背 `ActionResult` 时触发确定性降级。
+
+### 11.4 WebSocket 测试
+
+- 玩家不能伪造其他玩家、角色或房间。
+- `narration.push` 只发送给正确场景，`view.private` 只发送给当前玩家。
+- 重发同一 `client_action_id` 不会重复执行引擎。
+- 非流式 MVP 消息包含 `streaming=false`、`seq=0`、`done=true`。
+
+## 12. 交接清单
+
+- **我负责什么**：玩家输入理解、运行时编排、OpenAI 适配、叙事生成、WebSocket 服务端接线和相关评测。
+- **我不负责什么**：规则裁决、状态写入、Event 权威存储、模组内容生产和规则审查。
+- **我向谁提供什么**：向成员 B 提供 `Intent`；向客户端提供 `NarrationOutput` 和 WebSocket 事件；向成员 C 提供解析与叙事评测反馈。
+- **我依赖谁提供什么**：依赖成员 B 提供 `ActionExecutor/ActionResult`；依赖成员 C 提供通过审查的 `ModuleContent`、Demo 和预期结果。

--- a/docs/architecture/成员B-确定性规则引擎流程架构.md
+++ b/docs/architecture/成员B-确定性规则引擎流程架构.md
@@ -1,0 +1,438 @@
+# 成员 B：确定性规则引擎流程架构
+
+> 文档状态：MVP 实施基线  
+> 主责成员：成员 B  
+> 核心产出：检定、规则、Event 权威写入、状态视图、约束和结局  
+> 术语说明：本文的“成员 B”指团队分工；“机制 B”特指条件满足后必然主动触发的规则机制，二者无关。
+
+## 1. 目标与系统定位
+
+成员 B 不开发自由对话 Agent，而是提供整个 Agent 系统的确定性裁决地基。主持 Agent 可以理解玩家、提出目标和检定候选，但只有规则引擎能够确认动作是否允许、检定如何结算、哪些规则必须触发、状态如何变化以及游戏是否结束。
+
+引擎的核心不变量：
+
+```text
+LLM 只提议
+→ 引擎重新验证
+→ 规则产生有限 Op
+→ Event 作为权威事实先写入
+→ 物化状态视图在同一事务中更新
+→ ActionResult 对外确认结果
+```
+
+最新版《数据模型设计》是规则和状态语义的最高依据；《协作修改建议》用于修正旧团队计划里“先更新状态、后补 EventLog”的错误顺序。下载目录中的后端代码只反映当前实现进度。
+
+## 2. 输入、输出与上下游
+
+| 方向 | 数据或服务 | 提供方 | 成员 B 如何使用 |
+| --- | --- | --- | --- |
+| 输入 | `Intent` | 成员 A | 作为不可信的动作提议，必须完整复核 |
+| 输入 | 可信执行上下文 | 成员 A / Gateway | 取得 `room_id`、`player_id` 和幂等动作 ID |
+| 输入 | `ModuleContent` | 成员 C | 读取 Scene、Entity、Checkpoint、Rule、WinCondition |
+| 输入 | `GameState` / 物化视图 | State Repository | 读取当前房间事实，所有读取受 `room_id` 隔离 |
+| 输出 | `Event` | 成员 B | 追加可回放、可重建的权威事实 |
+| 输出 | 物化状态视图 | 成员 B | 在与 Event 相同的事务内更新 |
+| 输出 | `ActionResult` | 成员 B | 向成员 A 返回已经确认的事实与可见信息 |
+
+三人之间的接口关系：
+
+```text
+成员 C ── ModuleContent ──→ 成员 B
+成员 A ── Intent ──→ 成员 B
+成员 B ── ActionResult ──→ 成员 A
+成员 B ── Event ──→ EventLog / 回放 / 审计
+```
+
+## 3. 主流程架构图
+
+```mermaid
+flowchart TB
+    subgraph INPUT["执行入口"]
+        INTENT["接收 Intent<br/>与可信执行上下文"]
+        LOAD["加载房间隔离的<br/>ModuleContent / GameState / EvalContext"]
+        RECHECK{"actor / target / scene / checkpoint<br/>是否全部通过引擎复核"}
+        BLOCK["返回 blocked / unrecognized<br/>无 Event、无状态变化"]
+    end
+
+    subgraph RESOLUTION["确定性解析"]
+        HARDEN["硬化技能候选、难度和成功线"]
+        ROUTE{"CheckProposal.route"}
+        NO_CHECK["无检定动作解析"]
+        AUTO["auto 检定<br/>生成 RollResult"]
+        OPS["生成候选 Op 集合"]
+    end
+
+    subgraph PIPELINE["Hook / Rule 流水线"]
+        RULES["按触发点与 priority 求值<br/>显式传入 EvalContext"]
+        MECH_A["机制 A：refuse_ops<br/>拒绝禁止的玩家 Op"]
+        MECH_B["机制 B：必然触发<br/>on_scene_enter / on_turn_end"]
+        MECH_C["机制 C：成功反转<br/>on_check_resolve 追加坏后果"]
+        MECH_D["机制 D：受保护值<br/>校验键空间与 invariant"]
+        OPS_OK{"最终 Op 与不变量<br/>是否全部有效"}
+        INVALID["拒绝或规则错误<br/>不产生部分状态变化"]
+    end
+
+    subgraph TX["单一数据库事务"]
+        BEGIN["开始事务"]
+        EVENTS[("append Event<br/>path / from / to / cause")]
+        VIEW[("更新物化状态视图<br/>entity_states / characters / room")]
+        WIN["基于事务内新视图<br/>求值 WinCondition"]
+        END_EVENT["若结局变化：追加结局 Event<br/>并更新房间视图"]
+        COMMIT{"事务是否成功"}
+        ROLLBACK["整体回滚<br/>Event 与视图均不留半成品"]
+    end
+
+    RESULT["ActionResult<br/>已确认事实、可见信息与状态变化"]
+
+    INTENT --> LOAD --> RECHECK
+    RECHECK -->|"否"| BLOCK
+    RECHECK -->|"是"| HARDEN --> ROUTE
+    ROUTE -->|"none"| NO_CHECK --> OPS
+    ROUTE -->|"module / default"| AUTO --> OPS
+    OPS --> RULES --> OPS_OK
+    RULES -.-> MECH_A
+    RULES -.-> MECH_B
+    RULES -.-> MECH_C
+    RULES -.-> MECH_D
+    MECH_A -.-> OPS_OK
+    MECH_B -.-> OPS_OK
+    MECH_C -.-> OPS_OK
+    MECH_D -.-> OPS_OK
+    OPS_OK -->|"否"| INVALID
+    OPS_OK -->|"是"| BEGIN --> EVENTS --> VIEW --> WIN
+    WIN --> END_EVENT --> COMMIT
+    COMMIT -->|"否"| ROLLBACK
+    COMMIT -->|"是"| RESULT
+
+    classDef agent fill:#dbeafe,stroke:#2563eb,color:#172554,stroke-width:2px;
+    classDef deterministic fill:#1f2937,stroke:#111827,color:#ffffff,stroke-width:2px;
+    classDef engine fill:#ffedd5,stroke:#ea580c,color:#7c2d12,stroke-width:2px;
+    classDef output fill:#dcfce7,stroke:#16a34a,color:#14532d,stroke-width:2px;
+    classDef failure fill:#fee2e2,stroke:#dc2626,color:#7f1d1d,stroke-width:2px;
+    classDef store fill:#f3e8ff,stroke:#7e22ce,color:#581c87,stroke-width:2px;
+
+    class INTENT agent;
+    class LOAD,RECHECK,HARDEN,ROUTE,NO_CHECK,AUTO,OPS,OPS_OK,BEGIN,WIN,END_EVENT,COMMIT deterministic;
+    class RULES,MECH_A,MECH_B,MECH_C,MECH_D engine;
+    class EVENTS,VIEW store;
+    class RESULT output;
+    class BLOCK,INVALID,ROLLBACK failure;
+```
+
+颜色约定：蓝色为上游 Agent 提议，深色为确定性代码，橙色为规则引擎，紫色圆柱为权威 Event/状态存储，绿色为已确认输出，红色为拒绝或回滚。
+
+## 4. 主流程逐步说明
+
+### 4.1 建立房间隔离的 `EvalContext`
+
+1. `ActionExecutor` 接收可信 `room_id`、`player_id`、`client_action_id` 和不可信 `Intent`。
+2. 所有 Content、GameState、角色、实体、Event 和表达式读取都由同一个 `room_id` 约束。
+3. `EvalContext` 显式携带房间、世界规则、当前 Scene、角色和本次动作数据；求值器禁止通过全局查询隐式读取其他房间。
+4. 幂等键已执行时直接返回先前结果，不重复掷骰、写 Event 或触发 Rule。
+
+### 4.2 复核 Agent 提议
+
+引擎必须重新验证：
+
+- `player_id` 是否绑定有效角色，且角色属于当前房间；
+- `target_id` 是否存在、对当前动作可引用并位于当前 Scene；
+- `checkpoint_id` 是否存在且属于当前 Scene；
+- Checkpoint 是否与动作类型、目标和当前状态兼容；
+- `proposed_skills` 是否与 `expand(checkpoint.skill)` 和角色实际技能有交集；
+- `default` 检定是否来自当前 World 的默认规则；
+- 客户端和 Agent 是否试图写入禁止字段或跨房间状态。
+
+任一复核失败都返回 `blocked` 或 `unrecognized`，不能产生部分状态变化。
+
+### 4.3 硬化检定并解析动作
+
+1. `none` 路由不主动掷骰，但仍进入规则流水线，因为动作可能触发机制 A、B 或 D。
+2. `module` 路由使用经过 Scene 复核的 Checkpoint。
+3. `default` 路由使用 World 明确定义的默认 Checkpoint/检定机制。
+4. 最终技能、难度、目标值和成功线由引擎硬化；LLM 只提供软候选。
+5. MVP 所有检定均为 `roll_mode="auto"`，由引擎生成原始骰点和 `RollResult`。
+6. 检定分支中的静态效果定义叫 `Outcome`；本次动态执行结果只叫 `ActionResult`。
+
+### 4.4 生成和求值有限 Op
+
+动作解析、Checkpoint Outcome 和 Rule 只能生成有限的 Op，例如：
+
+```text
+modify(path, set/add/subtract)
+grant_entity(entity_id, recipient)
+move_actor(scene_id)
+apply_condition(condition_id)
+emit_hook(hook_name)
+end_game(win_condition_id)
+```
+
+每个 Op 必须经过：
+
+- 路径白名单和类型检查；
+- 当前值读取与 `from` 值确认；
+- `Entity.refuse_ops` 检查；
+- 机制 D 保护值的写入权限和 invariant 检查；
+- 房间、实体、角色和 Scene 引用隔离；
+- 同一流水线内的冲突与优先级检查。
+
+禁止把任意 JSON Patch、任意属性赋值或 LLM 自由生成的数据库语句作为 Op。
+
+### 4.5 执行机制 A/B/C/D
+
+| 机制 | 触发源 | 引擎行为 | 书房 Demo |
+| --- | --- | --- | --- |
+| 机制 A：拒绝 | 玩家提出一个被禁止的 Op | 命中 `Entity.refuse_ops` 后默认拒绝；只有显式 Rule 满足时才能放行 | 无钥匙时拒绝 `open cabinet`，`key_found=true` 时由 Rule 放行 |
+| 机制 B：必然 | `on_scene_enter`、`on_turn_end` 等 Hook 条件满足 | 即使 Agent 没提起，也主动产生规则 Op | 管家在指定场景或回合进入 |
+| 机制 C：反转 | 引擎得到特定检定分支 | 在成功分支追加坏结果或代价 | 砸柜成功，但文件被毁 |
+| 机制 D：值 | 状态被 Rule 或 WinCondition 表达式读取 | 保护写入口、类型、数量和不变量 | `key_found`、`cabinet.opened`、`document.obtained` |
+
+同一实体可以同时属于多类。分类描述的是引擎为什么介入，不是实体种类。
+
+### 4.6 Event 权威写入和物化视图
+
+当所有候选 Op 均通过校验后，ActionExecutor 开始单一数据库事务：
+
+1. 锁定或按版本检查相关房间状态。
+2. 将每个状态变化转换为可重建 Event。
+3. 先追加 Event，再更新对应的物化状态视图。
+4. 在事务内新视图上执行 Hook 后续阶段和 `WinCondition` 求值。
+5. 若产生结局或额外状态变化，继续追加 Event 并更新视图。
+6. 所有写入成功后提交；任何一步失败都整体回滚。
+
+Event 不是事后审计日志，而是状态事实的权威来源。物化视图可删除并通过 Event 全量重建。
+
+### 4.7 生成 `ActionResult`
+
+只有事务提交成功后才构造并返回 `ActionResult`。它描述：
+
+- 动作是否被执行以及采用哪种解析路径；
+- 检定是否成功；
+- 最终发生了哪些事实，包括“成功但结果变坏”；
+- 哪些状态发生了变化及其原因；
+- 玩家可以知道什么；
+- Narrator 必须遵守什么限制；
+- 下一步是否需要澄清或其他动作。
+
+## 5. 模块职责与禁止事项
+
+### 5.1 成员 B 负责
+
+- `ActionExecutor` 事务边界和稳定端口。
+- Checkpoint 复核、技能展开、难度硬化和 auto 骰子。
+- Hook、Rule、priority、`when` 表达式和有限 Op 执行。
+- 机制 A/B/C/D、状态白名单和 invariant。
+- 房间隔离的 `EvalContext`。
+- Event 权威存储、物化视图更新和全量回放。
+- `WinCondition` 求值和游戏结局状态。
+- `ActionResult` 的事实完整性和玩家可见字段划分。
+- 规则、事务、并发、回放和跨房间隔离测试。
+
+### 5.2 成员 B 不负责
+
+- 不理解玩家自然语言，不自行调用主持 LLM 猜测 Intent。
+- 不生成最终沉浸式旁白或 NPC 文风。
+- 不信任 Agent 提交的角色、目标、Checkpoint、技能或难度。
+- 不允许绕过 Op 白名单直接修改任意状态路径。
+- 不先更新状态再事后补 Event。
+- 不在事务失败时保留部分 Event 或部分视图更新。
+- 不把内部秘密、暗骰细节和完整规则上下文作为玩家可见信息返回。
+
+## 6. 核心接口与数据契约
+
+### 6.1 `ActionExecutor`
+
+```python
+class ActionExecutor(Protocol):
+    async def execute(
+        self,
+        room_id: str,
+        player_id: str,
+        intent: Intent,
+    ) -> ActionResult:
+        ...
+```
+
+第二阶段引入手动掷骰后可以扩展为 `ActionResult | PendingCheck`，但 MVP 只返回 `ActionResult`。
+
+### 6.2 `Intent` / `CheckProposal`
+
+成员 B 将以下字段全部视为提议：
+
+| 字段 | 引擎复核规则 |
+| --- | --- |
+| `kind/action` | 必须映射到已注册的动作处理器和有限 Op |
+| `target` | 必须是当前 Scene 中有效、可引用的实体或目标 |
+| `check.route` | 仅允许 `none/module/default` |
+| `checkpoint_id` | `module` 时必须属于当前 Scene；其他路由不得滥用 |
+| `proposed_skills` | 与 Checkpoint 展开结果和角色技能求交集 |
+| `narrative_intent` | 只作解释和审计，不参与确定性求值 |
+
+### 6.3 `EvalContext`
+
+```text
+room_id
+module_id / world_ref
+scene_id
+player_id / character_id
+actor_state
+target_state
+party_snapshot
+current_hook
+check_resolution
+event_sequence
+```
+
+所有表达式求值必须从该上下文读取；禁止求值器通过未加房间条件的全局查询补数据。
+
+### 6.4 `Event` 与 `StateChange`
+
+状态变化 Event 的最小可重建语义：
+
+```json
+{
+  "type": "state.modified",
+  "room_id": "room_01",
+  "actor_id": "pc_1",
+  "path": "entities.cabinet.opened",
+  "from": false,
+  "to": true,
+  "cause": "op:open_cabinet"
+}
+```
+
+要求：
+
+- `path/from/to` 足以确定重放后的值；
+- `cause` 使用 `op:<id>`、`rule:<id>`、`checkpoint:<id>` 等稳定来源；
+- 单纯的 `{"type":"cabinet_opened"}` 语义事件不能替代状态变化 Event；
+- Event 带房间、顺序、时间、可见性和幂等动作关联信息。
+
+### 6.5 `ActionResult`
+
+```json
+{
+  "success": true,
+  "resolution": "checkpoint",
+  "confirmed_facts": ["柜门被砸开", "文件被毁"],
+  "player_visible_information": ["柜门已经打开，但文件无法阅读"],
+  "state_changes": [
+    {
+      "path": "entities.cabinet.opened",
+      "from": false,
+      "to": true,
+      "cause": "checkpoint:smash_cabinet"
+    },
+    {
+      "path": "entities.document.destroyed",
+      "from": false,
+      "to": true,
+      "cause": "rule:smash_success_cost"
+    }
+  ],
+  "narration_constraints": ["不得称文件完好"],
+  "next_required_action": null
+}
+```
+
+`success=true` 表示动作按规则完成，不代表后果对玩家有利。机制 C 必须能够表达“成功但更糟”。
+
+## 7. 异常与回滚路径
+
+| 异常 | 返回 | Event / 状态行为 |
+| --- | --- | --- |
+| 玩家或角色不属于房间 | `blocked` | 不写 Event，不改状态 |
+| 目标不在当前 Scene | `unrecognized` 或 `blocked` | 不写 Event，不改状态 |
+| Checkpoint 非当前 Scene 所有 | `blocked` | 不写 Event，不改状态 |
+| 技能候选无合法交集 | 使用引擎默认规则或 `blocked`，按 World 定义决定 | 不采用 Agent 的非法技能 |
+| 命中 `refuse_ops` | `blocked`，说明玩家可见失败事实 | 禁止的状态变化不落库 |
+| D 类 invariant 失败 | `blocked` | 整组候选变化不落库 |
+| Rule 表达式错误 | 技术错误或安全失败 | 当前事务整体回滚 |
+| Event append 失败 | 技术错误 | 状态视图不更新或整体回滚 |
+| 状态视图更新失败 | 技术错误 | 已追加 Event 与本事务一起回滚 |
+| WinCondition 求值失败 | 技术错误 | 当前事务整体回滚，不猜测结局 |
+| 重复 `client_action_id` | 返回先前 `ActionResult` | 不重复掷骰、触发或写 Event |
+
+## 8. 当前后端实现映射
+
+当前参考代码位于 `/Users/jiahao/Downloads/TRPG-master-LWC-1-Folder`：
+
+| 目标能力 | 当前模块 | 当前状态与差距 |
+| --- | --- | --- |
+| Intent / ActionResult 类型 | `packages/core/rules/models.py` | 已有判别式 Intent 和 ActionResult；当前 ActionResult 缺少通用 `state_changes(path/from/to/cause)`、叙事约束和明确可见事实集合 |
+| 规则执行 | `packages/core/rules/engine.py` | 已能处理调查、移动等部分动作；当前直接原地修改 GameState，尚未接入 Event 权威事务和完整 A/B/C/D 流水线 |
+| 检定解析 | `packages/core/rules/check_resolver.py` | 可作为技能、目标值和骰子硬化的实现入口，需确保全部输入经过房间和 Scene 复核 |
+| 状态仓储 | `packages/core/state/repo.py` | 当前保留 `load/save` 模式，由 Orchestrator 调用 `save`；目标是把写入收口到 ActionExecutor 事务 |
+| EventLog | `packages/core/state/event_log.py` | 已有独立 append/list 接口和表实现，但未接入主回合链路，也未与状态视图更新组成同一事务 |
+| Event 类型 | `packages/core/state/models.py` | 已有多种语义事件；当前缺少通用、可重建的 `state.modified(path/from/to/cause)` 变体 |
+| 内容规则 | `packages/core/content/models.py` | 已有 Entity.state、Entity.rules、Checkpoint、WinCondition；当前 Entity 缺少 `refuse_ops`，需补齐机制 A 表达能力 |
+
+## 9. 与其他成员的协作接口
+
+### 9.1 成员 A → 成员 B
+
+- 提供已通过结构校验但仍不可信的 `Intent`。
+- 提供从连接上下文取得的可信 `room_id` 和 `player_id`。
+- 测试期间通过 FakeActionExecutor 让双方并行，不让 A 依赖 B 的内部类。
+
+### 9.2 成员 B → 成员 A
+
+- 提供稳定 `ActionExecutor` 接口和完整 `ActionResult`。
+- 区分确认事实、玩家可见信息、内部调试信息和叙事约束。
+- 保证返回前事务已提交；失败时保证没有部分状态。
+
+### 9.3 成员 C → 成员 B
+
+- 提供通过 Schema 和规则审查的 `ModuleContent`。
+- 明确 Entity.rules、World.world_rules、Scene/Checkpoint 引用、`refuse_ops`、初始状态和 WinCondition。
+- 提供机制 A/B/C/D 的正向和负向 Demo 案例。
+
+## 10. MVP 交付顺序
+
+1. 冻结 `ActionExecutor`、`ActionResult`、`Event` 和有限 Op 契约。
+2. 实现房间隔离、actor/target/scene/checkpoint 复核和可重复 auto 检定。
+3. 建立 Event append 与状态视图更新的单一事务，并完成全量回放测试。
+4. 实现机制 A `refuse_ops` 和机制 D 受保护状态/invariant。
+5. 实现机制 C `on_check_resolve` 成功反转。
+6. 实现 `WinCondition` 和结局 Event。
+7. 实现机制 B `on_scene_enter/on_turn_end` 必然触发。
+8. 加入 Rule priority、并发冲突和完整幂等处理。
+
+第二阶段再实现：`PendingCheck`、手动掷骰、超时策略、更多暗骰、Condition、Ledger 和复杂规则调度。
+
+## 11. 测试与验收标准
+
+### 11.1 复核与检定
+
+- 非当前 Scene 的 `checkpoint_id` 被拒绝。
+- Agent 提议不存在或角色不会的技能时，引擎不会直接采用。
+- 同一固定随机种子产生可复现 `RollResult`。
+- `none/module/default` 三条路由行为符合 World 和 Scene 定义。
+
+### 11.2 机制 A/B/C/D
+
+- 无钥匙开柜命中机制 A，`cabinet.opened` 保持 `false`。
+- 砸柜成功触发机制 C，柜子打开但文件损毁，并能进入坏结局。
+- 管家在指定 Scene 或回合 Hook 上必然触发机制 B。
+- `key_found`、`cabinet.opened`、`document.obtained` 只能通过合法 Op 修改。
+- D 类 invariant 被破坏时，整个动作拒绝且无部分写入。
+
+### 11.3 Event、事务与回放
+
+- 每次状态变化都有包含 `path/from/to/cause` 的 Event。
+- 删除物化视图后可以从 Event 全量重建，结果与删除前一致。
+- Event append 后模拟视图更新失败，事务整体回滚。
+- WinCondition 产生的房间状态变化也有对应 Event。
+- 同一幂等动作重放不重复掷骰、不重复触发 Hook、不重复写 Event。
+
+### 11.4 隔离与并发
+
+- 两个房间拥有同名实体时不会读写串房。
+- 两个动作并发修改同一路径时由版本或锁策略确定性解决，不发生静默覆盖。
+- 任何跨房间 `party.size`、角色或实体读取都会被测试捕获。
+
+## 12. 交接清单
+
+- **我负责什么**：检定、Hook/Rule、有限 Op、机制 A/B/C/D、Event 权威写入、状态视图、房间隔离、结局和 ActionResult。
+- **我不负责什么**：自然语言理解、最终旁白文风、客户端 UI、模组原文解析和内容审查。
+- **我向谁提供什么**：向成员 A 提供 `ActionExecutor/ActionResult`；向回放和审计提供 Event；向成员 C 提供可执行规则和 Schema 反馈。
+- **我依赖谁提供什么**：依赖成员 A 提供可信执行上下文和结构化 Intent；依赖成员 C 提供通过审查的 ModuleContent、规则、初始状态和验收案例。

--- a/docs/architecture/成员C-模组解析与审查Agent流程架构.md
+++ b/docs/architecture/成员C-模组解析与审查Agent流程架构.md
@@ -1,0 +1,511 @@
+# 成员 C：模组解析与审查 Agent 流程架构
+
+> 文档状态：MVP 实施基线  
+> 主责成员：成员 C  
+> 核心产出：可运行的 ModuleContent、解析/审查流水线、共享 fixtures 与 evals  
+> 术语说明：本文的“成员 C”指团队分工；“机制 C”特指检定成功分支挂接坏结果的反转机制，二者无关。
+
+## 1. 目标与系统定位
+
+成员 C 负责把模组原始材料转成成员 A、B 能稳定消费的 `ModuleContent`，并建立导入前的确定性校验、Agent 审查、人工批准和质量评测流程。
+
+这项工作分两个阶段，但共用同一条发布管线：
+
+```text
+MVP：人工编写标准 Demo
+后期：模组原文 → Parser Agent 生成草稿
+
+两者共同进入：
+Schema 规范化 → 引用校验 → Reviewer Agent → 人工批准 → 发布
+```
+
+第一阶段不等待完整自动解析 Agent。先以人工 `demo-module.json` 固定三人共同接口和验收案例；运行时能稳定消费后，再把人工生产步骤逐段替换为 Parser Agent。
+
+最新版《数据模型设计》是内容字段、规则归属和机制 A/B/C/D 的最高依据；《协作修改建议》用于修正旧团队计划中的顶层 `rules`、旧协议名和过弱 Demo。下载目录中的后端代码只用于映射现有 Content 和导入骨架。
+
+## 2. 输入、输出与上下游
+
+| 方向 | 数据或服务 | 提供方 | 成员 C 如何使用 |
+| --- | --- | --- | --- |
+| 输入 | 模组原文、附件和素材 | 作者 / 产品 | 作为 Parser Agent 的唯一事实来源 |
+| 输入 | World / 数据模型 Schema | 三人共同契约 | 规范字段、枚举、规则挂载位置和引用 |
+| 输入 | 规则执行约束 | 成员 B | 确保 Rule、Op、Checkpoint、WinCondition 可执行 |
+| 输入 | 运行时上下文需求 | 成员 A | 确保 Scene、实体可见性和安全菜单信息可投影 |
+| 输出 | `ModuleContent` | 成员 C | 提供给成员 A、B 的稳定内容契约 |
+| 输出 | `ReviewReport` | Reviewer Agent | 给出阻断错误、警告、来源和修订建议 |
+| 输出 | `FixtureCase` / `EvalCase` | 成员 C | 作为三人共享的集成测试与 Agent 评测输入 |
+
+三人之间的接口关系：
+
+```text
+成员 C ── ModuleContent ──→ 成员 A、成员 B
+成员 C ── FixtureCase / EvalCase ──→ 三人共同测试
+成员 A ── Intent 与叙事失败反馈 ──→ 成员 C
+成员 B ── Schema 与规则执行反馈 ──→ 成员 C
+```
+
+## 3. 主流程架构图
+
+```mermaid
+flowchart TB
+    subgraph SOURCES["内容入口"]
+        MANUAL["MVP：人工编写<br/>Demo ModuleContent"]
+        RAW[("后期：模组原文<br/>Markdown / PDF / 附件")]
+        SEGMENT["确定性分段与来源编号<br/>生成 SourceFragment"]
+        PARSER["Parser Agent<br/>提取结构化 ModuleDraft"]
+        DRAFT["ModuleDraft<br/>字段携带 source_references"]
+    end
+
+    subgraph VALIDATE["确定性校验"]
+        NORMALIZE["Schema 与字段规范化<br/>ID / 枚举 / 必填项 / 字段位置"]
+        REFERENCES["引用完整性校验<br/>Scene / Entity / Checkpoint / Asset"]
+        STRUCTURE_OK{"结构是否可进入审查"}
+        STRUCTURE_FAIL["生成阻断 ValidationIssue<br/>返回人工或 Parser 修订"]
+    end
+
+    subgraph REVIEW["Reviewer Agent 与专项审查"]
+        REVIEWER["Reviewer Agent<br/>只审查，不直接发布"]
+        AB_A["机制 A：refuse_ops<br/>绝对不能执行的玩家 Op"]
+        AB_B["机制 B：必然 Hook<br/>条件满足后必须主动发生"]
+        AB_C["机制 C：成功反转<br/>成功分支上的坏后果"]
+        AB_D["机制 D：受保护值<br/>Rule / WinCondition 读取的状态"]
+        QUALITY["来源忠实度 / 秘密隔离<br/>可达性 / 结局 / 纯文本门"]
+        REPORT["ReviewReport<br/>errors / warnings / coverage"]
+        PASS{"是否无阻断错误"}
+        REVISE["人工或 Parser 按来源修订<br/>禁止凭空补设定"]
+    end
+
+    subgraph PUBLISH["批准、发布与消费"]
+        APPROVE["人工批准<br/>确认风险与警告"]
+        CONTENT[("版本化 ModuleContent<br/>进入 Content Repository")]
+        CASES[("fixtures / evals<br/>输入与预期结果")]
+        RUNTIME["成员 A：运行时上下文<br/>成员 B：规则执行"]
+    end
+
+    MANUAL --> NORMALIZE
+    RAW --> SEGMENT --> PARSER --> DRAFT --> NORMALIZE
+    NORMALIZE --> REFERENCES --> STRUCTURE_OK
+    STRUCTURE_OK -->|"否"| STRUCTURE_FAIL --> REVISE
+    STRUCTURE_OK -->|"是"| REVIEWER
+    REVIEWER -.-> AB_A
+    REVIEWER -.-> AB_B
+    REVIEWER -.-> AB_C
+    REVIEWER -.-> AB_D
+    REVIEWER -.-> QUALITY
+    AB_A --> REPORT
+    AB_B --> REPORT
+    AB_C --> REPORT
+    AB_D --> REPORT
+    QUALITY --> REPORT --> PASS
+    PASS -->|"否"| REVISE --> NORMALIZE
+    PASS -->|"是"| APPROVE --> CONTENT
+    CONTENT --> CASES
+    CONTENT --> RUNTIME
+    CASES --> RUNTIME
+
+    classDef agent fill:#dbeafe,stroke:#2563eb,color:#172554,stroke-width:2px;
+    classDef deterministic fill:#1f2937,stroke:#111827,color:#ffffff,stroke-width:2px;
+    classDef engine fill:#ffedd5,stroke:#ea580c,color:#7c2d12,stroke-width:2px;
+    classDef output fill:#dcfce7,stroke:#16a34a,color:#14532d,stroke-width:2px;
+    classDef failure fill:#fee2e2,stroke:#dc2626,color:#7f1d1d,stroke-width:2px;
+    classDef store fill:#f3e8ff,stroke:#7e22ce,color:#581c87,stroke-width:2px;
+
+    class PARSER,REVIEWER agent;
+    class MANUAL,SEGMENT,NORMALIZE,REFERENCES,STRUCTURE_OK,PASS,APPROVE deterministic;
+    class AB_A,AB_B,AB_C,AB_D,QUALITY engine;
+    class RAW,DRAFT,CONTENT,CASES store;
+    class RUNTIME,REPORT output;
+    class STRUCTURE_FAIL,REVISE failure;
+```
+
+颜色约定：蓝色为 Agent/LLM，深色为确定性校验器和人工批准点，橙色为规则/质量专项审查，紫色圆柱为来源、草稿、内容和测试资产，绿色为可消费输出，红色为阻断与修订循环。
+
+## 4. 主流程逐步说明
+
+### 4.1 MVP 先人工建立标准 Demo
+
+第一阶段直接人工编写 `demo-module.json`，目的是固定：
+
+- `ModuleContent` 最小可运行结构；
+- Scene、Entity、Checkpoint、Rule 和 WinCondition 的引用关系；
+- 机制 A/B/C/D 的真实表达方式；
+- 成员 A 预期生成的 Intent；
+- 成员 B 预期返回的 ActionResult、Event 和状态变化；
+- Narrator 必须表达或禁止表达的事实。
+
+人工 Demo 也必须走与自动解析相同的 Schema、引用、Reviewer 和批准流程。人工编写不等于可以绕过质量门。
+
+### 4.2 分段原始材料并保留来源
+
+后期自动导入时：
+
+1. 将原文、图片说明、表格和附件登记为 `SourceDocument`。
+2. 用确定性逻辑按章节、页码或段落生成稳定 `SourceFragment.id`。
+3. Parser Agent 输出的实体、秘密、规则和结局必须携带 `source_references`。
+4. 无法找到来源的设定必须标为缺失或推断，不能静默写成确定事实。
+5. 原始文件只读保存，解析草稿与正式 ModuleContent 分开管理。
+
+### 4.3 Parser Agent 生成 `ModuleDraft`
+
+Parser Agent 负责提取而不是裁决发布：
+
+- World 与 `world_ref`；
+- Module 元信息和背景；
+- Scene、出口和内容关系；
+- Entity、公开描述、秘密、初始 state；
+- Checkpoint、技能、难度、静态 Outcome；
+- Rule、Hook、Op、WinCondition；
+- 素材和角色模板引用；
+- 每一项对应的来源片段与置信度。
+
+Parser 不得因为“这样更好玩”而补造原文没有的机制。若原文含糊，应保留 `ValidationIssue` 或人工确认点。
+
+### 4.4 确定性规范化与引用校验
+
+这一步不用 LLM 猜测，负责：
+
+- JSON Schema 和 Pydantic 类型验证；
+- 必填字段、枚举、数值范围和额外字段检查；
+- ID 格式、唯一性和稳定性；
+- `world_ref`、Scene、Entity、Checkpoint、Rule、Asset、WinCondition 引用存在性；
+- Scene 出口和 Checkpoint 归属；
+- Rule/Op 字段位置和表达式语法；
+- 秘密字段与公开字段的结构隔离；
+- 顶层禁止模组级 `rules`。
+
+正式 ModuleContent 中：
+
+- 模组实体规则放在 `Entity.rules`；
+- 世界通用规则放在 `World.world_rules`；
+- `Entity` 的 MVP 字段必须能表达 `state`、`refuse_ops` 和 `rules`；
+- Scene 必须能明确引用可用 Checkpoint；
+- WinCondition 读取的状态必须能够被 Event 和物化视图承载。
+
+### 4.5 Reviewer Agent 专项审查
+
+Reviewer 只读取已经通过结构校验的草稿，输出 `ReviewReport`，不直接写入 Content Repository。
+
+专项审查包括：
+
+| 审查项 | 核心问题 | 阻断示例 |
+| --- | --- | --- |
+| 来源忠实度 | 每个关键事实是否能追溯到原文 | Parser 凭空补出新结局 |
+| 机制 A | 是否存在 LLM 会被说服、但作者要求绝对拒绝的 Op | “小号绝不转让”却没有 `refuse_ops` |
+| 机制 B | 是否存在条件满足后无论如何都必须发生的事件 | 管家进入只写在叙述备注中，没有 Hook |
+| 机制 C | 是否存在成功检定反而产生代价或坏结果 | 成功砸柜的文件损毁只写在 prompt 中 |
+| 机制 D | Rule/WinCondition 读取的值是否落入受保护状态 | 结局读取 `document.obtained`，但没有初始 state/合法写入口 |
+| 秘密隔离 | 未发现秘密是否可能进入 PlayerView | `secrets` 被混入公开 `content` |
+| 引用完整性 | ID 和关系是否可解析 | Scene 引用不存在的 Checkpoint |
+| 可执行性 | Rule、Op、表达式是否被引擎支持 | 自由文本 Rule 无法转成有限 Op |
+| 可达性 | 关键 Scene、Checkpoint 和结局是否有合理路径 | 唯一结局引用永远无法置真的状态 |
+| 过度结构化 | 纯文本对象是否被错误做成复杂规则 | 普通抽屉被无必要地建成 A/B/C/D |
+
+### 4.6 区分纯文本“门”和 A/B/C/D
+
+Reviewer 对每个疑似规则对象按以下顺序判断：
+
+```text
+Q1 玩家发起某个 Op 时，引擎必须拒绝吗？
+   是 → 机制 A：Entity.refuse_ops
+
+Q2 某个条件满足时，引擎必须主动触发吗？
+   是 → 机制 B：Hook / Rule
+
+Q3 引擎求值为 success 时，是否必须挂坏后果？
+   是 → 机制 C：on_check_resolve Rule
+
+Q4 它是否被 Rule.when 或 WinCondition.expr 读取？
+   是 → 机制 D：受保护 entity_states 键
+
+四项都否 → 保持纯文本，由主持 Agent 灵活演绎
+```
+
+“门”本身通常不需要复杂规则。只有后续规则需要读取“门后获得了什么”时，相关值才按机制 D 落库。
+
+### 4.7 ReviewReport、人工批准与发布
+
+1. Reviewer 汇总结构错误、机制缺失、秘密风险、来源引用和覆盖率。
+2. `errors` 为阻断项，必须返回 Parser 或人工修订并重新从 Schema 校验开始。
+3. `warnings` 可以由人工接受，但必须保留审批记录。
+4. 审查通过后由人工批准，生成不可变版本号和内容摘要。
+5. 只有批准版本进入 Content Repository，供运行时房间绑定。
+6. 每个发布版本同时冻结 fixtures/evals，保证后续 Parser 或 Schema 修改不会悄悄改变玩法。
+
+## 5. 模块职责与禁止事项
+
+### 5.1 成员 C 负责
+
+- 人工标准 Demo 和正式 ModuleContent 内容生产。
+- Parser Agent、来源分段、字段提取和来源追踪。
+- 确定性 Schema、字段、枚举、ID 和引用校验。
+- Reviewer Agent 和机制 A/B/C/D 专项审查。
+- 秘密隔离、可执行性、可达性、结局和过度结构化审查。
+- `ReviewReport`、人工批准和版本化发布流程。
+- 三人共享的 fixtures、evals、错误分类和回归数据。
+- 向成员 A、B 反馈内容契约缺口和运行时不可表达问题。
+
+### 5.2 成员 C 不负责
+
+- 不在运行时理解玩家输入或生成最终旁白。
+- 不执行骰子、Rule、Op、Event、状态事务或 WinCondition。
+- 不让 Parser/Reviewer 绕过 Schema 直接发布内容。
+- 不让 Reviewer 自动接受自己的修订，正式发布必须有人审。
+- 不把顶层 `rules` 当成模组规则容器。
+- 不把所有叙事对象都做成状态或规则。
+- 不凭空补造来源中没有的事实来修复可达性。
+- 不用测试样例替代正式数据协议。
+
+## 6. 核心接口与数据契约
+
+### 6.1 `SourceDocument` 与 `SourceFragment`
+
+```json
+{
+  "document_id": "module_source_01",
+  "kind": "markdown",
+  "checksum": "sha256:...",
+  "fragments": [
+    {
+      "id": "src_ch2_p14_003",
+      "locator": "第二章 / 第14页 / 第3段",
+      "text": "……"
+    }
+  ]
+}
+```
+
+来源 ID 必须稳定，修订报告和 ModuleDraft 都通过它追踪证据。
+
+### 6.2 `ModuleDraft`
+
+```text
+raw_source_ref
+parser_version
+schema_version
+draft
+source_references
+confidence_notes
+unresolved_questions
+```
+
+`ModuleDraft` 是候选结构，不得被运行时加载，也不等于正式 `ModuleContent`。
+
+### 6.3 `ModuleContent`
+
+MVP 顶层最小结构：
+
+```json
+{
+  "world_ref": "coc-7e",
+  "scenes": [],
+  "entities": [],
+  "checkpoints": [],
+  "win_conditions": []
+}
+```
+
+Entity MVP 子集：
+
+```json
+{
+  "id": "cabinet",
+  "kind": "object",
+  "name": "上锁的柜子",
+  "content": "一只年代久远的木柜。",
+  "secrets": "文件藏在柜中。",
+  "state": { "opened": false },
+  "refuse_ops": ["open"],
+  "rules": []
+}
+```
+
+注意：`refuse_ops:["open"]` 表示默认拒绝；书房 Demo 必须另外在 `Entity.rules` 定义 `bookshelf.key_found == true` 时放行 `open`。上面的空 `rules` 只用于展示字段位置，不是完整柜子实例。“无钥匙拒绝、有钥匙放行”必须由成员 B 可确定执行的规则表达，不能只写在 `secrets` 中。
+
+### 6.4 `ValidationIssue`
+
+```text
+severity: error | warning
+code
+path
+message
+source_references
+suggested_fix
+```
+
+相同问题使用稳定 `code`，便于统计 Parser/Reviewer 回归。
+
+### 6.5 `ReviewReport`
+
+```json
+{
+  "status": "needs_revision",
+  "errors": [],
+  "warnings": [],
+  "source_references": [],
+  "suggested_fixes": [],
+  "coverage_summary": {
+    "schema": 1.0,
+    "references": 1.0,
+    "mechanism_abcd_reviewed": true,
+    "endings_reviewed": true
+  }
+}
+```
+
+`status` 只允许：
+
+- `pass`：无阻断错误，可以进入人工批准；
+- `needs_revision`：存在可修订的阻断错误；
+- `blocked`：缺少来源、Schema 或关键产品决策，无法安全修订。
+
+### 6.6 `FixtureCase` 与 `EvalCase`
+
+```text
+FixtureCase
+  initial_module_version
+  initial_state
+  player_input
+  expected_intent
+  expected_action_result
+  expected_events
+  expected_final_state
+  narration_constraints
+
+EvalCase
+  input
+  expected_properties
+  forbidden_properties
+  error_category
+  source_references
+```
+
+Fixture 用于确定性集成测试；Eval 用于评测 Parser、Reviewer、IntentParser 和 Narrator。
+
+## 7. 书房 MVP Demo 设计
+
+至少维护以下共享案例：
+
+| 案例 | 初始条件 | 预期 Intent / 规则 | 预期 Event 与结果 | 覆盖目标 |
+| --- | --- | --- | --- | --- |
+| 调查书架 | `key_found=false` | `investigate bookshelf`，module/auto 检定 | 成功时写 `key_found: false→true` | 普通 Checkpoint、机制 D |
+| 无钥匙开柜 | `key_found=false`、`cabinet.opened=false` | `interact open cabinet` | 引擎拒绝，柜子保持关闭 | 机制 A |
+| 有钥匙开柜 | `key_found=true` | 合法 open Op | `cabinet.opened: false→true`，`document.obtained: false→true` | 正常状态链 |
+| 砸柜 | 文件尚完好 | smash Checkpoint 成功 | 柜子打开，同时文件损毁，可能触发坏结局 | 机制 C |
+| 管家进入 | 到达指定 Scene 或回合 | 即使玩家未提到，也触发 Hook | 产生管家进入 Event 和可见事实 | 机制 B |
+| 结局求值 | `document.obtained/destroyed` 达到条件 | WinCondition 表达式求值 | 写结局 Event，更新房间阶段 | 机制 D、结局 |
+| 普通抽屉 | 没有规则读取其状态 | 保持纯文本处理 | 不创建不必要 Rule/Event | 防止过度结构化 |
+
+建议状态键统一为实体路径，避免含糊的全局布尔值：
+
+```text
+entities.bookshelf.key_found
+entities.cabinet.opened
+entities.document.obtained
+entities.document.destroyed
+entities.butler.entered
+```
+
+最终命名以三人冻结的 Schema 为准，但 fixtures、Event 和 WinCondition 必须使用同一套路径。
+
+## 8. 异常与修订路径
+
+| 异常 | 状态 | 处理 |
+| --- | --- | --- |
+| 原文缺失或无法读取 | `blocked` | 请求补充来源，不让模型猜测 |
+| Parser 输出非法 JSON | `needs_revision` | 结构化重试；仍失败则人工处理 |
+| Schema/枚举错误 | `needs_revision` | 确定性报告字段路径和期望类型 |
+| 重复 ID 或悬空引用 | `needs_revision` | 阻断发布，修订后全量重验 |
+| 顶层出现模组 `rules` | `needs_revision` | 移到 Entity.rules 或 World.world_rules，并复核语义 |
+| 关键规则只写在 secrets/prompt | `needs_revision` | 转成 A/B/C/D 中对应的显式结构 |
+| 来源与提取事实冲突 | `needs_revision` 或 `blocked` | 以来源为准，人工裁定歧义 |
+| 秘密进入公开字段 | `needs_revision` | 阻断发布并增加泄密回归用例 |
+| 结局不可达 | `needs_revision` | 标记断裂路径；不得凭空新增通关手段 |
+| Reviewer 服务不可用 | `blocked` | 保留草稿，不自动批准 |
+| 只有 warning | `pass` 后人工批准 | 记录接受理由和审批人 |
+
+## 9. 当前后端实现映射
+
+当前参考代码位于 `/Users/jiahao/Downloads/TRPG-master-LWC-1-Folder`：
+
+| 目标能力 | 当前模块 | 当前状态与差距 |
+| --- | --- | --- |
+| 内容模型 | `packages/core/content/models.py` | 已有 World、ModulePack、Scene、Entity、Checkpoint、WinCondition；Entity 已有 `state/rules`，但缺少 `refuse_ops`；ModulePack 顶层目前没有 `rules`，与新版方向一致 |
+| Scene 与 Checkpoint 关系 | `packages/core/content/models.py` | 当前通过 `Scene.contents` 中的 checkpoint 项表达，而非直接 `checkpoint_ids`；正式契约需选定一种稳定表示并由校验器统一处理 |
+| 粗粒度导入 Agent | `packages/core/moduleimport/agent.py` | 已有 `parse()`、`validate_and_ingest()` 和 `ModulePackDraft` 桩；内部 Parser、确定性校验、Reviewer、ReviewReport 和批准流程尚未实现 |
+| 内容存储 | `packages/core/content/repo.py` | 可作为批准版本的持久化边界；草稿和 ReviewReport 不应混入正式运行时内容 |
+| fixtures / evals | 当前目录未发现完整实现 | 需要新增书房 Demo、预期 Intent/ActionResult/Event 和 Agent 评测集 |
+
+现有 `ModuleImportAgent` 粗粒度外部接口可以保留，但内部必须拆成来源分段、Parser、校验、Reviewer、人工批准和发布步骤，不能让 `validate_and_ingest` 成为不可观察的黑箱。
+
+## 10. 与其他成员的协作接口
+
+### 10.1 成员 C → 成员 A
+
+- 提供批准版本的 `ModuleContent`、稳定 Scene/Entity/Checkpoint ID 和玩家可见内容。
+- 提供 Intent 解析样例、歧义输入、未匹配输入和叙事约束。
+- 明确哪些字段是公开信息、秘密、发现后可见信息和永不直接展示的规则信息。
+
+### 10.2 成员 C → 成员 B
+
+- 提供可执行的 Rule、Hook、Op、`refuse_ops`、初始 state、Checkpoint 和 WinCondition。
+- 所有引用、状态路径和表达式在发布前通过确定性校验。
+- 为机制 A/B/C/D 分别提供正向、负向和边界案例。
+
+### 10.3 成员 A/B → 成员 C
+
+- A 反馈无法稳定解析的动作、菜单缺失和叙事泄密案例。
+- B 反馈无法执行的 Rule/Op、非法路径、回放不完整和 WinCondition 问题。
+- C 将反馈固化为 Schema 检查、Reviewer 规则或回归案例，而不是只人工修一次数据。
+
+## 11. MVP 交付顺序
+
+1. 冻结 ModuleContent MVP Schema、术语和 ID/状态路径约定。
+2. 人工编写书房 `demo-module.json`，覆盖普通动作和机制 A/B/C/D。
+3. 编写 10～20 条 `FixtureCase`，包含预期 Intent、ActionResult、Event、最终状态和叙事约束。
+4. 实现确定性 Schema、枚举、ID、引用、字段位置和秘密隔离校验。
+5. 输出第一版 ReviewReport 格式和人工审查清单。
+6. 与成员 A、B 跑通书房 Demo，修正不可消费或不可执行的内容契约。
+7. 开始最小 Parser 实验：先提取 Entity/Checkpoint 和来源引用。
+8. 运行时稳定后再实现完整 Parser → Reviewer → 批准 → 发布流水线。
+
+第二阶段再实现：复杂 PDF/表格/图片导入、自动修订循环、多模组批量导入、Review 仪表盘和更大规模评测集。
+
+## 12. 测试与验收标准
+
+### 12.1 Schema 与引用
+
+- 合法 Demo 能完整解析为 ModuleContent。
+- 非法枚举、额外顶层字段和错误字段位置被拒绝。
+- 重复 ID、悬空 Scene/Entity/Checkpoint/Asset 引用被拒绝。
+- 顶层模组 `rules` 被拒绝；Entity.rules 与 World.world_rules 可通过。
+- Entity 的 `state/refuse_ops/rules` 能表达 MVP Demo。
+
+### 12.2 Parser 与来源忠实度
+
+- 关键实体、秘密、Checkpoint、Rule 和结局均带来源引用。
+- 原文未提供的信息不会被静默补造。
+- 同一来源重复解析得到稳定 ID 或明确迁移映射。
+- Parser 非法输出不会进入正式内容仓储。
+
+### 12.3 Reviewer
+
+- 能识别无钥匙开柜缺失机制 A。
+- 能识别管家进入缺失机制 B Hook。
+- 能识别砸柜成功损毁文件缺失机制 C。
+- 能识别 WinCondition 读取但未落库的机制 D 状态。
+- 能发现 secrets 泄漏、不可达结局、自由文本不可执行 Rule 和过度结构化对象。
+- 存在阻断错误时不能进入人工批准后的发布步骤。
+
+### 12.4 三人集成
+
+- 成员 A 能用发布版 ModuleContent 生成正确 PlayerView/SceneActionMenu 和 Intent。
+- 成员 B 能执行全部 Demo Rule/Op，并从 Event 重建最终状态。
+- 成员 A 的 Narrator 能忠实表达正常、拒绝和“成功但坏结果”三类结果。
+- ModuleContent、Intent、ActionResult 和 Event 中的实体/状态路径一致。
+
+## 13. 交接清单
+
+- **我负责什么**：标准模组数据、Parser Agent、确定性校验、Reviewer Agent、人工批准、版本化发布、fixtures 和 evals。
+- **我不负责什么**：玩家意图理解、运行时旁白、规则实际执行、Event/状态事务和客户端交互。
+- **我向谁提供什么**：向成员 A、B 提供通过审查的 ModuleContent；向三人提供共享 fixtures/evals 和 ReviewReport。
+- **我依赖谁提供什么**：依赖成员 A 提供上下文、Intent 和叙事约束需求；依赖成员 B 提供可执行 Rule/Op、状态路径、Event 和 ActionResult 契约。


### PR DESCRIPTION
## 内容

补充 TRPG AI 主持人系统三名成员的 MVP 实施基线架构文档：

- 成员 A：主持编排 Agent，覆盖玩家输入、意图解析、规则引擎调用、结果脱敏与玩家可见叙事。
- 成员 B：确定性规则引擎，覆盖动作复核、检定、Hook / Rule 流水线、Event 权威写入和状态视图。
- 成员 C：模组解析与审查 Agent，覆盖 Demo 模组、Schema 校验、审查、人工批准与测试素材。

三份文档统一明确了 `ModuleContent`、`Intent`、`ActionResult` 等跨成员接口，以及 LLM 与确定性引擎的职责边界。

## 校验

- 对比三个源文件与仓库副本的 SHA-256，内容完全一致。
- 检查提交范围：仅新增上述 3 份 Markdown 文档，共 1,335 行。
- `git diff --check` 仅报告文档已有的 Markdown 显式换行（行尾双空格），为保留原稿格式未修改。