### PR TITLE
feat(auth): 账号注册/登录/会话 API + SDK 映射

### DIFF
--- a/trpg-backend/app/controller/v1/auth.py
+++ b/trpg-backend/app/controller/v1/auth.py
@@ -1,0 +1,73 @@
+"""Controller 层：`/api/v1/auth` 路由 —— 注册/登录/登出/当前用户（issue #58）。
+
+登录凭证通过标准的 `Authorization: Bearer <token>` 请求头传递，跟 rooms 模块
+自定义的 `X-Reconnect-Token` 是两套独立的身份体系：账号会话认的是"这是哪个
+用户"，重连凭证认的是"这是房间里的哪个玩家"。
+"""
+
+from fastapi import APIRouter, Header, status
+
+from app.core.errors import AppException, ErrorCode
+from app.dto.auth import AuthResult, LoginBody, MeRead, RegisterBody, UpdateNicknameBody
+from app.dto.common import ApiResponse
+from app.service import auth as auth_service
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _extract_token(authorization: str | None) -> str | None:
+    if authorization is None:
+        return None
+    prefix = "Bearer "
+    return authorization[len(prefix) :] if authorization.startswith(prefix) else authorization
+
+
+@router.post(
+    "/register", response_model=ApiResponse[AuthResult], status_code=status.HTTP_201_CREATED
+)
+async def register(payload: RegisterBody) -> ApiResponse[AuthResult]:
+    """POST /api/v1/auth/register —— 注册新账号，成功即登录。"""
+    try:
+        result = await auth_service.register(payload.account, payload.password, payload.nickname)
+    except auth_service.AccountExistsError as exc:
+        raise AppException(ErrorCode.CONFLICT, str(exc), status.HTTP_409_CONFLICT) from exc
+    return ApiResponse.ok(result)
+
+
+@router.post("/login", response_model=ApiResponse[AuthResult])
+async def login(payload: LoginBody) -> ApiResponse[AuthResult]:
+    """POST /api/v1/auth/login —— 账号密码登录。"""
+    try:
+        result = await auth_service.login(payload.account, payload.password)
+    except auth_service.InvalidCredentialsError as exc:
+        raise AppException(ErrorCode.UNAUTHORIZED, str(exc), status.HTTP_401_UNAUTHORIZED) from exc
+    return ApiResponse.ok(result)
+
+
+@router.post("/logout", response_model=ApiResponse[None])
+async def logout(authorization: str | None = Header(default=None)) -> ApiResponse[None]:
+    """POST /api/v1/auth/logout —— 退出登录，使当前 token 失效。"""
+    await auth_service.logout(_extract_token(authorization))
+    return ApiResponse.ok(None)
+
+
+@router.get("/me", response_model=ApiResponse[MeRead])
+async def get_me(authorization: str | None = Header(default=None)) -> ApiResponse[MeRead]:
+    """GET /api/v1/auth/me —— 获取当前登录用户，供刷新页面后恢复登录态使用。"""
+    try:
+        result = await auth_service.get_me(_extract_token(authorization))
+    except auth_service.AuthenticationError as exc:
+        raise AppException(ErrorCode.UNAUTHORIZED, str(exc), status.HTTP_401_UNAUTHORIZED) from exc
+    return ApiResponse.ok(result)
+
+
+@router.patch("/me", response_model=ApiResponse[MeRead])
+async def update_me(
+    payload: UpdateNicknameBody, authorization: str | None = Header(default=None)
+) -> ApiResponse[MeRead]:
+    """PATCH /api/v1/auth/me —— 修改昵称（账号只读，本期不允许修改）。"""
+    try:
+        result = await auth_service.update_nickname(_extract_token(authorization), payload.nickname)
+    except auth_service.AuthenticationError as exc:
+        raise AppException(ErrorCode.UNAUTHORIZED, str(exc), status.HTTP_401_UNAUTHORIZED) from exc
+    return ApiResponse.ok(result)

--- a/trpg-backend/app/controller/v1/router.py
+++ b/trpg-backend/app/controller/v1/router.py
@@ -6,11 +6,12 @@
 
 from fastapi import APIRouter
 
-from app.controller.v1 import examples, health, me, modules, rooms
+from app.controller.v1 import auth, examples, health, me, modules, rooms
 
 api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(health.router)
 api_router.include_router(examples.router)
+api_router.include_router(auth.router)
 api_router.include_router(rooms.router)
 api_router.include_router(modules.router)
 api_router.include_router(me.router)

--- a/trpg-backend/app/dto/auth.py
+++ b/trpg-backend/app/dto/auth.py
@@ -1,0 +1,62 @@
+"""认证模块（issue #58）的 pydantic 请求/响应模型。
+
+与 dto/room.py 的约定一致：JSON 层 camelCase，Python 层 snake_case。
+"""
+
+from typing import Annotated
+
+from pydantic import AliasGenerator, BaseModel, ConfigDict, StringConstraints
+from pydantic.alias_generators import to_camel
+
+
+def _to_camel(snake: str) -> str:
+    return to_camel(snake)
+
+
+class CamelModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=AliasGenerator(alias=_to_camel),
+        populate_by_name=True,
+    )
+
+
+AccountStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=3, max_length=50)]
+PasswordStr = Annotated[str, StringConstraints(min_length=6, max_length=100)]
+NicknameStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=50)]
+
+
+class RegisterBody(CamelModel):
+    """POST /api/v1/auth/register 请求体"""
+
+    account: AccountStr
+    password: PasswordStr
+    nickname: NicknameStr
+
+
+class LoginBody(CamelModel):
+    """POST /api/v1/auth/login 请求体"""
+
+    account: AccountStr
+    password: PasswordStr
+
+
+class UpdateNicknameBody(CamelModel):
+    """PATCH /api/v1/auth/me 请求体"""
+
+    nickname: NicknameStr
+
+
+class AuthResult(CamelModel):
+    """注册 / 登录成功后的返回：登录凭证 + 用户信息。"""
+
+    token: str
+    user_id: str
+    nickname: str
+
+
+class MeRead(CamelModel):
+    """GET /PATCH /api/v1/auth/me 返回"""
+
+    user_id: str
+    account: str
+    nickname: str

--- a/trpg-backend/app/service/auth.py
+++ b/trpg-backend/app/service/auth.py
@@ -4,6 +4,8 @@
 存在内存字典里换取用户，不做过期/续期（MS1 范围不包含"多设备会话管理"）。
 """
 
+import asyncio
+import hashlib
 import uuid
 
 import bcrypt
@@ -28,12 +30,21 @@ class AuthenticationError(PermissionError):
     """未提供有效的登录凭证。"""
 
 
+def _prehash(password: str) -> bytes:
+    """bcrypt 只认密码的前 72 字节，超出部分会被静默截断——密码开到 100 字符
+    时，两个仅在 72 字节之后不同的密码会算出同一个哈希，等于变相碰撞（code
+    review 用真实 bcrypt 4.3.0 复现过）。这里先用 sha256 摘要成固定 32 字节
+    再喂给 bcrypt，从根源上避开这个截断限制，而不是缩短密码长度上限。
+    """
+    return hashlib.sha256(password.encode()).digest()
+
+
 def _hash_password(password: str) -> str:
-    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    return bcrypt.hashpw(_prehash(password), bcrypt.gensalt()).decode()
 
 
 def _verify_password(password: str, password_hash: str) -> bool:
-    return bcrypt.checkpw(password.encode(), password_hash.encode())
+    return bcrypt.checkpw(_prehash(password), password_hash.encode())
 
 
 async def register(account: str, password: str, nickname: str) -> AuthResult:
@@ -41,10 +52,13 @@ async def register(account: str, password: str, nickname: str) -> AuthResult:
     if account in _accounts:
         raise AccountExistsError("账号已被注册")
     user_id = str(uuid.uuid4())
+    # bcrypt 是同步、CPU 密集的调用，直接在协程里跑会阻塞事件循环处理其它
+    # 并发请求，丢进线程池执行。
+    password_hash = await asyncio.to_thread(_hash_password, password)
     _users[user_id] = {
         "id": user_id,
         "account": account,
-        "password_hash": _hash_password(password),
+        "password_hash": password_hash,
         "nickname": nickname,
     }
     _accounts[account] = user_id
@@ -57,7 +71,10 @@ async def login(account: str, password: str) -> AuthResult:
     """账号密码登录。"""
     user_id = _accounts.get(account)
     user = _users.get(user_id) if user_id else None
-    if user is None or not _verify_password(password, user["password_hash"]):
+    if user is None:
+        raise InvalidCredentialsError("账号或密码不正确")
+    verified = await asyncio.to_thread(_verify_password, password, user["password_hash"])
+    if not verified:
         raise InvalidCredentialsError("账号或密码不正确")
     token = str(uuid.uuid4())
     _tokens[token] = user["id"]

--- a/trpg-backend/app/service/auth.py
+++ b/trpg-backend/app/service/auth.py
@@ -1,0 +1,93 @@
+"""Service 层：账号 + 会话（issue #58）—— MS1 内存 stub，跟 service/room.py 同款风格。
+
+密码用 bcrypt 加盐哈希存储，不落明文；会话是随机 token，登录/注册时签发，
+存在内存字典里换取用户，不做过期/续期（MS1 范围不包含"多设备会话管理"）。
+"""
+
+import uuid
+
+import bcrypt
+
+from app.dto.auth import AuthResult, MeRead
+
+# ── 内存数据存储（MS1 stub，后续替换为数据库） ──
+_users: dict[str, dict] = {}  # user_id -> {id, account, password_hash, nickname}
+_accounts: dict[str, str] = {}  # account -> user_id
+_tokens: dict[str, str] = {}  # token -> user_id
+
+
+class AccountExistsError(ValueError):
+    """账号已被注册。"""
+
+
+class InvalidCredentialsError(PermissionError):
+    """账号或密码不正确。"""
+
+
+class AuthenticationError(PermissionError):
+    """未提供有效的登录凭证。"""
+
+
+def _hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def _verify_password(password: str, password_hash: str) -> bool:
+    return bcrypt.checkpw(password.encode(), password_hash.encode())
+
+
+async def register(account: str, password: str, nickname: str) -> AuthResult:
+    """注册新账号，成功即视为登录，直接签发 token。"""
+    if account in _accounts:
+        raise AccountExistsError("账号已被注册")
+    user_id = str(uuid.uuid4())
+    _users[user_id] = {
+        "id": user_id,
+        "account": account,
+        "password_hash": _hash_password(password),
+        "nickname": nickname,
+    }
+    _accounts[account] = user_id
+    token = str(uuid.uuid4())
+    _tokens[token] = user_id
+    return AuthResult(token=token, user_id=user_id, nickname=nickname)
+
+
+async def login(account: str, password: str) -> AuthResult:
+    """账号密码登录。"""
+    user_id = _accounts.get(account)
+    user = _users.get(user_id) if user_id else None
+    if user is None or not _verify_password(password, user["password_hash"]):
+        raise InvalidCredentialsError("账号或密码不正确")
+    token = str(uuid.uuid4())
+    _tokens[token] = user["id"]
+    return AuthResult(token=token, user_id=user["id"], nickname=user["nickname"])
+
+
+async def logout(token: str | None) -> None:
+    """退出登录，使当前 token 失效。"""
+    if token is not None:
+        _tokens.pop(token, None)
+
+
+def _get_user_by_token(token: str | None) -> dict:
+    if token is None:
+        raise AuthenticationError("缺少登录凭证")
+    user_id = _tokens.get(token)
+    user = _users.get(user_id) if user_id else None
+    if user is None:
+        raise AuthenticationError("登录凭证无效")
+    return user
+
+
+async def get_me(token: str | None) -> MeRead:
+    """获取当前登录用户。"""
+    user = _get_user_by_token(token)
+    return MeRead(user_id=user["id"], account=user["account"], nickname=user["nickname"])
+
+
+async def update_nickname(token: str | None, nickname: str) -> MeRead:
+    """修改当前登录用户的昵称（账号只读，本期不允许修改）。"""
+    user = _get_user_by_token(token)
+    user["nickname"] = nickname
+    return MeRead(user_id=user["id"], account=user["account"], nickname=user["nickname"])

--- a/trpg-backend/pyproject.toml
+++ b/trpg-backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "aiosqlite>=0.20,<1.0",
   "asyncpg>=0.29,<1.0",
   "structlog>=24.4,<25.0",
+  "bcrypt>=4.2,<5.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/trpg-backend/tests/test_auth.py
+++ b/trpg-backend/tests/test_auth.py
@@ -1,0 +1,111 @@
+import pytest
+from httpx import AsyncClient
+
+from app.service import auth as auth_service
+
+AUTH_BASE = "/api/v1/auth"
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_stub() -> None:
+    auth_service._users.clear()
+    auth_service._accounts.clear()
+    auth_service._tokens.clear()
+
+
+def bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def register(client: AsyncClient, account: str = "alice", password: str = "secret1") -> dict:
+    response = await client.post(
+        f"{AUTH_BASE}/register",
+        json={"account": account, "password": password, "nickname": "爱丽丝"},
+    )
+    assert response.status_code == 201
+    return response.json()["data"]
+
+
+async def test_register_then_login_succeeds(client: AsyncClient) -> None:
+    await register(client)
+
+    response = await client.post(
+        f"{AUTH_BASE}/login", json={"account": "alice", "password": "secret1"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["nickname"] == "爱丽丝"
+
+
+async def test_register_rejects_duplicate_account(client: AsyncClient) -> None:
+    await register(client)
+
+    response = await client.post(
+        f"{AUTH_BASE}/register",
+        json={"account": "alice", "password": "secret2", "nickname": "另一个"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "CONFLICT"
+
+
+async def test_login_rejects_wrong_password(client: AsyncClient) -> None:
+    await register(client)
+
+    response = await client.post(
+        f"{AUTH_BASE}/login", json={"account": "alice", "password": "wrong-password"}
+    )
+
+    assert response.status_code == 401
+
+
+async def test_me_requires_valid_token(client: AsyncClient) -> None:
+    missing = await client.get(f"{AUTH_BASE}/me")
+    invalid = await client.get(f"{AUTH_BASE}/me", headers=bearer("not-a-real-token"))
+
+    assert missing.status_code == 401
+    assert invalid.status_code == 401
+
+
+async def test_me_reflects_session_after_login(client: AsyncClient) -> None:
+    session = await register(client)
+
+    response = await client.get(f"{AUTH_BASE}/me", headers=bearer(session["token"]))
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["account"] == "alice"
+    assert data["nickname"] == "爱丽丝"
+
+
+async def test_update_nickname_persists(client: AsyncClient) -> None:
+    session = await register(client)
+
+    updated = await client.patch(
+        f"{AUTH_BASE}/me", json={"nickname": "新昵称"}, headers=bearer(session["token"])
+    )
+    me = await client.get(f"{AUTH_BASE}/me", headers=bearer(session["token"]))
+
+    assert updated.status_code == 200
+    assert updated.json()["data"]["nickname"] == "新昵称"
+    assert me.json()["data"]["nickname"] == "新昵称"
+
+
+async def test_logout_invalidates_token(client: AsyncClient) -> None:
+    session = await register(client)
+
+    logout_response = await client.post(f"{AUTH_BASE}/logout", headers=bearer(session["token"]))
+    me_after_logout = await client.get(f"{AUTH_BASE}/me", headers=bearer(session["token"]))
+
+    assert logout_response.status_code == 200
+    assert me_after_logout.status_code == 401
+
+
+async def test_register_rejects_short_password(client: AsyncClient) -> None:
+    response = await client.post(
+        f"{AUTH_BASE}/register",
+        json={"account": "bob", "password": "123", "nickname": "鲍勃"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"

--- a/trpg-backend/tests/test_auth.py
+++ b/trpg-backend/tests/test_auth.py
@@ -109,3 +109,28 @@ async def test_register_rejects_short_password(client: AsyncClient) -> None:
 
     assert response.status_code == 422
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+async def test_long_passwords_differing_after_bcrypt_limit_are_not_confused(
+    client: AsyncClient,
+) -> None:
+    # bcrypt 本身只认密码的前 72 字节，两个仅在这之后不同的密码如果直接喂给
+    # bcrypt 会被当成同一个密码——这里用两个前 72 字节相同、只有末尾不同的
+    # 100 字符密码验证不会互相通过登录（回归 service/auth.py 里的 sha256
+    # 预哈希修复）。
+    password_a = "a" * 99 + "A"
+    password_b = "a" * 99 + "B"
+    await client.post(
+        f"{AUTH_BASE}/register",
+        json={"account": "carol", "password": password_a, "nickname": "卡罗尔"},
+    )
+
+    wrong = await client.post(
+        f"{AUTH_BASE}/login", json={"account": "carol", "password": password_b}
+    )
+    correct = await client.post(
+        f"{AUTH_BASE}/login", json={"account": "carol", "password": password_a}
+    )
+
+    assert wrong.status_code == 401
+    assert correct.status_code == 200

--- a/trpg-backend/uv.lock
+++ b/trpg-backend/uv.lock
@@ -83,6 +83,56 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", hash = "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18", size = 25697, upload-time = "2025-02-28T01:24:09.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/2c/3d44e853d1fe969d229bd58d39ae6902b3d924af0e2b5a60d17d4b809ded/bcrypt-4.3.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281", size = 483719, upload-time = "2025-02-28T01:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e2/58ff6e2a22eca2e2cff5370ae56dba29d70b1ea6fc08ee9115c3ae367795/bcrypt-4.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5eeac541cefd0bb887a371ef73c62c3cd78535e4887b310626036a7c0a817bb", size = 272001, upload-time = "2025-02-28T01:22:38.078Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1f/c55ed8dbe994b1d088309e366749633c9eb90d139af3c0a50c102ba68a1a/bcrypt-4.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59e1aa0e2cd871b08ca146ed08445038f42ff75968c7ae50d2fdd7860ade2180", size = 277451, upload-time = "2025-02-28T01:22:40.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/1c/794feb2ecf22fe73dcfb697ea7057f632061faceb7dcf0f155f3443b4d79/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0042b2e342e9ae3d2ed22727c1262f76cc4f345683b5c1715f0250cf4277294f", size = 272792, upload-time = "2025-02-28T01:22:43.144Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b7/0b289506a3f3598c2ae2bdfa0ea66969812ed200264e3f61df77753eee6d/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74a8d21a09f5e025a9a23e7c0fd2c7fe8e7503e4d356c0a2c1486ba010619f09", size = 289752, upload-time = "2025-02-28T01:22:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/24/d0fb023788afe9e83cc118895a9f6c57e1044e7e1672f045e46733421fe6/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:0142b2cb84a009f8452c8c5a33ace5e3dfec4159e7735f5afe9a4d50a8ea722d", size = 277762, upload-time = "2025-02-28T01:22:47.023Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/38/cde58089492e55ac4ef6c49fea7027600c84fd23f7520c62118c03b4625e/bcrypt-4.3.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:12fa6ce40cde3f0b899729dbd7d5e8811cb892d31b6f7d0334a1f37748b789fd", size = 272384, upload-time = "2025-02-28T01:22:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/d5026520843490cfc8135d03012a413e4532a400e471e6188b01b2de853f/bcrypt-4.3.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:5bd3cca1f2aa5dbcf39e2aa13dd094ea181f48959e1071265de49cc2b82525af", size = 277329, upload-time = "2025-02-28T01:22:51.603Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a3/4fc5255e60486466c389e28c12579d2829b28a527360e9430b4041df4cf9/bcrypt-4.3.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:335a420cfd63fc5bc27308e929bee231c15c85cc4c496610ffb17923abf7f231", size = 305241, upload-time = "2025-02-28T01:22:53.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/15/2b37bc07d6ce27cc94e5b10fd5058900eb8fb11642300e932c8c82e25c4a/bcrypt-4.3.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:0e30e5e67aed0187a1764911af023043b4542e70a7461ad20e837e94d23e1d6c", size = 309617, upload-time = "2025-02-28T01:22:55.461Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/1f/99f65edb09e6c935232ba0430c8c13bb98cb3194b6d636e61d93fe60ac59/bcrypt-4.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3b8d62290ebefd49ee0b3ce7500f5dbdcf13b81402c05f6dafab9a1e1b27212f", size = 335751, upload-time = "2025-02-28T01:22:57.81Z" },
+    { url = "https://files.pythonhosted.org/packages/00/1b/b324030c706711c99769988fcb694b3cb23f247ad39a7823a78e361bdbb8/bcrypt-4.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef6630e0ec01376f59a006dc72918b1bf436c3b571b80fa1968d775fa02fe7d", size = 355965, upload-time = "2025-02-28T01:22:59.181Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/20372a0579dd915dfc3b1cd4943b3bca431866fcb1dfdfd7518c3caddea6/bcrypt-4.3.0-cp313-cp313t-win32.whl", hash = "sha256:7a4be4cbf241afee43f1c3969b9103a41b40bcb3a3f467ab19f891d9bc4642e4", size = 155316, upload-time = "2025-02-28T01:23:00.763Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/52/45d969fcff6b5577c2bf17098dc36269b4c02197d551371c023130c0f890/bcrypt-4.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5c1949bf259a388863ced887c7861da1df681cb2388645766c89fdfd9004c669", size = 147752, upload-time = "2025-02-28T01:23:02.908Z" },
+    { url = "https://files.pythonhosted.org/packages/11/22/5ada0b9af72b60cbc4c9a399fdde4af0feaa609d27eb0adc61607997a3fa/bcrypt-4.3.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:f81b0ed2639568bf14749112298f9e4e2b28853dab50a8b357e31798686a036d", size = 498019, upload-time = "2025-02-28T01:23:05.838Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8c/252a1edc598dc1ce57905be173328eda073083826955ee3c97c7ff5ba584/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:864f8f19adbe13b7de11ba15d85d4a428c7e2f344bac110f667676a0ff84924b", size = 279174, upload-time = "2025-02-28T01:23:07.274Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5b/4547d5c49b85f0337c13929f2ccbe08b7283069eea3550a457914fc078aa/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e36506d001e93bffe59754397572f21bb5dc7c83f54454c990c74a468cd589e", size = 283870, upload-time = "2025-02-28T01:23:09.151Z" },
+    { url = "https://files.pythonhosted.org/packages/be/21/7dbaf3fa1745cb63f776bb046e481fbababd7d344c5324eab47f5ca92dd2/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:842d08d75d9fe9fb94b18b071090220697f9f184d4547179b60734846461ed59", size = 279601, upload-time = "2025-02-28T01:23:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/64/e042fc8262e971347d9230d9abbe70d68b0a549acd8611c83cebd3eaec67/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7c03296b85cb87db865d91da79bf63d5609284fc0cab9472fdd8367bbd830753", size = 297660, upload-time = "2025-02-28T01:23:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b8/6294eb84a3fef3b67c69b4470fcdd5326676806bf2519cda79331ab3c3a9/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:62f26585e8b219cdc909b6a0069efc5e4267e25d4a3770a364ac58024f62a761", size = 284083, upload-time = "2025-02-28T01:23:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e6/baff635a4f2c42e8788fe1b1633911c38551ecca9a749d1052d296329da6/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:beeefe437218a65322fbd0069eb437e7c98137e08f22c4660ac2dc795c31f8bb", size = 279237, upload-time = "2025-02-28T01:23:16.686Z" },
+    { url = "https://files.pythonhosted.org/packages/39/48/46f623f1b0c7dc2e5de0b8af5e6f5ac4cc26408ac33f3d424e5ad8da4a90/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:97eea7408db3a5bcce4a55d13245ab3fa566e23b4c67cd227062bb49e26c585d", size = 283737, upload-time = "2025-02-28T01:23:18.897Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8b/70671c3ce9c0fca4a6cc3cc6ccbaa7e948875a2e62cbd146e04a4011899c/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:191354ebfe305e84f344c5964c7cd5f924a3bfc5d405c75ad07f232b6dffb49f", size = 312741, upload-time = "2025-02-28T01:23:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fb/910d3a1caa2d249b6040a5caf9f9866c52114d51523ac2fb47578a27faee/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:41261d64150858eeb5ff43c753c4b216991e0ae16614a308a15d909503617732", size = 316472, upload-time = "2025-02-28T01:23:23.183Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cf/7cf3a05b66ce466cfb575dbbda39718d45a609daa78500f57fa9f36fa3c0/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:33752b1ba962ee793fa2b6321404bf20011fe45b9afd2a842139de3011898fef", size = 343606, upload-time = "2025-02-28T01:23:25.361Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b8/e970ecc6d7e355c0d892b7f733480f4aa8509f99b33e71550242cf0b7e63/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:50e6e80a4bfd23a25f5c05b90167c19030cf9f87930f7cb2eacb99f45d1c3304", size = 362867, upload-time = "2025-02-28T01:23:26.875Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/97/8d3118efd8354c555a3422d544163f40d9f236be5b96c714086463f11699/bcrypt-4.3.0-cp38-abi3-win32.whl", hash = "sha256:67a561c4d9fb9465ec866177e7aebcad08fe23aaf6fbd692a6fab69088abfc51", size = 160589, upload-time = "2025-02-28T01:23:28.381Z" },
+    { url = "https://files.pythonhosted.org/packages/29/07/416f0b99f7f3997c69815365babbc2e8754181a4b1899d921b3c7d5b6f12/bcrypt-4.3.0-cp38-abi3-win_amd64.whl", hash = "sha256:584027857bc2843772114717a7490a37f68da563b3620f78a849bcb54dc11e62", size = 152794, upload-time = "2025-02-28T01:23:30.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c1/3fa0e9e4e0bfd3fd77eb8b52ec198fd6e1fd7e9402052e43f23483f956dd/bcrypt-4.3.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0d3efb1157edebfd9128e4e46e2ac1a64e0c1fe46fb023158a407c7892b0f8c3", size = 498969, upload-time = "2025-02-28T01:23:31.945Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d4/755ce19b6743394787fbd7dff6bf271b27ee9b5912a97242e3caf125885b/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08bacc884fd302b611226c01014eca277d48f0a05187666bca23aac0dad6fe24", size = 279158, upload-time = "2025-02-28T01:23:34.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5d/805ef1a749c965c46b28285dfb5cd272a7ed9fa971f970435a5133250182/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6746e6fec103fcd509b96bacdfdaa2fbde9a553245dbada284435173a6f1aef", size = 284285, upload-time = "2025-02-28T01:23:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/698580547a4a4988e415721b71eb45e80c879f0fb04a62da131f45987b96/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:afe327968aaf13fc143a56a3360cb27d4ad0345e34da12c7290f1b00b8fe9a8b", size = 279583, upload-time = "2025-02-28T01:23:38.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/87/62e1e426418204db520f955ffd06f1efd389feca893dad7095bf35612eec/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9af79d322e735b1fc33404b5765108ae0ff232d4b54666d46730f8ac1a43676", size = 297896, upload-time = "2025-02-28T01:23:39.575Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c6/8fedca4c2ada1b6e889c52d2943b2f968d3427e5d65f595620ec4c06fa2f/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f1e3ffa1365e8702dc48c8b360fef8d7afeca482809c5e45e653af82ccd088c1", size = 284492, upload-time = "2025-02-28T01:23:40.901Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/4d/c43332dcaaddb7710a8ff5269fcccba97ed3c85987ddaa808db084267b9a/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3004df1b323d10021fda07a813fd33e0fd57bef0e9a480bb143877f6cba996fe", size = 279213, upload-time = "2025-02-28T01:23:42.653Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/1e36379e169a7df3a14a1c160a49b7b918600a6008de43ff20d479e6f4b5/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:531457e5c839d8caea9b589a1bcfe3756b0547d7814e9ce3d437f17da75c32b0", size = 284162, upload-time = "2025-02-28T01:23:43.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0a/644b2731194b0d7646f3210dc4d80c7fee3ecb3a1f791a6e0ae6bb8684e3/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:17a854d9a7a476a89dcef6c8bd119ad23e0f82557afbd2c442777a16408e614f", size = 312856, upload-time = "2025-02-28T01:23:46.011Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/62/2a871837c0bb6ab0c9a88bf54de0fc021a6a08832d4ea313ed92a669d437/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6fb1fd3ab08c0cbc6826a2e0447610c6f09e983a281b919ed721ad32236b8b23", size = 316726, upload-time = "2025-02-28T01:23:47.575Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a1/9898ea3faac0b156d457fd73a3cb9c2855c6fd063e44b8522925cdd8ce46/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e965a9c1e9a393b8005031ff52583cedc15b7884fce7deb8b0346388837d6cfe", size = 343664, upload-time = "2025-02-28T01:23:49.059Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/71b4ed65ce38982ecdda0ff20c3ad1b15e71949c78b2c053df53629ce940/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505", size = 363128, upload-time = "2025-02-28T01:23:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/12f6a58eca6dea4be992d6c681b7ec9410a1d9f5cf368c61437e31daa879/bcrypt-4.3.0-cp39-abi3-win32.whl", hash = "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a", size = 160598, upload-time = "2025-02-28T01:23:51.775Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/cf/45fb5261ece3e6b9817d3d82b2f343a505fd58674a92577923bc500bd1aa/bcrypt-4.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b", size = 152799, upload-time = "2025-02-28T01:23:53.139Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -600,6 +650,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "asyncpg" },
+    { name = "bcrypt" },
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -621,6 +672,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20,<1.0" },
     { name = "asyncpg", specifier = ">=0.29,<1.0" },
+    { name = "bcrypt", specifier = ">=4.2,<5.0" },
     { name = "fastapi", specifier = ">=0.115,<1.0" },
     { name = "pydantic", specifier = ">=2.9,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.5,<3.0" },

--- a/trpg-sdk/src/client.ts
+++ b/trpg-sdk/src/client.ts
@@ -88,6 +88,14 @@ export class ApiClient {
     return this.request<T>(path, { method: 'PUT', body: JSON.stringify(payload) });
   }
 
+  patch<T>(path: string, payload: unknown, init?: RequestInit): Promise<T> {
+    return this.request<T>(path, {
+      ...init,
+      method: 'PATCH',
+      body: JSON.stringify(payload)
+    });
+  }
+
   delete<T>(path: string): Promise<T> {
     return this.request<T>(path, { method: 'DELETE' });
   }

--- a/trpg-sdk/src/index.ts
+++ b/trpg-sdk/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { ApiClient, type ApiClientOptions } from './client';
+import { AuthResource } from './resources/auth';
 import { ExamplesResource } from './resources/examples';
 import { RoomsResource } from './resources/rooms';
 
@@ -18,11 +19,13 @@ export type { ApiClientOptions } from './client';
 export class TrpgSdk {
   readonly examples: ExamplesResource;
   readonly rooms: RoomsResource;
+  readonly auth: AuthResource;
 
   constructor(options: ApiClientOptions) {
     const client = new ApiClient(options);
     this.examples = new ExamplesResource(client);
     this.rooms = new RoomsResource(client);
+    this.auth = new AuthResource(client);
   }
 }
 

--- a/trpg-sdk/src/resources/auth.ts
+++ b/trpg-sdk/src/resources/auth.ts
@@ -1,0 +1,39 @@
+import type { ApiClient } from '../client';
+import type { AuthResult, LoginInput, Me, RegisterInput, UpdateNicknameInput } from '../types';
+
+/**
+ * `/api/v1/auth` 的类型化封装：注册/登录/登出/当前用户。
+ * 登录凭证走标准的 `Authorization: Bearer <token>` 请求头。
+ */
+export class AuthResource {
+  constructor(private readonly client: ApiClient) {}
+
+  private authenticated(token: string): RequestInit {
+    return { headers: { Authorization: `Bearer ${token}` } };
+  }
+
+  /** POST /api/v1/auth/register — 注册新账号，成功即登录 */
+  register(payload: RegisterInput): Promise<AuthResult> {
+    return this.client.post<AuthResult>('/auth/register', payload);
+  }
+
+  /** POST /api/v1/auth/login — 账号密码登录 */
+  login(payload: LoginInput): Promise<AuthResult> {
+    return this.client.post<AuthResult>('/auth/login', payload);
+  }
+
+  /** POST /api/v1/auth/logout — 退出登录，使当前 token 失效 */
+  logout(token: string): Promise<null> {
+    return this.client.post<null>('/auth/logout', null, this.authenticated(token));
+  }
+
+  /** GET /api/v1/auth/me — 获取当前登录用户，供刷新页面后恢复登录态使用 */
+  getMe(token: string): Promise<Me> {
+    return this.client.get<Me>('/auth/me', this.authenticated(token));
+  }
+
+  /** PATCH /api/v1/auth/me — 修改昵称 */
+  updateNickname(payload: UpdateNicknameInput, token: string): Promise<Me> {
+    return this.client.patch<Me>('/auth/me', payload, this.authenticated(token));
+  }
+}

--- a/trpg-sdk/src/types.ts
+++ b/trpg-sdk/src/types.ts
@@ -33,6 +33,42 @@ export interface ExampleUpdateInput {
 }
 
 // ──────────────────────────────────────────────
+// 认证（Auth）模块 — 与后端 dto/auth.py 手动保持同步
+// ──────────────────────────────────────────────
+
+/** POST /api/v1/auth/register 请求体 */
+export interface RegisterInput {
+  account: string;
+  password: string;
+  nickname: string;
+}
+
+/** POST /api/v1/auth/login 请求体 */
+export interface LoginInput {
+  account: string;
+  password: string;
+}
+
+/** PATCH /api/v1/auth/me 请求体 */
+export interface UpdateNicknameInput {
+  nickname: string;
+}
+
+/** 注册 / 登录成功后的返回：登录凭证 + 用户信息。 */
+export interface AuthResult {
+  token: string;
+  userId: string;
+  nickname: string;
+}
+
+/** GET/PATCH /api/v1/auth/me 返回 */
+export interface Me {
+  userId: string;
+  account: string;
+  nickname: string;
+}
+
+// ──────────────────────────────────────────────
 // 房间（Room）模块 — 与后端 dto/room.py 手动保持同步
 // ──────────────────────────────────────────────
 


### PR DESCRIPTION
## 概述

实现 issue #58「认证与应用入口」中定义的后端接口：账号注册/登录/登出、
会话恢复（GET /auth/me）、修改昵称（PATCH /auth/me），并同步补上
trpg-sdk 里的类型化封装（AuthResource）。

## 范围说明

本 PR 只包含后端 API（`trpg-backend/app/{dto,service,controller}/auth.py`）
和 SDK 映射（`trpg-sdk/src/resources/auth.ts` + `types.ts` + `client.ts`
新增的 PATCH 方法），不包含 `trpg-frontend` 的任何改动——真实的登录/注册/
主页/个人资料页面留给后续单独接入。

## 实现细节

- 密码用 bcrypt 加盐哈希存储，不落明文
- 会话凭证走标准的 `Authorization: Bearer <token>` 请求头，跟房间模块
  自定义的 `X-Reconnect-Token` 是两套独立的身份体系（前者认"这是哪个用户"，
  后者认"这是房间里的哪个玩家"）
- 沿用 `service/room.py` 已有的 MS1 内存 stub 风格（内存字典存储，
  后续接数据库时再替换），保持跟现有代码风格一致
- 覆盖 issue 验收标准里的：注册、登录、错误提示（401/409/422）、
  刷新页面恢复登录态、修改昵称、退出登录

## 测试

- `trpg-backend/tests/test_auth.py`：8 个测试，覆盖注册/登录/查重/
  错误密码/未登录访问/会话恢复/改昵称/登出后失效
- `uv run ruff check . && uv run ty check . && uv run pytest -q` 全部通过
- 真实起服务用 curl 跑过一遍注册→登录→查询 /me→改昵称→登出的完整链路
- `trpg-sdk`：`npm run build` 通过（rollup 打包 + 类型声明生成）

Closes #58