### PR TITLE
feat(character): 角色建卡 API + SDK 映射

### DIFF
--- a/trpg-backend/app/controller/v1/rooms.py
+++ b/trpg-backend/app/controller/v1/rooms.py
@@ -9,6 +9,7 @@ from typing import NoReturn
 from fastapi import APIRouter, Header, status
 
 from app.core.errors import AppException, ErrorCode
+from app.dto.character import CharacterDraftResult, CharacterUpdateBody
 from app.dto.common import ApiResponse
 from app.dto.room import (
     JoinRoomBody,
@@ -108,6 +109,73 @@ async def end_game(
         room_service.RoomAuthenticationError,
         room_service.RoomAuthorizationError,
         room_service.RoomConflictError,
+    ) as exc:
+        _raise_service_error(exc)
+    return ApiResponse.ok(None)
+
+
+@router.post(
+    "/{room_id}/characters",
+    response_model=ApiResponse[CharacterDraftResult],
+    status_code=status.HTTP_201_CREATED,
+    tags=["characters"],
+)
+async def create_character(
+    room_id: str,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+) -> ApiResponse[CharacterDraftResult]:
+    """POST /api/v1/rooms/{roomId}/characters —— 玩家创建一份角色草稿。"""
+    try:
+        result = await room_service.create_character_draft(room_id, reconnect_token)
+    except (
+        room_service.RoomNotFoundError,
+        room_service.RoomAuthenticationError,
+        room_service.RoomAuthorizationError,
+    ) as exc:
+        _raise_service_error(exc)
+    return ApiResponse.ok(result)
+
+
+@router.patch(
+    "/{room_id}/characters/{character_id}",
+    response_model=ApiResponse[None],
+    tags=["characters"],
+)
+async def update_character(
+    room_id: str,
+    character_id: str,
+    payload: CharacterUpdateBody,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+) -> ApiResponse[None]:
+    """PATCH /api/v1/rooms/{roomId}/characters/{characterId} —— 保存建卡向导算好的完整角色数据。"""
+    try:
+        await room_service.update_character(room_id, character_id, payload, reconnect_token)
+    except (
+        room_service.RoomNotFoundError,
+        room_service.RoomAuthenticationError,
+        room_service.RoomAuthorizationError,
+    ) as exc:
+        _raise_service_error(exc)
+    return ApiResponse.ok(None)
+
+
+@router.post(
+    "/{room_id}/characters/{character_id}/complete",
+    response_model=ApiResponse[None],
+    tags=["characters"],
+)
+async def complete_character(
+    room_id: str,
+    character_id: str,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+) -> ApiResponse[None]:
+    """POST /api/v1/rooms/{roomId}/characters/{characterId}/complete —— 标记建卡完成。"""
+    try:
+        await room_service.complete_character(room_id, character_id, reconnect_token)
+    except (
+        room_service.RoomNotFoundError,
+        room_service.RoomAuthenticationError,
+        room_service.RoomAuthorizationError,
     ) as exc:
         _raise_service_error(exc)
     return ApiResponse.ok(None)

--- a/trpg-backend/app/dto/character.py
+++ b/trpg-backend/app/dto/character.py
@@ -1,0 +1,49 @@
+"""角色（调查员）建卡（issue #59）的 pydantic 请求/响应模型。
+
+建卡流程分两段：POST 创建草稿 → PATCH 保存完整数据 → POST complete 标记完成，
+跟 trpg-app 原型（character-api.ts）的四步向导一一对应：信息/属性/技能三步
+在前端本地完成，第四步"完成"时把整份角色数据一次性 PATCH 上来。属性/衍生值/
+技能的具体数值由客户端算好后整体提交，后端只负责校验形状、持久化、以及把
+RoomPlayer.has_character 标记为 True——不在服务端重算 COC7 规则数值（本期
+职业/技能规则表也仍由前端本地维护，见 issue #59"本期不做"）。
+"""
+
+from pydantic import AliasGenerator, BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+def _to_camel(snake: str) -> str:
+    return to_camel(snake)
+
+
+class CamelModel(BaseModel):
+    """JSON 层 camelCase，Python 层 snake_case，跟 dto/room.py 的约定保持一致。"""
+
+    model_config = ConfigDict(
+        alias_generator=AliasGenerator(alias=_to_camel),
+        populate_by_name=True,
+    )
+
+
+class EquipmentItem(CamelModel):
+    name: str = Field(..., min_length=1, max_length=200)
+
+
+class CharacterUpdateBody(CamelModel):
+    """PATCH /api/v1/rooms/{roomId}/characters/{characterId} 请求体"""
+
+    name: str = Field(..., min_length=1, max_length=100)
+    attributes: dict[str, int]
+    derived_stats: dict[str, int]
+    skills: dict[str, int]
+    equipment: list[EquipmentItem] = Field(default_factory=list)
+    occupation: str | None = None
+    background: str = Field(default="", max_length=4000)
+    notes: str = Field(default="", max_length=4000)
+
+
+class CharacterDraftResult(CamelModel):
+    """POST /api/v1/rooms/{roomId}/characters 返回"""
+
+    character_id: str
+    status: str

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -9,6 +9,7 @@ import string
 import uuid
 from datetime import UTC, datetime
 
+from app.dto.character import CharacterDraftResult, CharacterUpdateBody
 from app.dto.room import (
     JoinRoomBody,
     ModuleRead,
@@ -23,6 +24,7 @@ from app.dto.room import (
 # ── 内存数据存储（MS1 stub，后续替换为数据库） ──
 _rooms: dict[str, dict] = {}
 _players: dict[str, dict] = {}
+_characters: dict[str, dict] = {}
 
 # 内置模组（MS1 只有一款内置模拟模组）
 _BUILTIN_MODULES: list[ModuleRead] = [
@@ -249,6 +251,60 @@ async def list_my_rooms(reconnect_token: str | None) -> list[MyRoomSummary]:
             )
         )
     return summaries
+
+
+async def create_character_draft(room_id: str, reconnect_token: str | None) -> CharacterDraftResult:
+    """房间内玩家创建一份角色草稿。"""
+    room = _find_room_by_id(room_id)
+    player = _get_player_by_token(reconnect_token)
+    if player["room_id"] != room["id"]:
+        raise RoomAuthorizationError("你不在这个房间里")
+
+    character_id = str(uuid.uuid4())
+    _characters[character_id] = {
+        "id": character_id,
+        "room_id": room_id,
+        "player_id": player["id"],
+        "status": "draft",
+    }
+    return CharacterDraftResult(character_id=character_id, status="draft")
+
+
+def _get_own_character(room_id: str, character_id: str, reconnect_token: str | None) -> dict:
+    player = _get_player_by_token(reconnect_token)
+    character = _characters.get(character_id)
+    if character is None or character["room_id"] != room_id:
+        raise RoomNotFoundError("角色不存在")
+    if character["player_id"] != player["id"]:
+        raise RoomAuthorizationError("不能编辑其他玩家的角色")
+    return character
+
+
+async def update_character(
+    room_id: str,
+    character_id: str,
+    payload: CharacterUpdateBody,
+    reconnect_token: str | None,
+) -> None:
+    """保存建卡向导算好的完整角色数据。"""
+    character = _get_own_character(room_id, character_id, reconnect_token)
+    character["name"] = payload.name
+    character["attributes"] = payload.attributes
+    character["derived_stats"] = payload.derived_stats
+    character["skills"] = payload.skills
+    character["equipment"] = [item.name for item in payload.equipment]
+    character["occupation"] = payload.occupation
+    character["background"] = payload.background
+    character["notes"] = payload.notes
+
+
+async def complete_character(room_id: str, character_id: str, reconnect_token: str | None) -> None:
+    """标记建卡完成，同步把对应玩家的 has_character 置为 True。"""
+    character = _get_own_character(room_id, character_id, reconnect_token)
+    character["status"] = "complete"
+    player = _players.get(character["player_id"])
+    if player is not None:
+        player["has_character"] = True
 
 
 async def end_game(room_id: str, reconnect_token: str | None) -> None:

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -1,0 +1,111 @@
+import pytest
+from httpx import AsyncClient
+
+from app.service import room as room_service
+
+ROOMS_BASE = "/api/v1/rooms"
+
+BUILT_CHARACTER = {
+    "name": "陈探员",
+    "attributes": {
+        "STR": 50,
+        "CON": 60,
+        "POW": 55,
+        "DEX": 45,
+        "APP": 50,
+        "SIZ": 60,
+        "INT": 70,
+        "EDU": 80,
+    },
+    "derivedStats": {"HP": 12, "SAN": 55, "MP": 11},
+    "skills": {"图书馆使用": 70, "侦查": 60},
+    "equipment": [{"name": "左轮手枪"}, {"name": "手电筒"}],
+    "occupation": "私家侦探",
+    "background": "曾是警察",
+    "notes": "",
+}
+
+
+@pytest.fixture(autouse=True)
+def clear_room_stub() -> None:
+    room_service._rooms.clear()
+    room_service._players.clear()
+    room_service._characters.clear()
+
+
+async def create_room(client: AsyncClient) -> dict:
+    response = await client.post(
+        ROOMS_BASE, json={"roomName": "测试房间", "nickname": "房主", "maxPlayers": 4}
+    )
+    assert response.status_code == 200
+    return response.json()["data"]
+
+
+def auth(token: str) -> dict[str, str]:
+    return {"X-Reconnect-Token": token}
+
+
+async def test_full_character_build_flow_marks_player_ready(client: AsyncClient) -> None:
+    room = await create_room(client)
+
+    draft = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+    )
+    assert draft.status_code == 201
+    character_id = draft.json()["data"]["characterId"]
+    assert draft.json()["data"]["status"] == "draft"
+
+    saved = await client.patch(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
+        json=BUILT_CHARACTER,
+        headers=auth(room["reconnectToken"]),
+    )
+    assert saved.status_code == 200
+
+    completed = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/complete",
+        headers=auth(room["reconnectToken"]),
+    )
+    assert completed.status_code == 200
+
+    preview = await client.get(f"{ROOMS_BASE}/{room['roomCode']}")
+    host = next(p for p in preview.json()["data"]["players"] if p["isHost"])
+    assert host["hasCharacter"] is True
+
+
+async def test_create_character_requires_token(client: AsyncClient) -> None:
+    room = await create_room(client)
+
+    response = await client.post(f"{ROOMS_BASE}/{room['roomId']}/characters")
+
+    assert response.status_code == 401
+
+
+async def test_cannot_edit_another_players_character(client: AsyncClient) -> None:
+    room = await create_room(client)
+    joined = (
+        await client.post(f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "玩家"})
+    ).json()["data"]
+    draft = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+    )
+    character_id = draft.json()["data"]["characterId"]
+
+    response = await client.patch(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
+        json=BUILT_CHARACTER,
+        headers=auth(joined["reconnectToken"]),
+    )
+
+    assert response.status_code == 403
+
+
+async def test_character_not_found_returns_404(client: AsyncClient) -> None:
+    room = await create_room(client)
+
+    response = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/missing/complete",
+        headers=auth(room["reconnectToken"]),
+    )
+
+    assert response.status_code == 404

--- a/trpg-sdk/src/index.ts
+++ b/trpg-sdk/src/index.ts
@@ -5,6 +5,7 @@
 
 import { ApiClient, type ApiClientOptions } from './client';
 import { AuthResource } from './resources/auth';
+import { CharactersResource } from './resources/characters';
 import { ExamplesResource } from './resources/examples';
 import { RoomsResource } from './resources/rooms';
 
@@ -20,12 +21,14 @@ export class TrpgSdk {
   readonly examples: ExamplesResource;
   readonly rooms: RoomsResource;
   readonly auth: AuthResource;
+  readonly characters: CharactersResource;
 
   constructor(options: ApiClientOptions) {
     const client = new ApiClient(options);
     this.examples = new ExamplesResource(client);
     this.rooms = new RoomsResource(client);
     this.auth = new AuthResource(client);
+    this.characters = new CharactersResource(client);
   }
 }
 

--- a/trpg-sdk/src/resources/characters.ts
+++ b/trpg-sdk/src/resources/characters.ts
@@ -1,0 +1,46 @@
+import type { ApiClient } from '../client';
+import type { CharacterDraftResult, UpdateCharacterInput } from '../types';
+
+/**
+ * `/api/v1/rooms/{roomId}/characters` 的类型化封装——房间内的建卡流程：
+ * 创建草稿 → 保存建卡向导算好的数据 → 标记完成。
+ */
+export class CharactersResource {
+  constructor(private readonly client: ApiClient) {}
+
+  private authenticated(reconnectToken: string): RequestInit {
+    return { headers: { 'X-Reconnect-Token': reconnectToken } };
+  }
+
+  /** POST /api/v1/rooms/{roomId}/characters — 创建一份角色草稿 */
+  createDraft(roomId: string, reconnectToken: string): Promise<CharacterDraftResult> {
+    return this.client.post<CharacterDraftResult>(
+      `/rooms/${roomId}/characters`,
+      null,
+      this.authenticated(reconnectToken)
+    );
+  }
+
+  /** PATCH /api/v1/rooms/{roomId}/characters/{characterId} — 保存建卡向导算好的完整角色数据 */
+  save(
+    roomId: string,
+    characterId: string,
+    payload: UpdateCharacterInput,
+    reconnectToken: string
+  ): Promise<null> {
+    return this.client.patch<null>(
+      `/rooms/${roomId}/characters/${characterId}`,
+      payload,
+      this.authenticated(reconnectToken)
+    );
+  }
+
+  /** POST /api/v1/rooms/{roomId}/characters/{characterId}/complete — 标记建卡完成 */
+  complete(roomId: string, characterId: string, reconnectToken: string): Promise<null> {
+    return this.client.post<null>(
+      `/rooms/${roomId}/characters/${characterId}/complete`,
+      null,
+      this.authenticated(reconnectToken)
+    );
+  }
+}

--- a/trpg-sdk/src/types.ts
+++ b/trpg-sdk/src/types.ts
@@ -143,3 +143,33 @@ export interface MyRoomSummary {
   maxPlayers: number;
   updatedAt: number;
 }
+
+// ──────────────────────────────────────────────
+// 角色建卡（Character）模块 — 与后端 dto/character.py 手动保持同步
+// ──────────────────────────────────────────────
+
+/** 建卡向导提交的一件装备。 */
+export interface CharacterEquipmentItem {
+  name: string;
+}
+
+/** PATCH /api/v1/rooms/{roomId}/characters/{characterId} 请求体——建卡向导算好的完整角色数据。 */
+export interface UpdateCharacterInput {
+  name: string;
+  /** 属性键位用大写，如 STR/CON/POW/DEX/APP/SIZ/INT/EDU。 */
+  attributes: Record<string, number>;
+  /** 衍生值键位用大写，如 HP/SAN/MP。 */
+  derivedStats: Record<string, number>;
+  /** 技能名 -> 最终值。 */
+  skills: Record<string, number>;
+  equipment: CharacterEquipmentItem[];
+  occupation: string | null;
+  background: string;
+  notes: string;
+}
+
+/** POST /api/v1/rooms/{roomId}/characters 返回 */
+export interface CharacterDraftResult {
+  characterId: string;
+  status: string;
+}


### PR DESCRIPTION
## 概述

实现 issue #59「角色系统」中定义的后端持久化接口：房间内角色建卡的
草稿创建 / 保存 / 完成三段式流程，并同步补上 trpg-sdk 里的类型化封装
（CharactersResource）。

## 范围说明

只包含后端 API（`trpg-backend/app/dto/character.py` + `service/room.py`
新增的角色相关函数 + `controller/v1/rooms.py` 新增的三个路由）和 SDK
映射（`trpg-sdk/src/resources/characters.ts` + `types.ts`），不包含
`trpg-frontend` 的任何改动。

四步建卡向导里的"信息/属性/技能"三步由前端本地完成（职业/技能规则表
目前也仍是前端本地维护，见 issue #59"本期不做"），第四步"完成"时把
整份角色数据一次性提交给这里实现的接口——跟 trpg-app 原型
（`services/character/character-api.ts`）的调用方式完全对应。

## 实现细节

- `POST /rooms/{roomId}/characters` —— 创建角色草稿
- `PATCH /rooms/{roomId}/characters/{characterId}` —— 保存建卡向导算好的
  完整数据（姓名/属性/派生值/技能/装备/职业/背景/笔记）
- `POST /rooms/{roomId}/characters/{characterId}/complete` —— 标记建卡完成，
  同步把 `RoomPlayer.has_character` 置为 `True`——角色准备页展示"全员完成
  状态"直接复用已有的 `GET /rooms/{roomCode}` 接口，不需要新接口
- 身份校验复用房间模块已有的 `X-Reconnect-Token` 重连凭证，只能编辑自己
  的角色（编辑他人角色返回 403）
- 沿用 `service/room.py` 已有的 MS1 内存 stub 风格，保持代码风格一致

## 测试

- `trpg-backend/tests/test_characters.py`：4 个测试，覆盖完整建卡流程
  （草稿→保存→完成→反映在房间玩家列表里）、缺凭证 401、编辑他人角色 403、
  角色不存在 404
- `uv run ruff check . && uv run ty check . && uv run pytest -q` 全部通过（30 个测试）
- 真实起服务用 curl 跑过一遍草稿→保存→完成→查房间预览的完整链路，
  确认 `hasCharacter` 正确变为 `true`
- `trpg-sdk`：`npm run build` 通过

Closes #59