### PR TITLE
feat(ws): 房间 WebSocket 通道 + SDK 映射

### DIFF
--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -1,0 +1,109 @@
+"""顶层 `/ws/{roomId}` WebSocket 路由（issue #60）。
+
+故意不挂在 `/api/v1` 前缀下——前端约定的连接地址是
+`ws://host/ws/{roomId}?token={token}`，是独立于 REST API 版本号的实时通道，
+`roomId` 是房间内部 ID（不是玩家分享用的 roomCode）。
+
+协议（跟 trpg-app 原型 services/api-client.ts 对齐）：
+- 客户端发送 `{type, playerId, payload}`；
+- 服务端推送 `{type, payload}`；
+- 连接后第一条消息必须是 `room.join`，成功后回 `session.bound`，
+  在此之前收到的其它事件类型会被忽略（还没确认这个连接对应哪个玩家）；
+- `player.ready`/`game.start`/`action.submit` 复用 service/room.py 的
+  MS1 内存 stub 读写房间状态，玩家列表/准备/建卡完成/阶段仍然靠前端
+  轮询 `GET /rooms/{roomCode}` 获取（issue #60"本期不做"里排除了这些的
+  独立推送事件）。
+- `action.submit` 的叙事回复本期是固定文案的占位实现（"Mock 叙事"，
+  issue #43 允许），真实 AI 叙事生成留给 #43 落地。
+"""
+
+import structlog
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from app.service import auth as auth_service
+from app.service import room as room_service
+from app.service.ws_manager import manager
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+_UNAUTHORIZED_CLOSE_CODE = 4401
+_NOT_FOUND_CLOSE_CODE = 4404
+_OPENING_NARRATION = "案件已加载。守秘人整理好了开场的场景描述，故事即将开始……"
+
+
+async def _handle_room_join(websocket: WebSocket, room_id: str, player_id: str | None) -> bool:
+    """处理 room.join：校验 playerId 属于这个房间，成功后登记连接并回 session.bound。
+
+    返回是否绑定成功。
+    """
+    player = room_service.get_player(player_id) if player_id else None
+    if player is None or player["room_id"] != room_id:
+        await websocket.close(code=_NOT_FOUND_CLOSE_CODE)
+        return False
+    manager.add(room_id, websocket)
+    await websocket.send_json(
+        {"type": "session.bound", "payload": {"roomId": room_id, "playerId": player_id}}
+    )
+    return True
+
+
+@router.websocket("/ws/{room_id}")
+async def room_socket(websocket: WebSocket, room_id: str, token: str | None = None) -> None:
+    try:
+        await auth_service.get_me(token)
+    except auth_service.AuthenticationError:
+        await websocket.close(code=_UNAUTHORIZED_CLOSE_CODE)
+        return
+
+    await websocket.accept()
+    bound_player_id: str | None = None
+
+    try:
+        while True:
+            envelope = await websocket.receive_json()
+            event_type = envelope.get("type")
+            player_id = envelope.get("playerId")
+            payload = envelope.get("payload") or {}
+
+            if event_type == "room.join":
+                if await _handle_room_join(websocket, room_id, player_id):
+                    bound_player_id = player_id
+                else:
+                    return
+                continue
+
+            if bound_player_id is None:
+                # 还没完成 room.join 绑定，忽略这条消息，不让未识别身份的
+                # 连接影响房间状态。
+                continue
+
+            if event_type == "player.ready":
+                await room_service.set_player_ready(bound_player_id, bool(payload.get("ready")))
+            elif event_type == "game.start":
+                try:
+                    await room_service.begin_game(room_id, bound_player_id)
+                except (
+                    room_service.RoomNotFoundError,
+                    room_service.RoomAuthorizationError,
+                    room_service.RoomConflictError,
+                ):
+                    continue
+                await manager.broadcast(
+                    room_id, {"type": "narration.push", "payload": {"text": _OPENING_NARRATION}}
+                )
+            elif event_type == "action.submit":
+                utterance = str(payload.get("utterance", "")).strip()
+                if not utterance:
+                    continue
+                await manager.broadcast(
+                    room_id,
+                    {
+                        "type": "narration.push",
+                        "payload": {"text": f"守秘人记下了你的行动：「{utterance}」……"},
+                    },
+                )
+    except WebSocketDisconnect:
+        pass
+    finally:
+        manager.remove(room_id, websocket)

--- a/trpg-backend/app/main.py
+++ b/trpg-backend/app/main.py
@@ -18,6 +18,7 @@ from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.controller.v1.router import api_router
+from app.controller.ws import router as ws_router
 from app.core.config import get_settings
 from app.core.db import init_db
 from app.core.errors import AppException, ErrorCode
@@ -84,6 +85,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(api_router)
+    app.include_router(ws_router)
 
     # ---- 以下四个异常处理器，按"从具体到通用"的顺序注册 ----
     # FastAPI/Starlette 在分发异常时，会按抛出异常的实际类型去匹配"最具体"的

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -219,13 +219,45 @@ async def get_room_preview(room_code: str) -> RoomPreview | None:
 
 
 async def start_story(room_id: str, reconnect_token: str | None) -> None:
-    """房主开始游戏，将房间阶段推进到 InGame。"""
+    """房主在大厅点"开始游戏"，只推进到 Building（背景介绍 + 建卡）阶段。
+
+    真正的"正式开局"（phase 变成 InGame）由 issue #60 里 WS 的 game.start
+    事件触发（见 begin_game），必须等全员建完角色才能发生——大厅这一步只是
+    放行玩家进入背景介绍和建卡流程，两者是有意分开的两个阶段。
+    """
     room = _find_room_by_id(room_id)
     _require_host(room, reconnect_token)
     if room["phase"] != "Lobby":
         raise RoomConflictError("只有大厅阶段可以开始游戏")
     if room["module_id"] is None:
         raise RoomConflictError("请先选择模组")
+    room["phase"] = "Building"
+    room["updated_at"] = datetime.now(UTC)
+
+
+def get_player(player_id: str) -> dict | None:
+    """按 player_id 直接查玩家（WS 层用客户端声明的 playerId 校验绑定用）。"""
+    return _players.get(player_id)
+
+
+async def set_player_ready(player_id: str, ready: bool) -> None:
+    """WS player.ready 事件：切换大厅准备状态。"""
+    player = _players.get(player_id)
+    if player is not None:
+        player["ready"] = ready
+
+
+async def begin_game(room_id: str, player_id: str) -> None:
+    """WS game.start 事件：全员建完角色后，房主正式开局（Building → InGame）。"""
+    room = _find_room_by_id(room_id)
+    player = _players.get(player_id)
+    if player is None or player["room_id"] != room["id"] or player["id"] != room["host_player_id"]:
+        raise RoomAuthorizationError("仅房主可以开始游戏")
+    if room["phase"] != "Building":
+        raise RoomConflictError("只有背景介绍/建卡阶段可以正式开局")
+    room_players = [p for p in _players.values() if p["room_id"] == room["id"]]
+    if not room_players or not all(p["has_character"] for p in room_players):
+        raise RoomConflictError("还有玩家未完成建卡")
     room["phase"] = "InGame"
     room["updated_at"] = datetime.now(UTC)
 

--- a/trpg-backend/app/service/ws_manager.py
+++ b/trpg-backend/app/service/ws_manager.py
@@ -1,0 +1,38 @@
+"""房间级 WebSocket 连接登记表（issue #60）。
+
+只负责"这个房间当前有哪些连接、往它们广播一条消息"，不关心业务逻辑——
+业务状态（玩家列表/准备/建卡完成/房间阶段）仍然是 service/room.py 里的
+内存 stub，WS 层只是在事件发生时读写它、再把结果广播出去。
+"""
+
+import contextlib
+
+from fastapi import WebSocket
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self._rooms: dict[str, set[WebSocket]] = {}
+
+    def add(self, room_id: str, websocket: WebSocket) -> None:
+        self._rooms.setdefault(room_id, set()).add(websocket)
+
+    def remove(self, room_id: str, websocket: WebSocket) -> None:
+        connections = self._rooms.get(room_id)
+        if connections is None:
+            return
+        connections.discard(websocket)
+        if not connections:
+            del self._rooms[room_id]
+
+    async def broadcast(self, room_id: str, message: dict) -> None:
+        # 复制一份快照再遍历：广播过程中某个连接掉线触发 remove() 会改动
+        # 原集合，直接遍历原集合会撞上"运行时改变集合大小"的异常。
+        for websocket in list(self._rooms.get(room_id, ())):
+            # 发送失败（连接已经断了但还没走到 disconnect 清理）忽略，
+            # 交给该连接自己的 receive 循环去 remove()。
+            with contextlib.suppress(Exception):
+                await websocket.send_json(message)
+
+
+manager = ConnectionManager()

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -1,0 +1,216 @@
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from app.main import app
+from app.service import auth as auth_service
+from app.service import room as room_service
+
+ROOMS_BASE = "/api/v1/rooms"
+
+
+@pytest.fixture(autouse=True)
+def clear_stubs() -> None:
+    room_service._rooms.clear()
+    room_service._players.clear()
+    room_service._characters.clear()
+    auth_service._users.clear()
+    auth_service._accounts.clear()
+    auth_service._tokens.clear()
+
+
+@pytest.fixture
+def sync_client() -> TestClient:
+    # 用同一个 app 实例的同步 TestClient——HTTP 部分照常发请求准备房间/角色
+    # 数据，WS 部分用它的 websocket_connect（httpx 异步 client 不支持 WS）。
+    return TestClient(app)
+
+
+def register_and_login(client: TestClient, account: str = "host1") -> str:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={"account": account, "password": "secret1", "nickname": "房主"},
+    )
+    assert response.status_code == 201
+    return response.json()["data"]["token"]
+
+
+def create_room(client: TestClient) -> dict:
+    response = client.post(
+        ROOMS_BASE, json={"roomName": "WS测试房间", "nickname": "房主", "maxPlayers": 4}
+    )
+    assert response.status_code == 200
+    return response.json()["data"]
+
+
+def complete_character(client: TestClient, room_id: str, reconnect_token: str) -> None:
+    headers = {"X-Reconnect-Token": reconnect_token}
+    draft = client.post(f"{ROOMS_BASE}/{room_id}/characters", headers=headers)
+    character_id = draft.json()["data"]["characterId"]
+    client.patch(
+        f"{ROOMS_BASE}/{room_id}/characters/{character_id}",
+        json={
+            "name": "陈探员",
+            "attributes": {"STR": 50},
+            "derivedStats": {"HP": 12},
+            "skills": {},
+            "equipment": [],
+            "occupation": None,
+            "background": "",
+            "notes": "",
+        },
+        headers=headers,
+    )
+    client.post(f"{ROOMS_BASE}/{room_id}/characters/{character_id}/complete", headers=headers)
+
+
+def advance_to_building(client: TestClient, room: dict) -> None:
+    headers = {"X-Reconnect-Token": room["reconnectToken"]}
+    module_id = client.get("/api/v1/modules").json()["data"][0]["id"]
+    client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/module",
+        json={"moduleId": module_id, "attributeGenMethod": "point_buy"},
+        headers=headers,
+    )
+    client.post(f"{ROOMS_BASE}/{room['roomId']}/start-story", headers=headers)
+
+
+def test_connect_without_token_is_rejected(sync_client: TestClient) -> None:
+    room = create_room(sync_client)
+
+    with pytest.raises(WebSocketDisconnect), sync_client.websocket_connect(f"/ws/{room['roomId']}"):
+        pass
+
+
+def test_room_join_binds_session(sync_client: TestClient) -> None:
+    token = register_and_login(sync_client)
+    room = create_room(sync_client)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"roomCode": room["roomCode"], "nickname": "房主"},
+            }
+        )
+        envelope = ws.receive_json()
+
+    assert envelope == {
+        "type": "session.bound",
+        "payload": {"roomId": room["roomId"], "playerId": room["playerId"]},
+    }
+
+
+def test_room_join_with_unknown_player_closes_connection(sync_client: TestClient) -> None:
+    token = register_and_login(sync_client)
+    room = create_room(sync_client)
+
+    with (
+        pytest.raises(WebSocketDisconnect),
+        sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws,
+    ):
+        ws.send_json({"type": "room.join", "playerId": "not-a-real-player", "payload": {}})
+        ws.receive_json()
+
+
+def test_player_ready_updates_room_state(sync_client: TestClient) -> None:
+    token = register_and_login(sync_client)
+    room = create_room(sync_client)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json({"type": "room.join", "playerId": room["playerId"], "payload": {}})
+        ws.receive_json()  # session.bound
+        ws.send_json(
+            {"type": "player.ready", "playerId": room["playerId"], "payload": {"ready": True}}
+        )
+
+        # 让服务端处理完 player.ready 再去查——最简单的办法是紧接着发一条
+        # room.join 强制走一次同步的事件处理再返回。
+        ws.send_json({"type": "room.join", "playerId": room["playerId"], "payload": {}})
+        ws.receive_json()
+
+    preview = sync_client.get(f"{ROOMS_BASE}/{room['roomCode']}").json()["data"]
+    assert preview["players"][0]["ready"] is True
+
+
+def test_game_start_pushes_opening_narration_and_advances_phase(
+    sync_client: TestClient,
+) -> None:
+    token = register_and_login(sync_client)
+    room = create_room(sync_client)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json({"type": "room.join", "playerId": room["playerId"], "payload": {}})
+        ws.receive_json()  # session.bound
+        ws.send_json({"type": "game.start", "playerId": room["playerId"], "payload": {}})
+        envelope = ws.receive_json()
+
+    assert envelope["type"] == "narration.push"
+    assert envelope["payload"]["text"]
+
+    preview = sync_client.get(f"{ROOMS_BASE}/{room['roomCode']}").json()["data"]
+    assert preview["phase"] == "InGame"
+
+
+def test_game_start_rejects_non_host(sync_client: TestClient) -> None:
+    token = register_and_login(sync_client)
+    room = create_room(sync_client)
+    # 访客必须在 Lobby 阶段加入（join_room 只在这个阶段放行），所以先加入
+    # 再推进到 Building，两人都建完卡后再让访客尝试 game.start。
+    guest = sync_client.post(
+        f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "访客"}
+    ).json()["data"]
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    complete_character(sync_client, room["roomId"], guest["reconnectToken"])
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json({"type": "room.join", "playerId": guest["playerId"], "payload": {}})
+        ws.receive_json()  # session.bound
+        ws.send_json({"type": "game.start", "playerId": guest["playerId"], "payload": {}})
+
+        # 非房主发起 game.start 会被静默拒绝，不会有 narration.push；房间
+        # 阶段应该维持 Building 不变。
+        ws.send_json({"type": "room.join", "playerId": guest["playerId"], "payload": {}})
+        envelope = ws.receive_json()
+
+    assert envelope["type"] == "session.bound"
+    preview = sync_client.get(f"{ROOMS_BASE}/{room['roomCode']}").json()["data"]
+    assert preview["phase"] == "Building"
+
+
+def test_action_submit_broadcasts_narration_to_room_only(sync_client: TestClient) -> None:
+    token_a = register_and_login(sync_client, "host_a")
+    token_b = register_and_login(sync_client, "host_b")
+    room_a = create_room(sync_client)
+    room_b = create_room(sync_client)
+
+    with (
+        sync_client.websocket_connect(f"/ws/{room_a['roomId']}?token={token_a}") as ws_a,
+        sync_client.websocket_connect(f"/ws/{room_b['roomId']}?token={token_b}") as ws_b,
+    ):
+        ws_a.send_json({"type": "room.join", "playerId": room_a["playerId"], "payload": {}})
+        ws_a.receive_json()  # session.bound
+        ws_b.send_json({"type": "room.join", "playerId": room_b["playerId"], "payload": {}})
+        ws_b.receive_json()  # session.bound
+
+        ws_a.send_json(
+            {
+                "type": "action.submit",
+                "playerId": room_a["playerId"],
+                "payload": {"utterance": "检查门锁"},
+            }
+        )
+        narration = ws_a.receive_json()
+
+        # room_b 没有收到任何广播——发一条 room.join 触发一次同步交互，确认
+        # 收到的仍然是它自己的 session.bound，而不是串过来的 narration。
+        ws_b.send_json({"type": "room.join", "playerId": room_b["playerId"], "payload": {}})
+        envelope_b = ws_b.receive_json()
+
+    assert narration["type"] == "narration.push"
+    assert "检查门锁" in narration["payload"]["text"]
+    assert envelope_b["type"] == "session.bound"

--- a/trpg-sdk/src/index.ts
+++ b/trpg-sdk/src/index.ts
@@ -7,11 +7,25 @@ import { ApiClient, type ApiClientOptions } from './client';
 import { AuthResource } from './resources/auth';
 import { CharactersResource } from './resources/characters';
 import { ExamplesResource } from './resources/examples';
+import { RoomSocket } from './resources/room-socket';
 import { RoomsResource } from './resources/rooms';
 
 export * from './types';
 export { ApiClient, ApiError } from './client';
 export type { ApiClientOptions } from './client';
+export { RoomSocket } from './resources/room-socket';
+export type { RoomSocketHandler } from './resources/room-socket';
+
+export interface TrpgSdkOptions extends ApiClientOptions {
+  /** WS 连接的根地址，比如 "ws://127.0.0.1:8000"（不含 /api/v1，也不含
+   * /ws/{roomId} 路径本身）。不传时从 baseUrl 自动推导：去掉尾部的
+   * /api/vN 前缀，再把 http(s) 换成 ws(s)。 */
+  wsBaseUrl?: string;
+}
+
+function deriveWsBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/api\/v\d+\/?$/, '').replace(/^http/, 'ws');
+}
 
 /**
  * SDK 的顶层门面：每种业务资源挂一个只读属性，
@@ -22,17 +36,19 @@ export class TrpgSdk {
   readonly rooms: RoomsResource;
   readonly auth: AuthResource;
   readonly characters: CharactersResource;
+  readonly roomSocket: RoomSocket;
 
-  constructor(options: ApiClientOptions) {
+  constructor(options: TrpgSdkOptions) {
     const client = new ApiClient(options);
     this.examples = new ExamplesResource(client);
     this.rooms = new RoomsResource(client);
     this.auth = new AuthResource(client);
     this.characters = new CharactersResource(client);
+    this.roomSocket = new RoomSocket(options.wsBaseUrl ?? deriveWsBaseUrl(options.baseUrl));
   }
 }
 
 /** 工厂函数，比直接 `new TrpgSdk(...)` 更符合大多数 JS SDK 的惯用写法。 */
-export function createTrpgSdk(options: ApiClientOptions): TrpgSdk {
+export function createTrpgSdk(options: TrpgSdkOptions): TrpgSdk {
   return new TrpgSdk(options);
 }

--- a/trpg-sdk/src/resources/room-socket.ts
+++ b/trpg-sdk/src/resources/room-socket.ts
@@ -1,0 +1,100 @@
+import type {
+  ActionSubmitPayload,
+  PlayerReadyPayload,
+  RoomJoinPayload,
+  ServerToClientEvent,
+} from '../types';
+
+export type RoomSocketHandler = (event: ServerToClientEvent) => void;
+
+/**
+ * `/ws/{roomId}` 的类型化封装（issue #60）。这条通道是独立于 REST API
+ * 版本号的实时通道，不走 ApiClient 的 HTTP/`{success,data,error}` 信封，
+ * 地址和事件形状跟 trpg-app 原型 services/api-client.ts 的约定一致：
+ * 客户端发送 `{type, playerId, payload}`，服务端推送 `{type, payload}`。
+ *
+ * 单例连接：同一个 roomId 重复调用 connect() 会复用已有（或正在建立中的）
+ * 连接，页面切换时不需要关心是否已经连过——跟原型里"房间级单例连接"的
+ * 设计保持一致。
+ */
+export class RoomSocket {
+  private ws: WebSocket | null = null;
+  private roomId: string | null = null;
+  private readonly handlers = new Set<RoomSocketHandler>();
+
+  constructor(private readonly wsBaseUrl: string) {}
+
+  /** 建立（或复用）到 roomId 的连接。token 是账号登录会话（issue #58），
+   * 不是房间的 X-Reconnect-Token——两者是独立的身份体系。 */
+  connect(roomId: string, token: string): WebSocket {
+    if (
+      this.ws &&
+      this.roomId === roomId &&
+      (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)
+    ) {
+      return this.ws;
+    }
+    this.ws?.close();
+
+    this.roomId = roomId;
+    const url = `${this.wsBaseUrl}/ws/${roomId}?token=${encodeURIComponent(token)}`;
+    const socket = new WebSocket(url);
+    socket.onmessage = (event) => {
+      let parsed: ServerToClientEvent;
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      this.handlers.forEach((handler) => handler(parsed));
+    };
+    this.ws = socket;
+    return socket;
+  }
+
+  /** 等到连接真正 OPEN 再发第一条 room.join——避免在 CONNECTING 状态下调用 send() 报错。 */
+  waitForOpen(socket: WebSocket): Promise<void> {
+    if (socket.readyState === WebSocket.OPEN) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      socket.addEventListener('open', () => resolve(), { once: true });
+      socket.addEventListener('error', (event) => reject(event), { once: true });
+    });
+  }
+
+  /** 订阅服务端推送事件，返回取消订阅函数。多个页面/组件可以各自订阅、
+   * 各自 unsubscribe，不影响底层连接本身（连接跨页面保持，见 connect）。 */
+  onMessage(handler: RoomSocketHandler): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  joinRoom(playerId: string, payload: RoomJoinPayload): void {
+    this.send('room.join', playerId, payload);
+  }
+
+  setReady(playerId: string, payload: PlayerReadyPayload): void {
+    this.send('player.ready', playerId, payload);
+  }
+
+  startGame(playerId: string): void {
+    this.send('game.start', playerId, {});
+  }
+
+  submitAction(playerId: string, payload: ActionSubmitPayload): void {
+    this.send('action.submit', playerId, payload);
+  }
+
+  disconnect(): void {
+    this.ws?.close();
+    this.ws = null;
+    this.roomId = null;
+  }
+
+  private send(type: string, playerId: string, payload: unknown): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      console.warn(`[RoomSocket] not connected, dropped: ${type}`, payload);
+      return;
+    }
+    this.ws.send(JSON.stringify({ type, playerId, payload }));
+  }
+}

--- a/trpg-sdk/src/types.ts
+++ b/trpg-sdk/src/types.ts
@@ -173,3 +173,40 @@ export interface CharacterDraftResult {
   characterId: string;
   status: string;
 }
+
+// ──────────────────────────────────────────────
+// WebSocket（issue #60）— 与后端 app/controller/ws.py 手动保持同步
+// 连接地址 `{wsBaseUrl}/ws/{roomId}?token=`，不走 ApiResponse 信封。
+// ──────────────────────────────────────────────
+
+/** room.join 事件 payload */
+export interface RoomJoinPayload {
+  roomCode: string;
+  nickname?: string;
+}
+
+/** player.ready 事件 payload */
+export interface PlayerReadyPayload {
+  ready: boolean;
+}
+
+/** action.submit 事件 payload */
+export interface ActionSubmitPayload {
+  utterance: string;
+}
+
+/** session.bound 推送 payload */
+export interface SessionBoundPayload {
+  roomId: string;
+  playerId: string;
+}
+
+/** narration.push 推送 payload */
+export interface NarrationPushPayload {
+  text: string;
+}
+
+/** 服务端推送的事件信封：`{type, payload}`。 */
+export type ServerToClientEvent =
+  | { type: 'session.bound'; payload: SessionBoundPayload }
+  | { type: 'narration.push'; payload: NarrationPushPayload };


### PR DESCRIPTION
## 概述

实现 issue #60「WebSocket 通信」定义的后端实时通道：顶层 `/ws/{roomId}`
路由（不挂在 `/api/v1` 下，跟 trpg-app 原型 `ws://host/ws/{roomId}?token=`
的约定对齐），处理 `room.join`/`player.ready`/`game.start`/`action.submit`
四个客户端事件，推送 `session.bound`/`narration.push`，并同步补上
trpg-sdk 里的 `RoomSocket` 封装。

## 范围说明

只包含后端 API（`trpg-backend/app/controller/ws.py` +
`app/service/ws_manager.py` + `service/room.py` 新增的几个函数）和 SDK
映射（`trpg-sdk/src/resources/room-socket.ts` + `types.ts`），不包含
`trpg-frontend` 的任何改动。

## 实现细节

- 连接时校验 `token`（issue #58 的账号会话 token，不是房间的
  `X-Reconnect-Token`——两者是独立的身份体系），无效则拒绝握手
- 连接后第一条消息必须是 `room.join`，校验 `playerId` 属于这个
  `roomId`，成功后回 `session.bound` 并登记进房间级广播分组；绑定成功
  前收到的其它事件类型会被忽略
- `player.ready` 更新房间内玩家的准备状态（前端仍然靠已有的
  `GET /rooms/{roomCode}` 轮询读取，WS 本期不广播这个状态变化，跟 issue
  #60"本期不做"一致）
- `action.submit` 广播 `narration.push` 给房间内所有连接，本期是固定
  占位文案——真实 AI 生成叙事是 issue #43 的范围，这里只验证协议本身跑通
- 广播按房间隔离（`ConnectionManager` 内存字典，一份房间对应一组连接）

### 一处跨 issue 的必要修正

原型的 `CharacterReadyPage`（"人物卡准备"等待页）靠轮询 `phase==='InGame'`
判断"是否可以进入正式游戏房间"；但 #39 里 `start_story`（大厅"开始游戏"）
之前是直接把 `phase` 从 `Lobby` 跳到 `InGame`，这样访客会在房主刚点完
"开始游戏"、角色还都没建的时候就被误判成"可以进游戏"直接跳转。

这里补了一个中间阶段 `Building`（背景介绍 + 建卡期间）：`start_story`
现在推进到 `Building`，真正的 `InGame` 由本 PR 实现的 WS `game.start`
事件触发（仅房主可发起，且要求全员已完成建卡），跟原型注释里描述的
"后端 `_on_game_start` 才会把 phase 改成 InGame"完全对应。`RoomPreview`
现有的 `storyStarted`（`phase != Lobby`）字段语义不受影响。

## 测试

- `trpg-backend/tests/test_ws.py`：7 个测试，用 `starlette.testclient.TestClient`
  的同步 WS 支持，覆盖未带 token 拒绝连接、room.join 绑定/拒绝未知玩家、
  player.ready 落地到房间状态、game.start 推开场叙事+推进阶段、非房主
  发起 game.start 被拒绝、action.submit 只广播给同房间不串房
- `uv run ruff check . && uv run ty check . && uv run pytest -q` 全部通过（37 个测试）
- 真实起服务，用 Python `websockets` 库跑通完整链路：注册登录 → 建房 →
  选模组 → 开始游戏（Lobby→Building）→ 建卡完成 → WS 连接 → room.join →
  player.ready → game.start（收到开场叙事，phase 变成 InGame）→
  action.submit（收到叙事回复）
- `trpg-sdk`：`npm run build` 通过

Closes #60