### PR TITLE
docs(readme): align documentation with MS1 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,212 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/milestone-MS1-brass?style=flat-square" />
-  <img src="https://img.shields.io/badge/rules-CoC_7th-darkred?style=flat-square" />
-  <img src="https://img.shields.io/badge/frontend-React_19_|_TypeScript-61dafb?style=flat-square" />
-  <img src="https://img.shields.io/badge/backend-FastAPI_|_Python-teal?style=flat-square" />
-  <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" />
+  <img src="https://img.shields.io/badge/milestone-MS1-brass?style=flat-square" alt="MS1" />
+  <img src="https://img.shields.io/badge/frontend-React_19_|_Vite_7-61dafb?style=flat-square" alt="React 19 and Vite 7" />
+  <img src="https://img.shields.io/badge/backend-FastAPI_|_Python_3.12+-teal?style=flat-square" alt="FastAPI and Python 3.12+" />
+  <img src="https://img.shields.io/badge/realtime-WebSocket-7050a0?style=flat-square" alt="WebSocket" />
 </p>
 
 # 🎲 TRPG-master
 
-> **有人就能跑。** AI 担任守秘人，多人联机，打开手机就能跑一把克苏鲁的呼唤。
+> **有人就能跑。** 面向移动端的多人在线 TRPG 应用，目标是由 AI 承担守秘人（KP）的叙事工作。
 
-TRPG-master 是一个手机端多人跑团应用。用大模型替代真人 KP（守秘人），解决跑团圈最大的痛点——**想玩，但没人愿意当主持人。**
+当前仓库是一个已经完成前后端联调的 **MS1 可运行版本**，包含 React 前端、TypeScript SDK 和 FastAPI 后端。用户可以完成注册登录、创建或加入房间、选择模组、创建角色、进入大厅、开始游戏和房间内互动等基础流程。
 
-规则引擎硬编码执行 D100 检定和 SAN 机制，保证骰子公平可验证。AI 只负责叙事和氛围——他不碰骰子。
+当前版本仍属于阶段性实现：AI 叙事、复盘摘要和部分游戏数据使用占位内容，账号、房间与角色等核心业务数据暂存在后端内存中。后端重启后，这些数据会被清空。
 
----
+## 当前功能
 
-## 进度
+| 模块 | 当前实现 |
+| --- | --- |
+| 账号 | 注册、登录、退出登录、获取个人信息、修改昵称 |
+| 首页 | 创建房间、输入房间码加入、查看我的房间、个人资料 |
+| 房间 | 房主选择模组、玩家列表、准备状态、房主开始与结束游戏 |
+| 角色 | CoC 风格建卡流程、属性与技能配置、装备和背景信息、完成建卡 |
+| 实时通信 | WebSocket 会话绑定、准备、开始游戏、提交行动、房间叙事广播 |
+| 游戏界面 | 对话区、角色卡、技能、地图、笔记和 D100/D20/D6 本地投骰交互 |
+| API SDK | 封装认证、房间、角色、示例资源和房间 WebSocket |
 
-**MS1 / 第 1–2 周** — 方向锁定，并行开发中。
+### 当前限制
 
+- AI 尚未接入真实大模型。开始游戏和提交行动后返回的是后端固定占位叙事。
+- 账号、会话、房间、玩家和角色使用内存存储，后端重启后会丢失。
+- SQLite 与异步 SQLAlchemy 基础设施已经接入，但目前主要用于示例 CRUD；核心业务尚未完成数据库持久化。
+- 后端当前只提供一个内置模组「追书人」。前端展示的其他规则系统和场景中，部分仍是概念入口或静态数据。
+- 投骰目前在前端本地执行，尚未接入后端统一规则引擎。
+- 复盘摘要、完整事件记录、语音输入等能力尚未完成。
+
+## 系统结构
+
+```text
+trpg-frontend (React)
+        │
+        ▼
+trpg-sdk (REST + WebSocket)
+        │
+        ▼
+trpg-backend (FastAPI)
+        ├── /api/v1/*       REST API
+        ├── /ws/{roomId}    房间实时通道
+        ├── 内存业务存储     账号、房间、角色、会话
+        └── SQLite          SQLAlchemy 示例数据
 ```
-产品方向 ✅ ── 战略决策文档 + 产品提案 + 三个窄提案
-原型设计 ✅ ── 纯 HTML 交互原型 + 前端 7 屏 React 应用
-架构设计 🚧 ── Schema 设计 + 四层数据模型 + 动态规则引擎
-后端开发 ⬜ ── FastAPI 骨架
-联调贯通 ⬜ ── 首尾可跑版本
+
+统一 REST 响应格式如下：
+
+```json
+{
+  "success": true,
+  "data": {},
+  "error": null
+}
 ```
 
----
+WebSocket 使用独立事件信封：客户端发送 `{ "type", "playerId", "payload" }`，服务端发送 `{ "type", "payload" }`。
+
+## 技术栈
+
+| 层 | 技术 |
+| --- | --- |
+| 前端 | React 19、TypeScript 5、Vite 7、Tailwind CSS 3、Zustand 5、React Router 7 |
+| SDK | TypeScript、Rollup 4 |
+| 后端 | Python 3.12+、FastAPI、Pydantic 2、SQLAlchemy Async、Uvicorn |
+| 实时通信 | WebSocket |
+| 数据与安全 | SQLite、PostgreSQL 异步驱动、bcrypt |
+| 工程质量 | pytest、ruff、ty、GitHub Actions |
+
+## 项目目录
+
+```text
+TRPG-master/
+├── trpg-frontend/        # 移动端 React 应用
+├── trpg-sdk/             # 前后端通信 SDK，前端通过本地依赖引用
+├── trpg-backend/         # FastAPI 服务、REST API、WebSocket 和测试
+├── .github/workflows/    # 后端 CI
+└── README.md
+```
+
+## 本地运行
+
+### 环境要求
+
+- Git
+- Node.js 与 npm（版本需支持 Vite 7）
+- Python 3.12 或更高版本；仓库的 `.python-version` 当前指定 3.13
+- 推荐安装 [uv](https://docs.astral.sh/uv/) 管理后端环境
+
+### 1. 克隆仓库
+
+```bash
+git clone https://github.com/1024XEngineer/TRPG-master.git
+cd TRPG-master
+```
+
+### 2. 构建 SDK
+
+前端通过 `file:../trpg-sdk` 引用 SDK，因此首次启动前需要先生成 `dist`。
+
+```bash
+cd trpg-sdk
+npm ci
+npm run build
+cd ..
+```
+
+### 3. 启动后端
+
+```bash
+cd trpg-backend
+uv sync --locked
+uv run uvicorn app.main:app --reload
+```
+
+后端默认地址：<http://127.0.0.1:8000>
+
+- 健康检查：<http://127.0.0.1:8000/api/v1/health>
+- Swagger API 文档：<http://127.0.0.1:8000/docs>
+- ReDoc API 文档：<http://127.0.0.1:8000/redoc>
+
+复制 `.env.example` 为 `.env` 后可以覆盖默认配置；不复制也可以使用代码内置的本地开发默认值。
+
+### 4. 启动前端
+
+另开一个终端：
+
+```bash
+cd trpg-frontend
+npm ci
+npm run dev
+```
+
+浏览器打开：<http://localhost:9877>
+
+默认后端 CORS 配置允许 `http://localhost:9877`。如果修改前端地址或端口，需要同步调整后端的 `CORS_ORIGINS`。
+
+## 环境变量
+
+### 后端 `trpg-backend/.env`
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `APP_ENV` | `development` | 运行环境：`development`、`production` 或 `test` |
+| `DATABASE_URL` | `sqlite+aiosqlite:///./app.db` | SQLAlchemy 异步数据库地址 |
+| `ENABLE_DOCS` | `true` | 是否开放 `/docs`、`/redoc` 和 `/openapi.json` |
+| `LOG_LEVEL` | `INFO` | 后端日志级别 |
+| `CORS_ORIGINS` | `["http://localhost:9877"]` | 允许跨域访问的前端来源列表 |
+
+### 前端 `trpg-frontend/.env`
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `VITE_API_BASE_URL` | `http://127.0.0.1:8000/api/v1` | REST API 根地址；WebSocket 地址由 SDK 自动推导 |
+
+## 构建与检查
+
+### SDK
+
+```bash
+cd trpg-sdk
+npm ci
+npm run build
+```
+
+### 前端
+
+```bash
+cd trpg-frontend
+npm ci
+npm run build
+```
+
+### 后端
+
+```bash
+cd trpg-backend
+uv sync --locked
+uv run ruff check .
+uv run ruff format --check .
+uv run ty check
+uv run pytest
+```
+
+后端 CI 会在 `trpg-backend/**` 发生变更时执行以上静态检查、格式检查、类型检查和测试。
 
 ## 团队
 
 | 成员 | GitHub |
-|------|--------|
+| --- | --- |
 | 高俊周 (GJZ) | [@WELT5350](https://github.com/WELT5350) |
 | 凌铭辉 (LMH) | [@LMH168](https://github.com/LMH168) |
 | 李敏譞 (LMX) | [@Ximaohu-LMX](https://github.com/Ximaohu-LMX) |
 | 张家豪 (ZJH) | [@JoshuaZ16](https://github.com/JoshuaZ16) |
 | 黄女珊 (HNS) | [@badadal](https://github.com/badadal) |
 | 卢玮晨 (LWC) | [@Lyltrum](https://github.com/Lyltrum) |
-| 曹明鸣 | [@mingmingtsao](https://github.com/mingmingtsao) |
+
+## 协作约定
+
+- 通过 fork + Pull Request 提交变更，不直接向主仓库主分支提交。
+- Commit message 遵循 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/v1.0.0/)。
+- 前后端接口类型发生变化时，需要同步更新 `trpg-sdk` 并重新构建。
 
 ---
 
-## 三个核心决策
-
-**1. 规则引擎硬编码**
-
-D100 六档检定（大成功 → 大失败）、SAN 机制、衍生属性——全部在后端代码中确定执行。AI 只建议"是否需要检定"，不碰判定的骰子。
-
-**2. AI 输出结构化 JSON**
-
-```json
-{
-  "narration": "走廊尽头的门缓缓打开...",
-  "skill_check": { "skill": "spot-hidden", "difficulty": "normal", "target": 50 },
-  "san_change": { "loss": "1d3" },
-  "private_info": { "targetPlayer": "player-2", "content": "你注意到墙上有一行血字..." },
-  "suggestions": ["调查门后的房间", "检查墙上的划痕"]
-}
-```
-
-叙事与规则解耦。AI 不能直接宣布"你成功了"——结果由引擎裁定后广播。
-
-**3. 云端 LLM 叙事**
-
-调用大模型 API 生成中文 CoC 恐怖叙事。多轮对话上下文管理（最近 6 轮 + 当前场景 + 角色状态 + 已获线索）。
-
----
-
-## 技术栈
-
-| 层 | 技术 |
-|---|------|
-| 前端 | React 19 · TypeScript · Vite 8 · Tailwind CSS 3 · Zustand · React Router 7 |
-| 后端 | Python FastAPI（计划） |
-| AI | 云端 LLM API（待选定：DeepSeek / Claude） |
-| 数据库 | PostgreSQL（计划） |
-| PWA | vite-plugin-pwa |
-
----
-
-## 快速开始
-
-```bash
-# 后端
-cd trpg-backend
-cp .env.example .env
-uv sync
-uv run uvicorn app.main:app --reload   # → http://127.0.0.1:8000，本地默认开启 /docs
-
-# SDK（前端依赖它调用后端，需先构建一次）
-cd trpg-sdk
-npm install
-npm run build
-
-# 前端
-cd trpg-frontend
-cp .env.example .env
-npm install
-npm run dev        # → http://localhost:9877
-```
-
----
-
-## 路线图
-
-| 里程碑 | 时间 | 目标 |
-|--------|------|------|
-| **MS1** | 第 1–2 周 | 方向锁定 + 架构骨架 + 首尾可跑版本 |
-| **MS2** | 第 3–4 周 | MVP 深化：AI 叙事集成 + 真实后端 |
-| **MS3** | 第 5–6 周 | 功能闭环：多人在线 + 语音输入 + 好友系统 |
-| **MS4** | 第 7–8 周 | 打磨、交付、发布 |
-
----
-
-## 许可
-
-MIT · [1024 XEngineer Camp](https://github.com/1024XEngineer) Season 6
+[1024 XEngineer Camp](https://github.com/1024XEngineer) Season 6


### PR DESCRIPTION
## What changed

- rewrite the root README around the current MS1 implementation;
- document the actual frontend, SDK, backend, REST, and WebSocket structure;
- add reproducible local setup, environment variable, build, and check commands;
- clearly separate implemented behavior from placeholder or future capabilities;
- update the project structure, technology stack, team, and collaboration guidance.

## Why

The previous README still described early plans such as a completed rules engine, cloud LLM narration, PWA support, and unfinished backend scaffolding. Those statements no longer matched the code on `main` and could mislead users and reviewers.

## Impact

This is a documentation-only change. It does not modify frontend, SDK, backend, API, or runtime behavior.

## Validation

- `git diff --check` passed;
- verified the documented scripts, ports, environment variables, routes, and current limitations against the MS1 source code;
- locally built the SDK and frontend successfully;
- locally verified the frontend and FastAPI documentation endpoints return HTTP 200.

Closes #70
