### PR TITLE
fix(backend): 房间码改用 secrets 生成密码学安全随机数

### DIFF
--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -6,7 +6,7 @@ issue #77 之前是内存字典 stub，本期切换为对 `rooms`/`players`/`gam
 决策：`auth`/`room`/`character`/`ws` 四个 service 各自独立切换）。
 """
 
-import random
+import secrets
 import string
 from datetime import UTC, datetime
 
@@ -71,7 +71,7 @@ class CharacterIncompleteError(RuntimeError):
 async def _generate_room_code(db: AsyncSession) -> str:
     """生成 6 位大写字母+数字房间码，避免碰撞。"""
     while True:
-        code = "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
+        code = "".join(secrets.choice(string.ascii_uppercase + string.digits) for _ in range(6))
         existing = await db.scalar(select(Room).where(Room.room_code == code))
         if existing is None:
             return code


### PR DESCRIPTION
Closes #79

## 改了什么
`trpg-backend/app/service/room.py` 的 `_generate_room_code`：房间码生成源从 `random.choices` 改为 `secrets.choice`（逐字符调用），并把顶部 `import random` 替换为 `import secrets`（`string` 保留）。

## 为什么
房间码是加入房间的门禁凭证。`random` 底层是 MT19937，观测到足够多次输出后可反推内部状态、预测后续生成的房间码，属于可预测凭证风险。`secrets` 模块基于操作系统提供的密码学安全随机源，不存在这个问题。

## 外部特征不变
- 仍是 6 位、字符集仍是大写字母+数字
- 仍然 `while True` 循环重试避免与已有房间码碰撞
- 函数签名、调用方、前端零影响

## 验证
`trpg-backend` 目录下：
- `uv run pytest` → 29 passed
- `uv run ruff check .` → All checks passed!
- `uv run ty check` → All checks passed!