### PR TITLE
chore: 清理 mock/examples 时代的类型不安全残留

### DIFF
--- a/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
+++ b/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
@@ -7,7 +7,7 @@ import { useAuthStore } from '@/stores/auth-store'
 import { ALL_SKILLS, calculateBaseValue } from '@/data/skills'
 import { ATTRIBUTE_LABELS } from '@/data/character-model'
 import { getOccupationById } from '@/data/occupations'
-import { connectWebSocket, disconnectWebSocket, sendWsMessage, waitForWsOpen } from '@/services/api-client'
+import { connectWebSocket, disconnectWebSocket, sdk, waitForWsOpen } from '@/services/api-client'
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 
 const ATTR_KEY_LIST = ['str', 'con', 'pow', 'dex', 'app', 'siz', 'int', 'edu'] as const
@@ -181,18 +181,18 @@ export default function CharacterReadyPage() {
     try {
       // ★ 这个页面从来没有主动建立过 WS 连接（只有 LobbyPage 会连）——如果
       // 刷新过页面、或者从没经过 Lobby 直接落到这里，connectWebSocket 拿到
-      // 的连接是关闭的，sendWsMessage 会静默丢弃 game.start，后端 phase
+      // 的连接是关闭的，startGame 会静默丢弃 game.start，后端 phase
       // 永远停在 Building，其他玩家会一直卡在轮询里。这里跟 RoomPage 一样，
       // 发 game.start 前先确保连接是通的、且已经 room.join 过（对已经连过
       // 的情况是幂等空操作）。
       const ws = connectWebSocket(roomId)
       await waitForWsOpen(ws)
-      sendWsMessage('room.join', playerId, {
+      sdk.roomSocket.joinRoom(playerId, {
         reconnectToken: reconnectToken || '',
         roomCode,
         nickname: nickname || '玩家',
       })
-      sendWsMessage('game.start', playerId, {})
+      sdk.roomSocket.startGame(playerId)
     } catch {
       setStarting(false)
       return

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect, type FormEvent } from 'react'
 import { useRoomStore } from '@/stores/room-store'
 import { useAuthStore } from '@/stores/auth-store'
 import { useCharacterStore } from '@/stores/character-store'
-import { connectWebSocket, waitForWsOpen, sendWsMessage, onWsMessage, disconnectWebSocket, friendlyErrorMessage } from '@/services/api-client'
+import { connectWebSocket, waitForWsOpen, sdk, onWsMessage, disconnectWebSocket, friendlyErrorMessage } from '@/services/api-client'
 import { endGame } from '@/services/room'
 import { ALL_SKILLS, calculateBaseValue } from '@/data/skills'
 import { ATTRIBUTE_LABELS } from '@/data/character-model'
@@ -368,6 +368,7 @@ export default function RoomPage() {
   const roomId = useRoomStore((s) => s.roomId)
   const roomCode = useRoomStore((s) => s.roomCode)
   const playerId = useRoomStore((s) => s.playerId)
+  const reconnectToken = useRoomStore((s) => s.reconnectToken)
   const nickname = useAuthStore((s) => s.nickname)
   // 按房间取角色卡，而不是直接读 s.character——本地缓存不按房间区分的话，
   // 换房间会把上一个房间的角色数据错误地展示出来（见 PR #67 review）。
@@ -418,13 +419,13 @@ export default function RoomPage() {
     waitForWsOpen(ws)
       .then(() => {
         if (cancelled) return
-        sendWsMessage('room.join', playerId, { roomCode, nickname: nickname || '玩家' })
+        sdk.roomSocket.joinRoom(playerId, { reconnectToken: reconnectToken || '', roomCode, nickname: nickname || '玩家' })
       })
       .catch(() => {})
     return () => {
       cancelled = true
     }
-  }, [roomId, playerId, roomCode, nickname])
+  }, [roomId, playerId, roomCode, nickname, reconnectToken])
 
   // 真实 AI 主持人回复：订阅 narration.push（不再是本地假打字模拟）
   useEffect(() => {
@@ -450,7 +451,7 @@ export default function RoomPage() {
     }])
     setInput('')
     setTyping(true)
-    sendWsMessage('action.submit', playerId, { utterance: text })
+    sdk.roomSocket.submitAction(playerId, { utterance: text })
   }
 
   const handleDiceResult = (result: number, diceType: DiceType) => {

--- a/trpg-frontend/src/routes/lobby/LobbyPage.tsx
+++ b/trpg-frontend/src/routes/lobby/LobbyPage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef } from 'react'
 import { UserPlus, ArrowLeft } from 'lucide-react'
 import { useRoomStore } from '@/stores/room-store'
 import { useAuthStore } from '@/stores/auth-store'
-import { connectWebSocket, sendWsMessage, onWsMessage, waitForWsOpen, disconnectWebSocket } from '@/services/api-client'
+import { connectWebSocket, sdk, onWsMessage, waitForWsOpen, disconnectWebSocket } from '@/services/api-client'
 import { startStory } from '@/services/room'
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 
@@ -41,7 +41,7 @@ export default function LobbyPage() {
     waitForWsOpen(ws)
       .then(() => {
         if (cancelled) return
-        sendWsMessage('room.join', playerId, {
+        sdk.roomSocket.joinRoom(playerId, {
           reconnectToken: reconnectToken || '',
           roomCode,
           nickname: nickname || '玩家',
@@ -88,7 +88,7 @@ export default function LobbyPage() {
     if (!playerId) return
     const next = !ready
     setReady(next)
-    sendWsMessage('player.ready', playerId, { ready: next })
+    sdk.roomSocket.setReady(playerId, { ready: next })
   }
 
   const handleLeave = () => {

--- a/trpg-frontend/src/services/api-client.ts
+++ b/trpg-frontend/src/services/api-client.ts
@@ -53,28 +53,6 @@ export function onWsMessage(handler: (envelope: ServerToClientEvent) => void): (
   return sdk.roomSocket.onMessage(handler);
 }
 
-export function sendWsMessage(type: string, playerId: string, payload: unknown) {
-  switch (type) {
-    case 'room.join':
-      sdk.roomSocket.joinRoom(
-        playerId,
-        payload as { reconnectToken: string; roomCode?: string; nickname?: string }
-      );
-      return;
-    case 'player.ready':
-      sdk.roomSocket.setReady(playerId, payload as { ready: boolean });
-      return;
-    case 'game.start':
-      sdk.roomSocket.startGame(playerId);
-      return;
-    case 'action.submit':
-      sdk.roomSocket.submitAction(playerId, payload as { utterance: string });
-      return;
-    default:
-      console.warn(`[WS] unknown event type: ${type}`, payload);
-  }
-}
-
 export function disconnectWebSocket() {
   sdk.roomSocket.disconnect();
 }

--- a/trpg-sdk/src/client.ts
+++ b/trpg-sdk/src/client.ts
@@ -27,7 +27,7 @@ export interface ApiClientOptions {
 
 /**
  * 最底层的 HTTP 封装：拼 URL、加公共 header、解析统一响应信封、
- * 把 `success:false` 转成 ApiError。上层的 `resources/*`（比如 ExamplesResource）
+ * 把 `success:false` 转成 ApiError。上层的 `resources/*`（比如 AuthResource）
  * 都是基于这个类的 get/post/put/delete 方法实现的，不直接碰 fetch。
  */
 export class ApiClient {


### PR DESCRIPTION
Closes #82

## 改了什么

**A. SDK 陈旧注释**：`trpg-sdk/src/client.ts` 里引用了已经在 #75 被删除的 `ExamplesResource`，换成当前真实存在的 `AuthResource`。

**B. 删掉 `sendWsMessage` 字符串分发包装**：`trpg-frontend/src/services/api-client.ts` 里的 `sendWsMessage(type, playerId, payload: unknown)` 用 `switch` + `payload as {...}` 强转分发到 `sdk.roomSocket.*`，绕过了 TypeScript 的类型检查。整个函数删掉，其余薄包装（`connectWebSocket`/`waitForWsOpen`/`onWsMessage`/`disconnectWebSocket`）不变。

**C. 三个调用点改成直接调用 SDK 类型化方法**：`CharacterReadyPage.tsx`、`LobbyPage.tsx`、`RoomPage.tsx` 里所有 `sendWsMessage(...)` 调用改成 `sdk.roomSocket.joinRoom/setReady/startGame/submitAction` 直调。

## 为什么

`sendWsMessage` 是 mock/examples 时代留下的字符串分发层，`payload as {...}` 的强转让 payload 形状失去了编译期检查——这正是 issue #82 要清理的类型不安全残留。改成直调后，payload 形状由 `sdk.roomSocket` 的方法签名保证，编译器能捕获形状不对的调用。

## 附带修复：RoomPage 的 room.join 漏传 reconnectToken

`RoomPage.tsx` 原来的调用是：

```ts
sendWsMessage('room.join', playerId, { roomCode, nickname: nickname || '玩家' })
```

漏了 `reconnectToken`（后端要求的必填字段，见 #78 的房间身份校验）。因为 `payload` 类型是 `unknown`、用 `as` 强转过去，这个缺陷一直没被编译器发现——访客走 `/join → /character → /character-ready → /room` 这条路径直接落到 RoomPage 时，room.join 一直会被后端拒绝。

改成 `sdk.roomSocket.joinRoom(playerId, {...})` 直调后，tsc 因为 `reconnectToken` 是必填字段直接报错，暴露了这个问题。修法是从 `useRoomStore` 取 `reconnectToken`（和 LobbyPage/CharacterReadyPage 已有的用法一致），补进 payload 和对应 `useEffect` 的依赖数组。

## 验证

`trpg-frontend` 目录下：

- `npm run lint` → 通过，0 warning：
  ```
  > trpg-frontend@0.0.0 lint
  > eslint . --max-warnings 0
  ```
- `npm run build`（`tsc -b && vite build`）→ 通过，`✓ 1836 modules transformed` `✓ built in 3.62s`，RoomPage 补上 `reconnectToken` 后类型检查顺利通过。

SDK 只改了注释，不影响类型，未重新 build trpg-sdk。