### PR TITLE
feat: COC7 建卡补齐幸运值（第 9 项属性，独立掷 3d6×5）

### DIFF
--- a/trpg-backend/app/core/coc7_content.py
+++ b/trpg-backend/app/core/coc7_content.py
@@ -27,6 +27,10 @@ COC7_ATTRIBUTES: list[AttributeSpec] = [
     AttributeSpec(key="SIZ", label="体型", generation="(2d6+6)*5"),
     AttributeSpec(key="INT", label="智力", generation="(2d6+6)*5"),
     AttributeSpec(key="EDU", label="教育", generation="(2d6+6)*5"),
+    # 幸运：COC7 里独立掷 3d6*5，不由任何属性推导，也不参与职业技能点公式与
+    # 技能基础值；但它是有状态、游戏中可被 `luck.spend` 消耗的属性，所以归在
+    # 属性而不是衍生值里。
+    AttributeSpec(key="LUCK", label="幸运", generation="3d6*5"),
 ]
 
 COC7_SKILLS: list[SkillSpec] = [

--- a/trpg-backend/app/core/coc7_rules.py
+++ b/trpg-backend/app/core/coc7_rules.py
@@ -24,7 +24,7 @@ from app.dto.game import OccupationSpec
 
 SKILL_CAP = 99
 
-COC7_ATTRIBUTE_KEYS = {"STR", "CON", "SIZ", "DEX", "APP", "INT", "POW", "EDU"}
+COC7_ATTRIBUTE_KEYS = {"STR", "CON", "SIZ", "DEX", "APP", "INT", "POW", "EDU", "LUCK"}
 ATTRIBUTE_MIN = 1
 ATTRIBUTE_MAX = 99
 

--- a/trpg-backend/app/core/seed.py
+++ b/trpg-backend/app/core/seed.py
@@ -27,10 +27,19 @@ async def ensure_seed_content(db: AsyncSession) -> None:
     coc7_ruleset = build_coc7_ruleset().model_dump(mode="json")
 
     if existing is not None:
-        # 种子数据本身已经跑过，但 `ruleset` 是 issue #84 S1 才补上的字段——
-        # 旧库里已存在的 GameSystem 行可能还没有，这里顺带补全，不破坏幂等性。
+        # 内置系统的 ruleset 每次启动都跟代码对齐（不只是"为空时补"）。
+        #
+        # 原来只在 `not system.ruleset` 时写入，导致改了 `coc7_content.py` 之后
+        # 已存在的库永远不同步：规则引擎（裁定用）直接 import 代码里的常量，而
+        # `get_ruleset()`（前端渲染用）读这张表，两边会漂移。issue #87 加幸运时
+        # 就撞上了——后端要求 9 个属性键，旧库的 ruleset 却还是 8 项。
+        #
+        # 内置系统的规则是随代码发版的，代码那份就是权威，这里让 DB 里的副本
+        # 无条件跟随；比较一下再写是为了避免每次启动都产生一次无谓的 UPDATE。
+        # （更彻底的做法是内置系统压根不入库、`get_ruleset` 直接返回代码里的，
+        # 那是"规则数据存储归属"那个独立议题的事，本 PR 不抢跑。）
         system = await db.get(GameSystem, BUILTIN_SYSTEM_ID)
-        if system is not None and not system.ruleset:
+        if system is not None and system.ruleset != coc7_ruleset:
             system.ruleset = coc7_ruleset
             await db.commit()
         return

--- a/trpg-backend/app/service/character.py
+++ b/trpg-backend/app/service/character.py
@@ -160,7 +160,9 @@ async def roll_attributes(
     """POST /rooms/{roomId}/characters/{characterId}/roll-attributes —— 服务端
     权威掷骰生成属性（issue #77 新增，取代前端 `Math.random()` 本地算骰值）。
 
-    COC7 标准生成法：STR/CON/DEX/APP/POW = 3d6*5，SIZ/INT/EDU = (2d6+6)*5；
+    COC7 标准生成法：STR/CON/DEX/APP/POW/LUCK = 3d6*5，SIZ/INT/EDU = (2d6+6)*5；
+    幸运（LUCK）独立掷骰、不由属性推导，也不参与技能点公式，但它是游戏中可被
+    消耗的有状态属性，所以跟其余 8 项一起放在 `attributes` 里而非衍生值；
     衍生值按标准公式：HP = (CON+SIZ)/10 取整，MP = POW/5 取整，SAN = POW*5
     （起始理智等于 POW 的 5 倍，跟 POW 属性值本身相等，这里遵循 COC7 规则
     直接抄一份 POW*5 = 属性打点后的数值）。
@@ -180,6 +182,7 @@ async def roll_attributes(
         "SIZ": (_roll(2, 6) + 6) * 5,
         "INT": (_roll(2, 6) + 6) * 5,
         "EDU": (_roll(2, 6) + 6) * 5,
+        "LUCK": _roll(3, 6) * 5,
     }
     derived_stats = {
         "HP": (attributes["CON"] + attributes["SIZ"]) // 10,

--- a/trpg-backend/tests/conftest.py
+++ b/trpg-backend/tests/conftest.py
@@ -75,6 +75,18 @@ async def _prepare_database() -> AsyncGenerator[None, None]:
 
 
 @pytest.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """给需要绕过 HTTP、直接读写数据库的用例用（多数用例走 `client` 就够了）。
+
+    注意别在测试模块里 `from tests.conftest import TestSessionLocal`——那会把
+    conftest 当成另一个模块再导入一次、连带新建一个引擎，表建在旧引擎上，
+    结果是 `no such table`。要拿 session 就用这个 fixture。
+    """
+    async with TestSessionLocal() as session:
+        yield session
+
+
+@pytest.fixture
 async def client() -> AsyncGenerator[AsyncClient, None]:
     """给测试用例注入一个能直接调用 FastAPI app 的异步 HTTP 客户端。
 

--- a/trpg-backend/tests/test_character_preview.py
+++ b/trpg-backend/tests/test_character_preview.py
@@ -8,7 +8,17 @@ from app.core.seed import BUILTIN_SYSTEM_ID
 
 PREVIEW_URL = f"/api/v1/systems/{BUILTIN_SYSTEM_ID}/character/preview"
 
-ATTRS = {"STR": 50, "CON": 50, "POW": 50, "DEX": 50, "APP": 50, "SIZ": 50, "INT": 50, "EDU": 50}
+ATTRS = {
+    "STR": 50,
+    "CON": 50,
+    "POW": 50,
+    "DEX": 50,
+    "APP": 50,
+    "SIZ": 50,
+    "INT": 50,
+    "EDU": 50,
+    "LUCK": 50,
+}
 
 
 def bearer(token: str) -> dict[str, str]:

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -13,6 +13,7 @@ BUILT_CHARACTER = {
         "SIZ": 60,
         "INT": 70,
         "EDU": 80,
+        "LUCK": 50,
     },
     "derivedStats": {"HP": 12, "SAN": 55, "MP": 11},
     # 私家侦探（occupation id=16）的两项职业技能，用真实技能 id 键控、分配在

--- a/trpg-backend/tests/test_coc7_rules.py
+++ b/trpg-backend/tests/test_coc7_rules.py
@@ -16,7 +16,17 @@ from app.core.coc7_rules import (
     validate_character,
 )
 
-ATTRS = {"STR": 50, "CON": 50, "POW": 50, "DEX": 50, "APP": 50, "SIZ": 50, "INT": 50, "EDU": 50}
+ATTRS = {
+    "STR": 50,
+    "CON": 50,
+    "POW": 50,
+    "DEX": 50,
+    "APP": 50,
+    "SIZ": 50,
+    "INT": 50,
+    "EDU": 50,
+    "LUCK": 50,
+}
 ACCOUNTANT_ID = 1
 ACCOUNTANT_NAME = "会计师"
 
@@ -207,6 +217,24 @@ def test_invalid_attributes_missing_key_rejected() -> None:
     issues = validate_character(attrs, ACCOUNTANT_NAME, {})
     codes = [issue.code for issue in issues]
     assert codes == ["INVALID_ATTRIBUTES"]
+
+
+def test_invalid_attributes_missing_luck_rejected() -> None:
+    """幸运是必填属性——建卡时必须掷出来，不能整项缺失。"""
+    attrs = {k: v for k, v in ATTRS.items() if k != "LUCK"}
+    issues = validate_character(attrs, ACCOUNTANT_NAME, {})
+    codes = [issue.code for issue in issues]
+    assert codes == ["INVALID_ATTRIBUTES"]
+
+
+def test_luck_does_not_affect_skill_point_budgets() -> None:
+    """幸运不参与任何职业技能点/兴趣技能点公式——改幸运值，两条预算都不动。
+    （COC7 里幸运是独立掷出的属性，只在游戏中被消耗，不换算成技能点。）"""
+    baseline = compute_preview(ATTRS, ACCOUNTANT_ID, {})
+    lucky = compute_preview({**ATTRS, "LUCK": 99}, ACCOUNTANT_ID, {})
+
+    assert lucky.occupation_skill_points.budget == baseline.occupation_skill_points.budget
+    assert lucky.interest_skill_points.budget == baseline.interest_skill_points.budget
 
 
 def test_invalid_attributes_extra_key_rejected() -> None:

--- a/trpg-backend/tests/test_games.py
+++ b/trpg-backend/tests/test_games.py
@@ -3,8 +3,10 @@
 """
 
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.seed import BUILTIN_SYSTEM_ID
+from app.core.seed import BUILTIN_SYSTEM_ID, ensure_seed_content
+from app.models.content import GameSystem
 
 
 async def test_get_ruleset_returns_full_coc7_data(client: AsyncClient) -> None:
@@ -45,3 +47,34 @@ async def test_get_ruleset_unknown_system_returns_404(client: AsyncClient) -> No
     response = await client.get("/api/v1/systems/00000000-0000-0000-0000-000000009999/ruleset")
 
     assert response.status_code == 404
+
+
+async def test_seed_refreshes_stale_builtin_ruleset(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """内置系统的 ruleset 每次启动都要跟代码对齐（PR #88 review #3）。
+
+    原来 seed 只在 `not system.ruleset` 时写入，于是改了 `coc7_content.py` 之后
+    已存在的库永远拿不到新规则——加幸运时就撞上了：后端要求 9 个属性键，旧库
+    的 ruleset 却还是 8 项，`GET /ruleset` 一直返回旧数据。这里模拟"旧库"：把
+    ruleset 改成过时的 8 项，再跑一次 seed，断言它被刷新回代码里的 9 项。
+    """
+    system = await db_session.get(GameSystem, BUILTIN_SYSTEM_ID)
+    assert system is not None
+    assert system.ruleset is not None
+    stale = dict(system.ruleset)
+    stale["attributes"] = [a for a in stale["attributes"] if a["key"] != "LUCK"]
+    system.ruleset = stale
+    await db_session.commit()
+
+    # 旧库状态：接口确实返回过时的 8 项
+    response = await client.get(f"/api/v1/systems/{BUILTIN_SYSTEM_ID}/ruleset")
+    assert len(response.json()["data"]["attributes"]) == 8
+
+    await ensure_seed_content(db_session)
+
+    # seed 跑完后应该被刷新回代码里的 9 项（含 LUCK）
+    response = await client.get(f"/api/v1/systems/{BUILTIN_SYSTEM_ID}/ruleset")
+    attributes = response.json()["data"]["attributes"]
+    assert len(attributes) == 9
+    assert any(a["key"] == "LUCK" for a in attributes)

--- a/trpg-backend/tests/test_games.py
+++ b/trpg-backend/tests/test_games.py
@@ -13,11 +13,13 @@ async def test_get_ruleset_returns_full_coc7_data(client: AsyncClient) -> None:
     assert response.status_code == 200
     data = response.json()["data"]
 
-    # 8 项基础属性，字段完整且带真实的 COC7 生成公式
-    assert len(data["attributes"]) == 8
+    # 9 项属性（8 项基础属性 + 幸运），字段完整且带真实的 COC7 生成公式
+    assert len(data["attributes"]) == 9
     attrs_by_key = {a["key"]: a for a in data["attributes"]}
     assert attrs_by_key["STR"] == {"key": "STR", "label": "力量", "generation": "3d6*5"}
     assert attrs_by_key["SIZ"]["generation"] == "(2d6+6)*5"
+    # 幸运独立掷 3d6*5，跟 STR 一组生成公式，不是 (2d6+6)*5 那一组
+    assert attrs_by_key["LUCK"] == {"key": "LUCK", "label": "幸运", "generation": "3d6*5"}
 
     # 80 项技能（前端 ALL_SKILLS 原有 76 条 + issue #84 S2 补齐的 3 条悬空引用
     # navigate/carpentry/illusion + PR #85 review 补的信用评级 credit-rating），

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -48,6 +48,7 @@ def complete_character(client: TestClient, room_id: str, reconnect_token: str) -
                 "SIZ": 50,
                 "INT": 50,
                 "EDU": 50,
+                "LUCK": 50,
             },
             "derivedStats": {"HP": 12},
             "skills": {},

--- a/trpg-frontend/src/data/character-model.ts
+++ b/trpg-frontend/src/data/character-model.ts
@@ -9,7 +9,7 @@ export interface InvestigatorInfo {
   occupationId: number | null
 }
 
-/** 8项基础属性 */
+/** 8 项基础属性 + 幸运（幸运独立掷骰，不参与点数购买，见 ATTRIBUTE_DEFAULTS） */
 export interface Attributes {
   str: number // 力量
   con: number // 体质
@@ -19,15 +19,20 @@ export interface Attributes {
   siz: number // 体型
   int: number // 智力
   edu: number // 教育
+  luck: number // 幸运
   // 索引签名：允许 Attributes 直接传给 Record<string, number> 形参
   // （建卡 PATCH 请求体/previewCharacter 都是这么用的），不用每处再转换。
   [key: string]: number
 }
 
-/** 基础属性默认值 (CoC7标准: 3d6×5 = 平均50) */
+// 基础属性默认值 (CoC7标准: 3d6×5 = 平均50)。
+// 幸运（luck）跟其余 8 项不同：COC7 里它只能掷（3d6*5），不能用属性点数购买，
+// 所以它不在建卡页的点数购买网格（ATTR_KEYS）与总点数预算里，这里给同样的
+// 平均值 50 作默认，真实掷骰由服务端权威的 roll-attributes 端点产出。
 export const ATTRIBUTE_DEFAULTS: Attributes = {
   str: 50, con: 50, pow: 50, dex: 50,
   app: 50, siz: 50, int: 50, edu: 50,
+  luck: 50,
 }
 
 // 纯展示用的中文标签映射，不是规则数据——后端 AttributeSpec 也带了 label，
@@ -42,4 +47,5 @@ export const ATTRIBUTE_LABELS: Record<keyof Attributes, { short: string; full: s
   siz: { short: 'SIZ', full: '体型' },
   int: { short: 'INT', full: '智力' },
   edu: { short: 'EDU', full: '教育' },
+  luck: { short: 'LUCK', full: '幸运' },
 }

--- a/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
+++ b/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
@@ -9,7 +9,9 @@ import { connectWebSocket, disconnectWebSocket, sdk, waitForWsOpen } from '@/ser
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 import { useRuleset } from '@/hooks/useRuleset'
 
-const ATTR_KEY_LIST = ['str', 'con', 'pow', 'dex', 'app', 'siz', 'int', 'edu'] as const
+// 角色卡是只读展示，幸运跟其余 8 项一起列出（建卡页才需要把它排除在加点
+// 网格外，因为 COC7 的幸运不能用属性点购买）。
+const ATTR_KEY_LIST = ['str', 'con', 'pow', 'dex', 'app', 'siz', 'int', 'edu', 'luck'] as const
 
 const SHEET_PAGES = [
   { key: 'info', label: '基本信息' },

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { useState, useMemo, useEffect, useRef } from 'react'
-import { ArrowLeft, Plus, Minus, Search, Shield, Heart, Brain, Zap, Eye, Maximize2, Lightbulb, BookOpen, ChevronDown, X, Info } from 'lucide-react'
+import { ArrowLeft, Plus, Minus, Search, Shield, Heart, Brain, Zap, Eye, Maximize2, Lightbulb, BookOpen, ChevronDown, X, Info, Clover } from 'lucide-react'
 import type { CharacterComputeResult, SkillComputeView } from 'trpg-sdk'
 import { OCCUPATION_ICONS, OCCUPATION_GROUPS } from '@/data/occupations'
 import { ATTRIBUTE_LABELS, type Attributes, type InvestigatorInfo } from '@/data/character-model'
@@ -138,10 +138,17 @@ export default function CharacterPage() {
   })
 
   // Attributes
+  // luck 不在 ATTR_KEYS 里（COC7 幸运只能掷、不能用属性点买），所以它不出现在
+  // 下面的点数购买网格，也不计入总点数预算，但要跟着一起提交给后端。
   const [attr, setAttr] = useState<Attributes>(() => existingCharacter?.attr ?? {
     str: 50, con: 50, pow: 50, dex: 50,
     app: 50, siz: 50, int: 50, edu: 50,
+    luck: 50,
   })
+
+  // 属性总点数只统计可购买的 8 项（ATTR_KEYS），不能用 Object.values(attr)——
+  // 那样会把不占点数预算的幸运也算进去，把 480 点撑爆。
+  const attrPointsTotal = ATTR_KEYS.reduce((sum, k) => sum + attr[k], 0)
 
   // Skill allocations: skillId -> points spent
   const [skillAlloc, setSkillAlloc] = useState<Record<string, number>>(() => existingCharacter ? { ...existingCharacter.skillAlloc } : {})
@@ -667,13 +674,13 @@ export default function CharacterPage() {
                   <div className="flex-1">
                     <div className="flex items-center justify-between mb-1">
                       <span className="text-[11px] font-medium text-text-muted">总点数</span>
-                      <span className="text-[12px] font-bold font-mono text-text-primary">{Object.values(attr).reduce((a, b) => a + b, 0)}<span className="text-text-dim font-normal">/480</span></span>
+                      <span className="text-[12px] font-bold font-mono text-text-primary">{attrPointsTotal}<span className="text-text-dim font-normal">/480</span></span>
                     </div>
                     <div className="h-1.5 rounded-full bg-border-light overflow-hidden">
-                      <div className="h-full rounded-full bg-brass transition-all duration-300" style={{ width: `${Math.min(100, (Object.values(attr).reduce((a, b) => a + b, 0) / 480) * 100)}%` }} />
+                      <div className="h-full rounded-full bg-brass transition-all duration-300" style={{ width: `${Math.min(100, (attrPointsTotal / 480) * 100)}%` }} />
                     </div>
                   </div>
-                  <span className="text-[10px] text-text-dim">{480 - Object.values(attr).reduce((a, b) => a + b, 0)} 点剩余</span>
+                  <span className="text-[10px] text-text-dim">{480 - attrPointsTotal} 点剩余</span>
                 </div>
                 <div className="grid grid-cols-1 gap-2">
                   {ATTR_KEYS.map(key => {
@@ -718,6 +725,22 @@ export default function CharacterPage() {
                       </div>
                     )
                   })}
+                </div>
+
+                {/* 幸运：COC7 里独立掷 3d6*5，不能用属性点购买，所以不在上面的
+                    加点网格里，这里只读展示（真实掷骰由服务端 roll-attributes 产出）。 */}
+                <div className="flex items-center gap-3 px-3 py-2.5 mt-2 bg-panel border border-border-light rounded-[6px]">
+                  <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: '#4a8a4a18' }}>
+                    <Clover className="w-4 h-4" style={{ color: '#4a8a4a' }} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[13px] font-semibold text-text-primary flex items-center gap-1.5">
+                      {ATTRIBUTE_LABELS.luck.full}
+                      <span className="text-[10px] font-mono text-text-dim font-normal">{ATTRIBUTE_LABELS.luck.short}</span>
+                    </div>
+                    <div className="text-[10px] text-text-dim mt-0.5">独立掷骰 3d6×5，不占属性点数</div>
+                  </div>
+                  <span className="text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{attr.luck}</span>
                 </div>
               </div>
 

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -3,7 +3,7 @@ import { useState, useMemo, useEffect, useRef } from 'react'
 import { ArrowLeft, Plus, Minus, Search, Shield, Heart, Brain, Zap, Eye, Maximize2, Lightbulb, BookOpen, ChevronDown, X, Info, Clover } from 'lucide-react'
 import type { CharacterComputeResult, SkillComputeView } from 'trpg-sdk'
 import { OCCUPATION_ICONS, OCCUPATION_GROUPS } from '@/data/occupations'
-import { ATTRIBUTE_LABELS, type Attributes, type InvestigatorInfo } from '@/data/character-model'
+import { ATTRIBUTE_DEFAULTS, ATTRIBUTE_LABELS, type Attributes, type InvestigatorInfo } from '@/data/character-model'
 import { useCharacterStore } from '@/stores/character-store'
 import { useRoomStore } from '@/stores/room-store'
 import { createCharacterDraft, saveCharacter, completeCharacter, toUpperAttrs } from '@/services/character/character-api'
@@ -140,11 +140,15 @@ export default function CharacterPage() {
   // Attributes
   // luck 不在 ATTR_KEYS 里（COC7 幸运只能掷、不能用属性点买），所以它不出现在
   // 下面的点数购买网格，也不计入总点数预算，但要跟着一起提交给后端。
-  const [attr, setAttr] = useState<Attributes>(() => existingCharacter?.attr ?? {
-    str: 50, con: 50, pow: 50, dex: 50,
-    app: 50, siz: 50, int: 50, edu: 50,
-    luck: 50,
-  })
+  //
+  // 必须跟 ATTRIBUTE_DEFAULTS 合并、不能直接用 existingCharacter.attr：角色卡
+  // 是 persist 到 localStorage 的，加幸运之前存下的旧角色只有 8 个键，直接拿来
+  // 用会让 attr.luck 是 undefined，提交时 toUpperAttrs 产不出 LUCK，被后端的
+  // 9 键校验判成 INVALID_ATTRIBUTES，旧角色就再也编辑不了了。
+  const [attr, setAttr] = useState<Attributes>(() => ({
+    ...ATTRIBUTE_DEFAULTS,
+    ...existingCharacter?.attr,
+  }))
 
   // 属性总点数只统计可购买的 8 项（ATTR_KEYS），不能用 Object.values(attr)——
   // 那样会把不占点数预算的幸运也算进去，把 480 点撑爆。
@@ -738,7 +742,7 @@ export default function CharacterPage() {
                       {ATTRIBUTE_LABELS.luck.full}
                       <span className="text-[10px] font-mono text-text-dim font-normal">{ATTRIBUTE_LABELS.luck.short}</span>
                     </div>
-                    <div className="text-[10px] text-text-dim mt-0.5">独立掷骰 3d6×5，不占属性点数</div>
+                    <div className="text-[10px] text-text-dim mt-0.5">不占属性点数（规则为独立掷 3d6×5，掷骰生成待接入，暂为默认值）</div>
                   </div>
                   <span className="text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{attr.luck}</span>
                 </div>

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -21,7 +21,9 @@ interface Message {
 
 interface MapLocation { icon: string; name: string; desc: string; isCurrent?: boolean }
 
-const ATTR_KEY_LIST = ['str', 'con', 'pow', 'dex', 'app', 'siz', 'int', 'edu'] as const
+// 角色卡是只读展示，幸运跟其余 8 项一起列出（建卡页才需要把它排除在加点
+// 网格外，因为 COC7 的幸运不能用属性点购买）。
+const ATTR_KEY_LIST = ['str', 'con', 'pow', 'dex', 'app', 'siz', 'int', 'edu', 'luck'] as const
 
 const MAP_LOCATIONS: MapLocation[] = [
   { icon: '🏚️', name: '惠特利旧宅 · 正门', desc: '当前所在 · 铁门虚掩', isCurrent: true },


### PR DESCRIPTION
Closes #87

COC7 建卡一直缺幸运值：`COC7_ATTRIBUTES` 只有 8 项、`_validate_attributes` 要求「正好 8 个键」、`roll_attributes` 也只掷 8 项，导致角色卡上没有幸运，已设计的 `luck.spend` 协议没有数据基础。本 PR 把幸运补齐为**第 9 项属性**。

## 为什么是属性、不是衍生值

查证了 COC7 规则（`COC7空白卡CY23Final.xlsx` 的 `属性注释` sheet + Chaosium 相关资料）：

- COC7 生成时是「roll or assign **nine** Characteristics」：STR/CON/POW/DEX/APP/SIZ/**Luck** 各 `3d6×5`，INT/EDU 各 `(2d6+6)×5`
- **7 版起幸运不再由 POW 推导**（6 版是），所以它在数据模型上就不是衍生值
- 幸运在游戏中会被消耗（规则「花费幸运值」：失败检定可消耗 `骰子出目 − 成功率` 点改判成功），是**有状态**的属性

## 改动

**后端**
- `coc7_content.py`：新增 `AttributeSpec(LUCK, 3d6*5)`，ruleset 属性 8 → 9
- `coc7_rules.py`：`COC7_ATTRIBUTE_KEYS` 补 `LUCK`，建卡校验要求幸运必填
- `character.py`：`roll_attributes` 补掷 `LUCK`

**前端**
- `character-model.ts`：`Attributes` / `ATTRIBUTE_DEFAULTS` / `ATTRIBUTE_LABELS` 补 `luck`
- `CharacterPage.tsx`：幸运**不进加点网格**（COC7 幸运不能用属性点购买，点数购买法只分给那 8 项），改为只读展示；属性总点数改用 `attrPointsTotal` 只累加 `ATTR_KEYS`，避免幸运被算进总预算
- `CharacterReadyPage.tsx` / `RoomPage.tsx`：两处角色卡只读视图各自硬编码了一份 8 项 `ATTR_KEY_LIST`，补上 `luck`，否则建好的卡看不到幸运

## 测试

新增 2 个用例，都是为了把规则约束固化住而不是凑覆盖率：

- `test_invalid_attributes_missing_luck_rejected`：缺 `LUCK` 被 `INVALID_ATTRIBUTES` 拦下
- `test_luck_does_not_affect_skill_point_budgets`：**改变幸运值，职业 / 兴趣两条技能点预算必须纹丝不动**——证明幸运没有漏进任何技能点公式

已有 fixture 补 `LUCK`（校验要求 9 键），`test_games` 断言 ruleset 返回 9 项并检查 `LUCK` 的生成公式。

## 验证

- 后端：67 passed / `ruff check` / `ruff format --check` / `ty check` 全过
- 前端：`tsc --noEmit` / `eslint --max-warnings 0` 全过
- 浏览器端到端实测（删 `app.db` 重建后走完整流程：注册 → 建房 → 建卡 → 完成）：
  - 加点网格是 8 项，幸运不在其中
  - 属性总点数 `400/480`，加点后 `410/480` —— **幸运没有被算进总预算**（若被算进会是 450/480）
  - 幸运只读卡片显示 50，无 +/- 按钮
  - 建卡 complete 通过，无 `INVALID_ATTRIBUTES`
  - 角色卡「查看」详情的基础属性区域显示 9 项，含 `LUCK 50`

## 本期不做

- 幸运的消耗 / 恢复机制（`luck.spend`、幸运检定）——属游戏内 check 链路
- 不为幸运新造掷骰入口：前端目前是点数购买法、从不调用 `roll-attributes`；服务端该端点本期已支持掷 `LUCK`，等前端接入「掷骰法 / 点数购买法」切换时一并处理，所以前端幸运当前显示默认值
- 幸运成长检定（每场游戏后 `1D100`）、年龄修正（15–19 岁掷 2 次取较高）
