### PR TITLE
fix: 补充房间角色卡运行时快照

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/engine/models.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/models.py
@@ -10,8 +10,11 @@ from collaboration_framework.contracts import ActionResult, ContractModel
 
 
 class ActorState(ContractModel):
-    player_id: str
-    name: str
+    player_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    source_character_id: str = Field(min_length=1)
+    source_character_version: int = Field(ge=1)
+    state: dict[str, JsonValue] = Field(default_factory=dict)
 
 
 class GameState(ContractModel):

--- a/agent-collaboration-framework/docs/数据模型设计.md
+++ b/agent-collaboration-framework/docs/数据模型设计.md
@@ -298,10 +298,20 @@ payload:
 | `phase` | `playing \| ended` |
 | `ending_id` | 已触发结局 |
 | `event_sequence` | Fake Event 单调序号 |
-| `actors` | Actor 与 Player 绑定 |
+| `actors` | Actor 与 Player 绑定及房间内角色卡快照 |
 | `entities` | Fake 权威实体状态 |
 
-`actors` 的值类型是 `ActorState`，当前字段为 `player_id` 与 `name`。它是 B 的内部权威状态，不允许 A 直接读取；A 只能获得由 `PlayerViewProvider` 投影后的安全视图。
+`actors` 的 key 是房间内 `actor_id`，值类型为 `ActorState`：
+
+| 字段 | 语义 |
+|---|---|
+| `player_id` | 当前控制角色的玩家 |
+| `name` | 房间内角色名称 |
+| `source_character_id` | 进入房间时选择的用户角色卡 |
+| `source_character_version` | 复制角色卡时的版本 |
+| `state` | 房间内独立运行的角色状态快照 |
+
+角色卡进入房间后复制到 `ActorState.state`，游戏内变化只修改该运行时快照，不反向覆盖用户角色卡。`ActorState` 是 B 的内部权威状态，不允许 A 直接读取；A 只能获得由 `PlayerViewProvider` 投影后的安全视图。
 
 ### 10.2 StateChange 与 Event
 

--- a/agent-collaboration-framework/fixtures/demo-state.json
+++ b/agent-collaboration-framework/fixtures/demo-state.json
@@ -7,7 +7,16 @@
   "actors": {
     "pc_1": {
       "player_id": "player_01",
-      "name": "调查员"
+      "name": "调查员",
+      "source_character_id": "character_01",
+      "source_character_version": 1,
+      "state": {
+        "hp": 10,
+        "san": 60,
+        "skills": {},
+        "inventory": [],
+        "conditions": []
+      }
     }
   },
   "entities": {

--- a/agent-collaboration-framework/tests/test_workflow.py
+++ b/agent-collaboration-framework/tests/test_workflow.py
@@ -117,6 +117,17 @@ class UnifiedWorkflowTests(unittest.TestCase):
         )
         return orchestrator, engine, recording
 
+    def test_actor_character_snapshot_is_loaded_and_preserved(self) -> None:
+        actor = self.state.actors["pc_1"]
+        self.assertEqual(actor.source_character_id, "character_01")
+        self.assertEqual(actor.source_character_version, 1)
+        self.assertEqual(actor.state["hp"], 10)
+        self.assertEqual(actor.state["san"], 60)
+
+        orchestrator, engine, _ = self.application()
+        self.run_turn(orchestrator)
+        self.assertEqual(engine.snapshot().actors["pc_1"], actor)
+
     def run_turn(self, orchestrator, player_input=None):
         return asyncio.run(orchestrator.run(player_input or self.player_input))
 


### PR DESCRIPTION
## 变更内容

- 扩展 `ActorState`，增加角色卡来源、版本和房间内运行时状态
- 更新 demo GameState，保存角色卡运行时快照
- 增加快照加载及动作执行后保持不变的回归测试
- 同步数据模型文档

## 原因

现有 `ActorState` 只允许 `player_id` 和 `name`，无法校验或保留进入房间时复制的角色卡状态，导致新增 demo 字段与严格 Pydantic 模型不一致。

## 影响

角色卡进入房间后保存在 `GameState.actors[actor_id]` 中，游戏内状态独立变化，不反向覆盖用户角色卡。公共 `PlayerInput`、`ActionRequest` 和 `PlayerView` 本次不变。

## 验证

- `uv run python -m unittest discover -s tests -v`
- 25 项测试通过

Closes #102
