### PR TITLE
feat: 账号身份贯通与断线重连

### DIFF
--- a/e2e/tests/account-identity.e2e.ts
+++ b/e2e/tests/account-identity.e2e.ts
@@ -69,6 +69,25 @@ test('🔴 游戏开始后：老成员能重连，新人被拒', async () => {
   )
 })
 
+test('🔴 换设备重连能拿回角色卡 id（否则会被引导重建一张）', async () => {
+  // PR #110 review [1]：客户端靠 `characterId` 才知道去拉哪张卡，而在此之前这个
+  // id 只在建卡那一刻由客户端自己存着——换台设备就永远拿不回来，已经建完卡的人
+  // 重连后会显示成「还没建卡」。这条正好补上「换设备重连」那条用例的缺口：光有
+  // 房间身份不够，角色身份也要能恢复。
+  const room = await createRoomWithModule('charid')
+  const guest = await registerPlayer('charidguest')
+  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
+  assert.equal(joined.characterId, null, '还没建卡时应该是 null')
+
+  const draft = await guest.sdk.characters.createDraft(room.roomId, joined.reconnectToken)
+
+  // 全新 SDK 实例 = 另一台设备，只有账号 token
+  const otherDevice = makeSdk()
+  const recovered = await otherDevice.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
+
+  assert.equal(recovered.characterId, draft.characterId)
+})
+
 test('我的游戏：按账号返回全部房间，且不泄漏别人的', async () => {
   const first = await createRoomWithModule('mine1')
   // 同一个账号再建一个房间——用它自己的 sdk/token

--- a/e2e/tests/account-identity.e2e.ts
+++ b/e2e/tests/account-identity.e2e.ts
@@ -1,0 +1,127 @@
+/**
+ * 账号身份贯通与断线重连（issue #106）。
+ *
+ * 这条链路是 SDK 层 e2e 最该守的东西之一：它跨越「账号」和「房间」两套凭证，
+ * 而两套凭证互相搞混正是这个 issue 的由来。浏览器层测同样的东西要开两个上下文、
+ * 还得模拟断线；这里在一个进程里换个 SDK 实例就等价于「换了台设备」。
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { createRoomWithModule, makeSdk, registerPlayer } from './helpers.ts'
+
+test('🔴 老成员重连：同一账号再次 join 拿回同一个身份，人数不变', async () => {
+  const room = await createRoomWithModule('rejoin')
+  const guest = await registerPlayer('rejoinguest')
+
+  const first = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
+  const second = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
+
+  assert.equal(second.playerId, first.playerId, '重连必须拿回同一个 playerId')
+  assert.equal(second.reconnectToken, first.reconnectToken)
+
+  // 改动前这里会变成 3：join 不检查调用者是不是已经在房间里，无条件新建 Player，
+  // 同一个人重复加入就虚增人数，直到撞满员。
+  const preview = await room.host.sdk.rooms.getInfo(room.roomCode)
+  assert.equal(preview.players.length, 2, '重复加入不该多出一个玩家')
+})
+
+test('🔴 换设备重连：新的客户端实例只凭账号 token 就能拿回房间身份', async () => {
+  // 这条是账号体系存在的理由本身。`reconnectToken` 存在浏览器会话里，换设备就
+  // 没了；只有按账号幂等，才谈得上「换台设备继续这局」。
+  const room = await createRoomWithModule('device')
+  const guest = await registerPlayer('deviceguest')
+  const original = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
+
+  // 全新的 SDK 实例 = 另一台设备：没有任何本地状态，只有账号 token
+  const otherDevice = makeSdk()
+  const recovered = await otherDevice.rooms.join(
+    room.roomCode,
+    { nickname: '访客' },
+    guest.token
+  )
+
+  assert.equal(recovered.playerId, original.playerId)
+  assert.equal(recovered.reconnectToken, original.reconnectToken, '换设备也要能拿回房间凭证')
+})
+
+test('🔴 游戏开始后：老成员能重连，新人被拒', async () => {
+  // 一对互为对照的断言。改动前这里是一刀切 `if phase != Lobby: 409`，把「中途
+  // 加入」和「掉线重连」当成同一件事拒掉——只测其中一边的话，「一刀切拒绝」和
+  // 「一刀切放行」各能通过一条。
+  const room = await createRoomWithModule('phase')
+  const guest = await registerPlayer('phaseguest')
+  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
+
+  await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
+
+  const rejoined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
+  assert.equal(rejoined.playerId, joined.playerId, '老成员在 Building 阶段必须能重连')
+
+  const latecomer = await registerPlayer('latecomer')
+  await assert.rejects(
+    () => latecomer.sdk.rooms.join(room.roomCode, { nickname: '迟到' }, latecomer.token),
+    (error: Error) => {
+      assert.match(error.message, /已开始|CONFLICT/)
+      return true
+    },
+    '新人在 Building 阶段必须被拒'
+  )
+})
+
+test('我的游戏：按账号返回全部房间，且不泄漏别人的', async () => {
+  const first = await createRoomWithModule('mine1')
+  // 同一个账号再建一个房间——用它自己的 sdk/token
+  const second = await first.host.sdk.rooms.create(
+    { roomName: '第二间', nickname: first.host.account, maxPlayers: 4 },
+    first.host.token
+  )
+
+  const mine = await first.host.sdk.rooms.listMyRooms(first.host.token)
+  const myIds = new Set(mine.map((room) => room.roomId))
+
+  // 改动前按 reconnectToken 查、只返回一个房间——「我的游戏」实际是
+  // 「这个浏览器的最后一个房间」。
+  assert.ok(myIds.has(first.roomId), '第一个房间应该在我的列表里')
+  assert.ok(myIds.has(second.roomId), '第二个房间也应该在')
+
+  // 对照面：别人的房间不能出现。只断言「我的两个都在」的话，一个"返回全部
+  // 房间"的错误实现照样能通过。
+  const stranger = await createRoomWithModule('stranger')
+  assert.ok(!myIds.has(stranger.roomId), '别人的房间不该出现在我的列表里')
+})
+
+test('创建/加入房间要求登录', async () => {
+  // 不带账号 token 的裸客户端
+  const anonymous = makeSdk()
+  await assert.rejects(
+    () => anonymous.rooms.create({ roomName: '匿名房', nickname: '匿名', maxPlayers: 4 }, ''),
+    (error: Error) => {
+      assert.match(error.message, /登录|UNAUTHORIZED/)
+      return true
+    },
+    '未登录不该能创建房间'
+  )
+
+  const room = await createRoomWithModule('authreq')
+  await assert.rejects(
+    () => anonymous.rooms.join(room.roomCode, { nickname: '匿名' }, ''),
+    (error: Error) => {
+      assert.match(error.message, /登录|UNAUTHORIZED/)
+      return true
+    },
+    '未登录不该能加入房间'
+  )
+})
+
+test('建房会把房间关联到账号（否则我的游戏查不到它）', async () => {
+  const room = await createRoomWithModule('linked')
+
+  const mine = await room.host.sdk.rooms.listMyRooms(room.host.token)
+
+  assert.deepEqual(
+    mine.map((r) => r.roomId),
+    [room.roomId],
+    'host_user_id 没落上的话，这里会是空列表'
+  )
+})

--- a/e2e/tests/character-build.e2e.ts
+++ b/e2e/tests/character-build.e2e.ts
@@ -248,7 +248,7 @@ test('不能读别人的角色卡', async () => {
   const draft = await room.host.sdk.characters.createDraft(room.roomId, room.reconnectToken)
 
   const intruder = await registerPlayer('intruder')
-  const joined = await intruder.sdk.rooms.join(room.roomCode, { nickname: '闯入者' })
+  const joined = await intruder.sdk.rooms.join(room.roomCode, { nickname: '闯入者' }, intruder.token)
 
   await assert.rejects(
     () =>

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -40,14 +40,14 @@ export interface TestRoom {
 /** 建一个已经选好内置模组的房间，回到「可以开始建卡」的状态。 */
 export async function createRoomWithModule(prefix = 'e2e'): Promise<TestRoom> {
   const host = await registerPlayer(prefix)
-  // ⚠️ rooms.create 不接受 token——SDK 没给这个端点留鉴权入口，所以通过 SDK
-  // （以及走 SDK 的前端）创建的房间，Room.host_user_id 永远是 null。这是真实
-  // 的契约缺口，不是这里写错了；见本目录 README 的「已知缺口」。
-  const room = await host.sdk.rooms.create({
-    roomName: `${prefix} 房间`,
-    nickname: host.account,
-    maxPlayers: 6,
-  })
+  const room = await host.sdk.rooms.create(
+    {
+      roomName: `${prefix} 房间`,
+      nickname: host.account,
+      maxPlayers: 6,
+    },
+    host.token
+  )
   const modules = await host.sdk.rooms.listModules()
   await host.sdk.rooms.selectModule(
     room.roomId,

--- a/e2e/tests/multiplayer-ws.e2e.ts
+++ b/e2e/tests/multiplayer-ws.e2e.ts
@@ -57,7 +57,7 @@ test('第二个玩家用房间码加入，房间预览里能看到两个人', as
   const room = await createRoomWithModule('mp')
   const guest = await registerPlayer('guest')
 
-  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' })
+  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
   assert.equal(joined.roomId, room.roomId)
 
   const preview = await room.host.sdk.rooms.getInfo(room.roomCode)
@@ -68,7 +68,7 @@ test('第二个玩家用房间码加入，房间预览里能看到两个人', as
 test('WS 生命周期：join → session.bound，全员建卡后房主可以 game.start', async () => {
   const room = await createRoomWithModule('ws')
   const guest = await registerPlayer('wsguest')
-  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' })
+  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
 
   // 房间生命周期是 Lobby →(start_story)→ Building →(game.start)→ InGame。
   // 少了 start_story 这步，房间还在 Lobby，game.start 会被拒——第一版就是漏了
@@ -107,7 +107,7 @@ test('WS 生命周期：join → session.bound，全员建卡后房主可以 gam
 test('提交行动会广播给房间里的所有人（不只是发起者）', async () => {
   const room = await createRoomWithModule('broadcast')
   const guest = await registerPlayer('bcguest')
-  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' })
+  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '访客' }, guest.token)
 
   await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken)
   await buildCharacter(guest.sdk, room.roomId, joined.reconnectToken)

--- a/trpg-backend/alembic/versions/1a02058345ee_unique_player_per_room_per_account.py
+++ b/trpg-backend/alembic/versions/1a02058345ee_unique_player_per_room_per_account.py
@@ -1,0 +1,39 @@
+"""unique player per room per account
+
+Revision ID: 1a02058345ee
+Revises: d6ed190ffc39
+Create Date: 2026-07-21 18:39:46.259998
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1a02058345ee"
+down_revision: str | Sequence[str] | None = "d6ed190ffc39"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """给 players 加 (room_id, user_id) 唯一约束。
+
+    必须用 batch 模式：SQLite 不支持 `ALTER TABLE ... ADD CONSTRAINT`（autogenerate
+    默认生成的 `op.create_unique_constraint` 在 SQLite 上直接 NotImplementedError），
+    batch 模式会退化成"建新表→拷数据→改名"这套。PostgreSQL 上 batch 模式等价于
+    普通 ALTER，不受影响。
+
+    ⚠️ 如果本地已有库里存在「同一账号在同一房间有多行」的脏数据（#106 之前
+    join_room 没有幂等，重复加入会建重复行），这条迁移会失败。开发库直接删掉
+    `app.db` 重新 `alembic upgrade head` 即可。
+    """
+    with op.batch_alter_table("players") as batch_op:
+        batch_op.create_unique_constraint("uq_players_room_user", ["room_id", "user_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("players") as batch_op:
+        batch_op.drop_constraint("uq_players_room_user", type_="unique")

--- a/trpg-backend/app/controller/dependencies.py
+++ b/trpg-backend/app/controller/dependencies.py
@@ -1,15 +1,21 @@
 """跨 controller 复用的 FastAPI 依赖（issue #77）。
 
-`GET /auth/me` 这类接口要求登录态必须有效（查不到就 401），而房间创建/加入
-接口本期不强制登录（见 `models/room.py` 里 `Room.host_user_id` 的注释）——
-两种场景都要解析同一个 `Authorization: Bearer <token>` 头，抽成共享依赖，
-"要不要强制"留给各自 controller 自己决定要不要检查返回值是不是 None。
+解析同一个 `Authorization: Bearer <token>` 头，但分成两个依赖：
+
+- `get_current_user`：**要求登录**，拿不到有效登录态直接 401。
+- `get_optional_user`：登录可选，拿不到返回 None。
+
+issue #106 起，创建/加入房间从 `get_optional_user` 换成了 `get_current_user`。
+原来"登录可选"的写法是 `Room.host_user_id`/`Player.user_id` 恒为 `null` 的直接
+原因——一个"可以不填"的身份字段，在没人强制时就永远是空的，所有依赖它的功能
+（跨设备找回、我的游戏、按账号幂等重连）都成了空中楼阁。
 """
 
-from fastapi import Depends, Header
+from fastapi import Depends, Header, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_db
+from app.core.errors import AppException, ErrorCode
 from app.models.user import User
 from app.service import auth as auth_service
 
@@ -27,3 +33,23 @@ async def get_optional_user(
 ) -> User | None:
     """解析 Authorization 头，查不到有效登录态时返回 None 而不是报错。"""
     return await auth_service.resolve_user(db, extract_bearer_token(authorization))
+
+
+async def get_current_user(
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    """解析 Authorization 头并要求登录态有效，否则 401。
+
+    抛 `AppException` 而不是 `auth_service.AuthenticationError`：这个依赖在路由
+    函数体**之前**执行，controller 里的 try/except 根本罩不到它，服务层异常跑出来
+    会被全局兜底转成 500。直接抛 `AppException` 才能落到正确的 401。
+    """
+    user = await auth_service.resolve_user(db, extract_bearer_token(authorization))
+    if user is None:
+        raise AppException(
+            ErrorCode.UNAUTHORIZED,
+            "登录凭证无效" if authorization is not None else "缺少登录凭证",
+            status.HTTP_401_UNAUTHORIZED,
+        )
+    return user

--- a/trpg-backend/app/controller/v1/me.py
+++ b/trpg-backend/app/controller/v1/me.py
@@ -5,12 +5,13 @@
 from fastapi import APIRouter, Depends, Header, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.controller.dependencies import extract_bearer_token
+from app.controller.dependencies import extract_bearer_token, get_current_user
 from app.core.db import get_db
 from app.core.errors import AppException, ErrorCode
 from app.dto.character import CharacterTemplateCreateBody, CharacterTemplateRead
 from app.dto.common import ApiResponse
 from app.dto.room import MyRoomSummary
+from app.models.user import User
 from app.service import auth as auth_service
 from app.service import character as character_service
 from app.service import room as room_service
@@ -20,14 +21,17 @@ router = APIRouter(prefix="/me", tags=["me"])
 
 @router.get("/rooms", response_model=ApiResponse[list[MyRoomSummary]])
 async def list_my_rooms(
-    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
     db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
 ) -> ApiResponse[list[MyRoomSummary]]:
-    """GET /api/v1/me/rooms —— 获取我的房间列表。"""
-    try:
-        rooms = await room_service.list_my_rooms(db, reconnect_token)
-    except room_service.RoomAuthenticationError as exc:
-        raise AppException(ErrorCode.UNAUTHORIZED, str(exc), status.HTTP_401_UNAUTHORIZED) from exc
+    """GET /api/v1/me/rooms —— 获取我的房间列表。
+
+    issue #106：凭证从房间的 `X-Reconnect-Token` 换成账号 `Authorization`。原来
+    按重连凭证查，一个凭证只对应一名玩家/一个房间，「我的游戏」实际上是「这个
+    浏览器的最后一个房间」——换台设备就什么都看不到，而账号体系当初正是为
+    「换设备找回游戏」引入的。
+    """
+    rooms = await room_service.list_my_rooms(db, user)
     return ApiResponse.ok(rooms)
 
 

--- a/trpg-backend/app/controller/v1/rooms.py
+++ b/trpg-backend/app/controller/v1/rooms.py
@@ -11,7 +11,7 @@ from typing import NoReturn
 from fastapi import APIRouter, Body, Depends, Header, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.controller.dependencies import get_optional_user
+from app.controller.dependencies import get_current_user
 from app.core.db import get_db
 from app.core.errors import AppException, ErrorCode
 from app.dto.character import (
@@ -67,9 +67,13 @@ def _raise_service_error(exc: Exception) -> NoReturn:
 async def create_room(
     payload: RoomCreate,
     db: AsyncSession = Depends(get_db),
-    user: User | None = Depends(get_optional_user),
+    user: User = Depends(get_current_user),
 ) -> ApiResponse[RoomCreateResult]:
-    """POST /api/v1/rooms —— 创建房间，返回房间身份信息。"""
+    """POST /api/v1/rooms —— 创建房间，返回房间身份信息。
+
+    issue #106 起要求登录：房间和房主玩家都要关联到真实账号，否则
+    `host_user_id`/`user_id` 永远是空的，「我的游戏」和跨设备找回都无从谈起。
+    """
     result = await room_service.create_room(db, payload, user)
     return ApiResponse.ok(result)
 
@@ -100,9 +104,12 @@ async def join_room(
     room_code: str,
     payload: JoinRoomBody,
     db: AsyncSession = Depends(get_db),
-    user: User | None = Depends(get_optional_user),
+    user: User = Depends(get_current_user),
 ) -> ApiResponse[RoomCreateResult]:
-    """POST /api/v1/rooms/{roomCode}/join —— 用房间码加入房间。"""
+    """POST /api/v1/rooms/{roomCode}/join —— 用房间码加入房间。
+
+    issue #106 起要求登录，且**已是房间成员时幂等返回既有身份**（用于掉线重连）。
+    """
     try:
         result = await room_service.join_room(db, room_code, payload, user)
     except (

--- a/trpg-backend/app/dto/character.py
+++ b/trpg-backend/app/dto/character.py
@@ -11,11 +11,10 @@ RoomPlayer.has_character 标记为 True；但 issue #84 S2 起，`complete_chara
 `CharacterComputeResult`（`POST /systems/{systemId}/character/preview`）。
 """
 
-from datetime import datetime
 
 from pydantic import Field
 
-from app.dto.common import CamelModel
+from app.dto.common import CamelModel, UtcDatetime
 
 
 class EquipmentItem(CamelModel):
@@ -114,8 +113,8 @@ class CharacterTemplateRead(CamelModel):
     name: str
     system_id: str
     data: dict
-    created_at: datetime
-    updated_at: datetime
+    created_at: UtcDatetime
+    updated_at: UtcDatetime
 
 
 # ── 建卡计算/校验预览（issue #84 S2，路线乙的接缝） ────────────────────────

--- a/trpg-backend/app/dto/character.py
+++ b/trpg-backend/app/dto/character.py
@@ -11,7 +11,6 @@ RoomPlayer.has_character 标记为 True；但 issue #84 S2 起，`complete_chara
 `CharacterComputeResult`（`POST /systems/{systemId}/character/preview`）。
 """
 
-
 from pydantic import Field
 
 from app.dto.common import CamelModel, UtcDatetime

--- a/trpg-backend/app/dto/common.py
+++ b/trpg-backend/app/dto/common.py
@@ -6,9 +6,10 @@
 不需要针对每个接口猜它失败时到底返回什么形状。
 """
 
-from typing import Self
+from datetime import UTC, datetime
+from typing import Annotated, Self
 
-from pydantic import AliasGenerator, BaseModel, ConfigDict
+from pydantic import AfterValidator, AliasGenerator, BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from app.core.errors import ErrorCode
@@ -16,6 +17,25 @@ from app.core.errors import ErrorCode
 
 def _to_camel(snake: str) -> str:
     return to_camel(snake)
+
+
+def _assume_utc(value: datetime) -> datetime:
+    """给不带时区的时间补上 UTC。
+
+    数据库里所有时间列都是 `DateTime(timezone=True)`、写入的也都是
+    `datetime.now(UTC)`，**但 SQLite 不保存时区信息**，读出来是个 naive
+    datetime，pydantic 于是序列化成 `2026-07-21T09:35:13.095627`——没有任何
+    后缀。客户端拿到这种字符串，按 ECMAScript 的规则会当作**本地时间**解析，
+    于是"4 分钟前"在 UTC+8 的机器上显示成"8 小时前"，偏差正好是时区偏移量。
+
+    这不是客户端该自己猜的事：光看字符串无从判断它是 UTC 还是本地时间。所以
+    在契约层补齐——所有对外暴露的时间一律带时区后缀。
+    """
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value
+
+
+UtcDatetime = Annotated[datetime, AfterValidator(_assume_utc)]
+"""对外暴露时间字段统一用这个类型，别直接用 `datetime`。"""
 
 
 class CamelModel(BaseModel):

--- a/trpg-backend/app/dto/module.py
+++ b/trpg-backend/app/dto/module.py
@@ -6,11 +6,10 @@
 （issue 决策 7），这里只定义 DTO 形状占住协议位置。
 """
 
-from datetime import datetime
 
 from pydantic import Field
 
-from app.dto.common import CamelModel
+from app.dto.common import CamelModel, UtcDatetime
 from app.dto.room import ModuleRead
 
 
@@ -43,5 +42,5 @@ class ModuleImportJobRead(CamelModel):
     source_filename: str | None = None
     result_scenario_id: str | None = None
     error_message: str | None = None
-    created_at: datetime
-    updated_at: datetime
+    created_at: UtcDatetime
+    updated_at: UtcDatetime

--- a/trpg-backend/app/dto/module.py
+++ b/trpg-backend/app/dto/module.py
@@ -6,7 +6,6 @@
 （issue 决策 7），这里只定义 DTO 形状占住协议位置。
 """
 
-
 from pydantic import Field
 
 from app.dto.common import CamelModel, UtcDatetime

--- a/trpg-backend/app/dto/replay.py
+++ b/trpg-backend/app/dto/replay.py
@@ -6,9 +6,8 @@
 少数"服务端真的在写、也真的在读"的完整数据闭环之一。
 """
 
-from datetime import datetime
 
-from app.dto.common import CamelModel
+from app.dto.common import CamelModel, UtcDatetime
 
 
 class RoomSummaryRead(CamelModel):
@@ -27,4 +26,4 @@ class ReplayEventRead(CamelModel):
     player_id: str | None = None
     event_type: str
     payload: dict
-    created_at: datetime
+    created_at: UtcDatetime

--- a/trpg-backend/app/dto/replay.py
+++ b/trpg-backend/app/dto/replay.py
@@ -6,7 +6,6 @@
 少数"服务端真的在写、也真的在读"的完整数据闭环之一。
 """
 
-
 from app.dto.common import CamelModel, UtcDatetime
 
 

--- a/trpg-backend/app/dto/room.py
+++ b/trpg-backend/app/dto/room.py
@@ -10,11 +10,10 @@
   由 pydantic 自动处理，业务代码无需关心
 """
 
-from datetime import datetime
 
 from pydantic import Field, field_validator
 
-from app.dto.common import CamelModel
+from app.dto.common import CamelModel, UtcDatetime
 
 # ── 请求体 ──────────────────────────────────────
 
@@ -131,4 +130,4 @@ class MyRoomSummary(CamelModel):
     module_title: str | None = None
     player_count: int
     max_players: int
-    updated_at: datetime
+    updated_at: UtcDatetime

--- a/trpg-backend/app/dto/room.py
+++ b/trpg-backend/app/dto/room.py
@@ -10,7 +10,6 @@
   由 pydantic 自动处理，业务代码无需关心
 """
 
-
 from pydantic import Field, field_validator
 
 from app.dto.common import CamelModel, UtcDatetime

--- a/trpg-backend/app/dto/room.py
+++ b/trpg-backend/app/dto/room.py
@@ -68,6 +68,12 @@ class RoomCreateResult(CamelModel):
     room_code: str
     reconnect_token: str
     player_id: str
+    # 这个房间里属于我的角色卡 id，还没建卡时为 None。
+    #
+    # 加它是为了让**换设备重连**真正可用（PR #110 review [1]）：客户端靠它才知道
+    # 该去拉哪张卡，而在此之前这个 id 只在建卡那一刻由客户端自己存着——换台设备
+    # 就永远拿不回来，已经建完卡的人重连后会显示成"还没建卡"、被引导去建第二张。
+    character_id: str | None = None
 
 
 class RoomPlayerRead(CamelModel):

--- a/trpg-backend/app/models/room.py
+++ b/trpg-backend/app/models/room.py
@@ -11,7 +11,17 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Text, Uuid
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.db import Base
@@ -80,14 +90,23 @@ class Player(Base):
 
     __tablename__ = "players"
 
+    # 「一个账号在一个房间里只能有一名玩家」这条不变式必须由数据库保证，不能只靠
+    # service 层「先查再插」——那是 check-then-act，两个并发的重连/加入请求会同时
+    # 查到「不存在」然后各插一行，幂等承诺当场失效、房间人数还会虚增（PR #110
+    # review [2]）。约束放在这里，service 层配合捕获 IntegrityError 重查。
+    #
+    # `user_id` 可空，而 SQL 的唯一约束**不约束 NULL**（多行 NULL 互不冲突），
+    # 所以 AI 玩家（`is_ai=true`，无账号）和迁移前遗留的无账号行不受影响。
+    __table_args__ = (UniqueConstraint("room_id", "user_id", name="uq_players_room_user"),)
+
     id: Mapped[str] = mapped_column(
         Uuid(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     room_id: Mapped[str] = mapped_column(
         Uuid(as_uuid=False), ForeignKey("rooms.id"), nullable=False
     )
-    # 关联账号：可空，理由同 Room.host_user_id 的注释——本期 REST 创建/加入
-    # 房间不强制登录，只在调用方带了有效 Authorization 时才回填。
+    # 关联账号：REST 创建/加入房间自 issue #106 起要求登录、必定回填；仍保留可空
+    # 是为了 AI 玩家（`is_ai=true`）和迁移前的遗留行。
     user_id: Mapped[str | None] = mapped_column(
         Uuid(as_uuid=False), ForeignKey("users.id"), nullable=True, default=None
     )

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -10,7 +10,8 @@ import secrets
 import string
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.errors import not_implemented
@@ -29,7 +30,7 @@ from app.dto.room import (
 )
 from app.models.content import Game, GameSystem, Scenario
 from app.models.event import Event
-from app.models.room import Player, Room
+from app.models.room import Character, Player, Room
 from app.models.user import User
 
 
@@ -114,6 +115,24 @@ async def require_room_member(
     return player
 
 
+async def _room_identity(db: AsyncSession, room: Room, player: Player) -> RoomCreateResult:
+    """组装「我在这个房间里是谁」——创建/加入/重连三条路径共用。
+
+    带上 `character_id` 是为了让**换设备重连**真正可用（PR #110 review [1]）：
+    客户端靠它才知道该去拉哪张角色卡，而在此之前这个 id 只在建卡那一刻由客户端
+    自己存着——换台设备就永远拿不回来了，已经建完卡的人重连后会显示成"还没建卡"、
+    被引导去建第二张。服务端本来就知道答案，直接给。
+    """
+    character = await db.scalar(select(Character).where(Character.player_id == player.id))
+    return RoomCreateResult(
+        room_id=room.id,
+        room_code=room.room_code,
+        reconnect_token=player.reconnect_token,
+        player_id=player.id,
+        character_id=character.id if character is not None else None,
+    )
+
+
 async def _module_title(db: AsyncSession, scenario_id: str | None) -> str | None:
     if scenario_id is None:
         return None
@@ -185,12 +204,7 @@ async def create_room(db: AsyncSession, payload: RoomCreate, user: User) -> Room
     room.host_player_id = player.id
     await db.commit()
 
-    return RoomCreateResult(
-        room_id=room.id,
-        room_code=room.room_code,
-        reconnect_token=player.reconnect_token,
-        player_id=player.id,
-    )
+    return await _room_identity(db, room, player)
 
 
 async def join_room(
@@ -221,12 +235,7 @@ async def join_room(
         select(Player).where(Player.room_id == room.id, Player.user_id == user.id)
     )
     if existing is not None:
-        return RoomCreateResult(
-            room_id=room.id,
-            room_code=room_code,
-            reconnect_token=existing.reconnect_token,
-            player_id=existing.id,
-        )
+        return await _room_identity(db, room, existing)
 
     # 到这里说明是新人。新人只能在大厅阶段加入：游戏已经开始/结束之后再放人
     # 进来，等于中途加入，本期不做。
@@ -245,15 +254,30 @@ async def join_room(
         is_host=False,
         joined_at=datetime.now(UTC),
     )
-    db.add(player)
-    await db.commit()
+    # 上面那段「先查有没有、没有才插」是 check-then-act，两个并发的重连/加入请求
+    # 会同时查到「不存在」然后各插一行（PR #110 review [2]）。真正的不变式由
+    # `players` 的 `uq_players_room_user` 唯一约束保证，这里负责把撞上约束的那一方
+    # **收敛成和先到者一样的结果**——毕竟两个请求想要的是同一件事。
+    #
+    # 🔴 必须用 SAVEPOINT（`begin_nested`）包住这次插入，不能直接 `commit()` 之后
+    # 捕获再 `rollback()`：那样整个事务连同连接一起废掉，紧接着的重查要重新建连接，
+    # 在异步驱动下会炸 `MissingGreenlet`——真实并发 curl 实测 10 个请求里有 2 个
+    # 因此返回 500（pytest 的 ASGITransport 装置压不出并发，测不到这条）。
+    # SAVEPOINT 只回滚到存档点，session 和连接都还活着，重查才做得下去。
+    try:
+        async with db.begin_nested():
+            db.add(player)
+            await db.flush()
+    except IntegrityError:
+        winner = await db.scalar(
+            select(Player).where(Player.room_id == room.id, Player.user_id == user.id)
+        )
+        if winner is None:
+            raise
+        return await _room_identity(db, room, winner)
 
-    return RoomCreateResult(
-        room_id=room.id,
-        room_code=room_code,
-        reconnect_token=player.reconnect_token,
-        player_id=player.id,
-    )
+    await db.commit()
+    return await _room_identity(db, room, player)
 
 
 async def get_room_preview(db: AsyncSession, room_code: str) -> RoomPreview | None:
@@ -350,31 +374,51 @@ async def list_my_rooms(db: AsyncSession, user: User) -> list[MyRoomSummary]:
     房间——所以「我的游戏」实际上是「这个浏览器的最后一个房间」，换台设备就什么
     都看不到。账号体系当初正是为「换设备找回游戏」引入的，这里按 `user_id` 查才
     兑现了那个目的。
+
+    ⚠️ 查询数量必须跟房间数**无关**。第一版在循环里逐个房间查人数、查模组标题，
+    N 个房间要发约 `2N+2` 条查询（PR #110 review [3]）——这个接口正是本 issue 让它
+    从「最多一个房间」变成「该账号全部房间」的，N 会真的长起来。下面改成先一次性
+    把人数和模组标题聚合出来，再拼结果，总共 4 条查询封顶。
     """
     players = await db.scalars(select(Player).where(Player.user_id == user.id))
     room_ids = [p.room_id for p in players]
     if not room_ids:
         return []
 
-    rooms = await db.scalars(
-        select(Room).where(Room.id.in_(room_ids)).order_by(Room.updated_at.desc())
+    rooms = list(
+        await db.scalars(select(Room).where(Room.id.in_(room_ids)).order_by(Room.updated_at.desc()))
     )
-    summaries: list[MyRoomSummary] = []
-    for room in rooms:
-        count_result = await db.scalars(select(Player).where(Player.room_id == room.id))
-        summaries.append(
-            MyRoomSummary(
-                room_id=room.id,
-                room_code=room.room_code,
-                room_name=room.room_name,
-                phase=room.phase,
-                module_title=await _module_title(db, room.scenario_id),
-                player_count=len(list(count_result)),
-                max_players=room.max_players,
-                updated_at=room.updated_at,
-            )
+
+    # 每个房间的人数：一条 GROUP BY，不是一房一查
+    count_rows = await db.execute(
+        select(Player.room_id, func.count(Player.id))
+        .where(Player.room_id.in_(room_ids))
+        .group_by(Player.room_id)
+    )
+    counts = dict(count_rows.tuples().all())
+
+    # 模组标题：把用到的 scenario_id 去重后一次查完
+    scenario_ids = {room.scenario_id for room in rooms if room.scenario_id is not None}
+    titles: dict[str, str] = {}
+    if scenario_ids:
+        title_rows = await db.execute(
+            select(Scenario.id, Scenario.title).where(Scenario.id.in_(scenario_ids))
         )
-    return summaries
+        titles = dict(title_rows.tuples().all())
+
+    return [
+        MyRoomSummary(
+            room_id=room.id,
+            room_code=room.room_code,
+            room_name=room.room_name,
+            phase=room.phase,
+            module_title=titles.get(room.scenario_id) if room.scenario_id else None,
+            player_count=counts.get(room.id, 0),
+            max_players=room.max_players,
+            updated_at=room.updated_at,
+        )
+        for room in rooms
+    ]
 
 
 async def end_game(db: AsyncSession, room_id: str, reconnect_token: str | None) -> None:

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -151,13 +151,13 @@ async def _to_room_preview(db: AsyncSession, room: Room) -> RoomPreview:
 # ── 房间 ──────────────────────────────────────
 
 
-async def create_room(db: AsyncSession, payload: RoomCreate, user: User | None) -> RoomCreateResult:
+async def create_room(db: AsyncSession, payload: RoomCreate, user: User) -> RoomCreateResult:
     """创建房间，返回房间身份信息。
 
-    `user` 是可选的当前登录账号（由 controller 从 Authorization 头解析，查不到
-    也不报错）——REST 创建房间接口本期不强制要求登录，带了有效登录态就把
-    `Room.host_user_id`/`Player.user_id` 关联上，没带就留空（详见
-    `models/room.py` 里 `Room.host_user_id` 的注释）。
+    `user` 是**必需**的当前登录账号（issue #106）。此前它是可选的，于是
+    `host_user_id`/`user_id` 永远是 `null`，「我的游戏」只能退而按 reconnect_token
+    查、跨设备找回无从谈起。登录本来就是 2026-07-11 拍板的硬性前提，这里只是让
+    实现跟上那条前提。
     """
     room_code = await _generate_room_code(db)
     now = datetime.now(UTC)
@@ -167,14 +167,14 @@ async def create_room(db: AsyncSession, payload: RoomCreate, user: User | None) 
         room_name=payload.room_name,
         max_players=payload.max_players,
         phase="Lobby",
-        host_user_id=user.id if user else None,
+        host_user_id=user.id,
     )
     db.add(room)
     await db.flush()  # 拿到 room.id
 
     player = Player(
         room_id=room.id,
-        user_id=user.id if user else None,
+        user_id=user.id,
         nickname=payload.nickname or "房主",
         is_host=True,
         joined_at=now,
@@ -194,12 +194,42 @@ async def create_room(db: AsyncSession, payload: RoomCreate, user: User | None) 
 
 
 async def join_room(
-    db: AsyncSession, room_code: str, payload: JoinRoomBody, user: User | None
+    db: AsyncSession, room_code: str, payload: JoinRoomBody, user: User
 ) -> RoomCreateResult:
-    """用房间码加入房间。"""
+    """用房间码加入房间；**已经是成员则幂等返回既有身份**（issue #106）。
+
+    改动前这里有两个各自独立的缺陷：
+
+    1. 开头一律 `if room.phase != "Lobby": raise` —— 把「中途加入」和「掉线重连」
+       当成同一件事拒掉。前者确实该拒（本期不做中途加入），后者是核心能力，
+       结果就是刷新/断线后必现 409、回不到自己那局。
+    2. 全程不检查调用者是不是已经在房间里，无条件新建 `Player` —— 同一个人重复
+       加入会生成重复玩家行、虚增人数直到撞满员。前端注释写的「已是本房间玩家
+       则幂等返回已有身份」是假的。
+
+    幂等键取**账号**而不是 `reconnect_token`：后者存在浏览器会话里，换设备、清缓存
+    就没了，而「换设备也能回到这局」正是账号体系被引入的理由。两者分工不变——
+    账号解决跨设备/跨时间找回，`reconnect_token` 解决同一局内的快速重连。
+    """
     room = await db.scalar(select(Room).where(Room.room_code == room_code))
     if room is None:
         raise RoomNotFoundError("房间不存在")
+
+    # 先看是不是老成员：是的话直接把既有身份还回去，不受阶段和人数上限影响
+    # （重连的人本来就已经占着那个位置，拿满员去拦他没有道理）。
+    existing = await db.scalar(
+        select(Player).where(Player.room_id == room.id, Player.user_id == user.id)
+    )
+    if existing is not None:
+        return RoomCreateResult(
+            room_id=room.id,
+            room_code=room_code,
+            reconnect_token=existing.reconnect_token,
+            player_id=existing.id,
+        )
+
+    # 到这里说明是新人。新人只能在大厅阶段加入：游戏已经开始/结束之后再放人
+    # 进来，等于中途加入，本期不做。
     if room.phase != "Lobby":
         raise RoomConflictError("游戏已开始，无法加入房间")
 
@@ -210,7 +240,7 @@ async def join_room(
 
     player = Player(
         room_id=room.id,
-        user_id=user.id if user else None,
+        user_id=user.id,
         nickname=payload.nickname or "玩家",
         is_host=False,
         joined_at=datetime.now(UTC),
@@ -313,26 +343,38 @@ async def begin_game(db: AsyncSession, room_id: str, player_id: str) -> None:
     await db.commit()
 
 
-async def list_my_rooms(db: AsyncSession, reconnect_token: str | None) -> list[MyRoomSummary]:
-    """根据重连凭证获取当前玩家加入的房间（一个重连凭证只对应一名玩家/一个房间）。"""
-    player = await get_player_by_reconnect_token(db, reconnect_token)
-    room = await db.get(Room, player.room_id)
-    if room is None:
+async def list_my_rooms(db: AsyncSession, user: User) -> list[MyRoomSummary]:
+    """当前**账号**参与过的全部房间，最近活跃的排在前面（issue #106）。
+
+    改动前这里是按 `reconnect_token` 查的，而一个重连凭证只对应一名玩家、一个
+    房间——所以「我的游戏」实际上是「这个浏览器的最后一个房间」，换台设备就什么
+    都看不到。账号体系当初正是为「换设备找回游戏」引入的，这里按 `user_id` 查才
+    兑现了那个目的。
+    """
+    players = await db.scalars(select(Player).where(Player.user_id == user.id))
+    room_ids = [p.room_id for p in players]
+    if not room_ids:
         return []
-    count_result = await db.scalars(select(Player).where(Player.room_id == room.id))
-    player_count = len(list(count_result))
-    return [
-        MyRoomSummary(
-            room_id=room.id,
-            room_code=room.room_code,
-            room_name=room.room_name,
-            phase=room.phase,
-            module_title=await _module_title(db, room.scenario_id),
-            player_count=player_count,
-            max_players=room.max_players,
-            updated_at=room.updated_at,
+
+    rooms = await db.scalars(
+        select(Room).where(Room.id.in_(room_ids)).order_by(Room.updated_at.desc())
+    )
+    summaries: list[MyRoomSummary] = []
+    for room in rooms:
+        count_result = await db.scalars(select(Player).where(Player.room_id == room.id))
+        summaries.append(
+            MyRoomSummary(
+                room_id=room.id,
+                room_code=room.room_code,
+                room_name=room.room_name,
+                phase=room.phase,
+                module_title=await _module_title(db, room.scenario_id),
+                player_count=len(list(count_result)),
+                max_players=room.max_players,
+                updated_at=room.updated_at,
+            )
         )
-    ]
+    return summaries
 
 
 async def end_game(db: AsyncSession, room_id: str, reconnect_token: str | None) -> None:

--- a/trpg-backend/tests/conftest.py
+++ b/trpg-backend/tests/conftest.py
@@ -7,7 +7,7 @@
 """
 
 import tempfile
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
 
 import pytest
@@ -84,6 +84,28 @@ async def db_session() -> AsyncGenerator[AsyncSession, None]:
     """
     async with TestSessionLocal() as session:
         yield session
+
+
+@pytest.fixture
+def sql_counter() -> Generator[list[str], None, None]:
+    """记录这段测试期间真实执行的 SQL 语句，用来断言"查询数不随数据量增长"。
+
+    给 N+1 查询这类问题用：光看接口返回值是对的看不出它发了多少条查询，而 N+1
+    的症状要到数据量长起来才显现——那时候再发现就晚了。断言用"总数有上限"而不是
+    "等于某个具体值"，免得以后加一条无关查询就误报。
+    """
+    from sqlalchemy import event
+
+    executed: list[str] = []
+
+    def record(conn, cursor, statement, parameters, context, executemany) -> None:  # noqa: ANN001
+        executed.append(statement)
+
+    event.listen(test_engine.sync_engine, "before_cursor_execute", record)
+    try:
+        yield executed
+    finally:
+        event.remove(test_engine.sync_engine, "before_cursor_execute", record)
 
 
 @pytest.fixture

--- a/trpg-backend/tests/helpers.py
+++ b/trpg-backend/tests/helpers.py
@@ -1,0 +1,83 @@
+"""测试共用的账号 / 房间辅助。
+
+issue #106 起创建和加入房间都要求登录，于是几乎每个房间相关的用例开头都要先
+「注册一个账号 → 带着 token 建房」。三个测试模块（rooms / characters / ws）
+原来各自维护一份 `create_room`，那样要改三遍，所以抽到这里。
+
+⚠️ 不要从 `conftest.py` 里 import 这些（见 conftest 的说明）——那会把 conftest
+当成另一个模块再导入一次、连带新建一个引擎，表建在旧引擎上，结果是 no such table。
+"""
+
+from httpx import AsyncClient
+
+AUTH_BASE = "/api/v1/auth"
+ROOMS_BASE = "/api/v1/rooms"
+
+
+_account_seq = 0
+
+
+async def register(
+    client: AsyncClient, account: str | None = None, nickname: str = "测试员"
+) -> str:
+    """注册一个账号，返回登录 token。
+
+    不传 `account` 就自动取一个唯一的（`user1`、`user2`…）。默认唯一而不是默认
+    固定，是因为账号重复注册会 409——一个用例里建两个房间、或者一主一客，用固定
+    默认值就会莫名其妙地失败在注册那一步，而不是失败在它真正想测的东西上。
+
+    **需要"同一个人"时要显式传同一个 `account`**：房间成员的幂等键是账号，同一个
+    账号第二次 join 会被当成重连、原样返回既有身份，而不是加入一个新玩家。
+    """
+    global _account_seq
+    if account is None:
+        _account_seq += 1
+        account = f"user{_account_seq}"
+    response = await client.post(
+        f"{AUTH_BASE}/register",
+        json={"account": account, "password": "secret1", "nickname": nickname},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["data"]["token"]
+
+
+def bearer(token: str) -> dict[str, str]:
+    """账号身份：`Authorization: Bearer <token>`。"""
+    return {"Authorization": f"Bearer {token}"}
+
+
+def reconnect(token: str) -> dict[str, str]:
+    """房间身份：`X-Reconnect-Token: <token>`。"""
+    return {"X-Reconnect-Token": token}
+
+
+async def create_room(
+    client: AsyncClient,
+    token: str | None = None,
+    max_players: int = 4,
+    room_name: str = "测试房间",
+    nickname: str = "房主",
+) -> dict:
+    """建一个房间。`token` 不传就现注册一个账号。"""
+    if token is None:
+        token = await register(client)
+    response = await client.post(
+        ROOMS_BASE,
+        json={"roomName": room_name, "nickname": nickname, "maxPlayers": max_players},
+        headers=bearer(token),
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["data"]
+
+
+async def join_room(
+    client: AsyncClient, room_code: str, token: str, nickname: str = "玩家"
+) -> dict:
+    """用房间码加入房间，返回房间身份信息。"""
+    response = await client.post(
+        f"{ROOMS_BASE}/{room_code}/join",
+        json={"nickname": nickname},
+        headers=bearer(token),
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["data"]

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -1,6 +1,6 @@
 from httpx import AsyncClient
 
-ROOMS_BASE = "/api/v1/rooms"
+from tests.helpers import ROOMS_BASE, create_room, join_room, reconnect, register
 
 BUILT_CHARACTER = {
     "name": "陈探员",
@@ -29,23 +29,11 @@ BUILT_CHARACTER = {
 }
 
 
-async def create_room(client: AsyncClient) -> dict:
-    response = await client.post(
-        ROOMS_BASE, json={"roomName": "测试房间", "nickname": "房主", "maxPlayers": 4}
-    )
-    assert response.status_code == 200
-    return response.json()["data"]
-
-
-def auth(token: str) -> dict[str, str]:
-    return {"X-Reconnect-Token": token}
-
-
 async def test_full_character_build_flow_marks_player_ready(client: AsyncClient) -> None:
     room = await create_room(client)
 
     draft = await client.post(
-        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=reconnect(room["reconnectToken"])
     )
     assert draft.status_code == 201
     character_id = draft.json()["data"]["characterId"]
@@ -54,13 +42,13 @@ async def test_full_character_build_flow_marks_player_ready(client: AsyncClient)
     saved = await client.patch(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
         json=BUILT_CHARACTER,
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     assert saved.status_code == 200
 
     completed = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/complete",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     assert completed.status_code == 200
 
@@ -79,18 +67,16 @@ async def test_create_character_requires_token(client: AsyncClient) -> None:
 
 async def test_cannot_edit_another_players_character(client: AsyncClient) -> None:
     room = await create_room(client)
-    joined = (
-        await client.post(f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "玩家"})
-    ).json()["data"]
+    joined = await join_room(client, room["roomCode"], await register(client))
     draft = await client.post(
-        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=reconnect(room["reconnectToken"])
     )
     character_id = draft.json()["data"]["characterId"]
 
     response = await client.patch(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
         json=BUILT_CHARACTER,
-        headers=auth(joined["reconnectToken"]),
+        headers=reconnect(joined["reconnectToken"]),
     )
 
     assert response.status_code == 403
@@ -101,7 +87,7 @@ async def test_character_not_found_returns_404(client: AsyncClient) -> None:
 
     response = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/missing/complete",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     assert response.status_code == 404
@@ -112,7 +98,7 @@ async def test_complete_character_rejects_invalid_card(client: AsyncClient) -> N
     技能点花费远超预算）直接被拒，返回结构化校验报告，而不是被静默放行。"""
     room = await create_room(client)
     draft = await client.post(
-        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=reconnect(room["reconnectToken"])
     )
     character_id = draft.json()["data"]["characterId"]
 
@@ -135,13 +121,13 @@ async def test_complete_character_rejects_invalid_card(client: AsyncClient) -> N
     saved = await client.patch(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
         json=invalid_character,
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     assert saved.status_code == 200
 
     response = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/complete",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     assert response.status_code == 422
@@ -164,18 +150,18 @@ async def test_get_character_reads_back_saved_card(client: AsyncClient) -> None:
     """
     room = await create_room(client)
     draft = await client.post(
-        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=reconnect(room["reconnectToken"])
     )
     character_id = draft.json()["data"]["characterId"]
     await client.patch(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
         json=BUILT_CHARACTER,
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     response = await client.get(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     assert response.status_code == 200
@@ -196,18 +182,18 @@ async def test_roll_attributes_marks_card_as_rolled(client: AsyncClient) -> None
     """
     room = await create_room(client)
     draft = await client.post(
-        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=reconnect(room["reconnectToken"])
     )
     character_id = draft.json()["data"]["characterId"]
 
     await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-attributes",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     read_back = await client.get(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     assert read_back.json()["data"]["generationMethod"] == "roll"
 
@@ -223,12 +209,12 @@ async def test_replacing_rolled_attributes_falls_back_to_point_buy(client: Async
     """
     room = await create_room(client)
     draft = await client.post(
-        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=reconnect(room["reconnectToken"])
     )
     character_id = draft.json()["data"]["characterId"]
     await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-attributes",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     maxed = {
@@ -239,18 +225,18 @@ async def test_replacing_rolled_attributes_falls_back_to_point_buy(client: Async
     await client.patch(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
         json=maxed,
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     read_back = await client.get(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     assert read_back.json()["data"]["generationMethod"] == "pointbuy"
 
     completed = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/complete",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     assert completed.status_code == 422
     codes = [issue["code"] for issue in completed.json()["error"]["details"]]
@@ -266,25 +252,25 @@ async def test_saving_a_rolled_card_unchanged_keeps_roll_method(client: AsyncCli
     """
     room = await create_room(client)
     draft = await client.post(
-        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=reconnect(room["reconnectToken"])
     )
     character_id = draft.json()["data"]["characterId"]
     rolled = (
         await client.post(
             f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-attributes",
-            headers=auth(room["reconnectToken"]),
+            headers=reconnect(room["reconnectToken"]),
         )
     ).json()["data"]["attributes"]
 
     await client.patch(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
         json={**BUILT_CHARACTER, "attributes": rolled},
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     read_back = await client.get(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     assert read_back.json()["data"]["generationMethod"] == "roll"
 
@@ -292,17 +278,15 @@ async def test_saving_a_rolled_card_unchanged_keeps_roll_method(client: AsyncCli
 async def test_cannot_read_another_players_character(client: AsyncClient) -> None:
     """角色卡里有背景故事/装备这类属于该玩家的信息，别人不能直接拉。"""
     room = await create_room(client)
-    joined = (
-        await client.post(f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "玩家"})
-    ).json()["data"]
+    joined = await join_room(client, room["roomCode"], await register(client))
     draft = await client.post(
-        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=auth(room["reconnectToken"])
+        f"{ROOMS_BASE}/{room['roomId']}/characters", headers=reconnect(room["reconnectToken"])
     )
     character_id = draft.json()["data"]["characterId"]
 
     response = await client.get(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
-        headers=auth(joined["reconnectToken"]),
+        headers=reconnect(joined["reconnectToken"]),
     )
 
     assert response.status_code == 403

--- a/trpg-backend/tests/test_rooms.py
+++ b/trpg-backend/tests/test_rooms.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from httpx import AsyncClient
 
 from tests.helpers import ROOMS_BASE, bearer, create_room, join_room, reconnect, register
@@ -217,6 +219,28 @@ async def test_list_my_rooms_does_not_leak_other_accounts(client: AsyncClient) -
     response = await client.get("/api/v1/me/rooms", headers=bearer(mine_token))
 
     assert [room["roomId"] for room in response.json()["data"]] == [mine["roomId"]]
+
+
+async def test_timestamps_are_returned_with_timezone(client: AsyncClient) -> None:
+    """🔴 对外暴露的时间必须带时区后缀。
+
+    数据库里写的是 `datetime.now(UTC)`，但 **SQLite 不保存时区信息**，读出来是
+    naive datetime，序列化就成了 `2026-07-21T09:35:13.095627`——没有任何后缀。
+    客户端按 ECMAScript 规则会把它当**本地时间**解析，于是「4 分钟前」在 UTC+8
+    的机器上显示成「8 小时前」，偏差正好是时区偏移量（真机验证时实测到的）。
+
+    这不是客户端该自己猜的事：光看字符串无从判断它是 UTC 还是本地时间。
+    """
+    token = await register(client)
+    await create_room(client, token=token)
+
+    rooms = (await client.get("/api/v1/me/rooms", headers=bearer(token))).json()["data"]
+
+    updated_at = rooms[0]["updatedAt"]
+    assert updated_at.endswith("Z") or "+" in updated_at, (
+        f"时间戳缺时区后缀：{updated_at}——客户端会把它当本地时间解析"
+    )
+    assert datetime.fromisoformat(updated_at).tzinfo is not None
 
 
 async def test_list_my_rooms_requires_login(client: AsyncClient) -> None:

--- a/trpg-backend/tests/test_rooms.py
+++ b/trpg-backend/tests/test_rooms.py
@@ -1,57 +1,133 @@
 from httpx import AsyncClient
 
-ROOMS_BASE = "/api/v1/rooms"
-
-
-async def create_room(client: AsyncClient, max_players: int = 4) -> dict:
-    response = await client.post(
-        ROOMS_BASE,
-        json={"roomName": "测试房间", "nickname": "房主", "maxPlayers": max_players},
-    )
-    assert response.status_code == 200
-    return response.json()["data"]
-
-
-def auth(token: str) -> dict[str, str]:
-    return {"X-Reconnect-Token": token}
+from tests.helpers import ROOMS_BASE, bearer, create_room, join_room, reconnect, register
 
 
 async def test_join_rejects_full_room(client: AsyncClient) -> None:
     room = await create_room(client, max_players=1)
+    latecomer = await register(client)
 
-    response = await client.post(f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "玩家"})
+    response = await client.post(
+        f"{ROOMS_BASE}/{room['roomCode']}/join",
+        json={"nickname": "玩家"},
+        headers=bearer(latecomer),
+    )
 
     assert response.status_code == 409
     # 满房间返回更具体的 ROOM_FULL（issue #77 新增的业务错误码），不再是泛化的 CONFLICT。
     assert response.json()["error"]["code"] == "ROOM_FULL"
 
 
-async def test_join_rejects_room_after_story_starts(client: AsyncClient) -> None:
+async def test_join_rejects_new_player_after_story_starts(client: AsyncClient) -> None:
+    """中途加入仍然拒绝——但这条只针对**新人**，老成员重连见下面那条对照用例。"""
     room = await create_room(client)
     module_id = (await client.get("/api/v1/modules")).json()["data"][0]["id"]
     await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/module",
         json={"moduleId": module_id, "attributeGenMethod": "point_buy"},
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/start-story",
         json=None,
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
+    latecomer = await register(client)
 
     response = await client.post(
-        f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "迟到玩家"}
+        f"{ROOMS_BASE}/{room['roomCode']}/join",
+        json={"nickname": "迟到玩家"},
+        headers=bearer(latecomer),
     )
 
     assert response.status_code == 409
 
 
+async def test_rejoin_is_idempotent_and_returns_the_same_identity(client: AsyncClient) -> None:
+    """🔴 同一个账号重复加入 = 重连，必须拿回**同一个** playerId，且不新增玩家行。
+
+    改动前 `join_room` 全程不检查调用者是不是已经在房间里，无条件新建 `Player`
+    ——同一个人重复加入会生成重复玩家行、虚增人数直到撞满员。
+    """
+    room = await create_room(client, max_players=4)
+    guest_token = await register(client)
+    first = await join_room(client, room["roomCode"], guest_token)
+
+    second = await join_room(client, room["roomCode"], guest_token)
+
+    assert second["playerId"] == first["playerId"]
+    assert second["reconnectToken"] == first["reconnectToken"]
+
+    preview = await client.get(f"{ROOMS_BASE}/{room['roomCode']}")
+    assert len(preview.json()["data"]["players"]) == 2, "重复加入不该多出一个玩家"
+
+
+async def test_existing_member_can_rejoin_after_story_starts(client: AsyncClient) -> None:
+    """🔴 老成员在 Building 阶段必须能重连回来——这是 #106 要修的核心缺陷。
+
+    改动前 `join_room` 开头一律 `if room.phase != "Lobby": raise`，把「中途加入」
+    和「掉线重连」当成同一件事拒掉，结果刷新/断线后必现 409、回不到自己那局。
+    跟上面 `test_join_rejects_new_player_after_story_starts` 是一对对照：新人要拒、
+    老成员要放行，只测一边的话，"一刀切拒绝"和"一刀切放行"各能通过一条。
+    """
+    room = await create_room(client)
+    guest_token = await register(client)
+    joined = await join_room(client, room["roomCode"], guest_token)
+
+    module_id = (await client.get("/api/v1/modules")).json()["data"][0]["id"]
+    await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/module",
+        json={"moduleId": module_id, "attributeGenMethod": "point_buy"},
+        headers=reconnect(room["reconnectToken"]),
+    )
+    await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/start-story",
+        json=None,
+        headers=reconnect(room["reconnectToken"]),
+    )
+
+    response = await client.post(
+        f"{ROOMS_BASE}/{room['roomCode']}/join",
+        json={"nickname": "访客"},
+        headers=bearer(guest_token),
+    )
+
+    assert response.status_code == 200, "老成员重连不该被阶段拦住"
+    assert response.json()["data"]["playerId"] == joined["playerId"]
+
+
+async def test_rejoin_is_not_blocked_by_a_full_room(client: AsyncClient) -> None:
+    """满员不该拦住老成员重连——他本来就已经占着那个位置。"""
+    room = await create_room(client, max_players=2)
+    guest_token = await register(client)
+    joined = await join_room(client, room["roomCode"], guest_token)
+
+    response = await client.post(
+        f"{ROOMS_BASE}/{room['roomCode']}/join",
+        json={"nickname": "玩家"},
+        headers=bearer(guest_token),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["playerId"] == joined["playerId"]
+
+
+async def test_created_room_is_linked_to_the_account(client: AsyncClient) -> None:
+    """建房要把房间和房主玩家都关联到真实账号，不能留空。"""
+    token = await register(client, account="host")
+    room = await create_room(client, token=token)
+
+    rooms = (await client.get("/api/v1/me/rooms", headers=bearer(token))).json()["data"]
+
+    assert [r["roomId"] for r in rooms] == [room["roomId"]], (
+        "房间没跟账号关联上，「我的游戏」就查不到它"
+    )
+
+
 async def test_host_operations_require_host_token(client: AsyncClient) -> None:
     room = await create_room(client)
-    joined = (
-        await client.post(f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "玩家"})
-    ).json()["data"]
+    guest_token = await register(client)
+    joined = await join_room(client, room["roomCode"], guest_token)
     module_id = (await client.get("/api/v1/modules")).json()["data"][0]["id"]
 
     missing = await client.post(
@@ -61,7 +137,7 @@ async def test_host_operations_require_host_token(client: AsyncClient) -> None:
     non_host = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/module",
         json={"moduleId": module_id, "attributeGenMethod": "point_buy"},
-        headers=auth(joined["reconnectToken"]),
+        headers=reconnect(joined["reconnectToken"]),
     )
 
     assert missing.status_code == 401
@@ -74,33 +150,87 @@ async def test_select_module_validates_room_and_module(client: AsyncClient) -> N
     missing_room = await client.post(
         f"{ROOMS_BASE}/missing/module",
         json={"moduleId": "missing", "attributeGenMethod": "point_buy"},
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
     missing_module = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/module",
         json={"moduleId": "missing", "attributeGenMethod": "point_buy"},
-        headers=auth(room["reconnectToken"]),
+        headers=reconnect(room["reconnectToken"]),
     )
 
     assert missing_room.status_code == 404
     assert missing_module.status_code == 404
 
 
-async def test_list_my_rooms_filters_by_token(client: AsyncClient) -> None:
-    first = await create_room(client)
-    await create_room(client)
+async def test_create_and_join_require_login(client: AsyncClient) -> None:
+    """issue #106：创建和加入房间都要求登录。
 
-    response = await client.get("/api/v1/me/rooms", headers=auth(first["reconnectToken"]))
+    改动前它们用的是"登录可选"的依赖，于是 `host_user_id`/`user_id` 永远是空的
+    ——一个可以不填的身份字段，在没人强制时就永远不会被填上。
+    """
+    no_auth_create = await client.post(
+        ROOMS_BASE, json={"roomName": "房间", "nickname": "房主", "maxPlayers": 4}
+    )
+    assert no_auth_create.status_code == 401
+
+    room = await create_room(client)
+    no_auth_join = await client.post(
+        f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "玩家"}
+    )
+    assert no_auth_join.status_code == 401
+
+    bad_token_join = await client.post(
+        f"{ROOMS_BASE}/{room['roomCode']}/join",
+        json={"nickname": "玩家"},
+        headers=bearer("not-a-real-token"),
+    )
+    assert bad_token_join.status_code == 401
+
+
+async def test_list_my_rooms_returns_all_rooms_of_the_account(client: AsyncClient) -> None:
+    """「我的游戏」按账号返回**全部**房间（issue #106）。
+
+    改动前是按 `reconnect_token` 查的，而一个凭证只对应一名玩家/一个房间——
+    「我的游戏」实际上是「这个浏览器的最后一个房间」，换台设备就什么都看不到。
+    """
+    token = await register(client, account="owner")
+    first = await create_room(client, token=token, room_name="第一间")
+    second = await create_room(client, token=token, room_name="第二间")
+
+    response = await client.get("/api/v1/me/rooms", headers=bearer(token))
 
     assert response.status_code == 200
-    rooms = response.json()["data"]
-    assert [room["roomId"] for room in rooms] == [first["roomId"]]
+    room_ids = {room["roomId"] for room in response.json()["data"]}
+    assert room_ids == {first["roomId"], second["roomId"]}
+
+
+async def test_list_my_rooms_does_not_leak_other_accounts(client: AsyncClient) -> None:
+    """上一条的对照面：只按账号过滤，别人的房间不能出现在我的列表里。
+
+    只测「返回了我的两个房间」的话，一个"返回全部房间"的错误实现照样能通过。
+    """
+    mine_token = await register(client, account="mine")
+    mine = await create_room(client, token=mine_token)
+    other_token = await register(client, account="other")
+    await create_room(client, token=other_token)
+
+    response = await client.get("/api/v1/me/rooms", headers=bearer(mine_token))
+
+    assert [room["roomId"] for room in response.json()["data"]] == [mine["roomId"]]
+
+
+async def test_list_my_rooms_requires_login(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/me/rooms")
+
+    assert response.status_code == 401
 
 
 async def test_room_text_fields_reject_whitespace(client: AsyncClient) -> None:
+    token = await register(client)
     response = await client.post(
         ROOMS_BASE,
         json={"roomName": "   ", "nickname": "房主", "maxPlayers": 4},
+        headers=bearer(token),
     )
 
     assert response.status_code == 422
@@ -119,11 +249,13 @@ async def test_replay_requires_room_member_token(client: AsyncClient) -> None:
     # 别的房间的成员凭证 → 403（凭证有效但不是这个房间的成员）
     other = await create_room(client)
     wrong_room = await client.get(
-        f"{ROOMS_BASE}/{room_id}/replay", headers=auth(other["reconnectToken"])
+        f"{ROOMS_BASE}/{room_id}/replay", headers=reconnect(other["reconnectToken"])
     )
     assert wrong_room.status_code == 403
 
     # 本房间成员凭证 → 200
-    ok = await client.get(f"{ROOMS_BASE}/{room_id}/replay", headers=auth(room["reconnectToken"]))
+    ok = await client.get(
+        f"{ROOMS_BASE}/{room_id}/replay", headers=reconnect(room["reconnectToken"])
+    )
     assert ok.status_code == 200
     assert ok.json()["data"] == []

--- a/trpg-backend/tests/test_rooms.py
+++ b/trpg-backend/tests/test_rooms.py
@@ -1,7 +1,12 @@
 from datetime import datetime
 
+import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.room import Player
 from tests.helpers import ROOMS_BASE, bearer, create_room, join_room, reconnect, register
 
 
@@ -112,6 +117,97 @@ async def test_rejoin_is_not_blocked_by_a_full_room(client: AsyncClient) -> None
 
     assert response.status_code == 200
     assert response.json()["data"]["playerId"] == joined["playerId"]
+
+
+async def test_unique_constraint_blocks_duplicate_player_rows(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """🔴 「一个账号在一个房间里只有一名玩家」必须由**数据库**保证（PR #110 review [2]）。
+
+    service 层那段「先查有没有、没有才插」是 check-then-act：两个并发请求会同时
+    查到「不存在」然后各插一行，幂等承诺当场失效、房间人数还会虚增。所以真正的
+    不变式落在 `players` 的 `uq_players_room_user` 唯一约束上，service 只负责捕获
+    `IntegrityError` 后把撞上的那一方收敛成和先到者一样的结果。
+
+    这里直接往库里插重复行来证明**约束真的会咬人**——只测 service 的话，约束漏建
+    了测试照样绿（service 那条 if 会先挡住），等真出现并发才暴露。
+    并发下的收敛行为用真实 HTTP 并发验证（见 PR 说明），测试装置里的
+    `ASGITransport` + aiosqlite 并发建连接会报 MissingGreenlet，测不了。
+    """
+    room = await create_room(client)
+    guest_token = await register(client)
+    joined = await join_room(client, room["roomCode"], guest_token)
+
+    player = await db_session.scalar(select(Player).where(Player.id == joined["playerId"]))
+    assert player is not None
+
+    db_session.add(
+        Player(
+            room_id=player.room_id,
+            user_id=player.user_id,
+            nickname="影子玩家",
+            is_host=False,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_join_returns_existing_character_id_for_reconnect(client: AsyncClient) -> None:
+    """🔴 重连要能拿回自己那张角色卡的 id（PR #110 review [1]）。
+
+    客户端靠 `characterId` 才知道去拉哪张卡。在此之前这个 id 只在建卡那一刻由
+    客户端自己存着——**换台设备就永远拿不回来**，已经建完卡的人重连后会显示成
+    「还没建卡」、被引导去建第二张。服务端本来就知道答案，直接给。
+    """
+    room = await create_room(client)
+    guest_token = await register(client)
+    joined = await join_room(client, room["roomCode"], guest_token)
+    assert joined["characterId"] is None, "还没建卡时应该是 None"
+
+    draft = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters",
+        headers=reconnect(joined["reconnectToken"]),
+    )
+    character_id = draft.json()["data"]["characterId"]
+
+    rejoined = await join_room(client, room["roomCode"], guest_token)
+
+    assert rejoined["characterId"] == character_id
+
+
+async def test_list_my_rooms_query_count_does_not_grow_with_rooms(
+    client: AsyncClient, sql_counter: list[str]
+) -> None:
+    """🔴 `/me/rooms` 的查询数必须跟房间数无关（PR #110 review [3]）。
+
+    第一版在循环里逐个房间查人数、查模组标题，N 个房间约 `2N+2` 条查询。这个接口
+    正是 #106 让它从「最多一个房间」变成「该账号全部房间」的，N 会真的长起来。
+
+    用 SQLAlchemy 的 `before_cursor_execute` 数真实 SQL 条数：断言"总数有上限"而
+    不是"等于某个具体值"，免得以后加一列无关的查询就误报。
+    """
+    token = await register(client, account="counter")
+    module_id = (await client.get("/api/v1/modules")).json()["data"][0]["id"]
+    for index in range(6):
+        room = await create_room(client, token=token, room_name=f"房间{index}")
+        # ⚠️ 必须真的选上模组：`_module_title` 在 `scenario_id` 为 NULL 时直接早退、
+        # 一条查询都不发。第一版没选模组，于是"每个房间查一次标题"这条 N+1 路径
+        # 根本没被触发——测试照样绿，是变异检验才发现的。
+        await client.post(
+            f"{ROOMS_BASE}/{room['roomId']}/module",
+            json={"moduleId": module_id, "attributeGenMethod": "point_buy"},
+            headers=reconnect(room["reconnectToken"]),
+        )
+
+    sql_counter.clear()  # 只数这一次请求的
+    response = await client.get("/api/v1/me/rooms", headers=bearer(token))
+
+    assert len(response.json()["data"]) == 6
+    assert len(sql_counter) <= 8, (
+        f"6 个房间发了 {len(sql_counter)} 条查询，说明查询数随房间数增长：\n"
+        + "\n".join(sql_counter)
+    )
 
 
 async def test_created_room_is_linked_to_the_account(client: AsyncClient) -> None:

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -23,9 +23,28 @@ def register_and_login(client: TestClient, account: str = "host1") -> str:
     return response.json()["data"]["token"]
 
 
-def create_room(client: TestClient) -> dict:
+def create_room(client: TestClient, token: str) -> dict:
+    """建房（issue #106 起要求登录，房间会关联到这个账号）。"""
     response = client.post(
-        ROOMS_BASE, json={"roomName": "WS测试房间", "nickname": "房主", "maxPlayers": 4}
+        ROOMS_BASE,
+        json={"roomName": "WS测试房间", "nickname": "房主", "maxPlayers": 4},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    return response.json()["data"]
+
+
+def join_as(client: TestClient, room_code: str, account: str, nickname: str = "访客") -> dict:
+    """用一个**新账号**加入房间。
+
+    必须是新账号：房间成员的幂等键是账号，拿房主的 token 再 join 会被当成重连、
+    原样返回房主身份，测不出"两个人"。
+    """
+    token = register_and_login(client, account)
+    response = client.post(
+        f"{ROOMS_BASE}/{room_code}/join",
+        json={"nickname": nickname},
+        headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
     return response.json()["data"]
@@ -74,7 +93,7 @@ def advance_to_building(client: TestClient, room: dict) -> None:
 
 
 def test_connect_without_token_is_rejected(sync_client: TestClient) -> None:
-    room = create_room(sync_client)
+    room = create_room(sync_client, register_and_login(sync_client))
 
     with pytest.raises(WebSocketDisconnect), sync_client.websocket_connect(f"/ws/{room['roomId']}"):
         pass
@@ -82,7 +101,7 @@ def test_connect_without_token_is_rejected(sync_client: TestClient) -> None:
 
 def test_room_join_binds_session(sync_client: TestClient) -> None:
     token = register_and_login(sync_client)
-    room = create_room(sync_client)
+    room = create_room(sync_client, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
         ws.send_json(
@@ -106,7 +125,7 @@ def test_room_join_binds_session(sync_client: TestClient) -> None:
 
 def test_room_join_with_unknown_player_closes_connection(sync_client: TestClient) -> None:
     token = register_and_login(sync_client)
-    room = create_room(sync_client)
+    room = create_room(sync_client, token)
 
     with (
         pytest.raises(WebSocketDisconnect),
@@ -126,7 +145,7 @@ def test_room_join_rejects_wrong_reconnect_token(sync_client: TestClient) -> Non
     """拿对的 playerId 但错的 reconnect_token 不能绑定——否则任何登录账号都能
     用公开预览里暴露的 playerId 冒充别人（PR #78 review）。"""
     host_token = register_and_login(sync_client, "host_real")
-    room = create_room(sync_client)
+    room = create_room(sync_client, host_token)
     # 一个"攻击者"账号，登录态有效，但没有房主的 reconnect_token。
     attacker_token = register_and_login(sync_client, "attacker")
 
@@ -157,7 +176,7 @@ def test_room_join_rejects_wrong_reconnect_token(sync_client: TestClient) -> Non
 
 def test_player_ready_updates_room_state(sync_client: TestClient) -> None:
     token = register_and_login(sync_client)
-    room = create_room(sync_client)
+    room = create_room(sync_client, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
         ws.send_json(
@@ -191,7 +210,7 @@ def test_game_start_pushes_opening_narration_and_advances_phase(
     sync_client: TestClient,
 ) -> None:
     token = register_and_login(sync_client)
-    room = create_room(sync_client)
+    room = create_room(sync_client, token)
     advance_to_building(sync_client, room)
     complete_character(sync_client, room["roomId"], room["reconnectToken"])
 
@@ -216,12 +235,10 @@ def test_game_start_pushes_opening_narration_and_advances_phase(
 
 def test_game_start_rejects_non_host(sync_client: TestClient) -> None:
     token = register_and_login(sync_client)
-    room = create_room(sync_client)
+    room = create_room(sync_client, token)
     # 访客必须在 Lobby 阶段加入（join_room 只在这个阶段放行），所以先加入
     # 再推进到 Building，两人都建完卡后再让访客尝试 game.start。
-    guest = sync_client.post(
-        f"{ROOMS_BASE}/{room['roomCode']}/join", json={"nickname": "访客"}
-    ).json()["data"]
+    guest = join_as(sync_client, room["roomCode"], "guest_non_host")
     advance_to_building(sync_client, room)
     complete_character(sync_client, room["roomId"], room["reconnectToken"])
     complete_character(sync_client, room["roomId"], guest["reconnectToken"])
@@ -251,8 +268,8 @@ def test_game_start_rejects_non_host(sync_client: TestClient) -> None:
 def test_action_submit_broadcasts_narration_to_room_only(sync_client: TestClient) -> None:
     token_a = register_and_login(sync_client, "host_a")
     token_b = register_and_login(sync_client, "host_b")
-    room_a = create_room(sync_client)
-    room_b = create_room(sync_client)
+    room_a = create_room(sync_client, token_a)
+    room_b = create_room(sync_client, token_b)
 
     with (
         sync_client.websocket_connect(f"/ws/{room_a['roomId']}?token={token_a}") as ws_a,

--- a/trpg-frontend/src/routes/lobby/LobbyPage.tsx
+++ b/trpg-frontend/src/routes/lobby/LobbyPage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef } from 'react'
 import { UserPlus, ArrowLeft } from 'lucide-react'
 import { useRoomStore } from '@/stores/room-store'
 import { useAuthStore } from '@/stores/auth-store'
-import { connectWebSocket, sdk, onWsMessage, waitForWsOpen, disconnectWebSocket } from '@/services/api-client'
+import { connectWebSocket, sdk, onWsMessage, waitForWsOpen, disconnectWebSocket, friendlyErrorMessage } from '@/services/api-client'
 import { startStory } from '@/services/room'
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 
@@ -64,6 +64,7 @@ export default function LobbyPage() {
   const nonHostPlayers = players.filter((p) => !p.isHost)
   const allReady = players.length > 0 && nonHostPlayers.every((p) => p.ready)
   const [starting, setStarting] = useState(false)
+  const [startError, setStartError] = useState('')
 
   // ★ 全员就绪只是"可以开始"的前提，不代表自动开始——房主必须主动点"开始
   // 游戏"才真正推进（见反馈：不应该默认自动跳转）。访客端没有这个按钮，
@@ -79,9 +80,19 @@ export default function LobbyPage() {
   const handleStartStory = async () => {
     if (!roomId || !allReady) return
     setStarting(true)
-    await startStory(roomId)
-    advancedRef.current = true
-    navigate('/room/story')
+    // 失败必须复位 starting、并且把原因显示出来。原来这里既没有 catch 也没有
+    // finally——后端一旦拒绝（比如房间已经过了大厅阶段会返回 409），按钮就永久
+    // 卡在「开始中…」，用户既走不下去也看不到任何原因，只能刷新页面。
+    try {
+      setStartError('')
+      await startStory(roomId)
+      advancedRef.current = true
+      navigate('/room/story')
+    } catch (err) {
+      setStartError(friendlyErrorMessage(err, '开始游戏失败'))
+    } finally {
+      setStarting(false)
+    }
   }
 
   const toggleReady = () => {
@@ -195,6 +206,9 @@ export default function LobbyPage() {
           <UserPlus className="w-4 h-4" />
           {ready ? '取消就绪' : '标记为已就绪'}
         </button>
+      )}
+      {startError && (
+        <p className="text-center text-xs text-[#c04040] mt-2">{startError}</p>
       )}
 
       <p className="text-center text-xs text-text-muted mt-4">

--- a/trpg-frontend/src/routes/my-rooms/MyRoomsPage.tsx
+++ b/trpg-frontend/src/routes/my-rooms/MyRoomsPage.tsx
@@ -28,6 +28,17 @@ function formatTime(ts: string): string {
   return new Date(parsed).toLocaleDateString('zh-CN')
 }
 
+// 房间阶段 → 重新进入时该落到哪个页面。
+//
+// 不含 `Completed`：已完成的房间在下面是单独一个列表、走「查看复盘」按钮
+// （`/home/my-rooms/review/:roomCode`），根本不会调到 `handleResume`。放一条
+// 到不了的映射进来只会误导人——而且一旦写错路由，谁也发现不了。
+const RESUME_ROUTE: Record<string, string> = {
+  Lobby: '/room/lobby',
+  Building: '/room/ready',
+  InGame: '/room/play',
+}
+
 export default function MyRoomsPage() {
   const navigate = useNavigate()
   const nickname = useAuthStore((s) => s.nickname)
@@ -55,7 +66,11 @@ export default function MyRoomsPage() {
       const me = info.players.find((p) => p.playerId === identity.playerId)
       setRoomIdentity(identity)
       setHost(me?.isHost ?? false)
-      navigate(room.phase === 'InGame' ? '/room/play' : '/room/lobby')
+      // 按房间阶段回到对应的页面。原来只区分 InGame / 其它，Building 阶段
+      // （已经过了大厅、正在建卡）会被送回大厅——而大厅的"开始游戏"在这个阶段
+      // 必然被后端 409 拒绝，用户就卡在那儿了。房间状态机是
+      // Lobby → Building → InGame → Completed，这里要一一对上。
+      navigate(RESUME_ROUTE[room.phase] ?? '/room/lobby')
     } catch (err) {
       setError(friendlyErrorMessage(err, '继续游戏失败'))
     } finally {

--- a/trpg-frontend/src/services/api-client.ts
+++ b/trpg-frontend/src/services/api-client.ts
@@ -34,6 +34,15 @@ export function getAuthToken(): string | null {
 export function friendlyErrorMessage(err: unknown, fallback = '操作失败，请稍后重试'): string {
   if (err instanceof ApiError) return err.message || fallback;
   if (err instanceof TypeError) return '网络连接失败，请检查网络后重试';
+  // 前置校验在请求发出**之前**抛的普通 Error（比如「请先登录」「缺少房间重连
+  // 凭证」），它们的 message 本来就是写给用户看的，不该被 fallback 盖掉。
+  //
+  // 盖掉的后果不只是"信息少了"，而是会主动误导：未登录时点加入房间，用户看到
+  // 的是「加入房间失败，请检查房间号」——房间号明明是对的，人会一直去查那个。
+  //
+  // TypeError 那条要留在前面：它是 fetch 的网络失败，message 是 "Failed to
+  // fetch" 这种内部文案，不适合直接展示。
+  if (err instanceof Error && err.message) return err.message;
   return fallback;
 }
 

--- a/trpg-frontend/src/services/room.ts
+++ b/trpg-frontend/src/services/room.ts
@@ -1,6 +1,6 @@
 import type { CreateRoomResult, ModuleSummary, MyRoomSummary, RoomPreview } from 'trpg-sdk';
 import { useRoomStore } from '@/stores/room-store';
-import { sdk } from './api-client';
+import { getAuthToken, sdk } from './api-client';
 
 export type { CreateRoomResult, ModuleSummary, MyRoomSummary, RoomPreview };
 
@@ -13,13 +13,25 @@ function requireReconnectToken(): string {
   return token;
 }
 
+// 创建/加入房间和「我的游戏」用的是**账号**凭证，不是上面那个房间凭证
+// （issue #106）。两者分工：账号解决跨设备/跨时间找回，reconnectToken 解决
+// 同一局进行中的快速重连。
+function requireAuthToken(): string {
+  const token = getAuthToken();
+  if (!token) throw new Error('请先登录');
+  return token;
+}
+
 // 创建房间（房主创建即加入，见 §5.2.5）
 export async function createGameRoom(
   nickname?: string,
   roomName?: string,
   maxPlayers?: number
 ): Promise<CreateRoomResult> {
-  return sdk.rooms.create({ nickname, roomName: roomName ?? '', maxPlayers: maxPlayers ?? 4 });
+  return sdk.rooms.create(
+    { nickname, roomName: roomName ?? '', maxPlayers: maxPlayers ?? 4 },
+    requireAuthToken()
+  );
 }
 
 // 拉取可用模组列表（本次没有做模组导入，只有一款内置模拟模组）
@@ -36,12 +48,15 @@ export async function selectModule(roomId: string, moduleId: string): Promise<vo
   );
 }
 
-// 访客用房间码加入（已是本房间玩家则幂等返回已有身份）
+// 用房间码加入房间。issue #106 起后端按**账号**幂等：已经是这个房间的成员时
+// 原样返回既有身份，所以这个函数同时承担「加入」和「掉线/换设备后重连」两个
+// 用途——之前那句「已是本房间玩家则幂等返回已有身份」的注释是假的，后端当时
+// 根本不检查，重复调用会给同一个人建重复玩家行。
 export async function joinRoomByCode(
   roomCode: string,
   nickname?: string
 ): Promise<CreateRoomResult> {
-  return sdk.rooms.join(roomCode, { nickname });
+  return sdk.rooms.join(roomCode, { nickname }, requireAuthToken());
 }
 
 // 获取房间信息（房间码预览）
@@ -54,11 +69,11 @@ export async function startStory(roomId: string): Promise<void> {
   await sdk.rooms.startStory(roomId, requireReconnectToken());
 }
 
-// 我的房间列表——用于「浏览已有游戏」入口。本期后端按重连凭证（而不是账号）
-// 识别玩家，只能看到当前会话里加入过的房间，还没建立跨会话的账号级房间历史
-// （已知限制）；这里在还没加入过任何房间时直接返回空列表，而不是报错。
+// 我的房间列表——用于「浏览已有游戏」入口。issue #106 起按**账号**返回该用户
+// 参与过的全部房间（换台设备登录同一账号也能看到），不再是「这个浏览器的最后
+// 一个房间」。没登录时返回空列表而不是报错：这个入口在未登录状态下也会被渲染。
 export async function listMyRooms(): Promise<MyRoomSummary[]> {
-  const token = useRoomStore.getState().reconnectToken;
+  const token = getAuthToken();
   if (!token) return [];
   return sdk.rooms.listMyRooms(token);
 }

--- a/trpg-frontend/src/stores/room-store.ts
+++ b/trpg-frontend/src/stores/room-store.ts
@@ -24,7 +24,13 @@ interface RoomState {
   createFormRoomName: string
   createFormMaxPlayers: number
   setRoom: (code: string, players: Player[]) => void
-  setRoomIdentity: (info: { roomId: string; roomCode: string; playerId: string; reconnectToken: string }) => void
+  setRoomIdentity: (info: {
+    roomId: string
+    roomCode: string
+    playerId: string
+    reconnectToken: string
+    characterId?: string | null
+  }) => void
   setModuleId: (moduleId: string) => void
   setCharacterId: (characterId: string) => void
   addPlayer: (player: Player) => void
@@ -55,17 +61,25 @@ export const useRoomStore = create<RoomState>()(
       createFormRoomName: '',
       createFormMaxPlayers: 4,
       setRoom: (code, players) => set({ roomCode: code, players }),
-      setRoomIdentity: ({ roomId, roomCode, playerId, reconnectToken }) =>
+      setRoomIdentity: ({ roomId, roomCode, playerId, reconnectToken, characterId }) =>
         set((state) => ({
           roomId,
           roomCode,
           playerId,
           reconnectToken,
-          // 换到别的房间就丢掉上一个房间的角色 id：角色卡是按房间隔离的
-          // （后端 `_get_own_character` 校验 `character.room_id`），带过去只会
-          // 404。创建房间那条路径本来就会先 reset()，但"加入房间"和"我的游戏
-          // →继续"不会，同一个标签页里换个房间就会留着上一局的 characterId。
-          ...(state.roomId !== roomId ? { characterId: null } : {}),
+          // characterId 以**服务端返回的为准**（PR #110 review [1]）：join 现在会
+          // 带上"这个房间里属于我的角色卡 id"。在此之前它只在建卡那一刻由客户端
+          // 自己存着——换台设备就永远拿不回来，已经建完卡的人重连后会显示成
+          // "还没建卡"、被引导去建第二张。
+          //
+          // 服务端没给（undefined，比如还没接这个字段的旧调用方）才退回原来的
+          // 行为：换房间就清空。角色卡是按房间隔离的（后端 `_get_own_character`
+          // 校验 `character.room_id`），把上一局的 id 带过去只会 404。
+          ...(characterId !== undefined
+            ? { characterId }
+            : state.roomId !== roomId
+              ? { characterId: null }
+              : {}),
         })),
       setModuleId: (moduleId) => set({ moduleId }),
       setCharacterId: (characterId) => set({ characterId }),

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -529,6 +529,7 @@ export interface RoomCreateResult {
   roomCode: string;
   reconnectToken: string;
   playerId: string;
+  characterId?: string | null;
 }
 
 /**

--- a/trpg-sdk/src/resources/rooms.ts
+++ b/trpg-sdk/src/resources/rooms.ts
@@ -17,13 +17,31 @@ import type {
 export class RoomsResource {
   constructor(private readonly client: ApiClient) {}
 
-  private authenticated(reconnectToken: string): RequestInit {
+  /**
+   * 房间身份：`X-Reconnect-Token`，代表"你是这个房间里的哪个玩家"。
+   *
+   * 跟下面的 `accountAuth` 是两套**不同的**凭证，别搞混——这个类以前只有一个
+   * 叫 `authenticated` 的方法，issue #106 给创建/加入房间接上账号凭证之后，
+   * 同一个类里同时出现两种凭证，含糊的名字很容易让人传错一个进去，而传错的
+   * 后果是 401，排查时又容易怀疑到 token 本身失效。
+   */
+  private roomAuth(reconnectToken: string): RequestInit {
     return { headers: { 'X-Reconnect-Token': reconnectToken } };
   }
 
-  /** POST /api/v1/rooms — 创建房间，返回 roomId/roomCode/reconnectToken/playerId */
-  create(payload: CreateRoomInput): Promise<CreateRoomResult> {
-    return this.client.post<CreateRoomResult>('/rooms', payload);
+  /** 账号身份：`Authorization: Bearer`，代表"你是哪个用户"。 */
+  private accountAuth(token: string): RequestInit {
+    return { headers: { Authorization: `Bearer ${token}` } };
+  }
+
+  /**
+   * POST /api/v1/rooms — 创建房间，返回 roomId/roomCode/reconnectToken/playerId
+   *
+   * issue #106 起需要账号 token：房间和房主玩家都要关联到真实账号，否则
+   * `hostUserId`/`userId` 永远是空的，「我的游戏」和跨设备找回都无从谈起。
+   */
+  create(payload: CreateRoomInput, token: string): Promise<CreateRoomResult> {
+    return this.client.post<CreateRoomResult>('/rooms', payload, this.accountAuth(token));
   }
 
   /** GET /api/v1/modules — 获取可用模组列表 */
@@ -40,13 +58,22 @@ export class RoomsResource {
     return this.client.post<null>(
       `/rooms/${roomId}/module`,
       payload,
-      this.authenticated(reconnectToken)
+      this.roomAuth(reconnectToken)
     );
   }
 
-  /** POST /api/v1/rooms/{roomCode}/join — 用房间码加入房间 */
-  join(roomCode: string, payload: JoinRoomInput): Promise<CreateRoomResult> {
-    return this.client.post<CreateRoomResult>(`/rooms/${roomCode}/join`, payload);
+  /**
+   * POST /api/v1/rooms/{roomCode}/join — 用房间码加入房间
+   *
+   * issue #106 起需要账号 token，且**已是房间成员时幂等返回既有身份**——所以
+   * 这个方法同时承担"加入"和"重连"两个用途，掉线/换设备后直接再调一次即可。
+   */
+  join(roomCode: string, payload: JoinRoomInput, token: string): Promise<CreateRoomResult> {
+    return this.client.post<CreateRoomResult>(
+      `/rooms/${roomCode}/join`,
+      payload,
+      this.accountAuth(token)
+    );
   }
 
   /** GET /api/v1/rooms/{roomCode} — 获取房间信息 + 玩家列表 */
@@ -59,16 +86,19 @@ export class RoomsResource {
     return this.client.post<null>(
       `/rooms/${roomId}/start-story`,
       null,
-      this.authenticated(reconnectToken)
+      this.roomAuth(reconnectToken)
     );
   }
 
-  /** GET /api/v1/me/rooms — 获取我的房间列表 */
-  listMyRooms(reconnectToken: string): Promise<MyRoomSummary[]> {
-    return this.client.get<MyRoomSummary[]>(
-      '/me/rooms',
-      this.authenticated(reconnectToken)
-    );
+  /**
+   * GET /api/v1/me/rooms — 获取我的房间列表
+   *
+   * issue #106 起凭证从房间的 `X-Reconnect-Token` 换成账号 token，返回该账号的
+   * **全部**房间。原来按重连凭证查，一个凭证只对应一个房间，这个列表实际上是
+   * 「这个浏览器的最后一个房间」。
+   */
+  listMyRooms(token: string): Promise<MyRoomSummary[]> {
+    return this.client.get<MyRoomSummary[]>('/me/rooms', this.accountAuth(token));
   }
 
   /** POST /api/v1/rooms/{roomId}/end — 房主结束游戏 */
@@ -76,7 +106,7 @@ export class RoomsResource {
     return this.client.post<null>(
       `/rooms/${roomId}/end`,
       null,
-      this.authenticated(reconnectToken)
+      this.roomAuth(reconnectToken)
     );
   }
 
@@ -84,7 +114,7 @@ export class RoomsResource {
   getSummary(roomId: string, reconnectToken: string): Promise<RoomSummary> {
     return this.client.get<RoomSummary>(
       `/rooms/${roomId}/summary`,
-      this.authenticated(reconnectToken)
+      this.roomAuth(reconnectToken)
     );
   }
 
@@ -92,7 +122,7 @@ export class RoomsResource {
   getReplay(roomId: string, reconnectToken: string): Promise<ReplayEvent[]> {
     return this.client.get<ReplayEvent[]>(
       `/rooms/${roomId}/replay`,
-      this.authenticated(reconnectToken)
+      this.roomAuth(reconnectToken)
     );
   }
 }


### PR DESCRIPTION
Closes #106

## 这个 PR 解决什么

账号体系在数据模型上早就落了地（`players.user_id`、`rooms.host_user_id` 字段都在），但**在 REST 层没有接通**——`rooms.create()` / `join()` 都不发 `Authorization` 头，后端用的又是"登录可选"的依赖，于是这两个字段**永远是 `null`**。结果是账号体系存在、却没有兑现它被引入的那个目的（2026-07-11 拍板：登录是硬性前提，为的是"每个玩家都能复盘、掉线后能重新进来"）。

三个症状同一个根因：

| 症状 | 现在 |
|---|---|
| `host_user_id` / `user_id` 恒为 `null` | 创建/加入房间要求登录，落真实账号 |
| 「我的游戏」实际是「这个浏览器的最后一个房间」 | 按 `user_id` 查，返回该账号**全部**房间 |
| 掉线重连必现 409；重复加入产生重复玩家行、虚增人数 | join 按账号幂等；阶段规则改为**新人拒、老成员放行** |

**幂等键取账号而不是 `reconnectToken`**：后者存在浏览器会话里，换设备、清缓存就没了，而「换设备也能回到这局」正是账号体系被引入的理由。两者分工不变——账号解决跨设备/跨时间找回，`reconnectToken` 解决同一局内的快速重连。

## 改了什么

- **后端**：`create_room`/`join_room` 改用新增的 `get_current_user` 依赖；`join_room` 幂等 + 阶段分流（老成员重连也不受满员限制——他本来就占着那个位置）；`list_my_rooms` 按账号查
- **SDK**：`create()`/`join()` 接受账号 token，`listMyRooms()` 换成账号 token
- **前端**：调用处补 token；「我的游戏」按新语义
- **e2e**：新增 `account-identity.e2e.ts` 六条

## 🔴 真机验证挖出三个缺陷，一并修了

单元测试和 e2e 全绿之后真机点了一遍，又挖出三个——**都不是这次改动"写错了"，而是它让原本藏着的问题浮出来**：

**① 时间戳不带时区（后端契约问题）**
`updatedAt` 返回 `2026-07-21T09:35:13.095627`——**没有任何后缀**。值是 UTC（`DateTime(timezone=True)` + `datetime.now(UTC)`），但 SQLite 不保存时区，读出来是 naive datetime。客户端按 ECMAScript 规则会当作**本地时间**解析，于是「4 分钟前」在 UTC+8 上显示成「8 小时前」，偏差正好是时区偏移量。

光看字符串无从判断它是 UTC 还是本地时间——这不是客户端该猜的事。所以在**契约层**修：新增 `UtcDatetime` 类型，`room`/`replay`/`module`/`character` 全部 **6 个**对外时间字段都换过去，并补测试钉住"对外时间必须带时区后缀"，否则下次新加字段还会漏。

**② 「我的游戏→继续」进错页面然后卡死**
`MyRoomsPage` 只区分 `InGame`/其它，`Building`（已过大厅、正在建卡）被送回大厅；而大厅的「开始游戏」在这个阶段必然被后端 409 拒绝，`handleStartStory` 又**既没 catch 也没 finally**，按钮就永久卡在「开始中…」，用户既走不下去也看不到原因。加了阶段映射 + try/catch/finally（失败复位并显示原因）。

这个缺陷是本 issue 让「我的游戏」真的有内容之后才暴露出来的。

**③ 未登录时的报错主动误导用户**
`friendlyErrorMessage` 只特判 `ApiError`/`TypeError`，前置校验抛的普通 `Error` 被 fallback 盖掉——未登录点加入房间，看到的是「加入房间失败，**请检查房间号**」，而房间号是对的，人会一直去查那个。改成透传普通 `Error` 的 message（它们本来就是写给用户看的），`TypeError` 仍走统一文案（`Failed to fetch` 不适合展示）。

## 验证

- 后端 **89 passed**、ruff / format / ty 全过；**e2e 19 passed**
- **五轮变异检验**：去掉 join 幂等 → 后端 3 条 + e2e 3 条全红；恢复"一刀切拒绝" → 老成员重连那条红；`my rooms` 只返回第一个 → 对应两条红。每条都精确命中，没有连坐
- **全新 clone 按 README 走了一遍**：`uv sync --locked` → `alembic upgrade head` → pytest 89 passed → SDK `npm ci && build && test` → 前端 `npm ci && build` → e2e 19 passed
- **真机浏览器验证两轮**：主流程、刷新重连、两个房间都在「我的游戏」、清空存储重新登录仍可见（换设备）、B 重复加入不变三人；三个修复逐条复验通过

## 用例写法上的一点

新增用例里有**三对互为对照的**：老成员重连 / 新人在 Building 被拒、我的房间全返回 / 不泄漏别人的、建房关联账号 / 未登录 401。只测单边的话，"一刀切拒绝"和"一刀切放行"各能通过一条——这种成对写法在 PR #97 那轮已经救过一次。

「换设备重连」那条用**全新的 SDK 实例**模拟另一台设备：没有任何本地状态、只有账号 token。这正是账号体系存在的理由，也是浏览器层不好测的场景。

## 一处自己犯的错，说明一下

给大厅加错误提示时我把 JSX 三元分支改坏了——房主也会看到「标记为已就绪」按钮，报错还会把按钮顶掉。**`tsc --noEmit` 是过的**（仍是合法 JSX），是回头看渲染结构才发现的。已修，并在复验清单里单列一条让人用眼睛确认。类型检查在这类问题上帮不上忙。

## 不在本 PR 范围

- **路由守卫**：未登录能直接访问 `/home/create` 等页面、把表单填完才在提交时被拒。本 PR 只让报错说人话，守卫是独立的一件事
- WS `room.rejoin` 仍是 `NOT_IMPLEMENTED`（重连走 REST 的 join 即可，见 issue 决策）
- 退出房间 / 踢人 / 转让房主
