### PR TITLE
feat: implement player-safe Host Agent tools (#117)

### DIFF
--- a/agent-collaboration-framework/README.md
+++ b/agent-collaboration-framework/README.md
@@ -36,10 +36,13 @@ PlayerInput
 `astream(HostAgentContext)` 流式入口：接收可信 `PlayerInput` 和 B 已去密的 `PlayerView`，可产生零到多个脱敏的工具进度事件，
 最后必须以且仅以一个 `agent.completed` 或 `agent.failed` 结束。
 
-`agent.completed.raw_output` 只是普通、不可信的 JSON candidate；后续仍必须由 `IntentParser` 做确定性校验。当前离线
-`FakeHostAgent` 只用于锁定 Adapter 共同契约，尚未接入上面的 `Orchestrator` 主链，也不执行真实 AI、真实工具、规则动作或状态写入。
-真实只读工具与 SDK Adapter 分别由 [Issue #117](https://github.com/1024XEngineer/TRPG-master/issues/117) 和
-[Issue #118](https://github.com/1024XEngineer/TRPG-master/issues/118) 跟踪。
+`agent.completed.raw_output` 只是普通、不可信的 JSON candidate；后续仍必须由 `IntentParser` 做确定性校验。当前已有
+`host/tools` 中绑定 `HostAgentContext.player_view` 的两个只读工具，以及拒绝模型自行传入身份作用域的框架无关
+`ToolRegistry`。它们只搜索/读取当前 `PlayerView`，不访问引擎、数据库或完整模组。
+
+`FakeHostAgent` 和这些工具尚未接入上面的 `Orchestrator` 主链，也不执行真实 AI、规则动作或状态写入。OpenAI Agents SDK
+与 Qwen Adapter 以及工具预算、timeout 和事件桥接由 [Issue #118](https://github.com/1024XEngineer/TRPG-master/issues/118)
+跟踪。
 
 ## 2、3、4 点的统一结论
 
@@ -97,6 +100,7 @@ collaboration_framework/
 │   ├── ports/                 # Intent/Narration/Host Agent 模型抽象及 TurnPort
 │   ├── adapters/fakes/        # 无网络、无 API Key 的离线 Fake
 │   ├── schemas/               # A 内部 Agent/Context/Turn/Narration Schema
+│   ├── tools/                 # 绑定当前 PlayerView 的 player-safe 只读工具
 │   └── gateway/               # Player-safe WebSocket 输出
 ├── engine/                    # 成员 B：Service、Kernel、Store 端口/适配器与内部模型
 │   ├── service.py            # 跨房间复用的 ActionExecutor / PlayerViewSource
@@ -123,6 +127,7 @@ collaboration_framework/
 | `EngineRuntimeSnapshot`/`CompletedAction` | B | B | Store 加载快照与幂等执行记录 |
 | `NarrationOutput` | A | Gateway | 模型原始 JSON 经 Pydantic 和事实引用校验后的输出 |
 | `HostAgentContext`/`HostAgentEvent`/`HostAgentUsage` | A | A 的 Host Agent Adapter | A 内部、框架无关；不是 A/B/C 共享契约，也尚未接入 Orchestrator |
+| `ToolRegistry` 与 player-safe 工具 | A | A 的 Host Agent Adapter | 绑定当前 Context，只读；参数/结果均由项目 Schema 校验 |
 | `ModuleContent`/`CheckpointSpec`/`RuleSpec` | B/C 共审 | B、C | 声明式内容语言；A 不直接消费 |
 
 ## ModuleContent 为什么在 `contracts/module.py`
@@ -166,10 +171,14 @@ Schema 文件由 Pydantic 模型自动生成，不应手工维护：
 - `schemas/host-agent-usage.schema.json`（A 内部 Adapter 边界）
 - `schemas/host-agent-event.schema.json`（A 内部 Adapter 边界）
 
+工具参数与结果不额外生成一组仓库级 Schema 文件。`ToolDefinition.arguments_json_schema()` /
+`result_json_schema()` 直接从对应的严格 Pydantic 模型产生 Adapter 可消费的 Schema，避免第二份手写协议。
+
 ## 当前明确不做
 
 - 不连接真实 LLM 或编写 Prompt。
-- 不实现或注册 Host Agent 真实工具，不引入模型 SDK，也不把 Host Agent 接入 Orchestrator。
+- 不引入模型 SDK，也不把 Host Agent 或只读工具接入 Orchestrator。
+- 不实现工具预算、timeout、并行调用、数据库/RAG/网络搜索或任何写工具。
 - 不使用 LangGraph。
 - 不由主持层实现 Rule、Hook、Checkpoint 执行、Dice、GameState 修改或 Event 写入。
 - 不把 `TurnState`、`EngineExecutionResult`、Event 或摘要 Outbox 暴露为跨组件公共契约。

--- a/agent-collaboration-framework/collaboration_framework/host/application/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/__init__.py
@@ -3,12 +3,24 @@ from .intent_parser import IntentParser, validate_intent_against_view
 from .narrator import Narrator
 from .orchestrator import Orchestrator
 from .player_view_projector import PlayerViewProjector
+from .tool_registry import (
+    BoundToolRegistry,
+    ToolAccess,
+    ToolDefinition,
+    ToolHandler,
+    ToolRegistry,
+)
 
 __all__ = [
     "ContextAssembler",
+    "BoundToolRegistry",
     "IntentParser",
     "Narrator",
     "Orchestrator",
     "PlayerViewProjector",
+    "ToolAccess",
+    "ToolDefinition",
+    "ToolHandler",
+    "ToolRegistry",
     "validate_intent_against_view",
 ]

--- a/agent-collaboration-framework/collaboration_framework/host/application/tool_registry.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/tool_registry.py
@@ -1,0 +1,141 @@
+"""Framework-independent registration and invocation for Host Agent tools."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+import re
+from types import MappingProxyType
+from typing import Any, Literal, TypeAlias
+
+from pydantic import ValidationError
+
+from collaboration_framework.contracts import ContractModel
+from collaboration_framework.host.schemas import (
+    HostAgentContext,
+    ToolErrorResult,
+    make_tool_error,
+)
+
+
+ToolAccess: TypeAlias = Literal["read_only"]
+ToolHandler: TypeAlias = Callable[
+    [HostAgentContext, Any],
+    Awaitable[Any],
+]
+
+_TOOL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDefinition:
+    """Trusted project-owned metadata and implementation for one tool."""
+
+    name: str
+    description: str
+    args_model: type[ContractModel]
+    result_model: type[ContractModel]
+    public_progress_label: str
+    handler: ToolHandler
+    access: ToolAccess = "read_only"
+
+    def __post_init__(self) -> None:
+        if not _TOOL_NAME_PATTERN.fullmatch(self.name):
+            raise ValueError(
+                "tool name must start with a lowercase letter and contain "
+                "only lowercase letters, digits, and underscores"
+            )
+        if not self.description.strip():
+            raise ValueError("tool description must not be empty")
+        if not self.public_progress_label.strip():
+            raise ValueError("tool public progress label must not be empty")
+        if self.access != "read_only":
+            raise ValueError("Host Agent tools must be read_only")
+        for field_name, model in (
+            ("args_model", self.args_model),
+            ("result_model", self.result_model),
+        ):
+            if not isinstance(model, type) or not issubclass(model, ContractModel):
+                raise TypeError(f"{field_name} must be a ContractModel type")
+        if not callable(self.handler):
+            raise TypeError("tool handler must be callable")
+
+    def arguments_json_schema(self) -> dict[str, object]:
+        return self.args_model.model_json_schema(
+            by_alias=True,
+            mode="validation",
+        )
+
+    def result_json_schema(self) -> dict[str, object]:
+        return self.result_model.model_json_schema(
+            by_alias=True,
+            mode="validation",
+        )
+
+
+class ToolRegistry:
+    """Immutable registry of the only callables available to a Host Agent."""
+
+    def __init__(self, definitions: Iterable[ToolDefinition]) -> None:
+        registered: dict[str, ToolDefinition] = {}
+        for definition in definitions:
+            if definition.name in registered:
+                raise ValueError(f"duplicate tool registration: {definition.name}")
+            registered[definition.name] = definition
+        self._definitions = MappingProxyType(registered)
+
+    @property
+    def definitions(self) -> tuple[ToolDefinition, ...]:
+        return tuple(
+            self._definitions[name]
+            for name in sorted(self._definitions)
+        )
+
+    def bind(self, context: HostAgentContext) -> BoundToolRegistry:
+        if not isinstance(context, HostAgentContext):
+            raise TypeError("context must be a HostAgentContext")
+        return BoundToolRegistry(self, context)
+
+    def _find(self, name: str) -> ToolDefinition | None:
+        return self._definitions.get(name)
+
+
+@dataclass(frozen=True, slots=True)
+class BoundToolRegistry:
+    """A registry view whose trusted player scope cannot be model-supplied."""
+
+    registry: ToolRegistry
+    context: HostAgentContext
+
+    @property
+    def definitions(self) -> tuple[ToolDefinition, ...]:
+        return self.registry.definitions
+
+    async def ainvoke(
+        self,
+        tool_name: str,
+        arguments: object,
+    ) -> ContractModel:
+        if not isinstance(tool_name, str):
+            return make_tool_error("TOOL_NOT_FOUND")
+        definition = self.registry._find(tool_name)
+        if definition is None:
+            return make_tool_error("TOOL_NOT_FOUND")
+
+        try:
+            parsed_arguments = definition.args_model.model_validate(arguments)
+        except (TypeError, ValueError, ValidationError):
+            return make_tool_error("INVALID_TOOL_ARGUMENTS")
+
+        try:
+            raw_result = await definition.handler(self.context, parsed_arguments)
+        except Exception:
+            return make_tool_error("TOOL_INTERNAL_ERROR")
+
+        if isinstance(raw_result, ToolErrorResult):
+            return raw_result
+
+        try:
+            return definition.result_model.model_validate(raw_result)
+        except (TypeError, ValueError, ValidationError):
+            return make_tool_error("INVALID_TOOL_RESULT")

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/__init__.py
@@ -20,6 +20,17 @@ from .output import (
     WebSocketOutput,
 )
 from .turn import TurnState
+from .tools import (
+    GetVisibleEntityArgs,
+    GetVisibleEntityResult,
+    SearchVisibleEntitiesArgs,
+    SearchVisibleEntitiesResult,
+    ToolError,
+    ToolErrorCode,
+    ToolErrorResult,
+    VisibleEntitySummary,
+    make_tool_error,
+)
 
 __all__ = [
     "HostAgentCompleted",
@@ -34,11 +45,20 @@ __all__ = [
     "HostAgentToolCompleted",
     "HostAgentToolStarted",
     "HostAgentUsage",
+    "GetVisibleEntityArgs",
+    "GetVisibleEntityResult",
     "IntentContext",
     "NarrationContext",
     "NarrationOutput",
     "PlayerTurnPayload",
+    "SearchVisibleEntitiesArgs",
+    "SearchVisibleEntitiesResult",
+    "ToolError",
+    "ToolErrorCode",
+    "ToolErrorResult",
     "TurnOutput",
     "TurnState",
+    "VisibleEntitySummary",
     "WebSocketOutput",
+    "make_tool_error",
 ]

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/tools.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/tools.py
@@ -1,0 +1,78 @@
+"""Framework-independent schemas for player-safe Host Agent tools."""
+
+from __future__ import annotations
+
+from typing import Literal, TypeAlias
+
+from pydantic import Field
+
+from collaboration_framework.contracts import CheckpointOption, ContractModel
+
+
+ToolErrorCode: TypeAlias = Literal[
+    "TOOL_NOT_FOUND",
+    "INVALID_TOOL_ARGUMENTS",
+    "ENTITY_NOT_VISIBLE",
+    "INVALID_TOOL_RESULT",
+    "TOOL_INTERNAL_ERROR",
+]
+
+
+class SearchVisibleEntitiesArgs(ContractModel):
+    query: str = Field(min_length=1, max_length=200)
+    kind: Literal["npc", "object", "location"] | None = None
+    limit: int = Field(default=5, ge=1, le=5)
+
+
+class VisibleEntitySummary(ContractModel):
+    id: str = Field(min_length=1)
+    kind: Literal["npc", "object", "location"]
+    name: str = Field(min_length=1)
+
+
+class SearchVisibleEntitiesResult(ContractModel):
+    matches: tuple[VisibleEntitySummary, ...] = ()
+
+
+class GetVisibleEntityArgs(ContractModel):
+    entity_id: str = Field(min_length=1)
+
+
+class GetVisibleEntityResult(ContractModel):
+    id: str = Field(min_length=1)
+    kind: Literal["npc", "object", "location"]
+    name: str = Field(min_length=1)
+    aliases: tuple[str, ...] = ()
+    content: str
+    checkpoint_options: tuple[CheckpointOption, ...] = ()
+
+
+class ToolError(ContractModel):
+    code: ToolErrorCode
+    message: str = Field(min_length=1)
+
+
+class ToolErrorResult(ContractModel):
+    error: ToolError
+
+
+_ERROR_MESSAGES: dict[ToolErrorCode, str] = {
+    "TOOL_NOT_FOUND": "The requested tool is not available.",
+    "INVALID_TOOL_ARGUMENTS": "The tool arguments are invalid.",
+    "ENTITY_NOT_VISIBLE": (
+        "The requested entity is not available in the current player view."
+    ),
+    "INVALID_TOOL_RESULT": "The tool returned an invalid result.",
+    "TOOL_INTERNAL_ERROR": "The tool could not complete the request.",
+}
+
+
+def make_tool_error(code: ToolErrorCode) -> ToolErrorResult:
+    """Build a stable error without accepting provider or exception text."""
+
+    return ToolErrorResult(
+        error=ToolError(
+            code=code,
+            message=_ERROR_MESSAGES[code],
+        )
+    )

--- a/agent-collaboration-framework/collaboration_framework/host/tools/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/tools/__init__.py
@@ -1,0 +1,32 @@
+"""Player-safe Host Agent tool definitions."""
+
+from collaboration_framework.host.application.tool_registry import ToolRegistry
+
+from .visible_entities import (
+    GET_VISIBLE_ENTITY_TOOL,
+    SEARCH_VISIBLE_ENTITIES_TOOL,
+    get_visible_entity,
+    normalize_search_text,
+    search_visible_entities,
+)
+
+
+def build_player_view_tool_registry() -> ToolRegistry:
+    """Build the immutable first-party read-only tool set."""
+
+    return ToolRegistry(
+        (
+            SEARCH_VISIBLE_ENTITIES_TOOL,
+            GET_VISIBLE_ENTITY_TOOL,
+        )
+    )
+
+
+__all__ = [
+    "GET_VISIBLE_ENTITY_TOOL",
+    "SEARCH_VISIBLE_ENTITIES_TOOL",
+    "build_player_view_tool_registry",
+    "get_visible_entity",
+    "normalize_search_text",
+    "search_visible_entities",
+]

--- a/agent-collaboration-framework/collaboration_framework/host/tools/visible_entities.py
+++ b/agent-collaboration-framework/collaboration_framework/host/tools/visible_entities.py
@@ -1,0 +1,128 @@
+"""Read-only tools over the PlayerView already bound to a Host Agent run."""
+
+from __future__ import annotations
+
+import unicodedata
+
+from collaboration_framework.host.application.tool_registry import ToolDefinition
+from collaboration_framework.host.schemas import (
+    GetVisibleEntityArgs,
+    GetVisibleEntityResult,
+    HostAgentContext,
+    SearchVisibleEntitiesArgs,
+    SearchVisibleEntitiesResult,
+    ToolErrorResult,
+    VisibleEntitySummary,
+    make_tool_error,
+)
+
+
+def normalize_search_text(value: str) -> str:
+    """Normalize text deterministically without fuzzy or semantic matching."""
+
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return " ".join(normalized.split())
+
+
+async def search_visible_entities(
+    context: HostAgentContext,
+    arguments: SearchVisibleEntitiesArgs,
+) -> SearchVisibleEntitiesResult:
+    query = normalize_search_text(arguments.query)
+    ranked: list[tuple[int, str, VisibleEntitySummary]] = []
+
+    for entity in context.player_view.visible_entities:
+        if arguments.kind is not None and entity.kind != arguments.kind:
+            continue
+
+        normalized_name = normalize_search_text(entity.name)
+        normalized_aliases = tuple(
+            normalize_search_text(alias) for alias in entity.aliases
+        )
+        normalized_content = normalize_search_text(entity.content)
+
+        if query in normalized_name:
+            rank = 0
+        elif any(query in alias for alias in normalized_aliases):
+            rank = 1
+        elif query in normalized_content:
+            rank = 2
+        else:
+            continue
+
+        ranked.append(
+            (
+                rank,
+                entity.id,
+                VisibleEntitySummary(
+                    id=entity.id,
+                    kind=entity.kind,
+                    name=entity.name,
+                ),
+            )
+        )
+
+    ranked.sort(key=lambda item: (item[0], item[1]))
+    return SearchVisibleEntitiesResult(
+        matches=tuple(item[2] for item in ranked[: arguments.limit])
+    )
+
+
+async def get_visible_entity(
+    context: HostAgentContext,
+    arguments: GetVisibleEntityArgs,
+) -> GetVisibleEntityResult | ToolErrorResult:
+    entity = next(
+        (
+            visible_entity
+            for visible_entity in context.player_view.visible_entities
+            if visible_entity.id == arguments.entity_id
+        ),
+        None,
+    )
+    if entity is None:
+        return make_tool_error("ENTITY_NOT_VISIBLE")
+
+    checkpoint_options = tuple(
+        sorted(
+            (
+                option
+                for option in context.player_view.checkpoint_options
+                if option.target_id == entity.id
+            ),
+            key=lambda option: option.id,
+        )
+    )
+    return GetVisibleEntityResult(
+        id=entity.id,
+        kind=entity.kind,
+        name=entity.name,
+        aliases=entity.aliases,
+        content=entity.content,
+        checkpoint_options=checkpoint_options,
+    )
+
+
+SEARCH_VISIBLE_ENTITIES_TOOL = ToolDefinition(
+    name="search_visible_entities",
+    description=(
+        "Search the entities visible in the current player view by name, "
+        "alias, or player-safe description."
+    ),
+    args_model=SearchVisibleEntitiesArgs,
+    result_model=SearchVisibleEntitiesResult,
+    public_progress_label="正在查找当前场景中的可见实体",
+    handler=search_visible_entities,
+)
+
+GET_VISIBLE_ENTITY_TOOL = ToolDefinition(
+    name="get_visible_entity",
+    description=(
+        "Read player-safe details and current checkpoint options for one "
+        "entity returned by search_visible_entities."
+    ),
+    args_model=GetVisibleEntityArgs,
+    result_model=GetVisibleEntityResult,
+    public_progress_label="正在读取可见实体信息",
+    handler=get_visible_entity,
+)

--- a/agent-collaboration-framework/docs/architecture.md
+++ b/agent-collaboration-framework/docs/architecture.md
@@ -14,7 +14,7 @@
 - B 负责 Rule、Hook、Checkpoint 执行、Dice、GameState 修改、Event 写入和事务/幂等。
 - C 负责模组解析、审查和发布 `ModuleContent`。
 - A 只能通过 `ActionExecutor.execute()` 发出可能影响权威状态的动作。
-- 当前使用离线模型 Fake 和完整 `InMemoryEngineStore`，不连接真实模型、LangGraph、PostgreSQL 或 FastAPI。
+- 当前使用离线模型 Fake、player-safe 只读工具和完整 `InMemoryEngineStore`，不连接真实模型、LangGraph、PostgreSQL 或 FastAPI。
 
 ## 2. 最终回合时序
 
@@ -244,6 +244,14 @@ flowchart LR
 4. 类型：A 内部应用数据模型。
 5. LangGraph 迁移：`TurnState` 可能变化；Narration Context/Output 通常可复用。
 
+### `host/tools/`
+
+1. 为什么需要：给 Host Agent 提供只读取当前玩家安全视图的确定性检索能力。
+2. 如果没有：SDK Adapter 会自行定义参数、权限和返回形态，形成供应商绑定和越权风险。
+3. 边界：工具只能读取调用时绑定的 `HostAgentContext.player_view`；不得访问引擎、数据库、完整模组、其他玩家数据或写入口。
+4. 类型：A 的框架无关只读能力；`ToolRegistry` 负责注册、Context 绑定、参数/结果校验和脱敏错误。
+5. LangGraph 迁移：不需要修改；任何 Agent Runtime 都消费同一 Registry 和 Pydantic Schema。
+
 ### `host/gateway/`
 
 1. 为什么需要：把连接协议和 player-safe 输出与回合用例分开。
@@ -288,8 +296,11 @@ flowchart TD
     HAPP --> HSCHEMA
     HAPP --> XPORTS
     HAPP --> CONTRACTS
+    HTOOLS["host/tools"] --> HAPP
+    HTOOLS --> HSCHEMA
     HADAPTER["host/adapters"] --> HPORTS
     HADAPTER --> HSCHEMA
+    HADAPTER --> HTOOLS
     GATEWAY["host/gateway"] --> HPORTS
     GATEWAY --> HSCHEMA
     ENGINE["engine"] --> XPORTS
@@ -332,10 +343,16 @@ A 输出/内部边界 Schema：
 - `HostAgentContext`（A 内部；导出 JSON Schema 供 Adapter 对齐）
 - `HostAgentUsage`（A 内部；导出 JSON Schema 供 Adapter 对齐）
 - `HostAgentEvent`（A 内部可判别事件联合；导出 JSON Schema 供 Adapter 对齐）
+- `SearchVisibleEntitiesArgs` / `SearchVisibleEntitiesResult`（A 内部工具参数/结果）
+- `GetVisibleEntityArgs` / `GetVisibleEntityResult`（A 内部工具参数/结果）
+- `ToolError` / `ToolErrorResult`（A 内部稳定脱敏工具错误）
 
 `HostAgentPort.astream()` 是 A 在规则引擎之前的框架无关意图理解边界，只接收可信 `PlayerInput` 与 player-safe
-`PlayerView`。它当前只有离线 Fake，尚未接入 `Orchestrator`；completed 的 raw JSON 仍须交给 `IntentParser`，
-且该 Port 不得调用 `ActionExecutor`。上述三个 Host Agent Schema 虽然导出为 JSON Schema，但不因此成为 A/B/C 共享业务契约。
+`PlayerView`。`ToolRegistry.bind(context)` 把工具调用固定到这一 Context，模型参数中没有 room/player/actor 身份入口。
+当前两个工具只搜索 `visible_entities` 或返回其中一个实体及其当前 checkpoint 候选；它们与离线 Fake 均尚未接入
+`Orchestrator`。completed 的 raw JSON 仍须交给 `IntentParser`，且该 Port/Registry 都不得调用 `ActionExecutor`。
+上述三个 Host Agent Schema 虽然导出为仓库级 JSON Schema，但不因此成为 A/B/C 共享业务契约；工具定义则直接从
+参数/结果 Pydantic 模型生成 Adapter Schema，不维护重复文件。
 
 B 内部模型（不属于跨组件 Schema）：
 
@@ -356,3 +373,5 @@ B 内部模型（不属于跨组件 Schema）：
 8. 若未来迁移 LangGraph，先用同一测试套件证明 `run()`、执行一次语义和 WebSocket 输出未变，再替换实现。
 9. 修改 `HostAgentContext`、`HostAgentUsage`、`HostAgentEvent` 或 `HostAgentPort` 由 A 评审，并同步其契约测试、生成 Schema
    和现行文档；SDK 类型只能存在于未来的 Adapter，不能进入这些稳定业务字段。
+10. 修改 `ToolRegistry` 或 Host 工具由 A 评审；参数/结果必须经过项目 Pydantic Schema，工具只能绑定当前
+    `HostAgentContext`，所有工具保持只读，运行预算与 timeout 由 Adapter 的单一运行配置执行。

--- a/agent-collaboration-framework/docs/数据模型设计.md
+++ b/agent-collaboration-framework/docs/数据模型设计.md
@@ -50,7 +50,7 @@ flowchart LR
 | `Intent` / `ActionRequest` | A/B | A、B | `execution` 旁路、Dice 结果、StateChange |
 | `ActionResult` | A/B | A | GameState、完整 Event payload、内部规则轨迹 |
 | A 的 Context/Turn 模型 | A | 仅 `host/` | B/C 内部对象 |
-| A 的 Host Agent Context/Usage/Event | A | 仅 `host/` Adapter | GameState、ModuleContent、完整 Event、数据库/身份入口、SDK 对象、Prompt、reasoning、工具原始参数/结果 |
+| A 的 Host Agent Context/Usage/Event 与工具模型 | A | 仅 `host/` Adapter | GameState、ModuleContent、完整 Event、数据库/身份入口、SDK 对象、Prompt、reasoning、工具原始参数/结果 |
 | B 的状态/Event/执行结果 | B | 仅 `engine/` 和 B 的测试 | A 模型上下文、WebSocket DTO |
 
 ## 2. 公共模型基础规则
@@ -267,8 +267,31 @@ request_id 未命中 CompletedAction
 最后必须以且仅以一个 `HostAgentCompleted` 或 `HostAgentFailed` 结束，终止后不得继续产出。Port 没有第二套独立
 `run()` loop，也不读取 `GameState`/完整 `ModuleContent`/完整 Event/数据库，不调用 `ActionExecutor`。
 
-当前 `FakeHostAgent` 完全离线，只验证“工具进度后完成”“工具错误后失败”和“零工具直接完成”路径；真实只读工具与 SDK
-Adapter 分别由 [Issue #117](https://github.com/1024XEngineer/TRPG-master/issues/117) 和
+`ToolRegistry` 是 A 内部、框架无关且构造后不可扩充的只读工具登记表。它以
+`ToolDefinition(name/description/args_model/result_model/public_progress_label/handler/access)` 描述工具，通过
+`bind(HostAgentContext)` 固定可信作用域，再由 `ainvoke(tool_name, arguments)` 依次完成工具查找、参数校验、Handler
+调用和结果校验。模型参数没有 `room_id/player_id/actor_id`，也不能替换已绑定 Context。
+
+工具模型定义：`host/schemas/tools.py`
+
+| 模型 | 字段 | 语义 |
+|---|---|---|
+| `SearchVisibleEntitiesArgs` | `query`, `kind`, `limit` | 在当前 `visible_entities` 中进行 NFKC + casefold + 空白折叠后的确定性包含匹配；limit 为 1–5 |
+| `VisibleEntitySummary` | `id`, `kind`, `name` | 搜索只返回识别候选所需的最小 player-safe 摘要 |
+| `SearchVisibleEntitiesResult` | `matches` | 按 name、alias、content 优先级及实体 ID 稳定排序；无匹配为空 tuple |
+| `GetVisibleEntityArgs` | `entity_id` | 只能按 ID 请求当前 `PlayerView` 中已经可见的实体 |
+| `GetVisibleEntityResult` | `id`, `kind`, `name`, `aliases`, `content`, `checkpoint_options` | player-safe 实体详情；候选仅含 `target_id` 匹配项并按 checkpoint ID 排序 |
+| `ToolError` | `code`, `message` | 稳定错误码和固定脱敏消息，不含参数、候选全集或内部异常 |
+| `ToolErrorResult` | `error` | 可安全回填模型的 `{"error": ...}` 结果 |
+
+首期错误码为 `TOOL_NOT_FOUND`、`INVALID_TOOL_ARGUMENTS`、`ENTITY_NOT_VISIBLE`、`INVALID_TOOL_RESULT` 和
+`TOOL_INTERNAL_ERROR`。不可见、不存在、其他房间或其他玩家的实体统一表现为 `ENTITY_NOT_VISIBLE`，不提供侧信道。
+
+每个 `ToolDefinition` 直接从 `args_model` / `result_model` 生成 Adapter 可消费的 JSON Schema。Registry 不执行模型轮数、
+整轮工具预算、单工具 timeout、并行策略或 usage 统计；这些由后续 SDK Adapter 的单一运行配置负责。
+
+当前 `FakeHostAgent` 完全离线，只验证 Host Agent 事件契约；`search_visible_entities` 与 `get_visible_entity` 也完全离线，
+但尚未接入 Fake 或 `Orchestrator`。SDK Adapter 和工具桥接由
 [Issue #118](https://github.com/1024XEngineer/TRPG-master/issues/118) 跟踪。
 
 ### 9.3 `TurnState`
@@ -471,6 +494,8 @@ TurnOutput -> WebSocketOutput
 
 三份 Host Agent Schema 是 A 内部 Adapter 边界的机器可读定义，不是 A/B/C 共享 Contract。TurnState、GameState、
 StateChange、完整 Event、EngineExecutionResult、EngineRuntimeSnapshot 和 CompletedAction 不导出 JSON Schema。
+工具参数/结果通过 `ToolDefinition.arguments_json_schema()` / `result_json_schema()` 按调用定义即时导出，不增加一组重复的
+仓库级 Schema 文件。
 
 ## 14. 演进规则
 
@@ -480,6 +505,7 @@ StateChange、完整 Event、EngineExecutionResult、EngineRuntimeSnapshot 和 C
 | `contracts/player_view.py` | A/B | 泄密审查、投影测试、本文 |
 | `contracts/module.py` | B/C | fixtures、Schema、本文 |
 | `host/schemas/` | A | WebSocket 安全投影、必要的本文更新 |
+| `host/application/tool_registry.py`、`host/tools/` | A | 工具权限/脱敏测试、参数与结果 Schema、本文；不得导入权威端口或 SDK |
 | `engine/models.py`、`engine/ports/`、`engine/adapters/` | B | Store/Service 契约测试、本文；不得泄漏到公共 Schema |
 
 公共字段变化需要说明所有者、调用方、玩家可见性、重放语义、版本影响和向后兼容性。

--- a/agent-collaboration-framework/tests/test_architecture.py
+++ b/agent-collaboration-framework/tests/test_architecture.py
@@ -88,6 +88,40 @@ class ArchitectureTests(unittest.TestCase):
                     f"{path.relative_to(PACKAGE)}: {imported}",
                 )
 
+    def test_host_agent_tools_are_read_only_and_authority_independent(self) -> None:
+        from collaboration_framework.host.tools import (
+            build_player_view_tool_registry,
+        )
+
+        tool_paths = (
+            PACKAGE / "host" / "application" / "tool_registry.py",
+            PACKAGE / "host" / "schemas" / "tools.py",
+            PACKAGE / "host" / "tools" / "visible_entities.py",
+        )
+        forbidden_prefixes = (
+            "agents",
+            "openai",
+            "collaboration_framework.engine",
+            "collaboration_framework.module",
+            "collaboration_framework.ports",
+        )
+        for path in tool_paths:
+            self.assertTrue(path.is_file(), path)
+            for imported in imports_for(path):
+                self.assertFalse(
+                    imported.startswith(forbidden_prefixes),
+                    f"{path.relative_to(PACKAGE)}: {imported}",
+                )
+
+        definitions = build_player_view_tool_registry().definitions
+        self.assertEqual(
+            {definition.name for definition in definitions},
+            {"search_visible_entities", "get_visible_entity"},
+        )
+        self.assertTrue(
+            all(definition.access == "read_only" for definition in definitions)
+        )
+
     def test_engine_does_not_import_host(self) -> None:
         for path in (PACKAGE / "engine").rglob("*.py"):
             for imported in imports_for(path):
@@ -152,6 +186,8 @@ class ArchitectureTests(unittest.TestCase):
             StateModifiedPayload,
         )
         from collaboration_framework.host.schemas import (
+            GetVisibleEntityArgs,
+            GetVisibleEntityResult,
             HostAgentCompleted,
             HostAgentContext,
             HostAgentFailed,
@@ -162,8 +198,13 @@ class ArchitectureTests(unittest.TestCase):
             NarrationContext,
             NarrationOutput,
             PlayerTurnPayload,
+            SearchVisibleEntitiesArgs,
+            SearchVisibleEntitiesResult,
+            ToolError,
+            ToolErrorResult,
             TurnOutput,
             TurnState,
+            VisibleEntitySummary,
             WebSocketOutput,
         )
 
@@ -183,6 +224,13 @@ class ArchitectureTests(unittest.TestCase):
             HostAgentToolCompleted,
             HostAgentCompleted,
             HostAgentFailed,
+            SearchVisibleEntitiesArgs,
+            VisibleEntitySummary,
+            SearchVisibleEntitiesResult,
+            GetVisibleEntityArgs,
+            GetVisibleEntityResult,
+            ToolError,
+            ToolErrorResult,
             PlayerTurnPayload,
             WebSocketOutput,
             TurnOutput,

--- a/agent-collaboration-framework/tests/test_host_agent_tools.py
+++ b/agent-collaboration-framework/tests/test_host_agent_tools.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from io import StringIO
+import json
+import logging
+import unittest
+
+from collaboration_framework.contracts import (
+    CheckpointOption,
+    ContractModel,
+    PlayerInput,
+    PlayerView,
+    VisibleEntity,
+)
+from collaboration_framework.host.application import ToolDefinition, ToolRegistry
+from collaboration_framework.host.schemas import (
+    GetVisibleEntityArgs,
+    GetVisibleEntityResult,
+    HostAgentContext,
+    SearchVisibleEntitiesArgs,
+    SearchVisibleEntitiesResult,
+    ToolErrorResult,
+)
+from collaboration_framework.host.tools import build_player_view_tool_registry
+
+
+SECRET = "SECRET_SENTINEL_DO_NOT_LEAK"
+
+
+def make_context() -> HostAgentContext:
+    return HostAgentContext(
+        player_input=PlayerInput(
+            room_id="room_001",
+            player_id="player_001",
+            actor_id="actor_001",
+            client_action_id="action_001",
+            utterance="检查书架",
+        ),
+        player_view=PlayerView(
+            room_id="room_001",
+            player_id="player_001",
+            actor_id="actor_001",
+            scene_id="library",
+            phase="playing",
+            revision="7",
+            visible_entities=(
+                VisibleEntity(
+                    id="entity_b",
+                    kind="object",
+                    name="Ancient Shelf",
+                    aliases=("Bookcase",),
+                    content="Old oak furniture.",
+                ),
+                VisibleEntity(
+                    id="entity_a",
+                    kind="location",
+                    name="Shelf Door",
+                    content="A narrow exit.",
+                ),
+                VisibleEntity(
+                    id="entity_c",
+                    kind="object",
+                    name="Locked Cabinet",
+                    aliases=("Book Shelf",),
+                    content="Its doors are locked.",
+                ),
+                VisibleEntity(
+                    id="entity_d",
+                    kind="npc",
+                    name="Curator",
+                    content="Dust from a shelf marks their coat.",
+                ),
+                VisibleEntity(
+                    id="entity_e",
+                    kind="location",
+                    name="ＲＥＤ   Door",
+                    content="A painted doorway.",
+                ),
+                VisibleEntity(
+                    id="entity_f",
+                    kind="object",
+                    name="Reading Desk",
+                    content="A plain writing desk.",
+                ),
+            ),
+            checkpoint_options=(
+                CheckpointOption(
+                    id="checkpoint_z",
+                    target_id="entity_b",
+                    action_hint="inspect",
+                    skills=("spot_hidden",),
+                ),
+                CheckpointOption(
+                    id="checkpoint_other",
+                    target_id="entity_c",
+                    action_hint="open",
+                    skills=("lockpick",),
+                ),
+                CheckpointOption(
+                    id="checkpoint_a",
+                    target_id="entity_b",
+                    action_hint="search",
+                    skills=("investigation",),
+                ),
+            ),
+        ),
+    )
+
+
+def error_code(result: ContractModel) -> str:
+    if not isinstance(result, ToolErrorResult):
+        raise AssertionError(f"expected ToolErrorResult, got {type(result)!r}")
+    return result.error.code
+
+
+class ToolRegistryTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.registry = build_player_view_tool_registry()
+        self.bound = self.registry.bind(make_context())
+
+    def test_definitions_are_immutable_sorted_and_read_only(self) -> None:
+        self.assertEqual(
+            [definition.name for definition in self.registry.definitions],
+            ["get_visible_entity", "search_visible_entities"],
+        )
+        for definition in self.registry.definitions:
+            with self.subTest(definition=definition.name):
+                self.assertEqual(definition.access, "read_only")
+                self.assertTrue(definition.description)
+                self.assertTrue(definition.public_progress_label)
+        with self.assertRaises(FrozenInstanceError):
+            self.registry.definitions[0].name = "changed"  # type: ignore[misc]
+
+    def test_bind_requires_validated_host_agent_context(self) -> None:
+        with self.assertRaisesRegex(TypeError, "HostAgentContext"):
+            self.registry.bind(object())  # type: ignore[arg-type]
+
+    def test_duplicate_registration_fails(self) -> None:
+        definition = self.registry.definitions[0]
+        with self.assertRaisesRegex(ValueError, "duplicate tool registration"):
+            ToolRegistry((definition, definition))
+
+    async def test_unknown_tool_does_not_execute_registered_handler(self) -> None:
+        calls = 0
+
+        async def counted_handler(
+            _context: HostAgentContext,
+            _arguments: ContractModel,
+        ) -> SearchVisibleEntitiesResult:
+            nonlocal calls
+            calls += 1
+            return SearchVisibleEntitiesResult()
+
+        definition = ToolDefinition(
+            name="known_tool",
+            description="A known read-only tool.",
+            args_model=SearchVisibleEntitiesArgs,
+            result_model=SearchVisibleEntitiesResult,
+            public_progress_label="正在执行已知工具",
+            handler=counted_handler,
+        )
+        result = await ToolRegistry((definition,)).bind(make_context()).ainvoke(
+            "unknown_tool",
+            {"query": "shelf"},
+        )
+
+        self.assertEqual(error_code(result), "TOOL_NOT_FOUND")
+        self.assertEqual(calls, 0)
+
+        non_string_result = await ToolRegistry((definition,)).bind(
+            make_context()
+        ).ainvoke(
+            ["known_tool"],  # type: ignore[arg-type]
+            {"query": "shelf"},
+        )
+        self.assertEqual(error_code(non_string_result), "TOOL_NOT_FOUND")
+        self.assertEqual(calls, 0)
+
+    async def test_invalid_arguments_are_rejected_before_handler(self) -> None:
+        invalid_payloads = (
+            {},
+            {"query": ""},
+            {"query": "   "},
+            {"query": "shelf", "kind": "secret"},
+            {"query": "shelf", "limit": 0},
+            {"query": "shelf", "limit": 6},
+            {"query": "shelf", "unexpected": True},
+            {"query": "shelf", "room_id": "other_room"},
+            {"query": "shelf", "player_id": "other_player"},
+            {"query": "shelf", "actor_id": "other_actor"},
+        )
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                result = await self.bound.ainvoke(
+                    "search_visible_entities",
+                    payload,
+                )
+                self.assertEqual(error_code(result), "INVALID_TOOL_ARGUMENTS")
+
+    async def test_result_is_validated_against_declared_model(self) -> None:
+        async def malformed_handler(
+            _context: HostAgentContext,
+            _arguments: ContractModel,
+        ) -> object:
+            return {
+                "matches": [
+                    {"id": "", "kind": "object", "name": "Invalid"}
+                ]
+            }
+
+        definition = ToolDefinition(
+            name="malformed_tool",
+            description="Returns an invalid result for contract testing.",
+            args_model=SearchVisibleEntitiesArgs,
+            result_model=SearchVisibleEntitiesResult,
+            public_progress_label="正在验证工具结果",
+            handler=malformed_handler,
+        )
+        result = await ToolRegistry((definition,)).bind(make_context()).ainvoke(
+            "malformed_tool",
+            {"query": "shelf"},
+        )
+
+        self.assertEqual(error_code(result), "INVALID_TOOL_RESULT")
+
+    async def test_internal_exception_is_redacted(self) -> None:
+        async def failing_handler(
+            _context: HostAgentContext,
+            _arguments: ContractModel,
+        ) -> object:
+            raise RuntimeError(f"database detail: {SECRET}")
+
+        definition = ToolDefinition(
+            name="failing_tool",
+            description="Fails for redaction testing.",
+            args_model=SearchVisibleEntitiesArgs,
+            result_model=SearchVisibleEntitiesResult,
+            public_progress_label="正在验证失败脱敏",
+            handler=failing_handler,
+        )
+        result = await ToolRegistry((definition,)).bind(make_context()).ainvoke(
+            "failing_tool",
+            {"query": "shelf"},
+        )
+
+        self.assertEqual(error_code(result), "TOOL_INTERNAL_ERROR")
+        self.assertNotIn(SECRET, result.model_dump_json())
+        self.assertNotIn("database", result.model_dump_json())
+
+    async def test_base_exception_is_not_swallowed(self) -> None:
+        class StopRun(BaseException):
+            pass
+
+        async def stopping_handler(
+            _context: HostAgentContext,
+            _arguments: ContractModel,
+        ) -> object:
+            raise StopRun()
+
+        definition = ToolDefinition(
+            name="stopping_tool",
+            description="Stops the run for contract testing.",
+            args_model=SearchVisibleEntitiesArgs,
+            result_model=SearchVisibleEntitiesResult,
+            public_progress_label="正在停止测试运行",
+            handler=stopping_handler,
+        )
+        with self.assertRaises(StopRun):
+            await ToolRegistry((definition,)).bind(make_context()).ainvoke(
+                "stopping_tool",
+                {"query": "shelf"},
+            )
+
+    def test_adapter_schemas_are_json_safe_and_scope_free(self) -> None:
+        forbidden = {
+            "room_id",
+            "player_id",
+            "actor_id",
+            "secret",
+            "sdk",
+            "reasoning",
+        }
+        for definition in self.registry.definitions:
+            with self.subTest(definition=definition.name):
+                arguments_schema = definition.arguments_json_schema()
+                result_schema = definition.result_json_schema()
+                self.assertFalse(arguments_schema["additionalProperties"])
+                self.assertFalse(result_schema["additionalProperties"])
+
+                rendered = json.dumps(
+                    {
+                        "arguments": arguments_schema,
+                        "result": result_schema,
+                    },
+                    ensure_ascii=False,
+                ).lower()
+                for token in forbidden:
+                    self.assertNotIn(token, rendered)
+                self.assertNotIn(SECRET.lower(), rendered)
+
+
+class VisibleEntityToolTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.context = make_context()
+        self.bound = build_player_view_tool_registry().bind(self.context)
+        self.hidden_entity = VisibleEntity(
+            id="hidden_entity",
+            kind="object",
+            name=SECRET,
+            content=f"Hidden content: {SECRET}",
+        )
+
+    async def search(self, **arguments: object) -> SearchVisibleEntitiesResult:
+        result = await self.bound.ainvoke(
+            "search_visible_entities",
+            arguments,
+        )
+        self.assertIsInstance(result, SearchVisibleEntitiesResult)
+        return result
+
+    async def test_searches_name_alias_and_content_with_stable_priority(self) -> None:
+        result = await self.search(query="shelf")
+        self.assertEqual(
+            [match.id for match in result.matches],
+            ["entity_a", "entity_b", "entity_c", "entity_d"],
+        )
+
+    async def test_search_normalizes_nfkc_case_and_whitespace(self) -> None:
+        result = await self.search(query="red door")
+        self.assertEqual([match.id for match in result.matches], ["entity_e"])
+
+        full_width_result = await self.search(query="ＳＨＥＬＦ")
+        self.assertEqual(
+            [match.id for match in full_width_result.matches],
+            ["entity_a", "entity_b", "entity_c", "entity_d"],
+        )
+
+    async def test_search_applies_kind_filter_and_limit(self) -> None:
+        filtered = await self.search(query="shelf", kind="object")
+        self.assertEqual(
+            [match.id for match in filtered.matches],
+            ["entity_b", "entity_c"],
+        )
+
+        limited = await self.search(query="shelf", limit=2)
+        self.assertEqual(
+            [match.id for match in limited.matches],
+            ["entity_a", "entity_b"],
+        )
+
+    async def test_search_returns_each_entity_once_at_its_best_rank(self) -> None:
+        result = await self.search(query="shelf")
+        ids = [match.id for match in result.matches]
+        self.assertEqual(ids.count("entity_c"), 1)
+        self.assertLess(ids.index("entity_c"), ids.index("entity_d"))
+
+    async def test_search_without_matches_is_successful_and_empty(self) -> None:
+        result = await self.search(query="telescope")
+        self.assertEqual(result.matches, ())
+
+    async def test_search_never_reads_unbound_hidden_entities(self) -> None:
+        result = await self.search(query=SECRET)
+        self.assertEqual(result.matches, ())
+        self.assertNotIn(SECRET, result.model_dump_json())
+        self.assertEqual(self.hidden_entity.name, SECRET)
+
+    async def test_get_returns_safe_detail_and_only_related_checkpoints(self) -> None:
+        result = await self.bound.ainvoke(
+            "get_visible_entity",
+            {"entity_id": "entity_b"},
+        )
+
+        self.assertIsInstance(result, GetVisibleEntityResult)
+        self.assertEqual(result.id, "entity_b")
+        self.assertEqual(result.aliases, ("Bookcase",))
+        self.assertEqual(
+            [option.id for option in result.checkpoint_options],
+            ["checkpoint_a", "checkpoint_z"],
+        )
+        self.assertNotIn("checkpoint_other", result.model_dump_json())
+
+    async def test_get_rejects_scope_fields_and_missing_id(self) -> None:
+        invalid_payloads = (
+            {},
+            {"entity_id": ""},
+            {"entity_id": "entity_b", "room_id": "other_room"},
+            {"entity_id": "entity_b", "player_id": "other_player"},
+            {"entity_id": "entity_b", "actor_id": "other_actor"},
+        )
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                result = await self.bound.ainvoke(
+                    "get_visible_entity",
+                    payload,
+                )
+                self.assertEqual(error_code(result), "INVALID_TOOL_ARGUMENTS")
+
+    async def test_get_uses_one_error_for_hidden_foreign_and_missing_ids(self) -> None:
+        payloads: list[dict[str, str]] = [
+            {"entity_id": "hidden_entity"},
+            {"entity_id": "other_player_entity"},
+            {"entity_id": "does_not_exist"},
+        ]
+        serialized_errors: list[str] = []
+        for payload in payloads:
+            result = await self.bound.ainvoke("get_visible_entity", payload)
+            self.assertEqual(error_code(result), "ENTITY_NOT_VISIBLE")
+            serialized_errors.append(result.model_dump_json())
+
+        self.assertEqual(len(set(serialized_errors)), 1)
+        self.assertEqual(
+            json.loads(serialized_errors[0]),
+            {
+                "error": {
+                    "code": "ENTITY_NOT_VISIBLE",
+                    "message": (
+                        "The requested entity is not available in the "
+                        "current player view."
+                    ),
+                }
+            },
+        )
+        self.assertNotIn(SECRET, serialized_errors[0])
+
+    async def test_tool_calls_do_not_log_arguments_results_or_secrets(self) -> None:
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        root_logger = logging.getLogger()
+        root_logger.addHandler(handler)
+        try:
+            search_result = await self.bound.ainvoke(
+                "search_visible_entities",
+                {"query": SECRET},
+            )
+            get_result = await self.bound.ainvoke(
+                "get_visible_entity",
+                {"entity_id": "hidden_entity"},
+            )
+        finally:
+            root_logger.removeHandler(handler)
+
+        combined = (
+            search_result.model_dump_json()
+            + get_result.model_dump_json()
+            + stream.getvalue()
+        )
+        self.assertNotIn(SECRET, combined)
+
+
+class ToolSchemaModelTests(unittest.TestCase):
+    def test_declared_models_forbid_unknown_fields(self) -> None:
+        models = (
+            SearchVisibleEntitiesArgs,
+            SearchVisibleEntitiesResult,
+            GetVisibleEntityArgs,
+            GetVisibleEntityResult,
+        )
+        for model in models:
+            with self.subTest(model=model.__name__):
+                self.assertEqual(model.model_config["extra"], "forbid")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

完成 Issue #117 的 player-safe 只读工具与框架无关 Tool Registry：

- 新增不可变的 `ToolDefinition` / `ToolRegistry` / `BoundToolRegistry`；
- 将工具调用绑定到可信 `HostAgentContext`，模型不能通过参数切换 room/player/actor；
- 新增 `search_visible_entities` 与 `get_visible_entity`；
- 参数、成功结果和稳定错误均使用项目 Pydantic Schema；
- 增加确定性排序、权限、错误脱敏、Schema 安全和秘密哨兵测试；
- 更新 README、架构与数据模型文档。

## 范围与边界

本 PR 仅修改成员 A 的 Host 私有实现、测试和文档：

- 不修改 A/B/C 公共 Contract；
- 不修改 Engine、Module 或持久化实现；
- 不访问 GameState、完整模组、数据库或其他玩家数据；
- 所有工具均为 read-only；
- 不将 `ActionExecutor` 注册为工具；
- SDK Adapter、工具预算与 timeout 继续由 #118 跟踪。

因此本 PR 不需要 B/C Contract 对齐。

## 验证

使用 Python 3.12.13 / Pydantic 2.13.4：

- `python -m unittest tests.test_host_agent_tools -v`：20 tests passed；
- `python -m unittest discover -s tests -v`：72 tests passed；
- 移除 OpenAI/DashScope/Qwen API Key 后全量 72 tests passed；
- `python -m compileall collaboration_framework tests`：通过；
- `python -m collaboration_framework.schema_export`：通过且无生成差异；
- `git diff --check`：通过。

Closes #117
