### PR TITLE
fix: 对齐模组身份并加载追书人 ModuleContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ uv run uvicorn app.main:app --reload
 > 里只有空的历史表、没有真实数据，**直接删掉重新迁移即可**（`rm trpg-backend/app.db`
 > 再 `alembic upgrade head`）。
 
+首次启动后，应用 Seed 只会创建 COC7 规则系统和 `wip` 状态的追书人目录，不会
+内嵌简化版模组内容。在另一个终端执行固定的本地加载命令，将仓库中的追书人
+ModuleContent 经过 Validation 后原子写入数据库，并把目录标记为 `ready`：
+
+```bash
+cd trpg-backend
+uv run python scripts/load_paper_chase.py
+```
+
+该命令只读取
+`agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-draft.json`。
+重复执行相同内容会返回 `unchanged`；同一版本已有不同内容时会拒绝覆盖。
+
 后端默认地址：<http://127.0.0.1:8000>
 
 - 健康检查：<http://127.0.0.1:8000/api/v1/health>

--- a/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-draft.json
+++ b/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-draft.json
@@ -811,7 +811,7 @@
       "scene_id": "kimball_house",
       "action": "read",
       "target_id": "douglas_diary",
-      "skills": ["language-english"],
+      "skills": ["language-foreign-1"],
       "difficulty": "regular",
       "outcomes": {
         "success": {

--- a/trpg-backend/alembic/versions/b7e4c2d1a6f9_align_module_identity_v1.py
+++ b/trpg-backend/alembic/versions/b7e4c2d1a6f9_align_module_identity_v1.py
@@ -1,0 +1,243 @@
+"""Align database module identity with ModuleContent v1.
+
+Revision ID: b7e4c2d1a6f9
+Revises: 9c4e7a2b1d6f
+Create Date: 2026-07-25 16:30:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b7e4c2d1a6f9"
+down_revision: str | Sequence[str] | None = "9c4e7a2b1d6f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _guard_existing_data() -> None:
+    """本期不迁移历史目录或运行时数据，任何相关数据都必须显式拒绝。"""
+
+    connection = op.get_bind()
+    for table_name in (
+        "action_executions",
+        "game_events",
+        "game_sessions",
+        "module_versions",
+        "scenarios",
+        "game_systems",
+    ):
+        if connection.execute(sa.text(f"SELECT 1 FROM {table_name} LIMIT 1")).first():
+            raise RuntimeError(
+                f"迁移已中止：{table_name} 存在历史数据；"
+                "Issue #141 不处理历史数据兼容，请重建本地数据库。"
+            )
+
+
+def _drop_engine_tables() -> None:
+    op.drop_table("action_executions")
+    op.drop_index("ix_game_events_room_client_action", table_name="game_events")
+    op.drop_table("game_events")
+    op.drop_table("game_sessions")
+    op.drop_table("module_versions")
+
+
+def _create_engine_tables(*, stable_module_identity: bool) -> None:
+    module_id_type = sa.String(length=200) if stable_module_identity else sa.Uuid(as_uuid=False)
+    scenario_target = "scenarios.module_id" if stable_module_identity else "scenarios.id"
+
+    op.create_table(
+        "module_versions",
+        sa.Column("module_id", module_id_type, nullable=False),
+        sa.Column("version", sa.String(length=50), nullable=False),
+        sa.Column("world_ref", sa.String(length=200), nullable=False),
+        sa.Column(
+            "content_schema_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("content_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "content_schema_version >= 1",
+            name="ck_module_versions_content_schema_version",
+        ),
+        sa.ForeignKeyConstraint(
+            ["module_id"],
+            [scenario_target],
+            name="fk_module_versions_scenario_module_id"
+            if stable_module_identity
+            else "fk_module_versions_scenario_id",
+        ),
+        sa.PrimaryKeyConstraint("module_id", "version", name="pk_module_versions"),
+    )
+    op.create_table(
+        "game_sessions",
+        sa.Column("room_id", sa.Uuid(as_uuid=False), nullable=False),
+        sa.Column("module_id", module_id_type, nullable=False),
+        sa.Column("module_version", sa.String(length=50), nullable=False),
+        sa.Column(
+            "state_schema_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("state_json", sa.JSON(), nullable=False),
+        sa.Column(
+            "state_version",
+            sa.BigInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "state_schema_version >= 1",
+            name="ck_game_sessions_state_schema_version",
+        ),
+        sa.CheckConstraint(
+            "state_version >= 0",
+            name="ck_game_sessions_state_version",
+        ),
+        sa.ForeignKeyConstraint(
+            ["module_id", "module_version"],
+            ["module_versions.module_id", "module_versions.version"],
+            name="fk_game_sessions_module_version",
+        ),
+        sa.ForeignKeyConstraint(["room_id"], ["rooms.id"]),
+        sa.PrimaryKeyConstraint("room_id"),
+    )
+    op.create_table(
+        "game_events",
+        sa.Column("room_id", sa.Uuid(as_uuid=False), nullable=False),
+        sa.Column("sequence", sa.BigInteger(), nullable=False),
+        sa.Column("event_id", sa.String(length=100), nullable=False),
+        sa.Column("client_action_id", sa.String(length=200), nullable=False),
+        sa.Column("type", sa.String(length=50), nullable=False),
+        sa.Column("actor_id", sa.String(length=100), nullable=False),
+        sa.Column("visibility", sa.String(length=20), nullable=False),
+        sa.Column("cause", sa.Text(), nullable=False),
+        sa.Column(
+            "event_schema_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("sequence >= 1", name="ck_game_events_sequence"),
+        sa.CheckConstraint(
+            "event_schema_version >= 1",
+            name="ck_game_events_event_schema_version",
+        ),
+        sa.CheckConstraint(
+            "visibility IN ('public', 'private', 'hidden')",
+            name="ck_game_events_visibility",
+        ),
+        sa.ForeignKeyConstraint(["room_id"], ["game_sessions.room_id"]),
+        sa.PrimaryKeyConstraint("room_id", "sequence", name="pk_game_events"),
+        sa.UniqueConstraint("room_id", "event_id", name="uq_game_events_room_event"),
+    )
+    op.create_index(
+        "ix_game_events_room_client_action",
+        "game_events",
+        ["room_id", "client_action_id"],
+        unique=False,
+    )
+    op.create_table(
+        "action_executions",
+        sa.Column("room_id", sa.Uuid(as_uuid=False), nullable=False),
+        sa.Column("request_id", sa.String(length=200), nullable=False),
+        sa.Column(
+            "request_schema_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("request_json", sa.JSON(), nullable=False),
+        sa.Column(
+            "result_schema_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("result_json", sa.JSON(), nullable=False),
+        sa.Column("committed_state_version", sa.BigInteger(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "request_schema_version >= 1",
+            name="ck_action_executions_request_schema_version",
+        ),
+        sa.CheckConstraint(
+            "result_schema_version >= 1",
+            name="ck_action_executions_result_schema_version",
+        ),
+        sa.CheckConstraint(
+            "committed_state_version >= 0",
+            name="ck_action_executions_committed_state_version",
+        ),
+        sa.ForeignKeyConstraint(["room_id"], ["game_sessions.room_id"]),
+        sa.PrimaryKeyConstraint("room_id", "request_id", name="pk_action_executions"),
+    )
+
+
+def upgrade() -> None:
+    """增加稳定身份字段，并用字符串 module_id 重建空的运行时表。"""
+
+    _guard_existing_data()
+    _drop_engine_tables()
+
+    op.add_column(
+        "game_systems",
+        sa.Column(
+            "world_ref",
+            sa.String(length=200),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    with op.batch_alter_table("game_systems") as batch_op:
+        batch_op.alter_column(
+            "world_ref",
+            existing_type=sa.String(length=200),
+            server_default=None,
+        )
+        batch_op.create_unique_constraint("uq_game_systems_world_ref", ["world_ref"])
+
+    op.add_column(
+        "scenarios",
+        sa.Column(
+            "module_id",
+            sa.String(length=200),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    with op.batch_alter_table("scenarios") as batch_op:
+        batch_op.alter_column(
+            "module_id",
+            existing_type=sa.String(length=200),
+            server_default=None,
+        )
+        batch_op.create_unique_constraint("uq_scenarios_module_id", ["module_id"])
+
+    _create_engine_tables(stable_module_identity=True)
+
+
+def downgrade() -> None:
+    """恢复仅支持内部 UUID module_id 的空表结构。"""
+
+    _guard_existing_data()
+    _drop_engine_tables()
+
+    with op.batch_alter_table("scenarios") as batch_op:
+        batch_op.drop_constraint("uq_scenarios_module_id", type_="unique")
+        batch_op.drop_column("module_id")
+    with op.batch_alter_table("game_systems") as batch_op:
+        batch_op.drop_constraint("uq_game_systems_world_ref", type_="unique")
+        batch_op.drop_column("world_ref")
+
+    _create_engine_tables(stable_module_identity=False)

--- a/trpg-backend/app/core/seed.py
+++ b/trpg-backend/app/core/seed.py
@@ -7,98 +7,25 @@
 带上 `app/core/coc7_content.py` 的规则数据（属性/技能/职业目录），供
 `GET /systems/{systemId}/ruleset` 返回。
 
-issue #89 起，``Scenario`` 只保存目录和展示信息；规则引擎消费的完整内容保存为
-不可变的 ``ModuleVersion``。内置版本在写入前通过当前 ``ModuleContent`` 契约
-校验，并且至少包含一个可开局 Scene。
+issue #141 起，``Scenario`` 只保存目录和展示信息。规则引擎消费的完整内容由
+本地追书人加载脚本经过 Validation 后写入不可变的 ``ModuleVersion``；Seed
+不再内嵌或发布简化版 ModuleContent。
 
 用固定 UUID + 幂等插入（先查是否已存在）：应用启动时、测试 fixture 里都可以
-放心重复调用，不会插入重复数据，也不会原地覆盖已经发布的版本内容。
+放心重复调用，不会插入重复数据，也不会改变加载脚本已经发布的版本和 ready 状态。
 """
 
-from collaboration_framework.contracts import ModuleContent
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.coc7_content import build_coc7_ruleset
 from app.models.content import Game, GameSystem, Scenario
-from app.models.engine import ModuleVersion
 
 BUILTIN_GAME_ID = "00000000-0000-0000-0000-000000000001"
 BUILTIN_SYSTEM_ID = "00000000-0000-0000-0000-000000000002"
 BUILTIN_SCENARIO_ID = "00000000-0000-0000-0000-000000000003"
+BUILTIN_MODULE_ID = "paper-chase-zh-coc7"
 BUILTIN_MODULE_VERSION = "1.0.0"
-BUILTIN_WORLD_REF = "coc7-modern"
-
-# 从 dict 入口做校验，确保这份最终写入 JSON 列的发布内容与真实导入/发布边界一致。
-# to_json_dict() 同时将 tuple、别名等 Pydantic 表示转换为数据库可序列化的 JSON。
-BUILTIN_MODULE_CONTENT = ModuleContent.model_validate(
-    {
-        "module_id": BUILTIN_SCENARIO_ID,
-        "version": BUILTIN_MODULE_VERSION,
-        "world_ref": BUILTIN_WORLD_REF,
-        "scenes": [
-            {
-                "id": "scene-old-bookshop",
-                "name": "旧书店",
-                "content": "调查员来到一间即将打烊的旧书店，寻找失踪藏书留下的线索。",
-                "entity_ids": ["location-old-bookshop"],
-                "checkpoint_ids": ["checkpoint-search-ledger"],
-            }
-        ],
-        "entities": [
-            {
-                "id": "location-old-bookshop",
-                "kind": "location",
-                "name": "旧书店",
-                "aliases": ["书店"],
-                "content": "狭窄的书架后是一张堆满账本的木桌。",
-                "secrets": "最新的借阅记录夹在账本封底。",
-                "state": {"ledger_found": False},
-                "direct_responses": {"observe": "木桌上的账本有一页明显被反复翻动过。"},
-            }
-        ],
-        "checkpoints": [
-            {
-                "id": "checkpoint-search-ledger",
-                "scene_id": "scene-old-bookshop",
-                "action": "search",
-                "target_id": "location-old-bookshop",
-                "skills": ["spot-hidden"],
-                "difficulty": "regular",
-                "mvp_check_result": "success",
-                "outcomes": {
-                    "success": {
-                        "facts": ["调查员找到了失踪藏书的借阅记录。"],
-                        "player_visible_information": ["账本封底夹着一张近期借阅单。"],
-                        "narration_constraints": ["说明借阅单仍然清晰可读。"],
-                        "ops": [
-                            {
-                                "op": "modify",
-                                "path": "entities.location-old-bookshop.ledger_found",
-                                "set": True,
-                            }
-                        ],
-                    },
-                    "failure": {
-                        "facts": ["调查员暂时没有发现账本里的暗格。"],
-                        "player_visible_information": ["成叠账本让搜索变得十分困难。"],
-                        "narration_constraints": ["不要透露借阅单的位置。"],
-                    },
-                },
-            }
-        ],
-        "win_conditions": [
-            {
-                "id": "ending-ledger-found",
-                "when": {
-                    "path": "entities.location-old-bookshop.ledger_found",
-                    "equals": True,
-                },
-                "fact": "调查员取得了追查失踪藏书所需的关键记录。",
-                "player_visible_information": "借阅单为下一步调查指明了方向。",
-            }
-        ],
-    }
-).to_json_dict()
+BUILTIN_WORLD_REF = "coc-7e"
 
 BUILTIN_STORY_PAGES = [
     {
@@ -128,19 +55,22 @@ async def ensure_seed_content(db: AsyncSession) -> None:
             GameSystem(
                 id=BUILTIN_SYSTEM_ID,
                 game_id=BUILTIN_GAME_ID,
+                world_ref=BUILTIN_WORLD_REF,
                 name="COC7",
                 version="7th",
                 ruleset=coc7_ruleset,
             )
         )
-    elif system.ruleset != coc7_ruleset:
-        # 内置规则随代码发版，数据库副本每次启动都跟代码对齐。
+    else:
+        # 内置规则与稳定 world_ref 随代码发版，数据库副本每次启动都跟代码对齐。
+        system.world_ref = BUILTIN_WORLD_REF
         system.ruleset = coc7_ruleset
 
     scenario = await db.get(Scenario, BUILTIN_SCENARIO_ID)
     if scenario is None:
         scenario = Scenario(
             id=BUILTIN_SCENARIO_ID,
+            module_id=BUILTIN_MODULE_ID,
             game_system_id=BUILTIN_SYSTEM_ID,
             title="追书人（内置）",
             version=BUILTIN_MODULE_VERSION,
@@ -150,7 +80,7 @@ async def ensure_seed_content(db: AsyncSession) -> None:
             difficulty=1,
             estimated_duration="2-3 小时",
             synopsis="内置模拟模组，供 MS1 骨架联调使用。",
-            status="ready",
+            status="wip",
             name_en="The Book Seeker",
             story_label="CASE-001",
             subtitle="失踪藏书留下的最后线索",
@@ -158,27 +88,11 @@ async def ensure_seed_content(db: AsyncSession) -> None:
         )
         db.add(scenario)
     else:
-        # 目录展示信息可以随应用更新；已发布的 ModuleVersion 内容不能原地修改。
-        scenario.version = BUILTIN_MODULE_VERSION
-        scenario.status = "ready"
+        # 目录展示信息可以随应用更新；加载器写入的推荐版本和 ready 状态必须保留。
+        scenario.module_id = BUILTIN_MODULE_ID
         scenario.name_en = "The Book Seeker"
         scenario.story_label = "CASE-001"
         scenario.subtitle = "失踪藏书留下的最后线索"
         scenario.story_pages = BUILTIN_STORY_PAGES
-
-    module_version = await db.get(
-        ModuleVersion,
-        (BUILTIN_SCENARIO_ID, BUILTIN_MODULE_VERSION),
-    )
-    if module_version is None:
-        db.add(
-            ModuleVersion(
-                module_id=BUILTIN_SCENARIO_ID,
-                version=BUILTIN_MODULE_VERSION,
-                world_ref=BUILTIN_WORLD_REF,
-                content_schema_version=1,
-                content_json=BUILTIN_MODULE_CONTENT,
-            )
-        )
 
     await db.commit()

--- a/trpg-backend/app/core/turn.py
+++ b/trpg-backend/app/core/turn.py
@@ -71,7 +71,10 @@ def build_turn_application(
     """装配唯一的主持编排纵切；模型端口后续可原位替换为 #111 的生产 Adapter。"""
 
     orchestrator = Orchestrator(
-        context_assembler=ContextAssembler(),
+        # ContextAssembler 从 ModuleContent v1 起要求显式背景；当前后端组合根仍是
+        # 全局单例，按房间注入真实背景属于后续 Host Agent 组合改造。本期先提供
+        # 非空占位，真实 ModuleContent 仍由 EngineStore 按房间完整加载。
+        context_assembler=ContextAssembler("当前房间的模组背景与叙事基调。"),
         intent_parser=IntentParser(FakeIntentModel()),
         action_executor=engine,
         player_view_projector=PlayerViewProjector(engine),

--- a/trpg-backend/app/dto/game.py
+++ b/trpg-backend/app/dto/game.py
@@ -26,6 +26,7 @@ class GameSystemRead(CamelModel):
     model_config = {"from_attributes": True}
     id: str
     game_id: str
+    world_ref: str
     name: str
     version: str | None = None
 

--- a/trpg-backend/app/models/content.py
+++ b/trpg-backend/app/models/content.py
@@ -45,6 +45,7 @@ class GameSystem(Base):
     game_id: Mapped[str] = mapped_column(
         Uuid(as_uuid=False), ForeignKey("games.id"), nullable=False
     )
+    world_ref: Mapped[str] = mapped_column(String(200), nullable=False, unique=True)
     name: Mapped[str] = mapped_column(String(200), nullable=False)
     version: Mapped[str | None] = mapped_column(String(50), nullable=True)
     ruleset: Mapped[dict | None] = mapped_column(JSON, nullable=True)
@@ -89,6 +90,7 @@ class Scenario(Base):
     id: Mapped[str] = mapped_column(
         Uuid(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
     )
+    module_id: Mapped[str] = mapped_column(String(200), nullable=False, unique=True)
     world_id: Mapped[str | None] = mapped_column(
         Uuid(as_uuid=False), ForeignKey("worlds.id"), nullable=True
     )

--- a/trpg-backend/app/models/engine.py
+++ b/trpg-backend/app/models/engine.py
@@ -45,7 +45,7 @@ class ModuleVersion(Base):
     )
 
     module_id: Mapped[str] = mapped_column(
-        Uuid(as_uuid=False), ForeignKey("scenarios.id"), nullable=False
+        String(200), ForeignKey("scenarios.module_id"), nullable=False
     )
     version: Mapped[str] = mapped_column(String(50), nullable=False)
     world_ref: Mapped[str] = mapped_column(String(200), nullable=False)
@@ -79,7 +79,7 @@ class GameSession(Base):
     room_id: Mapped[str] = mapped_column(
         Uuid(as_uuid=False), ForeignKey("rooms.id"), primary_key=True
     )
-    module_id: Mapped[str] = mapped_column(Uuid(as_uuid=False), nullable=False)
+    module_id: Mapped[str] = mapped_column(String(200), nullable=False)
     module_version: Mapped[str] = mapped_column(String(50), nullable=False)
     state_schema_version: Mapped[int] = mapped_column(
         Integer, nullable=False, default=1, server_default="1"

--- a/trpg-backend/app/service/paper_chase_loader.py
+++ b/trpg-backend/app/service/paper_chase_loader.py
@@ -1,0 +1,178 @@
+"""将仓库内固定的追书人 ModuleContent 加载到本地数据库。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from collaboration_framework.module import validate_module_json
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dto.game import RulesetRead
+from app.models.content import GameSystem, Scenario
+from app.models.engine import ModuleVersion
+
+PAPER_CHASE_MODULE_ID = "paper-chase-zh-coc7"
+PAPER_CHASE_VERSION = "1.0.0"
+PAPER_CHASE_WORLD_REF = "coc-7e"
+PAPER_CHASE_SOURCE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "agent-collaboration-framework"
+    / "docs"
+    / "module-parser"
+    / "examples"
+    / "module-content-validation"
+    / "追书人"
+    / "module-content-draft.json"
+)
+
+
+class PaperChaseLoadError(RuntimeError):
+    """追书人不能通过校验或不能安全写入数据库。"""
+
+
+@dataclass(frozen=True)
+class PaperChaseLoadResult:
+    module_id: str
+    version: str
+    world_ref: str
+    scene_count: int
+    entity_count: int
+    checkpoint_count: int
+    rule_count: int
+    win_condition_count: int
+    outcome: str
+
+    def summary_lines(self) -> tuple[str, ...]:
+        return (
+            f"module_id: {self.module_id}",
+            f"version: {self.version}",
+            f"world_ref: {self.world_ref}",
+            f"scenes: {self.scene_count}",
+            f"entities: {self.entity_count}",
+            f"checkpoints: {self.checkpoint_count}",
+            f"rules: {self.rule_count}",
+            f"win_conditions: {self.win_condition_count}",
+            f"result: {self.outcome}",
+        )
+
+
+def _check_catalog(ruleset: RulesetRead) -> set[str]:
+    """构造 Validation 使用的 COC7 检定目录。
+
+    ModuleDraft 目前把技能和属性检定都放在 ``Checkpoint.skills``。因此目录以
+    Ruleset 的技能 ID 为主体，同时加入属性键及其小写形式，以接受追书人中现有的
+    ``STR`` 与 ``luck`` 检定；所有值仍然只来自数据库 Ruleset。
+    """
+
+    if not ruleset.skills:
+        raise PaperChaseLoadError("coc-7e GameSystem 的 Ruleset 没有可用技能目录")
+    catalog = {skill.id for skill in ruleset.skills}
+    for attribute in ruleset.attributes:
+        catalog.add(attribute.key)
+        catalog.add(attribute.key.lower())
+    return catalog
+
+
+async def load_paper_chase(
+    db: AsyncSession,
+    *,
+    _before_commit: Callable[[], None] | None = None,
+) -> PaperChaseLoadResult:
+    """校验并原子、幂等地加载固定的追书人 JSON。"""
+
+    try:
+        payload = PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PaperChaseLoadError(f"无法读取固定追书人文件: {PAPER_CHASE_SOURCE_PATH}") from exc
+
+    async with db.begin():
+        system = await db.scalar(
+            select(GameSystem).where(GameSystem.world_ref == PAPER_CHASE_WORLD_REF)
+        )
+        if system is None:
+            raise PaperChaseLoadError("找不到 world_ref=coc-7e 的 GameSystem，请先迁移并 Seed")
+        if not system.ruleset:
+            raise PaperChaseLoadError("coc-7e GameSystem 的 Ruleset 为空")
+        try:
+            ruleset = RulesetRead.model_validate(system.ruleset)
+        except ValidationError as exc:
+            raise PaperChaseLoadError("coc-7e GameSystem 的 Ruleset 无法构造技能目录") from exc
+
+        report = validate_module_json(payload, skill_catalog=_check_catalog(ruleset))
+        if report.status != "pass" or report.content is None:
+            issues = "; ".join(f"{issue.code}@{issue.path}" for issue in report.errors)
+            raise PaperChaseLoadError(
+                f"追书人 Validation 未通过（status={report.status}）"
+                + (f": {issues}" if issues else "")
+            )
+        content = report.content
+        actual_identity = (content.module_id, content.version, content.world_ref)
+        expected_identity = (
+            PAPER_CHASE_MODULE_ID,
+            PAPER_CHASE_VERSION,
+            PAPER_CHASE_WORLD_REF,
+        )
+        if actual_identity != expected_identity:
+            raise PaperChaseLoadError(
+                f"追书人身份不匹配，期望 {expected_identity!r}，实际 {actual_identity!r}"
+            )
+
+        scenario = await db.scalar(
+            select(Scenario).where(Scenario.module_id == PAPER_CHASE_MODULE_ID)
+        )
+        if scenario is None:
+            raise PaperChaseLoadError(
+                "找不到 module_id=paper-chase-zh-coc7 的 Scenario，请先迁移并 Seed"
+            )
+        if scenario.game_system_id != system.id:
+            raise PaperChaseLoadError("追书人 Scenario 与 coc-7e GameSystem 不匹配")
+
+        normalized_content = content.to_json_dict()
+        module_version = await db.get(
+            ModuleVersion,
+            (PAPER_CHASE_MODULE_ID, PAPER_CHASE_VERSION),
+        )
+        if module_version is None:
+            module_version = ModuleVersion(
+                module_id=PAPER_CHASE_MODULE_ID,
+                version=PAPER_CHASE_VERSION,
+                world_ref=PAPER_CHASE_WORLD_REF,
+                content_schema_version=1,
+                content_json=normalized_content,
+            )
+            db.add(module_version)
+            outcome = "inserted"
+        elif (
+            module_version.world_ref == PAPER_CHASE_WORLD_REF
+            and module_version.content_schema_version == 1
+            and module_version.content_json == normalized_content
+        ):
+            outcome = "unchanged"
+        else:
+            raise PaperChaseLoadError(
+                "同一 (module_id, version) 已存在不同内容；"
+                "请调整版本或重建本地数据库，加载器不会静默覆盖"
+            )
+
+        scenario.version = PAPER_CHASE_VERSION
+        scenario.status = "ready"
+        await db.flush()
+        if _before_commit is not None:
+            _before_commit()
+
+    entity_rule_count = sum(len(entity.rules) for entity in content.entities)
+    return PaperChaseLoadResult(
+        module_id=content.module_id,
+        version=content.version,
+        world_ref=content.world_ref,
+        scene_count=len(content.scenes),
+        entity_count=len(content.entities),
+        checkpoint_count=len(content.checkpoints),
+        rule_count=len(content.module_rules) + entity_rule_count,
+        win_condition_count=len(content.win_conditions),
+        outcome=outcome,
+    )

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -149,6 +149,13 @@ async def _module_title(db: AsyncSession, scenario_id: str | None) -> str | None
     return scenario.title if scenario is not None else None
 
 
+async def _module_identity(db: AsyncSession, scenario_id: str | None) -> str | None:
+    if scenario_id is None:
+        return None
+    scenario = await db.get(Scenario, scenario_id)
+    return scenario.module_id if scenario is not None else None
+
+
 async def _to_room_preview(db: AsyncSession, room: Room) -> RoomPreview:
     result = await db.scalars(select(Player).where(Player.room_id == room.id))
     room_players = list(result)
@@ -158,7 +165,7 @@ async def _to_room_preview(db: AsyncSession, room: Room) -> RoomPreview:
         room_name=room.room_name,
         phase=room.phase,
         story_started=room.phase != "Lobby",
-        module_id=room.scenario_id,
+        module_id=await _module_identity(db, room.scenario_id),
         module_title=await _module_title(db, room.scenario_id),
         player_count=len(room_players),
         max_players=room.max_players,
@@ -307,20 +314,23 @@ async def select_module(
     if room.phase != "Lobby":
         raise RoomConflictError("只能在大厅阶段选择模组")
 
-    scenario = await db.get(Scenario, payload.module_id)
+    scenario = await db.scalar(select(Scenario).where(Scenario.module_id == payload.module_id))
     if scenario is None:
         raise ModuleNotFoundError("模组不存在")
     if scenario.status != "ready":
         raise RoomConflictError("只有 ready 状态的模组可以用于正式开局")
-    module_version = await db.get(ModuleVersion, (scenario.id, scenario.version))
+    module_version = await db.get(ModuleVersion, (scenario.module_id, scenario.version))
     if module_version is None:
         raise ModuleNotFoundError("模组当前推荐版本尚未发布")
+
+    system = await db.get(GameSystem, scenario.game_system_id)
+    if system is None or system.world_ref != module_version.world_ref:
+        raise RoomConflictError("模组版本引用的规则系统不存在或不匹配")
 
     room.scenario_id = scenario.id
     room.module_version = module_version.version
     room.system_id = scenario.game_system_id
-    system = await db.get(GameSystem, scenario.game_system_id)
-    room.game_id = system.game_id if system is not None else None
+    room.game_id = system.game_id
     room.attribute_gen_method = payload.attribute_gen_method
     await db.commit()
 
@@ -379,12 +389,18 @@ async def begin_game(db: AsyncSession, room_id: str, player_id: str) -> None:
     if await db.get(GameSession, room.id) is not None:
         raise RoomConflictError("该房间已经创建过 GameSession")
 
+    scenario = await db.get(Scenario, room.scenario_id)
+    if scenario is None:
+        raise ModuleNotSelectedError("房间引用的模组目录不存在")
     module_version = await db.get(
         ModuleVersion,
-        (room.scenario_id, room.module_version),
+        (scenario.module_id, room.module_version),
     )
     if module_version is None:
         raise ModuleNotSelectedError("房间固定的模组版本不存在")
+    system = await db.get(GameSystem, scenario.game_system_id)
+    if system is None or system.world_ref != module_version.world_ref:
+        raise RoomConflictError("房间固定的模组版本与规则系统不匹配")
     try:
         module_content = ModuleContent.model_validate(module_version.content_json)
     except ValueError as exc:
@@ -710,19 +726,27 @@ async def list_modules(db: AsyncSession) -> list[ModuleRead]:
         .order_by(Scenario.title, Scenario.id)
     )
     return [
-        ModuleRead.model_validate(scenario).model_copy(update={"game_system_name": system_name})
+        ModuleRead.model_validate(scenario).model_copy(
+            update={
+                "id": scenario.module_id,
+                "game_system_name": system_name,
+            }
+        )
         for scenario, system_name in result.tuples()
     ]
 
 
 async def get_module_detail(db: AsyncSession, module_id: str) -> ModuleDetailRead | None:
     """GET /api/v1/modules/{moduleId} —— 模组详情。"""
-    scenario = await db.get(Scenario, module_id)
+    scenario = await db.scalar(select(Scenario).where(Scenario.module_id == module_id))
     if scenario is None:
         return None
     system = await db.get(GameSystem, scenario.game_system_id)
     return ModuleDetailRead.model_validate(scenario).model_copy(
-        update={"game_system_name": system.name if system is not None else None}
+        update={
+            "id": scenario.module_id,
+            "game_system_name": system.name if system is not None else None,
+        }
     )
 
 

--- a/trpg-backend/scripts/load_paper_chase.py
+++ b/trpg-backend/scripts/load_paper_chase.py
@@ -1,0 +1,31 @@
+"""本地加载固定的追书人 ModuleContent。
+
+用法：
+
+    uv run python scripts/load_paper_chase.py
+"""
+
+import asyncio
+import sys
+
+from app.core.db import async_session_factory, engine
+from app.service.paper_chase_loader import PaperChaseLoadError, load_paper_chase
+
+
+async def _run() -> int:
+    try:
+        async with async_session_factory() as db:
+            result = await load_paper_chase(db)
+    except PaperChaseLoadError as exc:
+        print(f"追书人 ModuleContent 加载失败: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        await engine.dispose()
+
+    print("追书人 ModuleContent 加载完成")
+    print("\n".join(result.summary_lines()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_run()))

--- a/trpg-backend/tests/conftest.py
+++ b/trpg-backend/tests/conftest.py
@@ -22,6 +22,7 @@ from app.core.db import Base, get_db
 from app.core.seed import ensure_seed_content
 from app.core.turn import build_turn_application
 from app.main import app
+from app.service.paper_chase_loader import load_paper_chase
 
 # 用临时文件 SQLite，不用 ":memory:"+StaticPool。关键原因是并发模型：异步 HTTP
 # 测试跑在 pytest-asyncio 的事件循环里，而同步 TestClient 的 WebSocket 跑在它
@@ -77,6 +78,7 @@ async def _prepare_database() -> AsyncGenerator[None, None]:
     # 依赖内置模组的用例（建房选模组、GET /modules 等）会因为库里没有模组而失败。
     async with TestSessionLocal() as session:
         await ensure_seed_content(session)
+        await load_paper_chase(session)
     yield
     async with test_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -446,6 +446,7 @@ async def test_complete_character_rejects_unconfigured_ruleset(
         GameSystem(
             id=UNCONFIGURED_SYSTEM_ID,
             game_id=BUILTIN_GAME_ID,
+            world_ref="test-unconfigured",
             name="未配置规则的系统",
             ruleset=None,
         )

--- a/trpg-backend/tests/test_engine_persistence.py
+++ b/trpg-backend/tests/test_engine_persistence.py
@@ -1,21 +1,24 @@
 """Issue #89 的 ORM、约束与内置 ModuleVersion 测试。"""
 
 from collaboration_framework.contracts import ModuleContent
-from sqlalchemy import CheckConstraint, PrimaryKeyConstraint, UniqueConstraint
+from sqlalchemy import CheckConstraint, PrimaryKeyConstraint, String, UniqueConstraint, delete
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import Base
 from app.core.seed import (
-    BUILTIN_MODULE_CONTENT,
+    BUILTIN_MODULE_ID,
     BUILTIN_MODULE_VERSION,
     BUILTIN_SCENARIO_ID,
+    BUILTIN_SYSTEM_ID,
+    BUILTIN_WORLD_REF,
     ensure_seed_content,
 )
-from app.models.content import Scenario
+from app.models.content import GameSystem, Scenario
 from app.models.engine import ActionExecution, GameEvent, GameSession, ModuleVersion
 from app.models.event import Event
 from app.models.room import Character, Player, Room
+from app.service.paper_chase_loader import load_paper_chase
 
 
 def _constraint_names(table_name: str, constraint_type: type) -> set[str]:
@@ -44,6 +47,26 @@ def test_engine_tables_and_constraints_are_registered() -> None:
         if isinstance(constraint, PrimaryKeyConstraint)
     )
     assert [column.name for column in module_pk.columns] == ["module_id", "version"]
+    assert isinstance(module_versions.c.module_id.type, String)
+    assert {
+        (foreign_key.parent.name, foreign_key.target_fullname)
+        for foreign_key in module_versions.foreign_keys
+    } == {("module_id", "scenarios.module_id")}
+
+    scenarios = Base.metadata.tables["scenarios"]
+    game_systems = Base.metadata.tables["game_systems"]
+    assert scenarios.c.module_id.nullable is False
+    assert game_systems.c.world_ref.nullable is False
+    assert ("module_id",) in {
+        tuple(constraint.columns.keys())
+        for constraint in scenarios.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+    assert ("world_ref",) in {
+        tuple(constraint.columns.keys())
+        for constraint in game_systems.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
 
     game_sessions = Base.metadata.tables["game_sessions"]
     assert [column.name for column in game_sessions.primary_key.columns] == ["room_id"]
@@ -65,25 +88,52 @@ def test_engine_tables_and_constraints_are_registered() -> None:
     assert Base.metadata.tables["events"].c.correlation_id.nullable
 
 
-async def test_seed_persists_valid_playable_module_version(db_session: AsyncSession) -> None:
+async def test_seed_only_creates_wip_catalog_and_ruleset(db_session: AsyncSession) -> None:
+    await db_session.execute(delete(ModuleVersion))
+    await db_session.execute(delete(Scenario))
+    await db_session.commit()
+
+    await ensure_seed_content(db_session)
+
     scenario = await db_session.get(Scenario, BUILTIN_SCENARIO_ID)
     module_version = await db_session.get(
         ModuleVersion,
-        (BUILTIN_SCENARIO_ID, BUILTIN_MODULE_VERSION),
+        (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
     )
+    system = await db_session.get(GameSystem, BUILTIN_SYSTEM_ID)
 
     assert scenario is not None
-    assert scenario.status == "ready"
+    assert scenario.module_id == BUILTIN_MODULE_ID
+    assert scenario.status == "wip"
     assert scenario.version == BUILTIN_MODULE_VERSION
     assert scenario.story_pages
+    assert system is not None
+    assert system.world_ref == BUILTIN_WORLD_REF
+    assert module_version is None
 
+
+async def test_loader_persists_valid_playable_module_version(db_session: AsyncSession) -> None:
+    scenario = await db_session.get(Scenario, BUILTIN_SCENARIO_ID)
+    module_version = await db_session.get(
+        ModuleVersion,
+        (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
+    )
+    assert scenario is not None
+    assert scenario.status == "ready"
     assert module_version is not None
     publication = ModuleContent.model_validate(module_version.content_json)
+    assert publication.module_id == BUILTIN_MODULE_ID
     assert publication.module_id == module_version.module_id
     assert publication.version == module_version.version
     assert publication.world_ref == module_version.world_ref
-    assert publication.scenes
-    assert publication.to_json_dict() == BUILTIN_MODULE_CONTENT
+    assert publication.world_ref == BUILTIN_WORLD_REF
+    assert len(publication.scenes) == 11
+    assert len(publication.entities) == 16
+    assert publication.background
+
+    await db_session.commit()
+    repeated = await load_paper_chase(db_session)
+    assert repeated.outcome == "unchanged"
 
 
 async def test_seed_does_not_overwrite_published_module_content(
@@ -92,16 +142,16 @@ async def test_seed_does_not_overwrite_published_module_content(
     """重复 seed 可更新目录数据，但不能原地修改已发布版本。"""
     module_version = await db_session.get(
         ModuleVersion,
-        (BUILTIN_SCENARIO_ID, BUILTIN_MODULE_VERSION),
+        (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
     )
     assert module_version is not None
     existing_publication = dict(module_version.content_json)
-    existing_publication["scenes"] = [
-        {
-            **existing_publication["scenes"][0],
-            "content": "已经发布、不得被 seed 覆盖的内容。",
-        }
-    ]
+    scenes = list(existing_publication["scenes"])
+    scenes[0] = {
+        **scenes[0],
+        "content": "已经发布、不得被 seed 覆盖的内容。",
+    }
+    existing_publication["scenes"] = scenes
     ModuleContent.model_validate(existing_publication)
     module_version.content_json = existing_publication
     await db_session.commit()

--- a/trpg-backend/tests/test_engine_runtime.py
+++ b/trpg-backend/tests/test_engine_runtime.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters import SqlAlchemyEngineStore
 from app.core.seed import (
+    BUILTIN_MODULE_ID,
     BUILTIN_MODULE_VERSION,
     BUILTIN_SCENARIO_ID,
     BUILTIN_SYSTEM_ID,
@@ -129,6 +130,7 @@ async def _start_room(
     *,
     room_number: int = 1,
     player_count: int = 1,
+    prepare_checkpoint: bool = True,
 ) -> tuple[Room, list[Player], list[Character]]:
     room, players, characters = await _create_building_room(
         db,
@@ -136,6 +138,15 @@ async def _start_room(
         player_count=player_count,
     )
     await room_service.begin_game(db, room.id, players[0].id)
+    if prepare_checkpoint:
+        game_session = await db.get(GameSession, room.id)
+        assert game_session is not None
+        state = GameState.model_validate(game_session.state_json)
+        game_session.state_json = state.model_copy(
+            update={"scene_id": "conversation"},
+            deep=True,
+        ).to_json_dict()
+        await db.commit()
     return room, players, characters
 
 
@@ -154,13 +165,13 @@ def _checkpoint_request(
         source_view_revision=revision,
         intent=Intent(
             kind="action",
-            verb="search",
-            target=MatchedTarget(id="location-old-bookshop"),
+            verb="follow",
+            target=MatchedTarget(id="douglas"),
             check=ModuleCheck(
-                checkpoint_id="checkpoint-search-ledger",
-                proposed_skills=("spot-hidden",),
+                checkpoint_id="follow_douglas_underground",
+                proposed_skills=(),
             ),
-            summary="搜索旧书店账本",
+            summary="跟随道格拉斯进入地下",
         ),
     )
 
@@ -196,13 +207,13 @@ async def test_turn_application_resolves_actor_and_replays_one_execution(
         room_id=room.id,
         player_id=players[0].id,
         client_action_id="turn-application-122",
-        utterance="我看看旧书店",
+        utterance="我看看道格拉斯",
     )
     replayed = await application.handle(
         room_id=room.id,
         player_id=players[0].id,
         client_action_id="turn-application-122",
-        utterance="我看看旧书店",
+        utterance="我看看道格拉斯",
     )
 
     _, action_count = await _counts(db_session, room.id)
@@ -222,7 +233,7 @@ async def test_select_module_pins_recommended_published_version(
     response = await client.post(
         f"/api/v1/rooms/{room['roomId']}/module",
         json={
-            "moduleId": BUILTIN_SCENARIO_ID,
+            "moduleId": BUILTIN_MODULE_ID,
             "attributeGenMethod": "point_buy",
         },
         headers=reconnect(room["reconnectToken"]),
@@ -238,7 +249,11 @@ async def test_select_module_pins_recommended_published_version(
 async def test_begin_game_creates_stable_actor_snapshots(
     db_session: AsyncSession,
 ) -> None:
-    room, players, characters = await _start_room(db_session, player_count=2)
+    room, players, characters = await _start_room(
+        db_session,
+        player_count=2,
+        prepare_checkpoint=False,
+    )
 
     game_session = await db_session.get(GameSession, room.id)
     assert game_session is not None
@@ -247,10 +262,10 @@ async def test_begin_game_creates_stable_actor_snapshots(
 
     assert room.phase == "InGame"
     assert room.started_at is not None
-    assert game_session.module_id == BUILTIN_SCENARIO_ID
+    assert game_session.module_id == BUILTIN_MODULE_ID
     assert game_session.module_version == BUILTIN_MODULE_VERSION
     assert game_session.state_version == state.event_sequence == 0
-    assert state.scene_id == "scene-old-bookshop"
+    assert state.scene_id == "client_briefing"
     assert state.phase == "playing"
     assert list(state.actors) == ["actor_1", "actor_2"]
     assert state.actors["actor_1"].player_id == players[0].id
@@ -259,7 +274,8 @@ async def test_begin_game_creates_stable_actor_snapshots(
     assert state.actors["actor_1"].source_character_version == characters[0].version
     assert "actor_1" not in {character.id for character in characters}
     assert state.actors["actor_1"].state["attributes"] == {"HP_SOURCE": 1}
-    assert state.entities["location-old-bookshop"]["ledger_found"] is False
+    assert state.entities["thomas"]["case_open"] is True
+    assert state.entities["case_tracker"]["investigator_disappeared"] is False
 
     with pytest.raises(room_service.RoomConflictError):
         await room_service.begin_game(db_session, room.id, players[0].id)
@@ -347,7 +363,7 @@ async def test_suspend_blocks_new_actions_and_resume_allows_rule_ending(
     assert completed_session is not None
     completed_state = GameState.model_validate(completed_session.state_json)
     assert completed_state.phase == "ended"
-    assert completed_state.ending_id == "ending-ledger-found"
+    assert completed_state.ending_id == "ending_followed_underground"
     assert completed_room.phase == "Completed"
     assert completed_room.ended_at is not None
 
@@ -418,13 +434,13 @@ async def test_loaded_runtime_is_deep_copy_isolated(
 
     async with store.transaction(room.id) as transaction:
         runtime = await transaction.load_runtime()
-        runtime.game_state.entities["location-old-bookshop"]["ledger_found"] = True
+        runtime.game_state.entities["case_tracker"]["investigator_disappeared"] = True
         runtime.module_content.entities[0].direct_responses["invented"] = "泄漏"
 
     async with store.transaction(room.id) as transaction:
         reloaded = await transaction.load_runtime()
 
-    assert reloaded.game_state.entities["location-old-bookshop"]["ledger_found"] is False
+    assert reloaded.game_state.entities["case_tracker"]["investigator_disappeared"] is False
     assert "invented" not in reloaded.module_content.entities[0].direct_responses
 
 

--- a/trpg-backend/tests/test_games.py
+++ b/trpg-backend/tests/test_games.py
@@ -5,7 +5,12 @@
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.seed import BUILTIN_GAME_ID, BUILTIN_SYSTEM_ID, ensure_seed_content
+from app.core.seed import (
+    BUILTIN_GAME_ID,
+    BUILTIN_SYSTEM_ID,
+    BUILTIN_WORLD_REF,
+    ensure_seed_content,
+)
 from app.models.content import GameSystem
 from tests.helpers import bearer, register
 
@@ -81,6 +86,15 @@ async def test_get_ruleset_unknown_system_returns_404(client: AsyncClient) -> No
     assert response.status_code == 404
 
 
+async def test_game_system_catalog_returns_stable_world_ref(client: AsyncClient) -> None:
+    response = await client.get(f"/api/v1/games/{BUILTIN_GAME_ID}/systems")
+
+    assert response.status_code == 200
+    systems = response.json()["data"]
+    assert systems[0]["id"] == BUILTIN_SYSTEM_ID
+    assert systems[0]["worldRef"] == BUILTIN_WORLD_REF
+
+
 async def test_seed_refreshes_stale_builtin_ruleset(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:
@@ -126,6 +140,7 @@ async def _add_unconfigured_system(db_session: AsyncSession) -> str:
         GameSystem(
             id=UNCONFIGURED_SYSTEM_ID,
             game_id=BUILTIN_GAME_ID,
+            world_ref="test-unconfigured",
             name="未配置规则的系统",
             ruleset=None,
         )

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
-HEAD_REVISION = "9c4e7a2b1d6f"
+ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
+HEAD_REVISION = "b7e4c2d1a6f9"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -55,6 +56,14 @@ def _unique_column_sets(database: Path, table: str) -> set[tuple[str, ...]]:
         }
 
 
+def _foreign_keys(database: Path, table: str) -> set[tuple[str, str, str]]:
+    with sqlite3.connect(database) as connection:
+        return {
+            (row[3], row[2], row[4])
+            for row in connection.execute(f"PRAGMA foreign_key_list('{table}')")
+        }
+
+
 def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None:
     database = tmp_path / "round-trip.db"
 
@@ -70,6 +79,15 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
     assert {"status", "name_en", "story_label", "subtitle", "story_pages"}.issubset(
         _column_names(database, "scenarios")
     )
+    assert "module_id" in _column_names(database, "scenarios")
+    assert "world_ref" in _column_names(database, "game_systems")
+    assert ("module_id",) in _unique_column_sets(database, "scenarios")
+    assert ("world_ref",) in _unique_column_sets(database, "game_systems")
+    assert ("module_id", "scenarios", "module_id") in _foreign_keys(database, "module_versions")
+    assert {
+        ("module_id", "module_versions", "module_id"),
+        ("module_version", "module_versions", "version"),
+    }.issubset(_foreign_keys(database, "game_sessions"))
     assert "module_version" in _column_names(database, "rooms")
     assert "version" in _column_names(database, "characters")
     assert "correlation_id" in _column_names(database, "events")
@@ -150,3 +168,40 @@ def test_migration_rejects_nonempty_room_sessions_before_ddl(tmp_path: Path) -> 
     assert "room_sessions 存在历史数据" in result.stdout + result.stderr
     assert "room_sessions" in _table_names(database)
     assert "status" not in _column_names(database, "scenarios")
+
+
+def test_module_identity_migration_rejects_existing_catalog_data(tmp_path: Path) -> None:
+    database = tmp_path / "existing-catalog.db"
+    _upgrade_or_fail(database, ENGINE_IDENTITY_PREVIOUS_REVISION)
+
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """
+            INSERT INTO games (id, name, created_at)
+            VALUES (?, ?, ?)
+            """,
+            (
+                "40000000-0000-0000-0000-000000000001",
+                "历史游戏",
+                "2026-07-25 00:00:00",
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO game_systems (id, game_id, name, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                "40000000-0000-0000-0000-000000000002",
+                "40000000-0000-0000-0000-000000000001",
+                "历史规则系统",
+                "2026-07-25 00:00:00",
+            ),
+        )
+
+    result = _run_alembic(database, "upgrade", "head")
+
+    assert result.returncode != 0
+    assert "game_systems 存在历史数据" in result.stdout + result.stderr
+    assert "world_ref" not in _column_names(database, "game_systems")
+    assert "module_id" not in _column_names(database, "scenarios")

--- a/trpg-backend/tests/test_paper_chase_loader.py
+++ b/trpg-backend/tests/test_paper_chase_loader.py
@@ -1,0 +1,166 @@
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.seed import (
+    BUILTIN_MODULE_ID,
+    BUILTIN_MODULE_VERSION,
+    BUILTIN_SCENARIO_ID,
+    BUILTIN_SYSTEM_ID,
+)
+from app.models.content import GameSystem, Scenario
+from app.models.engine import ModuleVersion
+from app.service import paper_chase_loader as loader
+
+
+async def test_loader_is_idempotent_and_reports_real_content(
+    db_session: AsyncSession,
+) -> None:
+    result = await loader.load_paper_chase(db_session)
+
+    assert result.outcome == "unchanged"
+    assert result.module_id == BUILTIN_MODULE_ID
+    assert result.version == BUILTIN_MODULE_VERSION
+    assert result.world_ref == "coc-7e"
+    assert result.scene_count == 11
+    assert result.entity_count == 16
+    assert result.checkpoint_count == 20
+    assert result.rule_count >= 9
+    assert result.win_condition_count == 4
+    assert "result: unchanged" in result.summary_lines()
+
+
+async def test_loader_rejects_other_identity_without_database_changes(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(loader.PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8"))
+    payload["module_id"] = "some-other-module"
+    source = tmp_path / "other-module.json"
+    source.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    monkeypatch.setattr(loader, "PAPER_CHASE_SOURCE_PATH", source)
+
+    scenario = await db_session.get(Scenario, BUILTIN_SCENARIO_ID)
+    module_version = await db_session.get(
+        ModuleVersion,
+        (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
+    )
+    assert scenario is not None
+    assert module_version is not None
+    original_content = module_version.content_json
+    await db_session.commit()
+
+    with pytest.raises(loader.PaperChaseLoadError, match="身份不匹配"):
+        await loader.load_paper_chase(db_session)
+
+    db_session.expire_all()
+    unchanged_scenario = await db_session.get(Scenario, BUILTIN_SCENARIO_ID)
+    unchanged_version = await db_session.get(
+        ModuleVersion,
+        (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
+    )
+    assert unchanged_scenario is not None
+    assert unchanged_scenario.status == "ready"
+    assert unchanged_version is not None
+    assert unchanged_version.content_json == original_content
+
+
+async def test_loader_rejects_validation_failure_before_writing(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(loader.PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8"))
+    payload["checkpoints"][0]["skills"] = ["not-a-coc7-skill"]
+    source = tmp_path / "invalid-paper-chase.json"
+    source.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    monkeypatch.setattr(loader, "PAPER_CHASE_SOURCE_PATH", source)
+
+    with pytest.raises(loader.PaperChaseLoadError, match="Validation 未通过"):
+        await loader.load_paper_chase(db_session)
+
+    assert (
+        await db_session.get(
+            ModuleVersion,
+            (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
+        )
+        is not None
+    )
+
+
+async def test_loader_does_not_overwrite_different_immutable_version(
+    db_session: AsyncSession,
+) -> None:
+    module_version = await db_session.get(
+        ModuleVersion,
+        (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
+    )
+    assert module_version is not None
+    changed_content = dict(module_version.content_json)
+    changed_content["background"] = "同版本的另一份内容"
+    module_version.content_json = changed_content
+    await db_session.commit()
+
+    with pytest.raises(loader.PaperChaseLoadError, match="不会静默覆盖"):
+        await loader.load_paper_chase(db_session)
+
+    db_session.expire_all()
+    unchanged = await db_session.get(
+        ModuleVersion,
+        (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
+    )
+    assert unchanged is not None
+    assert unchanged.content_json == changed_content
+
+
+async def test_loader_rolls_back_module_and_ready_status_together(
+    db_session: AsyncSession,
+) -> None:
+    await db_session.execute(
+        delete(ModuleVersion).where(
+            ModuleVersion.module_id == BUILTIN_MODULE_ID,
+            ModuleVersion.version == BUILTIN_MODULE_VERSION,
+        )
+    )
+    scenario = await db_session.get(Scenario, BUILTIN_SCENARIO_ID)
+    assert scenario is not None
+    scenario.status = "wip"
+    await db_session.commit()
+
+    def fail_before_commit() -> None:
+        raise RuntimeError("injected failure")
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        await loader.load_paper_chase(db_session, _before_commit=fail_before_commit)
+
+    db_session.expire_all()
+    rolled_back_scenario = await db_session.get(Scenario, BUILTIN_SCENARIO_ID)
+    assert rolled_back_scenario is not None
+    assert rolled_back_scenario.status == "wip"
+    assert (
+        await db_session.get(
+            ModuleVersion,
+            (BUILTIN_MODULE_ID, BUILTIN_MODULE_VERSION),
+        )
+        is None
+    )
+
+
+async def test_loader_requires_database_ruleset_without_partial_write(
+    db_session: AsyncSession,
+) -> None:
+    system = await db_session.get(GameSystem, BUILTIN_SYSTEM_ID)
+    assert system is not None
+    system.ruleset = None
+    await db_session.commit()
+
+    with pytest.raises(loader.PaperChaseLoadError, match="Ruleset 为空"):
+        await loader.load_paper_chase(db_session)
+
+    scenario = await db_session.get(Scenario, BUILTIN_SCENARIO_ID)
+    assert scenario is not None
+    assert scenario.status == "ready"

--- a/trpg-backend/tests/test_rooms.py
+++ b/trpg-backend/tests/test_rooms.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.seed import BUILTIN_SCENARIO_ID, BUILTIN_SYSTEM_ID
+from app.core.seed import BUILTIN_MODULE_ID, BUILTIN_SYSTEM_ID
 from app.models.content import Scenario
 from app.models.room import Player
 from tests.helpers import ROOMS_BASE, bearer, create_room, join_room, reconnect, register
@@ -272,6 +272,7 @@ async def test_module_catalog_filters_hidden_and_rejects_wip_selection(
         [
             Scenario(
                 id=wip_id,
+                module_id="test-wip-module",
                 game_system_id=BUILTIN_SYSTEM_ID,
                 title="开发中模组",
                 name_en="Work in Progress",
@@ -287,6 +288,7 @@ async def test_module_catalog_filters_hidden_and_rejects_wip_selection(
             ),
             Scenario(
                 id=hidden_id,
+                module_id="test-hidden-module",
                 game_system_id=BUILTIN_SYSTEM_ID,
                 title="隐藏模组",
                 version="1.0.0",
@@ -300,16 +302,16 @@ async def test_module_catalog_filters_hidden_and_rejects_wip_selection(
 
     catalog = (await client.get("/api/v1/modules")).json()["data"]
     ids = {module["id"] for module in catalog}
-    assert BUILTIN_SCENARIO_ID in ids
-    assert wip_id in ids
-    assert hidden_id not in ids
-    wip = next(module for module in catalog if module["id"] == wip_id)
+    assert BUILTIN_MODULE_ID in ids
+    assert "test-wip-module" in ids
+    assert "test-hidden-module" not in ids
+    wip = next(module for module in catalog if module["id"] == "test-wip-module")
     assert wip["gameSystemId"] == BUILTIN_SYSTEM_ID
     assert wip["status"] == "wip"
     assert wip["nameEn"] == "Work in Progress"
     assert wip["synopsis"] == "用于验证目录状态。"
 
-    detail = (await client.get(f"/api/v1/modules/{BUILTIN_SCENARIO_ID}")).json()["data"]
+    detail = (await client.get(f"/api/v1/modules/{BUILTIN_MODULE_ID}")).json()["data"]
     assert detail["status"] == "ready"
     assert detail["storyPages"][0]["title"]
     assert detail["storyPages"][0]["content"]
@@ -317,7 +319,7 @@ async def test_module_catalog_filters_hidden_and_rejects_wip_selection(
     room = await create_room(client)
     rejected = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/module",
-        json={"moduleId": wip_id, "attributeGenMethod": "point_buy"},
+        json={"moduleId": "test-wip-module", "attributeGenMethod": "point_buy"},
         headers=reconnect(room["reconnectToken"]),
     )
     assert rejected.status_code == 409

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -332,7 +332,7 @@ def test_action_submit_broadcasts_narration_to_room_only(sync_client: TestClient
                 "playerId": guest["playerId"],
                 "payload": {
                     "clientActionId": "action-broadcast-122",
-                    "utterance": "我看看旧书店",
+                    "utterance": "我看看托马斯",
                 },
             }
         )
@@ -347,7 +347,7 @@ def test_action_submit_broadcasts_narration_to_room_only(sync_client: TestClient
                 "playerId": room_a["playerId"],
                 "payload": {
                     "clientActionId": "action-broadcast-122",
-                    "utterance": "我看看旧书店",
+                    "utterance": "我看看托马斯",
                 },
             }
         )

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -334,6 +334,7 @@ export interface GameStartPayload {}
 export interface GameSystemRead {
   id: string;
   gameId: string;
+  worldRef: string;
   name: string;
   version?: string | null;
 }


### PR DESCRIPTION
## 变更摘要

- 为 `Scenario` 增加唯一稳定的 `module_id`，为 `GameSystem` 增加唯一 `world_ref`
- 将 `ModuleVersion.module_id` 和 `GameSession.module_id` 改为字符串身份，并保持复合版本外键
- 调整模组列表、详情、房间选择、正式开局和运行时加载链路，API 对外只暴露稳定 module ID，`Room.scenario_id` 继续保存内部 UUID
- 更新 Seed：COC7 使用 `world_ref=coc-7e`，追书人目录初始为 `wip`，不再内嵌简化 ModuleContent 或创建 ModuleVersion
- 新增固定追书人加载命令 `uv run python scripts/load_paper_chase.py`
  - 从数据库 Ruleset 构造检定目录
  - 经过现有确定性 Validation
  - 原子写入标准化 ModuleContent
  - 支持安全重复执行，拒绝静默覆盖同版本不同内容
- 增加空库 Alembic 迁移、ORM/迁移/加载器/真实开局/Store 回读测试
- 将追书人示例中的英语检定 ID 对齐到数据库 COC7 目录的 `language-foreign-1`

## 原因与影响

Issue #141 要求数据库内部 UUID 与 ModuleContent 稳定身份分离；Issue #142 依赖该结构，将仓库内真实追书人内容作为本地规则引擎开发输入。

本迁移按 Issue 范围不处理历史数据：相关表非空时会明确中止并提示重建本地数据库，避免静默丢失或错误转换。

## 验证

- `pytest -q`: 134 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- `ty check`: passed
- 协作框架 ModuleContent/Validation 专项：18 passed

Closes #141
Closes #142
