### PR TITLE
feat(agent): add OpenAI-compatible provider support (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ npm run dev
 | `ENABLE_DOCS` | `true` | 是否开放 `/docs`、`/redoc` 和 `/openapi.json` |
 | `LOG_LEVEL` | `INFO` | 后端日志级别 |
 | `CORS_ORIGINS` | `["http://localhost:9877"]` | 允许跨域访问的前端来源列表 |
-| `HOST_MODEL_PROVIDER` | `fake` | 主持模型：`fake`、`openai` 或 `qwen` |
+| `HOST_MODEL_PROVIDER` | `fake` | 主持模型：`fake`、`openai`、`qwen` 或 `deepseek` |
 | `OPENAI_API_KEY` | 空 | `openai` 提供商的 API 密钥 |
 | `OPENAI_BASE_URL` | `https://api.openai.com/v1` | OpenAI Responses API 根地址 |
 | `OPENAI_MODEL` | `gpt-5.6-luna` | OpenAI 模型名称 |
@@ -191,6 +191,10 @@ npm run dev
 | `QWEN_BASE_URL` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | 千问 OpenAI 兼容接口根地址 |
 | `QWEN_MODEL` | `qwen3.7-plus` | 千问模型名称 |
 | `QWEN_TIMEOUT_SECONDS` | `30` | 千问请求超时秒数 |
+| `DEEPSEEK_API_KEY` | 空 | DeepSeek 或其他兼容 provider 的 API 密钥 |
+| `DEEPSEEK_BASE_URL` | `https://api.deepseek.com` | OpenAI-compatible Chat Completions 根地址 |
+| `DEEPSEEK_MODEL` | `deepseek-chat` | DeepSeek 模型名称 |
+| `DEEPSEEK_TIMEOUT_SECONDS` | `30` | DeepSeek 请求超时秒数 |
 | `HOST_AGENT_MAX_TURNS` | `6` | 单次 Host Agent 最大模型轮数 |
 | `HOST_AGENT_MAX_TOOL_CALLS` | `8` | 单次 Host Agent 最大工具调用数 |
 | `HOST_AGENT_TOOL_TIMEOUT_SECONDS` | `5` | 单工具超时秒数 |
@@ -205,6 +209,7 @@ npm run dev
 | `fake` | 不发送网络请求 | 默认值；本地开发、自动化测试和无密钥运行 |
 | `openai` | OpenAI Responses API + 严格 JSON Schema | 使用原生支持 `text.format=json_schema` 的模型 |
 | `qwen` | 千问 Chat Completions JSON Mode + 本地 Pydantic 校验 | 阿里云百炼千问 3.7 Plus |
+| `deepseek` | OpenAI-compatible Chat Completions + JSON Mode + 本地 Pydantic 校验 | DeepSeek；兼容同一协议的 provider 可复用 |
 
 无论使用哪种远程模型，模型只负责提出结构化意图或叙事候选；目标、场景、技能和事实引用仍会在应用边界重新校验，最终状态只由规则引擎修改。
 
@@ -249,9 +254,25 @@ npm run dev
    ```
 
 健康检查只能确认后端存活，不会调用模型。请进入房间提交一次自然语言行动进行验证。
-Qwen 模式缺少 Key 时后端启动失败；Host Agent 超时、预算耗尽、非法输出或越权候选
+远程 provider 模式缺少 Key 时后端启动失败；Host Agent 超时、预算耗尽、非法输出或越权候选
 会发送玩家安全的 `turn.failed`，规则引擎不会执行。Narrator 失败不会重跑 Host
 Agent、重新掷骰或重复写入状态；使用同一 `clientActionId` 重试只会复用已提交结果。
+
+#### 使用 DeepSeek 或兼容 provider
+
+复制 `trpg-backend/.env.example` 为 `.env`，填写：
+
+```dotenv
+HOST_MODEL_PROVIDER=deepseek
+DEEPSEEK_API_KEY=你的_API_Key
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+DEEPSEEK_MODEL=deepseek-chat
+DEEPSEEK_TIMEOUT_SECONDS=30
+```
+
+Host Agent 工具调用和结构化 Narrator 都使用 OpenAI-compatible Chat Completions。
+其他厂商如果遵循同一协议，可复用这组配置和 adapter；使用私有协议时应新增独立
+provider adapter，而不是把私有字段混入通用请求。
 
 公共 WebSocket 只发送安全进度：`turn.started`、`turn.phase_changed`、
 `tool.started`、`tool.completed`、`turn.failed` 和 `view.updated`。内部 call id、

--- a/agent-collaboration-framework/README.md
+++ b/agent-collaboration-framework/README.md
@@ -1,6 +1,6 @@
 # Agent Collaboration Framework
 
-这是成员 A（主持编排）、成员 B（确定性规则引擎）和成员 C（模组解析/审查）共同使用的模块化单体骨架。当前版本提供稳定边界、可运行的离线纵切、面向持久化的 `RuleEngineService + InMemoryEngineStore`，以及已经接入统一 Host 意图阶段的 OpenAI Agents SDK + Qwen Host Agent Adapter；不接 LangGraph、PostgreSQL 或 FastAPI。
+这是成员 A（主持编排）、成员 B（确定性规则引擎）和成员 C（模组解析/审查）共同使用的模块化单体骨架。当前版本提供稳定边界、可运行的离线纵切、面向持久化的 `RuleEngineService + InMemoryEngineStore`，以及已经接入统一 Host 意图阶段的 OpenAI Agents SDK + OpenAI-compatible Host Agent Adapter；不接 LangGraph、PostgreSQL 或 FastAPI。
 
 ## 阅读入口
 
@@ -22,7 +22,7 @@ Proposal、RFC、对比报告或阶段性讨论。
 PlayerInput
   -> PlayerViewProjector.project()
   -> HostAgentIntentResolver.resolve()
-       -> HostAgentPort.astream()        # Fake / Qwen / OneShot
+       -> HostAgentPort.astream()        # Fake / compatible provider / OneShot
        -> IntentParser.parse()           # Pydantic + 可信候选校验
   -> ActionExecutor.execute()            # 每个合法 Intent 恰好调用一次
   -> PlayerViewProjector.refresh()
@@ -39,7 +39,7 @@ PlayerInput
 
 当前 `HostAgentContext` 会把完整 PlayerView v2 交给一次 Host Agent run：其中包含同一 revision 的 `self_actor`、安全 `scene`
 （实体、人物、出口）、`known_information` 与可信 `checkpoint_options`。后端的
-OpenAI/Qwen Prompt Adapter 直接序列化这份 Context；不会附加 GameState、数据库记录
+OpenAI-compatible Prompt Adapter 直接序列化这份 Context；不会附加 GameState、数据库记录
 或完整 ModuleContent。Host Agent 的只读工具也只绑定这一份 PlayerView。
 
 ## Host Agent 契约
@@ -52,9 +52,9 @@ OpenAI/Qwen Prompt Adapter 直接序列化这份 Context；不会附加 GameStat
 `host/tools` 中绑定 `HostAgentContext.player_view` 的两个只读工具，以及拒绝模型自行传入身份作用域的框架无关
 `ToolRegistry`。它们只搜索/读取当前 `PlayerView`，不访问引擎、数据库或完整模组。
 
-`host/adapters/openai_agents/QwenHostAgentAdapter` 通过 OpenAI-compatible Chat Completions 运行 Qwen，并使用
+`host/adapters/openai_agents/OpenAICompatibleHostAgentAdapter` 通过 OpenAI-compatible Chat Completions 运行兼容 provider，并使用
 OpenAI Agents SDK 自带的 model/tool 循环。每次 `astream()` 独立绑定当前 Context 与两个只读工具；Adapter 负责
-最大模型轮数、工具调用预算、单工具/整轮 timeout、脱敏事件、部分 usage 和严格 final JSON 对象边界。SDK/Qwen
+最大模型轮数、工具调用预算、单工具/整轮 timeout、脱敏事件、部分 usage 和严格 final JSON 对象边界。SDK/provider
 类型只存在于该私有 Adapter 和 bootstrap 组合根。
 
 `FakeHostAgent`、真实 Adapter 和无工具的一次性模型兼容 Adapter 都通过
@@ -63,7 +63,7 @@ OpenAI Agents SDK 自带的 model/tool 循环。每次 `astream()` 独立绑定�
 终止或非法输出全部 fail closed。Adapter 和 Resolver 都不调用 `ActionExecutor`，
 不执行规则动作或状态写入。
 
-显式构造 Qwen Adapter 时，由调用方在 bootstrap 阶段提供以下环境变量；模块 import 不读取环境或创建网络客户端：
+显式构造 compatible Adapter 时，由调用方在 bootstrap 阶段提供以下环境变量；模块 import 不读取环境或创建网络客户端：
 
 | 环境变量 | 默认值 | 说明 |
 |---|---|---|
@@ -76,7 +76,7 @@ OpenAI Agents SDK 自带的 model/tool 循环。每次 `astream()` 独立绑定�
 | `HOST_AGENT_TIMEOUT_SECONDS` | `30` | 整轮 timeout |
 
 复制 `.env.example` 只用于准备非敏感默认项；项目不会在 import 时自动加载 `.env`。调用
-`bootstrap.host_agent.build_qwen_host_agent()` 才会验证配置并构造客户端。
+`bootstrap.host_agent.build_qwen_host_agent()` 或 `build_deepseek_host_agent()` 才会验证配置并构造客户端。
 
 ## 2、3、4 点的统一结论
 
@@ -133,7 +133,7 @@ collaboration_framework/
 │   ├── application/           # 普通 async 工作流与应用服务
 │   ├── ports/                 # Intent/Narration/Host Agent 模型抽象及 TurnPort
 │   ├── adapters/fakes/        # 无网络、无 API Key 的离线 Fake
-│   ├── adapters/openai_agents/# 私有 OpenAI Agents SDK + Qwen Adapter
+│   ├── adapters/openai_agents/# 私有 OpenAI Agents SDK + compatible Adapter
 │   ├── schemas/               # A 内部 Agent/Context/Turn/Narration Schema
 │   ├── tools/                 # 绑定当前 PlayerView 的 player-safe 只读工具
 │   └── gateway/               # Player-safe WebSocket 输出

--- a/agent-collaboration-framework/collaboration_framework/bootstrap/host_agent.py
+++ b/agent-collaboration-framework/collaboration_framework/bootstrap/host_agent.py
@@ -12,6 +12,8 @@ from pydantic import ValidationError
 from collaboration_framework.host.adapters.openai_agents import (
     DEFAULT_BASE_URL,
     DEFAULT_MODEL,
+    DEEPSEEK_BASE_URL,
+    DEEPSEEK_MODEL,
     OpenAICompatibleHostAgentAdapter,
     OpenAICompatibleHostAgentConfig,
 )
@@ -34,6 +36,8 @@ def build_qwen_host_agent(
         environ,
         tool_registry=tool_registry,
         model_settings_extra_body={"enable_thinking": False},
+        default_base_url=DEFAULT_BASE_URL,
+        default_model=DEFAULT_MODEL,
     )
 
 
@@ -48,6 +52,8 @@ def build_deepseek_host_agent(
         environ,
         tool_registry=tool_registry,
         model_settings_extra_body=None,
+        default_base_url=DEEPSEEK_BASE_URL,
+        default_model=DEEPSEEK_MODEL,
     )
 
 
@@ -56,6 +62,8 @@ def _build_host_agent(
     *,
     tool_registry: ToolRegistry | None,
     model_settings_extra_body: dict[str, bool] | None,
+    default_base_url: str,
+    default_model: str,
 ) -> OpenAICompatibleHostAgentAdapter:
     """Build a validated OpenAI-compatible Chat Completions Host Agent."""
 
@@ -67,8 +75,8 @@ def _build_host_agent(
     try:
         config = OpenAICompatibleHostAgentConfig(
             api_key=api_key,
-            base_url=source.get("HOST_AGENT_BASE_URL", DEFAULT_BASE_URL),
-            model=source.get("HOST_AGENT_MODEL", DEFAULT_MODEL),
+            base_url=source.get("HOST_AGENT_BASE_URL", default_base_url),
+            model=source.get("HOST_AGENT_MODEL", default_model),
             max_turns=_read_int(source, "HOST_AGENT_MAX_TURNS", 6),
             max_tool_calls=_read_int(source, "HOST_AGENT_MAX_TOOL_CALLS", 8),
             tool_timeout_seconds=_read_float(

--- a/agent-collaboration-framework/collaboration_framework/bootstrap/host_agent.py
+++ b/agent-collaboration-framework/collaboration_framework/bootstrap/host_agent.py
@@ -1,4 +1,4 @@
-"""Explicit production composition for the Qwen Host Agent adapter."""
+"""Explicit production composition for OpenAI-compatible Host Agent adapters."""
 
 from __future__ import annotations
 
@@ -12,8 +12,8 @@ from pydantic import ValidationError
 from collaboration_framework.host.adapters.openai_agents import (
     DEFAULT_BASE_URL,
     DEFAULT_MODEL,
-    QwenHostAgentAdapter,
-    QwenHostAgentConfig,
+    OpenAICompatibleHostAgentAdapter,
+    OpenAICompatibleHostAgentConfig,
 )
 from collaboration_framework.host.application.tool_registry import ToolRegistry
 from collaboration_framework.host.tools import build_player_view_tool_registry
@@ -27,8 +27,37 @@ def build_qwen_host_agent(
     environ: Mapping[str, str] | None = None,
     *,
     tool_registry: ToolRegistry | None = None,
-) -> QwenHostAgentAdapter:
-    """Build the real adapter only when explicitly called by a composition root."""
+) -> OpenAICompatibleHostAgentAdapter:
+    """Build Qwen with its provider-specific thinking switch disabled."""
+
+    return _build_host_agent(
+        environ,
+        tool_registry=tool_registry,
+        model_settings_extra_body={"enable_thinking": False},
+    )
+
+
+def build_deepseek_host_agent(
+    environ: Mapping[str, str] | None = None,
+    *,
+    tool_registry: ToolRegistry | None = None,
+) -> OpenAICompatibleHostAgentAdapter:
+    """Build DeepSeek without sending Qwen-only request fields."""
+
+    return _build_host_agent(
+        environ,
+        tool_registry=tool_registry,
+        model_settings_extra_body=None,
+    )
+
+
+def _build_host_agent(
+    environ: Mapping[str, str] | None,
+    *,
+    tool_registry: ToolRegistry | None,
+    model_settings_extra_body: dict[str, bool] | None,
+) -> OpenAICompatibleHostAgentAdapter:
+    """Build a validated OpenAI-compatible Chat Completions Host Agent."""
 
     source = os.environ if environ is None else environ
     api_key = source.get("HOST_AGENT_API_KEY", "")
@@ -36,16 +65,12 @@ def build_qwen_host_agent(
         raise HostAgentConfigurationError("HOST_AGENT_API_KEY is required")
 
     try:
-        config = QwenHostAgentConfig(
+        config = OpenAICompatibleHostAgentConfig(
             api_key=api_key,
             base_url=source.get("HOST_AGENT_BASE_URL", DEFAULT_BASE_URL),
             model=source.get("HOST_AGENT_MODEL", DEFAULT_MODEL),
             max_turns=_read_int(source, "HOST_AGENT_MAX_TURNS", 6),
-            max_tool_calls=_read_int(
-                source,
-                "HOST_AGENT_MAX_TOOL_CALLS",
-                8,
-            ),
+            max_tool_calls=_read_int(source, "HOST_AGENT_MAX_TOOL_CALLS", 8),
             tool_timeout_seconds=_read_float(
                 source,
                 "HOST_AGENT_TOOL_TIMEOUT_SECONDS",
@@ -56,6 +81,7 @@ def build_qwen_host_agent(
                 "HOST_AGENT_TIMEOUT_SECONDS",
                 30,
             ),
+            model_settings_extra_body=model_settings_extra_body,
         )
     except (TypeError, ValueError, ValidationError) as exc:
         raise HostAgentConfigurationError(
@@ -70,7 +96,7 @@ def build_qwen_host_agent(
         model=config.model,
         openai_client=client,
     )
-    return QwenHostAgentAdapter(
+    return OpenAICompatibleHostAgentAdapter(
         model=model,
         tool_registry=tool_registry or build_player_view_tool_registry(),
         config=config,

--- a/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/__init__.py
@@ -4,6 +4,8 @@ from .adapter import OpenAICompatibleHostAgentAdapter, QwenHostAgentAdapter
 from .config import (
     DEFAULT_BASE_URL,
     DEFAULT_MODEL,
+    DEEPSEEK_BASE_URL,
+    DEEPSEEK_MODEL,
     OpenAICompatibleHostAgentConfig,
     QwenHostAgentConfig,
 )
@@ -11,6 +13,8 @@ from .config import (
 __all__ = [
     "DEFAULT_BASE_URL",
     "DEFAULT_MODEL",
+    "DEEPSEEK_BASE_URL",
+    "DEEPSEEK_MODEL",
     "OpenAICompatibleHostAgentAdapter",
     "OpenAICompatibleHostAgentConfig",
     "QwenHostAgentAdapter",

--- a/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/__init__.py
@@ -1,15 +1,18 @@
-"""OpenAI Agents SDK + Qwen Host Agent adapter."""
+"""OpenAI Agents SDK Host Agent adapter for compatible chat providers."""
 
-from .adapter import QwenHostAgentAdapter
+from .adapter import OpenAICompatibleHostAgentAdapter, QwenHostAgentAdapter
 from .config import (
     DEFAULT_BASE_URL,
     DEFAULT_MODEL,
+    OpenAICompatibleHostAgentConfig,
     QwenHostAgentConfig,
 )
 
 __all__ = [
     "DEFAULT_BASE_URL",
     "DEFAULT_MODEL",
+    "OpenAICompatibleHostAgentAdapter",
+    "OpenAICompatibleHostAgentConfig",
     "QwenHostAgentAdapter",
     "QwenHostAgentConfig",
 ]

--- a/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/adapter.py
+++ b/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/adapter.py
@@ -1,4 +1,4 @@
-"""OpenAI Agents SDK HostAgentPort implementation backed by Qwen."""
+"""OpenAI Agents SDK HostAgentPort implementation for compatible providers."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from collaboration_framework.host.schemas import (
     HostAgentUsage,
 )
 
-from .config import QwenHostAgentConfig
+from .config import OpenAICompatibleHostAgentConfig
 from .event_mapper import EventObservation, SDKEventMappingError
 from .prompt import SYSTEM_PROMPT, build_agent_input
 from .tool_adapter import (
@@ -49,15 +49,15 @@ class InvalidHostAgentOutput(ValueError):
     """The model's final output was not one finite JSON object."""
 
 
-class QwenHostAgentAdapter:
-    """Run Qwen through the SDK while exposing only project-owned events."""
+class OpenAICompatibleHostAgentAdapter:
+    """Run a compatible chat model while exposing only project-owned events."""
 
     def __init__(
         self,
         *,
         model: Model,
         tool_registry: ToolRegistry,
-        config: QwenHostAgentConfig,
+        config: OpenAICompatibleHostAgentConfig,
         runner: Any = Runner,
     ) -> None:
         self._model = model
@@ -88,7 +88,7 @@ class QwenHostAgentAdapter:
                     temperature=0,
                     parallel_tool_calls=False,
                     include_usage=True,
-                    extra_body={"enable_thinking": False},
+                    extra_body=self._config.model_settings_extra_body,
                     tool_choice="auto",
                 ),
             )
@@ -172,6 +172,10 @@ class QwenHostAgentAdapter:
                 retryable=False,
             ):
                 yield event
+
+
+# Backward-compatible name for existing Qwen composition and tests.
+QwenHostAgentAdapter = OpenAICompatibleHostAgentAdapter
 
 
 def parse_raw_output(value: object) -> dict[str, JsonValue]:

--- a/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/config.py
+++ b/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/config.py
@@ -1,17 +1,17 @@
-"""Provider-private configuration for the Qwen Host Agent adapter."""
+"""Provider-private configuration for OpenAI-compatible Host Agent adapters."""
 
 from __future__ import annotations
 
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, SecretStr, field_validator
 
 
 DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 DEFAULT_MODEL = "qwen-plus"
 
 
-class QwenHostAgentConfig(BaseModel):
+class OpenAICompatibleHostAgentConfig(BaseModel):
     """Validated settings passed explicitly by the composition root."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -23,6 +23,7 @@ class QwenHostAgentConfig(BaseModel):
     max_tool_calls: int = Field(default=8, gt=0)
     tool_timeout_seconds: float = Field(default=5, gt=0)
     timeout_seconds: float = Field(default=30, gt=0)
+    model_settings_extra_body: dict[str, JsonValue] | None = {"enable_thinking": False}
 
     @field_validator("api_key")
     @classmethod
@@ -47,3 +48,7 @@ class QwenHostAgentConfig(BaseModel):
         if not normalized:
             raise ValueError("model must not be empty")
         return normalized
+
+
+# Keep the provider-specific name for existing Qwen callers and tests.
+QwenHostAgentConfig = OpenAICompatibleHostAgentConfig

--- a/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/config.py
+++ b/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/config.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue, SecretStr, field_v
 
 DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 DEFAULT_MODEL = "qwen-plus"
+DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+DEEPSEEK_MODEL = "deepseek-chat"
 
 
 class OpenAICompatibleHostAgentConfig(BaseModel):

--- a/agent-collaboration-framework/docs/architecture.md
+++ b/agent-collaboration-framework/docs/architecture.md
@@ -14,7 +14,7 @@
 - B 负责 Rule、Hook、Checkpoint 执行、Dice、GameState 修改、Event 写入和事务/幂等。
 - C 负责模组解析、审查和发布 `ModuleContent`。
 - A 只能通过 `ActionExecutor.execute()` 发出可能影响权威状态的动作。
-- 当前使用离线模型 Fake、player-safe 只读工具、完整 `InMemoryEngineStore`，并提供尚未接入 `Orchestrator` 的 OpenAI Agents SDK + Qwen Host Agent Adapter；不接 LangGraph、PostgreSQL 或 FastAPI。
+- 当前使用离线模型 Fake、player-safe 只读工具、完整 `InMemoryEngineStore`，并提供尚未接入 `Orchestrator` 的 OpenAI Agents SDK + OpenAI-compatible Host Agent Adapter；不接 LangGraph、PostgreSQL 或 FastAPI。
 
 ## 2. 最终回合时序
 
@@ -175,7 +175,7 @@ flowchart TD
 
 ### 15. 真实模型依赖
 
-选择：PydanticAI 与 LangGraph 保持移除；OpenAI Agents SDK、OpenAI 客户端、Qwen 配置和版本化 Prompt 只允许进入
+选择：PydanticAI 与 LangGraph 保持移除；OpenAI Agents SDK、OpenAI 客户端、compatible provider 配置和版本化 Prompt 只允许进入
 `host/adapters/openai_agents/` 与 bootstrap 组合根。稳定 Host Schema/Port、application、tools、Engine 和 Module
 继续与 SDK/provider 无关。
 
@@ -378,14 +378,14 @@ A 输出/内部边界 Schema：
 上述三个 Host Agent Schema 虽然导出为仓库级 JSON Schema，但不因此成为 A/B/C 共享业务契约；工具定义则直接从
 参数/结果 Pydantic 模型生成 Adapter Schema，不维护重复文件。
 
-`QwenHostAgentAdapter` 位于 `host/adapters/openai_agents/`。每次调用建立独立 SDK Agent、绑定 Registry 和运行计数；
+`OpenAICompatibleHostAgentAdapter` 位于 `host/adapters/openai_agents/`。每次调用建立独立 SDK Agent、绑定 Registry 和运行计数；
 SDK Runner 负责 `model -> tool -> model -> final` 循环，项目只负责权限、预算、timeout、安全事件和最终 JSON
 边界。模型设置固定为 `temperature=0`、串行工具、usage streaming 与关闭 thinking；每次 run 显式关闭 tracing 和
 敏感 trace data。默认限制为 6 轮模型、8 次工具、单工具 5 秒、整轮 30 秒。单工具 timeout 回填稳定
 `TOOL_TIMEOUT`，其余受控失败映射为项目 `HostAgentFailed`，不透传 provider 异常。
 
-真实客户端只能由 `bootstrap.host_agent.build_qwen_host_agent()` 显式构造；import 时不读取 `.env`/环境变量或创建客户端。
-API Key 必填且使用秘密类型，默认 endpoint 为 DashScope 北京 OpenAI-compatible `/v1`，默认模型为 `qwen-plus`。
+真实客户端只能由 `bootstrap.host_agent.build_qwen_host_agent()` 或 `build_deepseek_host_agent()` 显式构造；import 时不读取 `.env`/环境变量或创建客户端。
+API Key 必填且使用秘密类型；provider endpoint 和模型由组合根显式传入，Qwen 和 DeepSeek 的 provider-specific 请求字段不会泄漏到通用 adapter。
 主链 bootstrap 继续装配 Fake，不会自动把该 Adapter 注入 `Orchestrator`。
 
 B 内部模型（不属于跨组件 Schema）：

--- a/agent-collaboration-framework/tests/test_openai_agents_adapter.py
+++ b/agent-collaboration-framework/tests/test_openai_agents_adapter.py
@@ -384,6 +384,12 @@ class QwenConfigAndBootstrapTests(unittest.TestCase):
         self.assertIsNone(adapter._config.model_settings_extra_body)
         self.assertNotIn(SECRET, repr(adapter))
 
+    def test_deepseek_bootstrap_uses_deepseek_defaults(self) -> None:
+        adapter = build_deepseek_host_agent({"HOST_AGENT_API_KEY": SECRET})
+
+        self.assertEqual(adapter._config.base_url, "https://api.deepseek.com")
+        self.assertEqual(adapter._config.model, "deepseek-chat")
+
 
 class RawOutputTests(unittest.TestCase):
     def test_accepts_one_finite_json_object_with_optional_exact_fence(self) -> None:

--- a/agent-collaboration-framework/tests/test_openai_agents_adapter.py
+++ b/agent-collaboration-framework/tests/test_openai_agents_adapter.py
@@ -24,6 +24,7 @@ from openai.types.responses import (
 from pydantic import ValidationError
 
 from collaboration_framework.bootstrap.host_agent import (
+    build_deepseek_host_agent,
     HostAgentConfigurationError,
     build_qwen_host_agent,
 )
@@ -365,6 +366,22 @@ class QwenConfigAndBootstrapTests(unittest.TestCase):
             }
         )
         self.assertIsInstance(adapter, QwenHostAgentAdapter)
+        self.assertEqual(
+            adapter._config.model_settings_extra_body,
+            {"enable_thinking": False},
+        )
+        self.assertNotIn(SECRET, repr(adapter))
+
+    def test_deepseek_bootstrap_omits_qwen_only_request_fields(self) -> None:
+        adapter = build_deepseek_host_agent(
+            {
+                "HOST_AGENT_API_KEY": SECRET,
+                "HOST_AGENT_BASE_URL": "https://api.deepseek.example/v1",
+                "HOST_AGENT_MODEL": "deepseek-chat",
+            }
+        )
+        self.assertIsInstance(adapter, QwenHostAgentAdapter)
+        self.assertIsNone(adapter._config.model_settings_extra_body)
         self.assertNotIn(SECRET, repr(adapter))
 
 

--- a/trpg-backend/.env.example
+++ b/trpg-backend/.env.example
@@ -13,7 +13,7 @@ LOG_LEVEL=INFO
 # JSON 数组格式
 CORS_ORIGINS=["http://localhost:9877","http://127.0.0.1:9877"]
 
-# 默认 fake 可离线运行；可切换为 openai 或 qwen 并填写对应密钥。
+# 默认 fake 可离线运行；可切换为 openai、qwen 或 deepseek 并填写对应密钥。
 HOST_MODEL_PROVIDER=fake
 OPENAI_API_KEY=
 OPENAI_BASE_URL=https://api.openai.com/v1
@@ -25,12 +25,17 @@ QWEN_API_KEY=
 QWEN_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 QWEN_MODEL=qwen3.7-plus
 QWEN_TIMEOUT_SECONDS=30
+
+# OpenAI-compatible provider 示例：DeepSeek 是首个内置实现。
+DEEPSEEK_API_KEY=
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+DEEPSEEK_MODEL=deepseek-chat
+DEEPSEEK_TIMEOUT_SECONDS=30
 HOST_AGENT_MAX_TURNS=6
 HOST_AGENT_MAX_TOOL_CALLS=8
 HOST_AGENT_TOOL_TIMEOUT_SECONDS=5
 HOST_AGENT_TIMEOUT_SECONDS=30
 
-# 不配置则使用确定性占位叙事；配置后可接入 DeepSeek 兼容接口。
-# DEEPSEEK_API_KEY=
+# DEEPSEEK_API_KEY 同时用于 Host Agent 和讨论区 Narrator；未配置则使用占位叙事。
 # 测试专用：延迟 Narrator 以稳定覆盖行动锁并发场景。
 NARRATOR_DELAY_SECONDS=0

--- a/trpg-backend/app/adapters/__init__.py
+++ b/trpg-backend/app/adapters/__init__.py
@@ -1,5 +1,6 @@
 """后端对外部端口的基础设施 Adapter。"""
 
+from app.adapters.deepseek_models import DeepSeekChatCompletionsJsonClient
 from app.adapters.openai_models import (
     OpenAIResponsesJsonClient,
     PromptIntentModel,
@@ -10,6 +11,7 @@ from app.adapters.sqlalchemy_engine_store import SqlAlchemyEngineStore
 
 __all__ = [
     "OpenAIResponsesJsonClient",
+    "DeepSeekChatCompletionsJsonClient",
     "PromptIntentModel",
     "PromptNarrationModel",
     "QwenChatCompletionsJsonClient",

--- a/trpg-backend/app/adapters/deepseek_models.py
+++ b/trpg-backend/app/adapters/deepseek_models.py
@@ -1,12 +1,4 @@
-"""Qwen-compatible structured JSON client.
-
-Alibaba Cloud Model Studio exposes an OpenAI-compatible API, but its
-Responses endpoint does not currently document OpenAI's strict
-``text.format=json_schema`` parameter. Qwen's Chat Completions endpoint does
-support JSON mode, so this adapter embeds the authoritative JSON Schema in the
-system message, requests a JSON object, and leaves deterministic schema
-validation to the existing Pydantic application boundary.
-"""
+"""DeepSeek OpenAI-compatible structured JSON client."""
 
 from __future__ import annotations
 
@@ -16,10 +8,11 @@ import httpx
 from collaboration_framework.contracts import JsonObject
 
 from app.adapters.openai_models import StructuredJsonClient
+from app.adapters.qwen_models import chat_completion_output_text
 
 
-class QwenChatCompletionsJsonClient(StructuredJsonClient):
-    """Generate a JSON candidate through Qwen's OpenAI-compatible JSON mode."""
+class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
+    """Generate a JSON candidate through DeepSeek Chat Completions JSON mode."""
 
     def __init__(
         self,
@@ -61,8 +54,6 @@ class QwenChatCompletionsJsonClient(StructuredJsonClient):
                 },
             ],
             "response_format": {"type": "json_object"},
-            # JSON mode is most reliable when Qwen emits only the final answer.
-            "enable_thinking": False,
         }
         async with httpx.AsyncClient(
             headers={
@@ -78,29 +69,14 @@ class QwenChatCompletionsJsonClient(StructuredJsonClient):
             )
             response.raise_for_status()
 
-        output_text = chat_completion_output_text(response.json(), provider_name="Qwen")
+        output_text = chat_completion_output_text(
+            response.json(),
+            provider_name="DeepSeek",
+        )
         parsed = json.loads(output_text)
         if not isinstance(parsed, dict):
-            raise ValueError("Qwen structured output must be a JSON object")
+            raise ValueError("DeepSeek structured output must be a JSON object")
         return parsed
 
 
-def chat_completion_output_text(payload: object, *, provider_name: str) -> str:
-    if not isinstance(payload, dict):
-        raise ValueError(f"{provider_name} Chat Completions payload must be an object")
-    choices = payload.get("choices")
-    if not isinstance(choices, list) or not choices:
-        raise ValueError(f"{provider_name} Chat Completions payload has no choices")
-    first = choices[0]
-    if not isinstance(first, dict):
-        raise ValueError(f"{provider_name} Chat Completions choice must be an object")
-    message = first.get("message")
-    if not isinstance(message, dict):
-        raise ValueError(f"{provider_name} Chat Completions choice has no message")
-    content = message.get("content")
-    if not isinstance(content, str) or not content.strip():
-        raise ValueError(f"{provider_name} Chat Completions message has no text content")
-    return content
-
-
-__all__ = ["QwenChatCompletionsJsonClient", "chat_completion_output_text"]
+__all__ = ["DeepSeekChatCompletionsJsonClient"]

--- a/trpg-backend/app/core/config.py
+++ b/trpg-backend/app/core/config.py
@@ -42,9 +42,9 @@ class Settings(BaseSettings):
     # 本地默认放行 Vite 开发服务器的默认端口 9877。
     cors_origins: list[str] = ["http://localhost:9877", "http://127.0.0.1:9877"]
 
-    # 默认使用确定性的离线 Fake，便于本地启动和测试；显式切到 openai 或 qwen
+    # 默认使用确定性的离线 Fake，便于本地启动和测试；显式切到远程 provider
     # 后，Host/Narrator 才会调用远程模型。
-    host_model_provider: Literal["fake", "openai", "qwen"] = "fake"
+    host_model_provider: Literal["fake", "openai", "qwen", "deepseek"] = "fake"
     openai_api_key: SecretStr | None = None
     openai_base_url: str = Field(
         default="https://api.openai.com/v1",
@@ -59,6 +59,13 @@ class Settings(BaseSettings):
     )
     qwen_model: str = Field(default="qwen3.7-plus", min_length=1)
     qwen_timeout_seconds: float = Field(default=30.0, gt=0, le=120)
+    deepseek_api_key: SecretStr | None = None
+    deepseek_base_url: str = Field(
+        default="https://api.deepseek.com",
+        min_length=1,
+    )
+    deepseek_model: str = Field(default="deepseek-chat", min_length=1)
+    deepseek_timeout_seconds: float = Field(default=30.0, gt=0, le=120)
     host_agent_max_turns: int = Field(default=6, gt=0, le=20)
     host_agent_max_tool_calls: int = Field(default=8, gt=0, le=50)
     host_agent_tool_timeout_seconds: float = Field(default=5.0, gt=0, le=30)
@@ -66,7 +73,6 @@ class Settings(BaseSettings):
 
     # 讨论区/Narrator 主线的兼容配置：未配置时使用确定性占位叙事，测试可通过
     # 延迟钩子稳定覆盖行动锁并发分支。
-    deepseek_api_key: str | None = None
     narrator_delay_seconds: float = Field(default=0.0, ge=0, le=120)
 
     @model_validator(mode="after")
@@ -79,6 +85,10 @@ class Settings(BaseSettings):
             self.qwen_api_key is None or not self.qwen_api_key.get_secret_value().strip()
         ):
             raise ValueError("HOST_MODEL_PROVIDER=qwen 时必须设置 QWEN_API_KEY")
+        if self.host_model_provider == "deepseek" and (
+            self.deepseek_api_key is None or not self.deepseek_api_key.get_secret_value().strip()
+        ):
+            raise ValueError("HOST_MODEL_PROVIDER=deepseek 时必须设置 DEEPSEEK_API_KEY")
         return self
 
 

--- a/trpg-backend/app/core/narrator.py
+++ b/trpg-backend/app/core/narrator.py
@@ -134,7 +134,7 @@ def build_narrator(settings: Settings) -> Narrator:
     docstring），生产配置保持 0、不受影响。
     """
     narrator: Narrator = (
-        DeepSeekNarrator(settings.deepseek_api_key)
+        DeepSeekNarrator(settings.deepseek_api_key.get_secret_value())
         if settings.deepseek_api_key
         else FallbackNarrator()
     )

--- a/trpg-backend/app/core/narrator.py
+++ b/trpg-backend/app/core/narrator.py
@@ -105,6 +105,7 @@ class DeepSeekNarrator(Narrator):
         timeout_seconds: float = _REQUEST_TIMEOUT_SECONDS,
     ) -> None:
         self._model = model
+        self._timeout_seconds = timeout_seconds
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=timeout_seconds)
 
     async def narrate(self, context: NarrationContext) -> str:

--- a/trpg-backend/app/core/narrator.py
+++ b/trpg-backend/app/core/narrator.py
@@ -105,9 +105,7 @@ class DeepSeekNarrator(Narrator):
         timeout_seconds: float = _REQUEST_TIMEOUT_SECONDS,
     ) -> None:
         self._model = model
-        self._client = AsyncOpenAI(
-            api_key=api_key, base_url=base_url, timeout=timeout_seconds
-        )
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=timeout_seconds)
 
     async def narrate(self, context: NarrationContext) -> str:
         response = await self._client.chat.completions.create(

--- a/trpg-backend/app/core/narrator.py
+++ b/trpg-backend/app/core/narrator.py
@@ -96,14 +96,22 @@ class DeepSeekNarrator(Narrator):
     事件），职责不在这里。
     """
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = DEEPSEEK_BASE_URL,
+        model: str = DEEPSEEK_MODEL,
+        timeout_seconds: float = _REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        self._model = model
         self._client = AsyncOpenAI(
-            api_key=api_key, base_url=DEEPSEEK_BASE_URL, timeout=_REQUEST_TIMEOUT_SECONDS
+            api_key=api_key, base_url=base_url, timeout=timeout_seconds
         )
 
     async def narrate(self, context: NarrationContext) -> str:
         response = await self._client.chat.completions.create(
-            model=DEEPSEEK_MODEL,
+            model=self._model,
             messages=_build_messages(context),
         )
         return response.choices[0].message.content or ""
@@ -134,7 +142,12 @@ def build_narrator(settings: Settings) -> Narrator:
     docstring），生产配置保持 0、不受影响。
     """
     narrator: Narrator = (
-        DeepSeekNarrator(settings.deepseek_api_key.get_secret_value())
+        DeepSeekNarrator(
+            settings.deepseek_api_key.get_secret_value(),
+            base_url=settings.deepseek_base_url,
+            model=settings.deepseek_model,
+            timeout_seconds=settings.deepseek_timeout_seconds,
+        )
         if settings.deepseek_api_key
         else FallbackNarrator()
     )

--- a/trpg-backend/app/core/turn.py
+++ b/trpg-backend/app/core/turn.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass
 from typing import Literal
 
 import structlog
-from collaboration_framework.bootstrap.host_agent import build_qwen_host_agent
+from collaboration_framework.bootstrap.host_agent import (
+    build_deepseek_host_agent,
+    build_qwen_host_agent,
+)
 from collaboration_framework.contracts import (
     ActionRequest,
     ActionResult,
@@ -46,6 +49,7 @@ from collaboration_framework.host.schemas import (
 )
 
 from app.adapters import (
+    DeepSeekChatCompletionsJsonClient,
     OpenAIResponsesJsonClient,
     PromptIntentModel,
     PromptNarrationModel,
@@ -552,6 +556,34 @@ def _configured_models(
             HostAgentIntentResolver(FakeHostAgent()),
             FakeNarrationModel(),
             HostModelMetadata(provider="fake", model="deterministic"),
+        )
+    if settings.host_model_provider == "deepseek":
+        if settings.deepseek_api_key is None:
+            raise ValueError("DeepSeek Host 模型缺少 API key")
+        host_agent = build_deepseek_host_agent(
+            {
+                "HOST_AGENT_API_KEY": settings.deepseek_api_key.get_secret_value(),
+                "HOST_AGENT_BASE_URL": settings.deepseek_base_url,
+                "HOST_AGENT_MODEL": settings.deepseek_model,
+                "HOST_AGENT_MAX_TURNS": str(settings.host_agent_max_turns),
+                "HOST_AGENT_MAX_TOOL_CALLS": str(settings.host_agent_max_tool_calls),
+                "HOST_AGENT_TOOL_TIMEOUT_SECONDS": str(settings.host_agent_tool_timeout_seconds),
+                "HOST_AGENT_TIMEOUT_SECONDS": str(settings.host_agent_timeout_seconds),
+            }
+        )
+        client = DeepSeekChatCompletionsJsonClient(
+            api_key=settings.deepseek_api_key.get_secret_value(),
+            base_url=settings.deepseek_base_url,
+            model=settings.deepseek_model,
+            timeout_seconds=settings.deepseek_timeout_seconds,
+        )
+        return (
+            HostAgentIntentResolver(host_agent),
+            PromptNarrationModel(client),
+            HostModelMetadata(
+                provider="deepseek",
+                model=settings.deepseek_model,
+            ),
         )
     if settings.host_model_provider == "qwen":
         if settings.qwen_api_key is None:

--- a/trpg-backend/tests/test_narrator.py
+++ b/trpg-backend/tests/test_narrator.py
@@ -44,7 +44,7 @@ def test_build_narrator_uses_deepseek_with_api_key() -> None:
     assert isinstance(narrator, DeepSeekNarrator)
     assert narrator._model == "deepseek-custom"
     assert str(narrator._client.base_url) == "https://provider.example/v1/"
-    assert narrator._client.timeout.read == 12
+    assert narrator._timeout_seconds == 12
 
 
 def test_build_messages_includes_module_title_history_and_utterance() -> None:

--- a/trpg-backend/tests/test_narrator.py
+++ b/trpg-backend/tests/test_narrator.py
@@ -32,9 +32,19 @@ def test_build_narrator_falls_back_without_api_key() -> None:
 
 
 def test_build_narrator_uses_deepseek_with_api_key() -> None:
-    settings = Settings(deepseek_api_key="sk-test-key")
+    settings = Settings(
+        host_model_provider="deepseek",
+        deepseek_api_key="sk-test-key",
+        deepseek_base_url="https://provider.example/v1",
+        deepseek_model="deepseek-custom",
+        deepseek_timeout_seconds=12,
+    )
 
-    assert isinstance(build_narrator(settings), DeepSeekNarrator)
+    narrator = build_narrator(settings)
+    assert isinstance(narrator, DeepSeekNarrator)
+    assert narrator._model == "deepseek-custom"
+    assert str(narrator._client.base_url) == "https://provider.example/v1/"
+    assert narrator._client.timeout.read == 12
 
 
 def test_build_messages_includes_module_title_history_and_utterance() -> None:

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -33,6 +33,7 @@ from collaboration_framework.host.application import PlayerViewProjector
 from collaboration_framework.host.schemas import IntentContext, NarrationContext
 from pydantic import ValidationError
 
+from app.adapters.deepseek_models import DeepSeekChatCompletionsJsonClient
 from app.adapters.openai_models import (
     OpenAIResponsesJsonClient,
     PromptIntentModel,
@@ -593,6 +594,51 @@ async def test_qwen_client_posts_json_mode_with_schema_in_instructions() -> None
     assert json.loads(body["messages"][1]["content"]) == {"safe": True}
 
 
+async def test_deepseek_client_posts_compatible_json_mode_without_qwen_fields() -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers["Authorization"]
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"kind":"unknown"}',
+                        }
+                    }
+                ]
+            },
+        )
+
+    client = DeepSeekChatCompletionsJsonClient(
+        api_key="test-key",
+        base_url="https://api.deepseek.example/v1/",
+        model="deepseek-chat",
+        timeout_seconds=1,
+        transport=httpx.MockTransport(handler),
+    )
+    result = await client.generate(
+        schema_name="test_schema",
+        schema={"type": "object"},
+        instructions="Return the structured result.",
+        input_payload={"safe": True},
+    )
+
+    body = captured["body"]
+    assert result == {"kind": "unknown"}
+    assert captured["url"].endswith("/v1/chat/completions")
+    assert captured["authorization"] == "Bearer test-key"
+    assert body["model"] == "deepseek-chat"
+    assert body["response_format"] == {"type": "json_object"}
+    assert "enable_thinking" not in body
+    assert "test_schema" in body["messages"][0]["content"]
+
+
 def test_openai_provider_requires_api_key() -> None:
     with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
         Settings.model_validate(
@@ -609,6 +655,16 @@ def test_qwen_provider_requires_api_key() -> None:
             {
                 "host_model_provider": "qwen",
                 "qwen_api_key": None,
+            }
+        )
+
+
+def test_deepseek_provider_requires_api_key() -> None:
+    with pytest.raises(ValidationError, match="DEEPSEEK_API_KEY"):
+        Settings.model_validate(
+            {
+                "host_model_provider": "deepseek",
+                "deepseek_api_key": None,
             }
         )
 


### PR DESCRIPTION
## Summary

Closes #163.

- Generalize the OpenAI Agents Host Agent adapter for OpenAI-compatible Chat Completions providers.
- Add DeepSeek as the first selectable remote Host Agent provider.
- Use DeepSeek JSON mode for structured intent and Narrator outputs without Qwen-only request fields.
- Preserve Fake, OpenAI, and Qwen provider behavior and existing Qwen aliases.
- Document the compatibility boundary: providers using private protocols need a separate adapter.

## Configuration

Set the following in `trpg-backend/.env`:

```dotenv
HOST_MODEL_PROVIDER=deepseek
DEEPSEEK_API_KEY=...
DEEPSEEK_BASE_URL=https://api.deepseek.com
DEEPSEEK_MODEL=deepseek-chat
DEEPSEEK_TIMEOUT_SECONDS=30
```

## Verification

- Backend: 188 passed.
- Framework: 166 passed, 3 skipped.
- DeepSeek/Qwen adapter targeted tests and ruff checks passed.
- DeepSeek-configured backend startup and health check passed without a model request.
- No real API key or billable DeepSeek request was used in local verification.
