### PR TITLE
fix(conversation): 恢复房间重入历史对话 (#166)

### DIFF
--- a/trpg-backend/app/controller/v1/rooms.py
+++ b/trpg-backend/app/controller/v1/rooms.py
@@ -23,7 +23,7 @@ from app.dto.character import (
 )
 from app.dto.chat import ChatMessageRead
 from app.dto.common import ApiResponse
-from app.dto.replay import ReplayEventRead, RoomSummaryRead
+from app.dto.replay import ReplayEventRead, RoomConversationEventRead, RoomSummaryRead
 from app.dto.room import (
     JoinRoomBody,
     RoomCreate,
@@ -243,6 +243,26 @@ async def get_room_replay(
     """GET /api/v1/rooms/{roomId}/replay —— 逐条事件回放（仅本房间成员可查）。"""
     try:
         events = await room_service.get_replay(db, room_id, reconnect_token)
+    except (
+        room_service.RoomAuthenticationError,
+        room_service.RoomAuthorizationError,
+    ) as exc:
+        _raise_service_error(exc)
+    return ApiResponse.ok(events)
+
+
+@router.get("/{room_id}/conversation", response_model=ApiResponse[list[RoomConversationEventRead]])
+async def list_room_conversation(
+    room_id: str,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[list[RoomConversationEventRead]]:
+    """GET /api/v1/rooms/{roomId}/conversation —— 房间对话历史。
+
+    给房间页重进恢复用；只允许房间成员读取。
+    """
+    try:
+        events = await room_service.list_conversation_events(db, room_id, reconnect_token)
     except (
         room_service.RoomAuthenticationError,
         room_service.RoomAuthorizationError,

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -269,7 +269,9 @@ async def _send_check_request(
 
 
 async def _send_check_result(
+    db: AsyncSession,
     websocket: WebSocket,
+    room_id: str,
     player_id: str,
     prepared: PreparedTurn,
     action_result: ActionResult,
@@ -290,6 +292,16 @@ async def _send_check_result(
         passed=check_result.passed,
         result=check_result.success_level,
     )
+    recorded = await room_service.record_event(
+        db,
+        room_id,
+        player_id,
+        "check.result",
+        payload.model_dump(by_alias=True, mode="json"),
+        correlation_id=prepared.player_input.client_action_id,
+    )
+    if not recorded:
+        return
     envelope = ServerEnvelope(
         type="check.result",
         payload=payload.model_dump(by_alias=True),
@@ -350,6 +362,7 @@ async def _broadcast_action_utterance(
     db: AsyncSession,
     room_id: str,
     player_id: str,
+    client_action_id: str,
     utterance: str,
 ) -> None:
     """广播玩家原话，但不把讨论区消息混入叙事事件历史。"""
@@ -358,9 +371,20 @@ async def _broadcast_action_utterance(
     nickname = player.nickname if player is not None else "玩家"
     payload = ActionBroadcastPayload(
         player_id=player_id,
+        client_action_id=client_action_id,
         nickname=nickname,
         utterance=utterance,
     )
+    recorded = await room_service.record_event(
+        db,
+        room_id,
+        player_id,
+        "action.broadcast",
+        payload.model_dump(by_alias=True, mode="json"),
+        correlation_id=client_action_id,
+    )
+    if not recorded:
+        return
     envelope = ServerEnvelope(
         type="action.broadcast",
         payload=payload.model_dump(by_alias=True),
@@ -630,6 +654,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 db,
                                 room_id,
                                 bound_player_id,
+                                submit_payload.client_action_id,
                                 submit_payload.utterance,
                             )
 
@@ -723,7 +748,9 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 ),
                                 on_action_result=partial(
                                     _send_check_result,
+                                    db,
                                     websocket,
+                                    room_id,
                                     bound_player_id,
                                     pending_turn,
                                 ),

--- a/trpg-backend/app/dto/replay.py
+++ b/trpg-backend/app/dto/replay.py
@@ -6,6 +6,8 @@
 "真的在写、也真的在读"的完整数据闭环之一。
 """
 
+from typing import Literal
+
 from app.dto.common import CamelModel, UtcDatetime
 
 
@@ -24,5 +26,20 @@ class ReplayEventRead(CamelModel):
     id: str
     player_id: str | None = None
     event_type: str
+    payload: dict
+    created_at: UtcDatetime
+
+
+class RoomConversationEventRead(CamelModel):
+    """GET /api/v1/rooms/{roomId}/conversation 返回项。
+
+    它面向房间页恢复当前对话 UI：讨论区消息继续来自 `chat_messages`，行动频道
+    的玩家原话、主持叙事和检定结果来自 `events`。这不是 replay 的替代品；
+    讨论区仍然不进入 replay，也仍然会在结束游戏时按既有语义清理。
+    """
+
+    id: str
+    type: Literal["chat.message", "action.broadcast", "narration.push", "check.result"]
+    channel: Literal["discussion", "action"]
     payload: dict
     created_at: UtcDatetime

--- a/trpg-backend/app/dto/ws.py
+++ b/trpg-backend/app/dto/ws.py
@@ -159,6 +159,7 @@ class ActionBroadcastPayload(CamelModel):
     """action.submit 原话广播 payload。"""
 
     player_id: str
+    client_action_id: str
     nickname: str
     utterance: str
 

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -26,7 +26,7 @@ from app.core.errors import not_implemented
 from app.core.runtime_state import ruleset_labels, ruleset_skill_values
 from app.dto.game import GameRead, GameSystemRead, RulesetRead
 from app.dto.module import ModuleDetailRead
-from app.dto.replay import ReplayEventRead, RoomSummaryRead
+from app.dto.replay import ReplayEventRead, RoomConversationEventRead, RoomSummaryRead
 from app.dto.room import (
     JoinRoomBody,
     ModuleRead,
@@ -37,6 +37,7 @@ from app.dto.room import (
     RoomPreview,
     SelectModuleBody,
 )
+from app.models.chat import ChatMessage
 from app.models.content import Game, GameSystem, Scenario, World
 from app.models.engine import GameSession, ModuleVersion
 from app.models.event import Event
@@ -938,6 +939,92 @@ async def get_replay(
         select(Event).where(Event.room_id == room_id).order_by(Event.created_at)
     )
     return [ReplayEventRead.model_validate(e) for e in result]
+
+
+async def list_conversation_events(
+    db: AsyncSession, room_id: str, reconnect_token: str | None
+) -> list[RoomConversationEventRead]:
+    """GET /api/v1/rooms/{roomId}/conversation —— 房间对话历史。
+
+    这是给房间页"重进恢复聊天记录"用的服务端权威视图：
+
+    - 讨论区消息继续从 `chat_messages` 读；
+    - `action.broadcast`、`narration.push`、`check.result` 从 `events` 读；
+    - `check.result` 只返回给对应玩家，避免把原本只发给本人的结果扩大成全房间可见；
+    - 按创建时间正序合并，前端直接按顺序渲染即可。
+    """
+    player = await require_room_member(db, room_id, reconnect_token)
+
+    chat_rows = (
+        await db.execute(
+            select(ChatMessage, Player.nickname)
+            .join(Player, ChatMessage.player_id == Player.id)
+            .where(ChatMessage.room_id == room_id)
+            .order_by(ChatMessage.created_at, ChatMessage.id)
+        )
+    ).all()
+    conversation: list[RoomConversationEventRead] = [
+        RoomConversationEventRead(
+            id=message.id,
+            type="chat.message",
+            channel="discussion",
+            payload={
+                "messageId": message.id,
+                "playerId": message.player_id,
+                "nickname": nickname,
+                "text": message.text,
+                "sentAt": message.created_at,
+                "clientMessageId": message.client_message_id,
+            },
+            created_at=message.created_at,
+        )
+        for message, nickname in chat_rows
+    ]
+
+    event_rows = (
+        await db.execute(
+            select(Event)
+            .where(
+                Event.room_id == room_id,
+                Event.event_type.in_(["action.broadcast", "narration.push", "check.result"]),
+            )
+            .order_by(Event.created_at, Event.id)
+        )
+    ).scalars()
+    for event in event_rows:
+        if event.event_type == "action.broadcast":
+            conversation.append(
+                RoomConversationEventRead(
+                    id=event.correlation_id or event.id,
+                    type="action.broadcast",
+                    channel="action",
+                    payload=event.payload,
+                    created_at=event.created_at,
+                )
+            )
+        elif event.event_type == "narration.push":
+            conversation.append(
+                RoomConversationEventRead(
+                    id=event.correlation_id or event.id,
+                    type="narration.push",
+                    channel="action",
+                    payload=event.payload,
+                    created_at=event.created_at,
+                )
+            )
+        elif event.event_type == "check.result" and event.player_id == player.id:
+            conversation.append(
+                RoomConversationEventRead(
+                    id=event.correlation_id or event.id,
+                    type="check.result",
+                    channel="action",
+                    payload=event.payload,
+                    created_at=event.created_at,
+                )
+            )
+
+    conversation.sort(key=lambda item: (item.created_at, item.id))
+    return conversation
 
 
 async def get_summary(db: AsyncSession, room_id: str) -> RoomSummaryRead:

--- a/trpg-backend/scripts/export_schema.py
+++ b/trpg-backend/scripts/export_schema.py
@@ -76,6 +76,7 @@ _MODELS: list[type[BaseModel]] = [
     # 复盘 / 回放（issue #77 新增）
     replay.RoomSummaryRead,
     replay.ReplayEventRead,
+    replay.RoomConversationEventRead,
     # 通用响应信封里的错误详情（ApiResponse 本身手写，见上面的说明）
     common.ErrorDetail,
     # WebSocket 现有 6 个事件（issue #60/#75）

--- a/trpg-backend/tests/test_chat_ws.py
+++ b/trpg-backend/tests/test_chat_ws.py
@@ -19,12 +19,24 @@ from collections.abc import Iterator
 from uuid import uuid4
 
 import pytest
+from collaboration_framework.host.adapters.fakes import FakeNarrationModel
 from starlette.testclient import TestClient
 
+from app.controller import ws as ws_controller
 from app.core.narrator import FallbackNarrator
+from app.core.turn import build_turn_application
 from app.main import app
 from app.service.action_lock import RoomActionLockManager
-from tests.test_ws import ROOMS_BASE, create_room, register_and_login
+from tests.test_ws import (
+    ROOMS_BASE,
+    advance_to_building,
+    complete_character,
+    create_room,
+    join_as,
+    receive_until,
+    register_and_login,
+    start_game,
+)
 
 
 @pytest.fixture
@@ -63,6 +75,34 @@ def _submit_action(ws, player: dict, utterance: str) -> None:
             "playerId": player["playerId"],
             "payload": {"clientActionId": str(uuid4()), "utterance": utterance},
         }
+    )
+
+
+class _ConversationCheckIntentModel:
+    async def generate(self, context):  # noqa: ANN001
+        return {
+            "kind": "action",
+            "verb": "investigate",
+            "target": {"matched": True, "id": context.player_view.scene.id},
+            "check": {
+                "route": "default",
+                "proposed_skills": ["library-use", "stealth"],
+            },
+            "summary": context.player_input.utterance,
+        }
+
+
+def _use_candidate_turn_application(monkeypatch: pytest.MonkeyPatch) -> None:
+    current_application = ws_controller.turn_application
+    monkeypatch.setattr(
+        ws_controller,
+        "turn_application",
+        build_turn_application(
+            current_application.store,
+            current_application.engine,
+            intent_model=_ConversationCheckIntentModel(),
+            narration_model=FakeNarrationModel(),
+        ),
     )
 
 
@@ -310,3 +350,142 @@ def test_end_game_clears_chat_and_replay_stays_clean(sync_client: TestClient) ->
         "data"
     ]
     assert "这句话不该进复盘" not in str(replay)
+
+
+def test_conversation_restores_action_discussion_and_narration(
+    sync_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = register_and_login(sync_client, "conversation_host")
+    room = create_room(sync_client, token)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+    _use_candidate_turn_application(monkeypatch)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        assert ws.receive_json()["type"] == "session.bound"
+        assert ws.receive_json()["type"] == "view.updated"
+        _send_chat(ws, room, "先在讨论区确认路线", "conv-chat-1")
+        assert ws.receive_json()["type"] == "chat.message"
+        ws.send_json(
+            {
+                "type": "action.submit",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "conv-action-1",
+                    "utterance": "我查看图书馆的目录",
+                },
+            }
+        )
+        assert ws.receive_json()["type"] == "action.broadcast"
+        assert ws.receive_json()["type"] == "turn.started"
+        assert ws.receive_json()["type"] == "turn.phase_changed"
+        assert ws.receive_json()["type"] == "turn.phase_changed"
+        assert ws.receive_json()["type"] == "turn.phase_changed"
+        check_request, _ = receive_until(ws, lambda message: message.get("type") == "check.request")
+        ws.send_json(
+            {
+                "type": "check.roll",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "conv-action-1",
+                    "skill": "library-use",
+                    "rollValue": 18,
+                },
+            }
+        )
+        check_result, _ = receive_until(ws, lambda message: message.get("type") == "check.result")
+        assert check_request["payload"]["clientActionId"] == "conv-action-1"
+        assert check_result["payload"]["clientActionId"] == "conv-action-1"
+        completed, _ = receive_until(
+            ws, lambda message: message.get("message_type") == "turn.completed"
+        )
+        narration, _ = receive_until(ws, lambda message: message.get("type") == "narration.push")
+
+    assert completed["correlation_id"] == "conv-action-1"
+    assert narration["type"] == "narration.push"
+
+    conversation = sync_client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/conversation",
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    ).json()["data"]
+    assert [event["type"] for event in conversation] == [
+        "narration.push",
+        "chat.message",
+        "action.broadcast",
+        "check.result",
+        "narration.push",
+    ]
+    assert conversation[1]["channel"] == "discussion"
+    assert conversation[2]["channel"] == "action"
+    assert conversation[3]["payload"]["clientActionId"] == "conv-action-1"
+    assert conversation[4]["payload"]["text"]
+
+
+def test_check_result_stays_hidden_from_other_members(
+    sync_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = register_and_login(sync_client, "conversation_host_hidden")
+    room = create_room(sync_client, token, max_players=2)
+    guest = join_as(sync_client, room["roomCode"], "conversation_guest_hidden", "访客")
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    complete_character(sync_client, room["roomId"], guest["reconnectToken"])
+    start_game(sync_client, room, token)
+    _use_candidate_turn_application(monkeypatch)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        assert ws.receive_json()["type"] == "session.bound"
+        assert ws.receive_json()["type"] == "view.updated"
+        ws.send_json(
+            {
+                "type": "action.submit",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "conv-action-hidden",
+                    "utterance": "我再检查一次线索",
+                },
+            }
+        )
+        assert ws.receive_json()["type"] == "action.broadcast"
+        assert ws.receive_json()["type"] == "turn.started"
+        assert ws.receive_json()["type"] == "turn.phase_changed"
+        assert ws.receive_json()["type"] == "turn.phase_changed"
+        assert ws.receive_json()["type"] == "turn.phase_changed"
+        receive_until(ws, lambda message: message.get("type") == "check.request")
+        ws.send_json(
+            {
+                "type": "check.roll",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "conv-action-hidden",
+                    "skill": "stealth",
+                    "rollValue": 22,
+                },
+            }
+        )
+        receive_until(ws, lambda message: message.get("type") == "check.result")
+        receive_until(ws, lambda message: message.get("message_type") == "turn.completed")
+        receive_until(ws, lambda message: message.get("type") == "narration.push")
+
+    guest_conversation = sync_client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/conversation",
+        headers={"X-Reconnect-Token": guest["reconnectToken"]},
+    ).json()["data"]
+    assert [event["type"] for event in guest_conversation].count("check.result") == 0

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -1,0 +1,212 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RoomConversationEvent, ServerToClientEvent } from 'trpg-sdk'
+import RoomPage from './RoomPage'
+import { useAuthStore } from '@/stores/auth-store'
+import { useCharacterStore } from '@/stores/character-store'
+import { useRoomStore } from '@/stores/room-store'
+
+const {
+  emitWsMessage,
+  mockGetPlayerView,
+  mockJoinRoom,
+  mockListConversation,
+  mockOnWsMessage,
+  mockWaitForWsOpen,
+  wsHandlers,
+} = vi.hoisted(() => {
+  const handlers = new Set<(event: ServerToClientEvent) => void>()
+  return {
+    wsHandlers: handlers,
+    emitWsMessage: (event: ServerToClientEvent) => {
+      for (const handler of handlers) handler(event)
+    },
+    mockGetPlayerView: vi.fn(),
+    mockJoinRoom: vi.fn(),
+    mockListConversation: vi.fn(),
+    mockOnWsMessage: vi.fn((handler: (event: ServerToClientEvent) => void) => {
+      handlers.add(handler)
+      return () => handlers.delete(handler)
+    }),
+    mockWaitForWsOpen: vi.fn(() => Promise.resolve()),
+  }
+})
+
+vi.mock('@/services/api-client', () => ({
+  connectWebSocket: vi.fn(() => ({}) as WebSocket),
+  disconnectWebSocket: vi.fn(),
+  friendlyErrorMessage: vi.fn((_err: unknown, fallback: string) => fallback),
+  onWsMessage: mockOnWsMessage,
+  waitForWsOpen: mockWaitForWsOpen,
+  sdk: {
+    rooms: {
+      listConversation: mockListConversation,
+    },
+    roomSocket: {
+      getPlayerView: mockGetPlayerView,
+      joinRoom: mockJoinRoom,
+      rollCheck: vi.fn(),
+      sendChat: vi.fn(),
+      submitAction: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/services/room', () => ({
+  endGame: vi.fn(),
+}))
+
+vi.mock('@/hooks/useRoomPlayers', () => ({
+  useRoomPlayers: () => ({
+    phase: 'InGame',
+    moduleTitle: '追书人',
+    players: [
+      {
+        playerId: 'player-1',
+        nickname: '陈探员',
+        isHost: true,
+        ready: true,
+        hasCharacter: true,
+      },
+    ],
+  }),
+}))
+
+vi.mock('@/hooks/useRuleset', () => ({
+  useRuleset: () => ({
+    ruleset: { attributes: [], skills: [], occupations: [] },
+    loading: false,
+    error: '',
+  }),
+}))
+
+function renderRoomPage() {
+  return render(
+    <MemoryRouter>
+      <RoomPage />
+    </MemoryRouter>,
+  )
+}
+
+function conversationHistory(): RoomConversationEvent[] {
+  return [
+    {
+      id: 'chat-1',
+      type: 'chat.message',
+      channel: 'discussion',
+      payload: {
+        messageId: 'chat-1',
+        playerId: 'player-1',
+        nickname: '陈探员',
+        text: '先在讨论区确认路线',
+        sentAt: '2026-07-28T10:00:00Z',
+        clientMessageId: 'client-chat-1',
+      },
+      createdAt: '2026-07-28T10:00:00Z',
+    },
+    {
+      id: 'act-1',
+      type: 'action.broadcast',
+      channel: 'action',
+      payload: {
+        playerId: 'player-1',
+        clientActionId: 'act-1',
+        nickname: '陈探员',
+        utterance: '我查看书架',
+      },
+      createdAt: '2026-07-28T10:01:00Z',
+    },
+    {
+      id: 'act-1',
+      type: 'check.result',
+      channel: 'action',
+      payload: {
+        playerId: 'player-1',
+        clientActionId: 'act-1',
+        skillName: '图书馆使用',
+        targetValue: 50,
+        rollValue: 23,
+        difficulty: 'regular',
+        successLevel: 'regular',
+        passed: true,
+        result: 'regular',
+      },
+      createdAt: '2026-07-28T10:02:00Z',
+    },
+    {
+      id: 'act-1',
+      type: 'narration.push',
+      channel: 'action',
+      payload: {
+        text: '你发现书架后有一个暗格。',
+      },
+      createdAt: '2026-07-28T10:03:00Z',
+    },
+  ]
+}
+
+describe('RoomPage conversation history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wsHandlers.clear()
+    window.HTMLElement.prototype.scrollIntoView = vi.fn()
+    localStorage.clear()
+    sessionStorage.clear()
+    useRoomStore.getState().reset()
+    useAuthStore.getState().logout()
+    useCharacterStore.getState().clear()
+    useRoomStore.getState().setRoomIdentity({
+      roomId: 'room-1',
+      roomCode: 'ABC123',
+      playerId: 'player-1',
+      reconnectToken: 'reconnect-1',
+    })
+    useAuthStore.getState().login('token-1', 'user-1', '陈探员')
+    mockGetPlayerView.mockReturnValue(null)
+    mockListConversation.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('restores action history by default and discussion history after switching channel', async () => {
+    mockListConversation.mockResolvedValue(conversationHistory())
+
+    renderRoomPage()
+
+    expect(await screen.findByText('我查看书架')).toBeInTheDocument()
+    expect(screen.getByText('你发现书架后有一个暗格。')).toBeInTheDocument()
+    expect(screen.getByText('图书馆使用 50% · D100 23 · 成功')).toBeInTheDocument()
+    expect(mockListConversation).toHaveBeenCalledWith('room-1', 'reconnect-1')
+
+    fireEvent.click(screen.getByRole('button', { name: '讨论区' }))
+
+    expect(await screen.findByText('先在讨论区确认路线')).toBeInTheDocument()
+  })
+
+  it('does not duplicate realtime action broadcast already restored from history', async () => {
+    mockListConversation.mockResolvedValue([
+      conversationHistory().find((event) => event.type === 'action.broadcast')!,
+    ])
+
+    renderRoomPage()
+
+    expect(await screen.findByText('我查看书架')).toBeInTheDocument()
+
+    emitWsMessage({
+      type: 'action.broadcast',
+      payload: {
+        playerId: 'player-1',
+        clientActionId: 'act-1',
+        nickname: '陈探员',
+        utterance: '我查看书架',
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getAllByText('我查看书架')).toHaveLength(1)
+    })
+  })
+})

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom'
-import { TurnFailedError, type AgentPlayerView, type AgentTurnPhase, type CheckRequestPayload } from 'trpg-sdk'
+import { TurnFailedError, type AgentPlayerView, type AgentTurnPhase, type CheckRequestPayload, type RoomConversationEvent } from 'trpg-sdk'
 import { ArrowLeft, Users, Map, BookOpen, ScrollText, Star, X, SendHorizontal, Dice6, Plus, Save, FlagOff, Heart } from 'lucide-react'
 import { useState, useRef, useEffect, type FormEvent } from 'react'
 import { useRoomStore } from '@/stores/room-store'
@@ -77,6 +77,120 @@ function resourceValue(playerView: AgentPlayerView | null, id: string): number |
     item.name.toLocaleLowerCase() === normalized
   )
   return resource?.value ?? null
+}
+
+function formatRoomTime(value: string | Date): string {
+  return new Date(value).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })
+}
+
+function conversationMessageId(type: RoomConversationEvent['type'], id: string): string {
+  return `history:${type}:${id}`
+}
+
+function mergeHistoricalMessages(current: Message[], history: Message[]): Message[] {
+  const ids = new Set(current.flatMap((item) => (item.messageId ? [item.messageId] : [])))
+  return [...history.filter((item) => !item.messageId || !ids.has(item.messageId)), ...current]
+}
+
+function appendLiveMessage(current: Message[], message: Message): Message[] {
+  if (message.messageId && current.some((item) => item.messageId === message.messageId)) {
+    return current
+  }
+  return [...current, message]
+}
+
+function conversationEventToMessage(
+  event: RoomConversationEvent,
+  selfPlayerId: string | null,
+  senderName: string,
+): Message | null {
+  if (event.type === 'chat.message') {
+    const payload = event.payload as {
+      messageId: string
+      playerId: string
+      nickname: string
+      text: string
+      sentAt: string
+      clientMessageId: string
+    }
+    return {
+      type: 'player',
+      channel: 'discussion',
+      messageId: conversationMessageId(event.type, event.id),
+      sender: payload.nickname,
+      content: payload.text,
+      time: formatRoomTime(payload.sentAt),
+      isSelf: payload.playerId === selfPlayerId,
+    }
+  }
+  if (event.type === 'action.broadcast') {
+    const payload = event.payload as {
+      playerId: string
+      clientActionId: string
+      nickname: string
+      utterance: string
+    }
+    return {
+      type: 'player',
+      channel: 'action',
+      messageId: conversationMessageId(event.type, event.id),
+      sender: payload.nickname,
+      content: payload.utterance,
+      time: formatRoomTime(event.createdAt),
+      isSelf: payload.playerId === selfPlayerId,
+    }
+  }
+  if (event.type === 'narration.push') {
+    const payload = event.payload as { text: string }
+    return {
+      type: 'narr',
+      channel: 'action',
+      messageId: conversationMessageId(event.type, event.id),
+      sender: '守秘人',
+      content: payload.text,
+      time: formatRoomTime(event.createdAt),
+    }
+  }
+  if (event.type === 'check.result') {
+    const payload = event.payload as {
+      playerId: string
+      clientActionId: string
+      skillName: string
+      targetValue: number
+      rollValue: number
+      difficulty: string
+      successLevel: string
+      passed: boolean
+      result: string
+    }
+    const levelLabels: Record<string, string> = {
+      critical: '大成功',
+      extreme: '极难成功',
+      hard: '困难成功',
+      regular: '成功',
+      failure: '失败',
+      fumble: '大失败',
+    }
+    const difficultyLabels: Record<string, string> = {
+      regular: '常规',
+      hard: '困难',
+      extreme: '极难',
+    }
+    const levelLabel = levelLabels[payload.successLevel] ?? payload.result
+    const outcomeLabel = payload.passed
+      ? levelLabel
+      : `${levelLabel}（未通过${difficultyLabels[payload.difficulty] ?? ''}检定）`
+    return {
+      type: 'dice',
+      channel: 'action',
+      messageId: conversationMessageId(event.type, event.id),
+      sender: payload.playerId === selfPlayerId ? senderName : '玩家',
+      content: `${payload.skillName} ${payload.targetValue}% · D100 ${payload.rollValue} · ${outcomeLabel}`,
+      time: formatRoomTime(event.createdAt),
+      isSelf: payload.playerId === selfPlayerId,
+    }
+  }
+  return null
 }
 
 const DICE_OPTIONS = [
@@ -502,6 +616,7 @@ export default function RoomPage() {
   )
   const [lastSaved, setLastSaved] = useState<string | null>(() => (notesKey ? localStorage.getItem(notesKey) : null) ? new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' }) : null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const pendingNarrationActionIdRef = useRef<string | null>(null)
   const suspended = (roomPhase || roomInfo?.phase) === 'Suspended'
   const mapLocations = mapLocationsFromPlayerView(playerView)
   const currentHp = resourceValue(playerView, 'hp') ?? character?.derived.hp ?? null
@@ -514,21 +629,15 @@ export default function RoomPage() {
   useEffect(() => {
     if (!roomId || !reconnectToken) return
     let cancelled = false
-    void sdk.rooms.listMessages(roomId, reconnectToken, { limit: 100 }).then((history) => {
+    void sdk.rooms.listConversation(roomId, reconnectToken).then((history) => {
       if (cancelled) return
-      const restored: Message[] = history.reverse().map((message) => ({
-        type: 'player', channel: 'discussion', messageId: message.messageId,
-        sender: message.nickname, content: message.text,
-        time: new Date(message.sentAt).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' }),
-        isSelf: message.playerId === playerId,
-      }))
-      setMessages((current) => {
-        const ids = new Set(current.flatMap((item) => item.messageId ? [item.messageId] : []))
-        return [...restored.filter((item) => !item.messageId || !ids.has(item.messageId)), ...current]
-      })
+      const restored = history
+        .map((event) => conversationEventToMessage(event, playerId, senderName))
+        .filter((item): item is Message => item !== null)
+      setMessages((current) => mergeHistoricalMessages(current, restored))
     }).catch(() => {})
     return () => { cancelled = true }
-  }, [roomId, reconnectToken, playerId])
+  }, [roomId, reconnectToken, playerId, senderName])
 
   useEffect(() => {
     if (!playerView) return
@@ -579,32 +688,50 @@ export default function RoomPage() {
         setTyping(false)
         setProgressLabel(null)
         setMessages(prev => {
-          if (prev.at(-1)?.content === envelope.payload.text) return prev
-          return [...prev, {
-            type: 'narr', channel: 'action', sender: '守秘人',
+          const messageId = pendingNarrationActionIdRef.current
+            ? conversationMessageId('narration.push', pendingNarrationActionIdRef.current)
+            : undefined
+          if (messageId && prev.some((item) => item.messageId === messageId)) {
+            pendingNarrationActionIdRef.current = null
+            return prev
+          }
+          if (!messageId && prev.at(-1)?.content === envelope.payload.text) return prev
+          pendingNarrationActionIdRef.current = null
+          return appendLiveMessage(prev, {
+            type: 'narr',
+            channel: 'action',
+            messageId,
+            sender: '守秘人',
             content: envelope.payload.text,
-            time: new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' }),
-          }]
+            time: formatRoomTime(new Date()),
+          })
         })
       } else if (envelope.type === 'room.state') {
         setRoomPhase(envelope.payload.phase)
       } else if (envelope.type === 'chat.message') {
         setMessages((prev) => {
-          if (prev.some((item) => item.messageId === envelope.payload.messageId)) return prev
-          return [...prev, {
-            type: 'player', channel: 'discussion', messageId: envelope.payload.messageId,
-            sender: envelope.payload.nickname, content: envelope.payload.text,
-            time: new Date(envelope.payload.sentAt).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' }),
+          const messageId = conversationMessageId('chat.message', envelope.payload.messageId)
+          if (prev.some((item) => item.messageId === messageId)) return prev
+          return appendLiveMessage(prev, {
+            type: 'player',
+            channel: 'discussion',
+            messageId,
+            sender: envelope.payload.nickname,
+            content: envelope.payload.text,
+            time: formatRoomTime(envelope.payload.sentAt),
             isSelf: envelope.payload.playerId === playerId,
-          }]
+          })
         })
       } else if (envelope.type === 'action.broadcast') {
-        setMessages((prev) => [...prev, {
-          type: 'player', channel: 'action', sender: envelope.payload.nickname,
+        setMessages((prev) => appendLiveMessage(prev, {
+          type: 'player',
+          channel: 'action',
+          messageId: conversationMessageId('action.broadcast', envelope.payload.clientActionId),
+          sender: envelope.payload.nickname,
           content: envelope.payload.utterance,
-          time: new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' }),
+          time: formatRoomTime(new Date()),
           isSelf: envelope.payload.playerId === playerId,
-        }])
+        }))
       } else if (envelope.type === 'check.request') {
         setTyping(false)
         setProgressLabel(null)
@@ -629,13 +756,15 @@ export default function RoomPage() {
         const outcomeLabel = envelope.payload.passed
           ? levelLabel
           : `${levelLabel}（未通过${difficultyLabels[envelope.payload.difficulty] ?? ''}检定）`
-        setMessages(prev => [...prev, {
-          type: 'dice', channel: 'action',
+        setMessages(prev => appendLiveMessage(prev, {
+          type: 'dice',
+          channel: 'action',
+          messageId: conversationMessageId('check.result', envelope.payload.clientActionId),
           sender: envelope.payload.playerId === playerId ? senderName : '玩家',
           content: `${envelope.payload.skillName} ${envelope.payload.targetValue}% · D100 ${envelope.payload.rollValue} · ${outcomeLabel}`,
-          time: new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' }),
+          time: formatRoomTime(new Date()),
           isSelf: envelope.payload.playerId === playerId,
-        }])
+        }))
         setPendingCheck(current =>
           current?.clientActionId === envelope.payload.clientActionId ? null : current
         )
@@ -655,6 +784,7 @@ export default function RoomPage() {
         setActionError(envelope.payload.publicMessage)
         setActionErrorRetryable(envelope.payload.retryable)
         setActionErrorIsGuidance(envelope.payload.code === 'HOST_AGENT_INVALID_OUTPUT')
+        pendingNarrationActionIdRef.current = null
       } else if (envelope.type === 'view.updated') {
         if (envelope.payload.playerId === playerId) {
           setPlayerView(envelope.payload.playerView)
@@ -663,6 +793,7 @@ export default function RoomPage() {
         setTyping(false)
         setProgressLabel(null)
         setActionError(envelope.payload.message)
+        pendingNarrationActionIdRef.current = null
       }
     })
     return off
@@ -670,6 +801,7 @@ export default function RoomPage() {
 
   const submitPlayerAction = (action: { clientActionId: string; utterance: string }) => {
     if (!playerId || suspended) return
+    pendingNarrationActionIdRef.current = action.clientActionId
     setPendingAction(action)
     setActionError('')
     setActionErrorRetryable(false)
@@ -693,6 +825,7 @@ export default function RoomPage() {
         setActionErrorIsGuidance(
           error instanceof TurnFailedError && error.code === 'HOST_AGENT_INVALID_OUTPUT'
         )
+        pendingNarrationActionIdRef.current = null
       })
   }
 

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -14,6 +14,7 @@
  */
 export interface ActionBroadcastPayload {
   playerId: string;
+  clientActionId: string;
   nickname: string;
   utterance: string;
 }
@@ -669,6 +670,23 @@ export interface RollAttributesResult {
   derivedStats: {
     [k: string]: number;
   };
+}
+
+/**
+ * GET /api/v1/rooms/{roomId}/conversation 返回项。
+ *
+ * 它面向房间页恢复当前对话 UI：讨论区消息继续来自 `chat_messages`，行动频道
+ * 的玩家原话、主持叙事和检定结果来自 `events`。这不是 replay 的替代品；
+ * 讨论区仍然不进入 replay，也仍然会在结束游戏时按既有语义清理。
+ */
+export interface RoomConversationEventRead {
+  id: string;
+  type: "chat.message" | "action.broadcast" | "narration.push" | "check.result";
+  channel: "discussion" | "action";
+  payload: {
+    [k: string]: unknown;
+  };
+  createdAt: string;
 }
 
 /**

--- a/trpg-sdk/src/resources/room-socket.ts
+++ b/trpg-sdk/src/resources/room-socket.ts
@@ -313,6 +313,7 @@ const PAYLOAD_VALIDATORS: {
     typeof p.clientMessageId === 'string',
   'action.broadcast': (p) =>
     typeof p.playerId === 'string' &&
+    typeof p.clientActionId === 'string' &&
     typeof p.nickname === 'string' &&
     typeof p.utterance === 'string',
   'san.check.request': (p) => typeof p.playerId === 'string',

--- a/trpg-sdk/src/resources/rooms.test.ts
+++ b/trpg-sdk/src/resources/rooms.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { ApiClient } from '../client';
+import { RoomsResource } from './rooms';
+
+function captureRequest(): {
+  rooms: RoomsResource;
+  captured: () => { url: string; headers: Headers } | undefined;
+} {
+  let captured: { url: string; headers: Headers } | undefined;
+  const fakeFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    captured = {
+      url: String(input),
+      headers: new Headers(init?.headers),
+    };
+    return new Response(JSON.stringify({ success: true, data: [], error: null }));
+  }) as typeof fetch;
+
+  const client = new ApiClient({ baseUrl: 'http://test/api/v1', fetch: fakeFetch });
+  return { rooms: new RoomsResource(client), captured: () => captured };
+}
+
+test('listConversation 调用房间对话历史接口并携带房间凭证', async () => {
+  const { rooms, captured } = captureRequest();
+
+  await rooms.listConversation('room-1', 'reconnect-token-1');
+
+  assert.equal(captured()?.url, 'http://test/api/v1/rooms/room-1/conversation');
+  assert.equal(captured()?.headers.get('x-reconnect-token'), 'reconnect-token-1');
+});

--- a/trpg-sdk/src/resources/rooms.ts
+++ b/trpg-sdk/src/resources/rooms.ts
@@ -10,6 +10,7 @@ import type {
   MyRoomSummary,
   RoomSummary,
   ReplayEvent,
+  RoomConversationEvent,
 } from '../types';
 
 /**
@@ -123,6 +124,14 @@ export class RoomsResource {
   getReplay(roomId: string, reconnectToken: string): Promise<ReplayEvent[]> {
     return this.client.get<ReplayEvent[]>(
       `/rooms/${roomId}/replay`,
+      this.roomAuth(reconnectToken)
+    );
+  }
+
+  /** GET /api/v1/rooms/{roomId}/conversation — 房间对话历史 */
+  listConversation(roomId: string, reconnectToken: string): Promise<RoomConversationEvent[]> {
+    return this.client.get<RoomConversationEvent[]>(
+      `/rooms/${roomId}/conversation`,
       this.roomAuth(reconnectToken)
     );
   }

--- a/trpg-sdk/src/types.ts
+++ b/trpg-sdk/src/types.ts
@@ -54,6 +54,7 @@ export type {
   // 复盘 / 回放（issue #77）—— 对应后端 dto/replay.py
   RoomSummaryRead as RoomSummary,
   ReplayEventRead as ReplayEvent,
+  RoomConversationEventRead as RoomConversationEvent,
   // WebSocket 现有 6 个事件（issue #60）—— 对应后端 dto/ws.py
   RoomJoinPayload,
   PlayerReadyPayload,


### PR DESCRIPTION
## 关联 Issue

Closes #166

## 主要改动

- 新增 `GET /api/v1/rooms/{roomId}/conversation`，合并 `chat_messages` 与 `events` 作为房间对话历史。
- `action.broadcast`、`check.result` 现在也写入 `events`；`narration.push` 继续沿用现有事件日志。
- 前端 `RoomPage` 挂载时改为拉取 conversation，并按稳定 id 恢复行动页/讨论区消息。
- 新增 SDK 方法 `rooms.listConversation(...)` 和对应类型。
- 补充后端、SDK、前端回归测试。

## 采用该方案的原因

- 不新增表结构，不引入迁移风险，直接复用现有服务端权威历史源。
- 历史恢复和实时 WS 共用稳定消息 id，能避免重进房间后的重复渲染。

## 测试与验证

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest tests/test_chat_ws.py -q`
- [x] `uv run pytest tests/test_chat_ws.py::test_conversation_restores_action_discussion_and_narration tests/test_chat_ws.py::test_check_result_stays_hidden_from_other_members -q`
- [x] `uv run pytest tests/test_ws.py::test_skill_check_waits_for_player_selection_and_roll tests/test_ws.py::test_clarification_is_sent_only_to_action_owner -q`
- [x] `npm test` (trpg-sdk)
- [x] `npm run build` (trpg-sdk)
- [x] `npm test` (trpg-frontend)
- [x] `npm run build` (trpg-frontend)
- [ ] `uv run pytest -q`：本地环境仍有 2 个与本次改动无关的失败，分别是 `tests/test_engine_runtime.py::test_turn_application_resolves_actor_and_replays_one_execution`（DeepSeek 叙事输出解析）和 `tests/test_narrator.py::test_build_narrator_falls_back_without_api_key`（当前环境 `HOST_MODEL_PROVIDER=deepseek` 且未提供 API key）。

## 风险与回滚

- 风险：`narration.push` 目前仍沿用现有 WS payload，没有额外携带事件 id；当前通过动作关联键完成历史/实时去重。
- 回滚：回退本次 commit 即可恢复到旧的 `/messages` 恢复路径。

## UI 证据

- 已补 `RoomPage.test.tsx`，覆盖返回房间恢复历史、讨论区切换和去重。

## AI 使用情况

- 仅用于实现、测试补充和说明整理；改动已通过定向回归验证。

## 自检

- [x] 改动范围符合 Issue
- [x] 不包含无关改动
- [x] 已包含必要的测试
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查和人工 Review
