### PR TITLE
fix(narrator): 阻断玩家可见文本中的内部协议泄漏

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/contracts/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/__init__.py
@@ -92,6 +92,6 @@ from .player_view import (
     VisibleEntity,
     VisibleFact,
 )
-from .runtime import PlayerInput
+from .runtime import PlayerInput, player_input_fingerprint
 
 __all__ = [name for name in globals() if not name.startswith("_")]

--- a/agent-collaboration-framework/collaboration_framework/contracts/action.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/action.py
@@ -85,6 +85,14 @@ class ActionRequest(ContractModel):
     player_id: str = Field(min_length=1)
     actor_id: str = Field(min_length=1)
     source_view_revision: str = Field(min_length=1)
+    input_fingerprint: str | None = Field(
+        default=None,
+        pattern=r"^[0-9a-f]{64}$",
+        description=(
+            "Opaque SHA-256 identity of the normalized PlayerInput that created "
+            "this command; used to reject request_id reuse with different input."
+        ),
+    )
     intent: Intent
     roll_value: int | None = Field(default=None, ge=1, le=100)
 

--- a/agent-collaboration-framework/collaboration_framework/contracts/runtime.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/runtime.py
@@ -1,5 +1,8 @@
 """Runtime input contracts shared by the gateway, host, and engine."""
 
+import hashlib
+import json
+
 from pydantic import Field
 
 from .common import ContractModel
@@ -11,3 +14,22 @@ class PlayerInput(ContractModel):
     actor_id: str = Field(min_length=1)
     client_action_id: str = Field(min_length=1)
     utterance: str = Field(min_length=1)
+
+
+def player_input_fingerprint(player_input: PlayerInput) -> str:
+    """Return a stable opaque identity for one normalized player request."""
+
+    canonical = json.dumps(
+        {
+            "actor_id": player_input.actor_id,
+            "client_action_id": player_input.client_action_id,
+            "player_id": player_input.player_id,
+            "room_id": player_input.room_id,
+            "utterance": player_input.utterance,
+            "version": 1,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/agent-collaboration-framework/collaboration_framework/engine/service.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/service.py
@@ -118,12 +118,14 @@ class RuleEngineService:
             request.room_id,
             request.player_id,
             request.actor_id,
+            request.input_fingerprint,
             request.intent,
             request.roll_value,
         ) != (
             original.room_id,
             original.player_id,
             original.actor_id,
+            original.input_fingerprint,
             original.intent,
             original.roll_value,
         ):

--- a/agent-collaboration-framework/collaboration_framework/host/application/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/__init__.py
@@ -5,7 +5,7 @@ from .host_agent_intent_resolver import (
     TurnExecutionError,
 )
 from .intent_parser import IntentParser, validate_intent_against_view
-from .narrator import Narrator
+from .narrator import NarrationValidationError, Narrator
 from .orchestrator import Orchestrator
 from .player_view_projector import PlayerViewProjector
 from .tool_registry import (
@@ -22,6 +22,7 @@ __all__ = [
     "HostAgentEventObserver",
     "HostAgentIntentResolver",
     "IntentParser",
+    "NarrationValidationError",
     "Narrator",
     "Orchestrator",
     "PlayerViewProjector",

--- a/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
@@ -1,8 +1,128 @@
 """Application-level validation for player-visible narration."""
 
+from __future__ import annotations
+
+import re
+from typing import Literal
+
 from collaboration_framework.contracts import ContractError
 from collaboration_framework.host.ports import NarrationModelPort
 from collaboration_framework.host.schemas import NarrationContext, NarrationOutput
+
+NarrationRejectionReason = Literal[
+    "outer_schema",
+    "fact_scope",
+    "protocol_tail",
+    "schema_fragment",
+]
+
+_PROTOCOL_FIELD = (
+    r"(?<![A-Za-z0-9_])"
+    r"(?:claimed_fact_ids|claimedFactIds|suggested_actions|suggestedActions)"
+    r"(?![A-Za-z0-9_])"
+)
+_QUOTED_PROTOCOL_FIELD = rf"""(?:"|')?{_PROTOCOL_FIELD}(?:"|')?"""
+_STRUCTURED_VALUE = r"(?:\[[\s\S]*?\]|\{[\s\S]*?\}|null)"
+
+_STANDALONE_PROTOCOL_FIELD_RE = re.compile(
+    rf"""
+    ^[ \t]*[{{,]?[ \t]*
+    {_QUOTED_PROTOCOL_FIELD}
+    [ \t]*[:：][ \t]*
+    {_STRUCTURED_VALUE}
+    [ \t]*[,}}]?[ \t]*(?:\r?\n[ \t]*```)?[ \t]*$
+    """,
+    re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+)
+
+_TRAILING_PROTOCOL_FIELD_RE = re.compile(
+    rf"""
+    (?:^|[\r\n]|[。！？.!?]|(?<=\s))[ \t]*
+    [{{,]?[ \t]*
+    {_QUOTED_PROTOCOL_FIELD}
+    [ \t]*[:：][ \t]*
+    {_STRUCTURED_VALUE}
+    [ \t]*[,}}]*[ \t]*(?:\r?\n[ \t]*```)?[ \t]*$
+    """,
+    re.IGNORECASE | re.DOTALL | re.VERBOSE,
+)
+
+_TRAILING_OBJECT_FRAGMENT_RE = re.compile(
+    r"""
+    (?:^|[\r\n]|[。！？.!?]|(?<=\s))[ \t]*
+    (?:```(?:json)?[ \t]*[\r\n]+)?
+    (?P<object>\{.*)
+    [ \t]*$
+    """,
+    re.IGNORECASE | re.DOTALL | re.VERBOSE,
+)
+
+_NARRATION_KIND_RE = re.compile(
+    r"""(?:"|')?kind(?:"|')?[ \t]*[:：][ \t]*(?:"|')?(?:narration|clarification)(?:"|')?""",
+    re.IGNORECASE,
+)
+
+_NARRATION_FIELD_KEY_RE = re.compile(
+    r"""
+    (?:"|')?
+    (?P<field>kind|text|claimed_fact_ids|claimedFactIds|suggested_actions|suggestedActions)
+    (?:"|')?
+    [ \t]*[:：]
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_NARRATION_FIELD_TOKEN_RE = re.compile(
+    r"""(?:"|')?(kind|text|claimed_fact_ids|claimedFactIds|suggested_actions|suggestedActions)(?:"|')?""",
+    re.IGNORECASE,
+)
+
+_SCHEMA_MARKER_RE = re.compile(
+    r"""(?:"|')?(?:properties|required)(?:"|')?[ \t]*[:：]""",
+    re.IGNORECASE,
+)
+
+
+class NarrationValidationError(ContractError):
+    """A model candidate failed deterministic player-visible output policy."""
+
+    def __init__(self, reason: NarrationRejectionReason) -> None:
+        super().__init__("NarrationOutput 未通过玩家可见输出安全校验")
+        self.reason = reason
+
+
+def narration_text_rejection_reason(
+    text: str,
+) -> Literal["protocol_tail", "schema_fragment"] | None:
+    """Return a safe category for obvious Narration protocol residue."""
+
+    if _STANDALONE_PROTOCOL_FIELD_RE.search(text):
+        return "protocol_tail"
+    if _TRAILING_PROTOCOL_FIELD_RE.search(text):
+        return "protocol_tail"
+
+    object_match = _TRAILING_OBJECT_FRAGMENT_RE.search(text)
+    if object_match is None:
+        return None
+    candidate = object_match.group("object")
+    if _NARRATION_KIND_RE.search(candidate):
+        return "protocol_tail"
+
+    if _SCHEMA_MARKER_RE.search(candidate):
+        field_tokens = {
+            match.group(1).casefold()
+            for match in _NARRATION_FIELD_TOKEN_RE.finditer(candidate)
+        }
+        if len(field_tokens) >= 2:
+            return "schema_fragment"
+
+    field_keys = {
+        match.group("field").casefold()
+        for match in _NARRATION_FIELD_KEY_RE.finditer(candidate)
+    }
+    if len(field_keys) >= 2:
+        return "protocol_tail"
+    return None
 
 
 class Narrator:
@@ -11,8 +131,14 @@ class Narrator:
 
     async def narrate(self, context: NarrationContext) -> NarrationOutput:
         raw = await self._model.generate(context)
-        output = NarrationOutput.model_validate(raw)
+        try:
+            output = NarrationOutput.model_validate(raw)
+        except (TypeError, ValueError) as exc:
+            raise NarrationValidationError("outer_schema") from exc
         allowed = {fact.id for fact in context.action_result.visible_facts}
         if not set(output.claimed_fact_ids).issubset(allowed):
-            raise ContractError("NarrationOutput 引用了未确认的玩家可见事实")
+            raise NarrationValidationError("fact_scope")
+        rejection_reason = narration_text_rejection_reason(output.text)
+        if rejection_reason is not None:
+            raise NarrationValidationError(rejection_reason)
         return output

--- a/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
@@ -16,32 +16,34 @@ NarrationRejectionReason = Literal[
     "schema_fragment",
 ]
 
-_PROTOCOL_FIELD = (
+_NARRATION_FIELD = (
     r"(?<![A-Za-z0-9_])"
-    r"(?:claimed_fact_ids|claimedFactIds|suggested_actions|suggestedActions)"
+    r"(?:kind|text|claimed_fact_ids|claimedFactIds|suggested_actions|suggestedActions)"
     r"(?![A-Za-z0-9_])"
 )
-_QUOTED_PROTOCOL_FIELD = rf"""(?:"|')?{_PROTOCOL_FIELD}(?:"|')?"""
+_QUOTED_NARRATION_FIELD = rf"""(?:"|')?{_NARRATION_FIELD}(?:"|')?"""
 _STRUCTURED_VALUE = r"(?:\[[\s\S]*?\]|\{[\s\S]*?\}|null)"
+_QUOTED_STRING_VALUE = r"""(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')"""
+_NARRATION_FIELD_VALUE = rf"(?:{_STRUCTURED_VALUE}|{_QUOTED_STRING_VALUE}|narration|clarification)"
 
-_STANDALONE_PROTOCOL_FIELD_RE = re.compile(
+_STANDALONE_NARRATION_FIELD_RE = re.compile(
     rf"""
     ^[ \t]*[{{,]?[ \t]*
-    {_QUOTED_PROTOCOL_FIELD}
+    {_QUOTED_NARRATION_FIELD}
     [ \t]*[:：][ \t]*
-    {_STRUCTURED_VALUE}
+    (?:{_NARRATION_FIELD_VALUE})?
     [ \t]*[,}}]?[ \t]*(?:\r?\n[ \t]*```)?[ \t]*$
     """,
     re.IGNORECASE | re.MULTILINE | re.VERBOSE,
 )
 
-_TRAILING_PROTOCOL_FIELD_RE = re.compile(
+_TRAILING_NARRATION_FIELD_RE = re.compile(
     rf"""
     (?:^|[\r\n]|[。！？.!?]|(?<=\s))[ \t]*
     [{{,]?[ \t]*
-    {_QUOTED_PROTOCOL_FIELD}
+    {_QUOTED_NARRATION_FIELD}
     [ \t]*[:：][ \t]*
-    {_STRUCTURED_VALUE}
+    (?:{_NARRATION_FIELD_VALUE})?
     [ \t]*[,}}]*[ \t]*(?:\r?\n[ \t]*```)?[ \t]*$
     """,
     re.IGNORECASE | re.DOTALL | re.VERBOSE,
@@ -96,9 +98,9 @@ def narration_text_rejection_reason(
 ) -> Literal["protocol_tail", "schema_fragment"] | None:
     """Return a safe category for obvious Narration protocol residue."""
 
-    if _STANDALONE_PROTOCOL_FIELD_RE.search(text):
+    if _STANDALONE_NARRATION_FIELD_RE.search(text):
         return "protocol_tail"
-    if _TRAILING_PROTOCOL_FIELD_RE.search(text):
+    if _TRAILING_NARRATION_FIELD_RE.search(text):
         return "protocol_tail"
 
     object_match = _TRAILING_OBJECT_FRAGMENT_RE.search(text)

--- a/agent-collaboration-framework/collaboration_framework/host/application/orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/orchestrator.py
@@ -1,6 +1,10 @@
 """Explicit async MVP workflow with one stable class entry point."""
 
-from collaboration_framework.contracts import ActionRequest, PlayerInput
+from collaboration_framework.contracts import (
+    ActionRequest,
+    PlayerInput,
+    player_input_fingerprint,
+)
 from collaboration_framework.host.schemas import HostAgentContext, TurnOutput
 from collaboration_framework.ports import ActionExecutor
 
@@ -44,6 +48,7 @@ class Orchestrator:
                 player_id=player_input.player_id,
                 actor_id=player_input.actor_id,
                 source_view_revision=view_before.revision,
+                input_fingerprint=player_input_fingerprint(player_input),
                 intent=intent,
             )
         )

--- a/agent-collaboration-framework/docs/数据模型设计.md
+++ b/agent-collaboration-framework/docs/数据模型设计.md
@@ -175,9 +175,12 @@ A 只能从 `PlayerView.checkpoint_options` 选择 Checkpoint、对应 Target �
 | `request_id` | `str` | 幂等键，来自 `client_action_id` |
 | `room_id/player_id/actor_id` | `str` | 可信执行作用域 |
 | `source_view_revision` | `str` | A 解析 Intent 时所基于的视图版本 |
+| `input_fingerprint` | `str \| None` | 规范化 `PlayerInput` 的不透明 SHA-256 指纹；用于拒绝同一幂等键搭配不同玩家输入 |
 | `intent` | `Intent` | 已校验的语义提议 |
 
-首次执行时，B 校验身份绑定、source revision、当前 Scene、Target、Checkpoint、skills 和 request id 占用情况。
+首次执行时，A 根据规范化 `PlayerInput` 生成 `input_fingerprint`，但不把原始
+`utterance` 放入 B 的持久化命令。B 校验身份绑定、source revision、当前 Scene、
+Target、Checkpoint、skills 和 request id 占用情况。
 
 ## 7. 安全结果：`ActionResult`
 
@@ -228,7 +231,7 @@ request_id 未命中 CompletedAction
 
 同一个 `request_id` 重放时：
 
-1. room/player/actor 和 Intent 必须与首次命令相同；
+1. room/player/actor、`input_fingerprint`、Intent 和骰点必须与首次命令相同；
 2. `source_view_revision` 可以变化，因为中间可能已有其他提交；
 3. B 不重新执行规则、不追加 Event、不修改状态；
 4. resolution、outcome、visible facts、constraints、event refs 保留首次结果；
@@ -245,7 +248,10 @@ request_id 未命中 CompletedAction
 
 ### 8.4 非法复用
 
-同一个 `request_id` 如果换成不同 Actor 或不同 Intent，B 必须抛出可识别的 `ContractError`，不能静默返回另一命令的缓存。
+同一个 `request_id` 如果换成不同 Actor、不同玩家输入指纹、不同 Intent 或不同骰点，
+B 必须抛出可识别的 `ContractError`，不能静默返回另一命令的缓存。A 的快速
+Narrator 恢复路径在复用 `CompletedAction` 前执行相同的指纹校验；缺少指纹的旧记录
+无法证明是原请求，因此 fail closed。
 
 ## 9. A 内部模型
 

--- a/agent-collaboration-framework/schemas/action-request.schema.json
+++ b/agent-collaboration-framework/schemas/action-request.schema.json
@@ -246,6 +246,20 @@
       "title": "Source View Revision",
       "type": "string"
     },
+    "input_fingerprint": {
+      "anyOf": [
+        {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Opaque SHA-256 identity of the normalized PlayerInput that created this command; used to reject request_id reuse with different input.",
+      "title": "Input Fingerprint"
+    },
     "intent": {
       "$ref": "#/$defs/Intent"
     },

--- a/agent-collaboration-framework/tests/test_engine_service.py
+++ b/agent-collaboration-framework/tests/test_engine_service.py
@@ -146,6 +146,20 @@ class RuleEngineServiceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(self.store.inspect_events("room_01")), 1)
 
+    async def test_same_request_id_with_different_input_fingerprint_is_rejected(
+        self,
+    ) -> None:
+        request = checkpoint_request(request_id="fingerprint_collision").model_copy(
+            update={"input_fingerprint": "a" * 64}
+        )
+        await self.service.execute(request)
+        conflicting = request.model_copy(update={"input_fingerprint": "b" * 64})
+
+        with self.assertRaisesRegex(ContractError, "request_id 已用于不同"):
+            await self.service.execute(conflicting)
+
+        self.assertEqual(len(self.store.inspect_events("room_01")), 1)
+
     async def test_concurrent_stale_actions_cannot_overwrite_new_state(self) -> None:
         results = await asyncio.gather(
             self.service.execute(checkpoint_request(request_id="race_001")),

--- a/agent-collaboration-framework/tests/test_narrator_policy.py
+++ b/agent-collaboration-framework/tests/test_narrator_policy.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import unittest
+
+from collaboration_framework.host.application.narrator import (
+    narration_text_rejection_reason,
+)
+
+
+class NarrationTextPolicyTests(unittest.TestCase):
+    def test_rejects_protocol_field_assignments_and_json_tails(self) -> None:
+        cases = {
+            "托马斯看着你。 claimed_fact_ids: [],": "protocol_tail",
+            "托马斯看着你 claimed_fact_ids: []": "protocol_tail",
+            "suggested_actions: [\"继续询问\"]": "protocol_tail",
+            'suggested_actions: [\n  "继续询问",\n  "查看书架"\n]': "protocol_tail",
+            "'claimedFactIds'：null": "protocol_tail",
+            '他说完便沉默下来。\n"suggestedActions": []': "protocol_tail",
+            "他说完便沉默下来。\n```json\nclaimed_fact_ids: []\n```": "protocol_tail",
+            (
+                '{"kind":"narration","text":"托马斯看着你。",'
+                '"claimed_fact_ids":[]}'
+            ): "protocol_tail",
+            (
+                '托马斯后退一步 {"kind":"narration","text":"他保持沉默",'
+                '"claimed_fact_ids":[]}'
+            ): "protocol_tail",
+            (
+                "现场只剩下雨声。\n"
+                "```json\n"
+                '{"kind":"clarification","text":"你指的是哪一扇门？"}\n'
+                "```"
+            ): "protocol_tail",
+            (
+                "现场只剩下雨声。\n"
+                '{"properties":{"kind":{"type":"string"},'
+                '"claimed_fact_ids":{"type":"array"}}'
+            ): "schema_fragment",
+            (
+                "现场只剩下雨声。\n"
+                '{"required":["kind","text","claimed_fact_ids"]'
+            ): "schema_fragment",
+        }
+
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(narration_text_rejection_reason(text), expected)
+
+    def test_allows_natural_narration_and_non_protocol_technical_discussion(self) -> None:
+        cases = (
+            "托马斯抬起眼睛，耐心等着你继续问下去。",
+            "雨点敲打着窗框。\n\n屋里只剩壁炉燃烧的细响。",
+            "他问你 claimed_fact_ids 是什么意思。",
+            "纸上写着 claimed_fact_ids: []，旁边说明这是一个空列表。",
+            "日志中的 not_claimed_fact_ids: [] 是另一个测试字段。",
+            '终端显示 {"status":"ok","items":[]}，没有更多提示。',
+            '她念出 {"kind":"artifact","name":"旧铜钥匙"}，随后合上笔记。',
+        )
+
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertIsNone(narration_text_rejection_reason(text))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-collaboration-framework/tests/test_narrator_policy.py
+++ b/agent-collaboration-framework/tests/test_narrator_policy.py
@@ -17,6 +17,14 @@ class NarrationTextPolicyTests(unittest.TestCase):
             "'claimedFactIds'：null": "protocol_tail",
             '他说完便沉默下来。\n"suggestedActions": []': "protocol_tail",
             "他说完便沉默下来。\n```json\nclaimed_fact_ids: []\n```": "protocol_tail",
+            '托马斯沉默。\ntext: "托马斯沉默。"': "protocol_tail",
+            "托马斯沉默。\nkind: narration": "protocol_tail",
+            "'text'：'托马斯沉默。'": "protocol_tail",
+            '"kind"：clarification': "protocol_tail",
+            "托马斯沉默。\ntext:": "protocol_tail",
+            "托马斯沉默。\nkind:": "protocol_tail",
+            "托马斯沉默。\nclaimed_fact_ids:": "protocol_tail",
+            "托马斯沉默。\n```json\nsuggestedActions:\n```": "protocol_tail",
             (
                 '{"kind":"narration","text":"托马斯看着你。",'
                 '"claimed_fact_ids":[]}'
@@ -53,6 +61,8 @@ class NarrationTextPolicyTests(unittest.TestCase):
             "他问你 claimed_fact_ids 是什么意思。",
             "纸上写着 claimed_fact_ids: []，旁边说明这是一个空列表。",
             "日志中的 not_claimed_fact_ids: [] 是另一个测试字段。",
+            '纸上写着 text: "叙事"，旁边说明这是正文字段。',
+            "手册把 kind: narration 称为叙事类型。",
             '终端显示 {"status":"ok","items":[]}，没有更多提示。',
             '她念出 {"kind":"artifact","name":"旧铜钥匙"}，随后合上笔记。',
         )

--- a/agent-collaboration-framework/tests/test_workflow.py
+++ b/agent-collaboration-framework/tests/test_workflow.py
@@ -5,8 +5,6 @@ import json
 import unittest
 from pathlib import Path
 
-from pydantic import ValidationError
-
 from collaboration_framework.bootstrap import build_fake_application
 from collaboration_framework.contracts import (
     ContractError,
@@ -26,12 +24,14 @@ from collaboration_framework.host.application import (
     ContextAssembler,
     HostAgentIntentResolver,
     IntentParser,
+    NarrationValidationError,
     Narrator,
     Orchestrator,
     PlayerViewProjector,
     TurnExecutionError,
 )
 from collaboration_framework.schema_export import rendered_schemas
+from pydantic import ValidationError
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -88,6 +88,14 @@ class CountingEngine:
 
 
 class StaticIntentModel:
+    def __init__(self, payload) -> None:
+        self.payload = payload
+
+    async def generate(self, context):
+        return self.payload
+
+
+class StaticNarrationModel:
     def __init__(self, payload) -> None:
         self.payload = payload
 
@@ -247,6 +255,44 @@ class UnifiedWorkflowTests(unittest.TestCase):
         self.assertEqual(output.action_result.resolution, "unrecognized")
         self.assertEqual(output.status, "clarification")
         self.assertEqual(output.narration.kind, "clarification")
+
+    def test_narrator_classifies_invalid_outer_schema_at_application_boundary(
+        self,
+    ) -> None:
+        narrator = StaticNarrationModel(
+            {
+                "kind": "narration",
+                "text": "",
+                "claimed_fact_ids": [],
+                "suggested_actions": [],
+            }
+        )
+        orchestrator, engine, _ = self.application(narration_model=narrator)
+
+        with self.assertRaises(NarrationValidationError) as failed:
+            self.run_turn(orchestrator)
+
+        self.assertEqual(failed.exception.reason, "outer_schema")
+        self.assertEqual(engine.execute_calls, 1)
+
+    def test_narrator_classifies_unconfirmed_fact_at_application_boundary(
+        self,
+    ) -> None:
+        narrator = StaticNarrationModel(
+            {
+                "kind": "narration",
+                "text": "书架后传来一声轻响。",
+                "claimed_fact_ids": ["fact-not-confirmed"],
+                "suggested_actions": [],
+            }
+        )
+        orchestrator, engine, _ = self.application(narration_model=narrator)
+
+        with self.assertRaises(NarrationValidationError) as failed:
+            self.run_turn(orchestrator)
+
+        self.assertEqual(failed.exception.reason, "fact_scope")
+        self.assertEqual(engine.execute_calls, 1)
 
     def test_host_semantic_checkpoint_choice_is_not_rejected_by_verb_equality(
         self,

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -131,6 +131,12 @@ _NARRATION_INSTRUCTIONS = """\
 3 条，只能基于当前可信素材，并写成玩家可直接说出的角色内短句；不需要建议时返回
 空数组。claimed_fact_ids 只能包含 action_result.visible_facts 的精确 id，且只有
 正文实际表达了对应结果时才填写。
+
+【输出卫生】
+text 只能包含玩家可见的角色内叙事。kind、text、claimed_fact_ids 和
+suggested_actions 只能作为外层 JSON 字段各出现一次；不得把任何字段名、字段值、
+JSON/schema 片段、Markdown JSON 代码块、格式说明或自检内容重复写入 text。提交
+前再次检查 text，确保玩家只会看到自然叙事，而不会看到结构化输出协议。
 """
 
 
@@ -302,17 +308,12 @@ class PromptNarrationModel:
         self._client = client
 
     async def generate(self, context: NarrationContext) -> JsonObject:
-        raw = await self._client.generate(
+        return await self._client.generate(
             schema_name="trpg_narration",
             schema=NarrationOutput.model_json_schema(mode="serialization"),
             instructions=_NARRATION_INSTRUCTIONS,
             input_payload=context.to_json_dict(),
         )
-        output = NarrationOutput.model_validate(raw)
-        allowed_ids = {fact.id for fact in context.action_result.visible_facts}
-        if not set(output.claimed_fact_ids).issubset(allowed_ids):
-            raise ValueError("Narration claimed a fact outside ActionResult")
-        return output.to_json_dict()
 
 
 def _response_output_text(payload: object) -> str:

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -765,7 +765,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                             )
                         except Exception as exc:
                             code, _, retryable = _map_turn_error(exc)
-                            if code == "NARRATOR_FAILED" or not retryable:
+                            if code in {"NARRATOR_FAILED", "NARRATION_INVALID"} or not retryable:
                                 pending_turn = None
                             logger.warning(
                                 "ws_check_failed",

--- a/trpg-backend/app/core/turn.py
+++ b/trpg-backend/app/core/turn.py
@@ -28,6 +28,7 @@ from collaboration_framework.host.adapters.fakes import FakeHostAgent, FakeNarra
 from collaboration_framework.host.application import (
     ContextAssembler,
     HostAgentIntentResolver,
+    NarrationValidationError,
     Narrator,
     PlayerViewProjector,
     TurnExecutionError,
@@ -80,6 +81,7 @@ _PUBLIC_TOOL_LABELS = {
     "search_visible_entities": "守秘人正在查看当前场景",
     "get_visible_entity": "守秘人正在确认可见目标",
 }
+_MAX_NARRATION_ATTEMPTS = 2
 
 
 def _public_tool_label(tool_name: str) -> str:
@@ -101,6 +103,7 @@ class PreparedTurn:
     candidates: tuple[SkillCheckCandidate, ...]
     difficulty: CheckDifficulty
     stored_roll_value: int | None = None
+    completed_action_result: ActionResult | None = None
 
 
 @dataclass(frozen=True)
@@ -213,12 +216,20 @@ class TurnApplication:
         async with self.store.transaction(room_id) as transaction:
             completed = await transaction.find_completed_action(client_action_id)
         if completed is not None:
-            if completed.request.player_id != player_id or completed.request.actor_id != actor_id:
+            if (
+                completed.request.room_id != room_id
+                or completed.request.player_id != player_id
+                or completed.request.actor_id != actor_id
+            ):
                 raise ContractError("client_action_id belongs to another actor")
             intent = completed.request.intent
             candidates: tuple[SkillCheckCandidate, ...] = ()
             difficulty: CheckDifficulty = "regular"
             stored_roll_value = completed.request.roll_value
+            completed_action_result = completed.execution.action_result.model_copy(
+                update={"view_revision": view_before.revision},
+                deep=True,
+            )
         else:
             await emit_turn_event(
                 on_event,
@@ -269,6 +280,7 @@ class TurnApplication:
             )
             candidates, difficulty = self._check_candidates(intent, view_before)
             stored_roll_value = None
+            completed_action_result = None
             if candidates:
                 await emit_turn_event(
                     on_event,
@@ -284,6 +296,7 @@ class TurnApplication:
             candidates=candidates,
             difficulty=difficulty,
             stored_roll_value=stored_roll_value,
+            completed_action_result=completed_action_result,
         )
 
     async def complete(
@@ -297,6 +310,8 @@ class TurnApplication:
     ) -> TurnOutput:
         if (selected_skill is None) != (roll_value is None):
             raise ContractError("selected_skill and roll_value must be supplied together")
+        if prepared.completed_action_result is not None and selected_skill is not None:
+            raise ContractError("Completed action cannot accept another skill check")
 
         intent = prepared.intent
         if selected_skill is not None:
@@ -315,21 +330,24 @@ class TurnApplication:
                 phase="executing_action",
             ),
         )
-        action_result = await self.engine.execute(
-            ActionRequest(
-                request_id=prepared.player_input.client_action_id,
-                room_id=prepared.player_input.room_id,
-                player_id=prepared.player_input.player_id,
-                actor_id=prepared.player_input.actor_id,
-                source_view_revision=prepared.view_before.revision,
-                intent=intent,
-                roll_value=(
-                    roll_value if selected_skill is not None else prepared.stored_roll_value
-                ),
+        if prepared.completed_action_result is None:
+            action_result = await self.engine.execute(
+                ActionRequest(
+                    request_id=prepared.player_input.client_action_id,
+                    room_id=prepared.player_input.room_id,
+                    player_id=prepared.player_input.player_id,
+                    actor_id=prepared.player_input.actor_id,
+                    source_view_revision=prepared.view_before.revision,
+                    intent=intent,
+                    roll_value=(
+                        roll_value if selected_skill is not None else prepared.stored_roll_value
+                    ),
+                )
             )
-        )
-        if on_action_result is not None:
-            await on_action_result(action_result)
+            if on_action_result is not None:
+                await on_action_result(action_result)
+        else:
+            action_result = prepared.completed_action_result.model_copy(deep=True)
         await emit_turn_event(
             on_event,
             TurnPhaseChanged(
@@ -363,14 +381,39 @@ class TurnApplication:
             action_result,
             view_after,
         )
-        try:
-            narration = await Narrator(self.narration_model).narrate(narration_context)
-        except Exception as exc:
+        narrator = Narrator(self.narration_model)
+        narration = None
+        for attempt in range(1, _MAX_NARRATION_ATTEMPTS + 1):
+            try:
+                narration = await narrator.narrate(narration_context)
+                break
+            except NarrationValidationError as exc:
+                will_retry = attempt < _MAX_NARRATION_ATTEMPTS
+                logger.warning(
+                    "narration_validation_rejected",
+                    correlation_id=prepared.player_input.client_action_id,
+                    attempt=attempt,
+                    will_retry=will_retry,
+                    rejection_reason=exc.reason,
+                )
+                if not will_retry:
+                    raise TurnExecutionError(
+                        "NARRATION_INVALID",
+                        "规则结果已安全保存，但叙事未通过安全校验，请使用原请求重试",
+                        retryable=True,
+                    ) from exc
+            except Exception as exc:
+                raise TurnExecutionError(
+                    "NARRATOR_FAILED",
+                    "规则结果已安全保存，但叙事生成失败，请重试原动作",
+                    retryable=True,
+                ) from exc
+        if narration is None:
             raise TurnExecutionError(
                 "NARRATOR_FAILED",
                 "规则结果已安全保存，但叙事生成失败，请重试原动作",
                 retryable=True,
-            ) from exc
+            )
         return TurnOutput(
             status="clarification" if narration.kind == "clarification" else "completed",
             player_input=prepared.player_input,

--- a/trpg-backend/app/core/turn.py
+++ b/trpg-backend/app/core/turn.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Literal
@@ -21,6 +22,7 @@ from collaboration_framework.contracts import (
     ModuleCheck,
     PlayerInput,
     PlayerView,
+    player_input_fingerprint,
 )
 from collaboration_framework.engine import EngineStore, RuleEngineService
 from collaboration_framework.host.adapters import OneShotHostAgentAdapter
@@ -222,6 +224,15 @@ class TurnApplication:
                 or completed.request.actor_id != actor_id
             ):
                 raise ContractError("client_action_id belongs to another actor")
+            original_fingerprint = completed.request.input_fingerprint
+            submitted_fingerprint = player_input_fingerprint(player_input)
+            # Legacy records without a fingerprint cannot prove that a new payload is
+            # the original request, so the fast recovery path fails closed.
+            if original_fingerprint is None or not hmac.compare_digest(
+                original_fingerprint,
+                submitted_fingerprint,
+            ):
+                raise ContractError("request_id 已用于不同的动作请求")
             intent = completed.request.intent
             candidates: tuple[SkillCheckCandidate, ...] = ()
             difficulty: CheckDifficulty = "regular"
@@ -338,6 +349,7 @@ class TurnApplication:
                     player_id=prepared.player_input.player_id,
                     actor_id=prepared.player_input.actor_id,
                     source_view_revision=prepared.view_before.revision,
+                    input_fingerprint=player_input_fingerprint(prepared.player_input),
                     intent=intent,
                     roll_value=(
                         roll_value if selected_skill is not None else prepared.stored_roll_value

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -374,6 +374,10 @@ async def test_prompts_treat_scene_orientation_as_narration_not_form_validation(
     assert "一段场景描述" in narration_instructions
     assert "不要要求玩家先指定目标或先做检定" in narration_instructions
     assert "不得借此创造门窗、出口、人物、物品、路线" in narration_instructions
+    assert "text 只能包含玩家可见的角色内叙事" in narration_instructions
+    assert "claimed_fact_ids" in narration_instructions
+    assert "JSON/schema 片段" in narration_instructions
+    assert "Markdown JSON 代码块" in narration_instructions
     serialized_view = client.inputs["trpg_narration"]["player_view"]
     assert serialized_view["scene"]["visible_entities"][0]["id"] == "thomas"
     assert serialized_view["scene"]["description"] == "托马斯坐在你面前，等待你回应他的委托。"
@@ -597,6 +601,78 @@ async def test_qwen_client_posts_json_mode_with_schema_in_instructions() -> None
     assert "test_schema" in body["messages"][0]["content"]
     assert '"additionalProperties":false' in body["messages"][0]["content"]
     assert json.loads(body["messages"][1]["content"]) == {"safe": True}
+
+
+async def test_qwen_style_protocol_leak_is_retried_offline() -> None:
+    narration_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal narration_calls
+        body = json.loads(request.content)
+        instructions = body["messages"][0]["content"]
+        if 'named "trpg_intent"' in instructions:
+            output = {
+                "kind": "dialogue",
+                "verb": "talk",
+                "target": {"matched": True, "id": "cemetery_figure"},
+                "check": {"route": "none"},
+                "summary": "我询问眼前人的情况",
+            }
+        else:
+            assert 'named "trpg_narration"' in instructions
+            narration_calls += 1
+            output = {
+                "kind": "narration",
+                "text": (
+                    "眼前的人压低了声音。 claimed_fact_ids: [],"
+                    if narration_calls == 1
+                    else "眼前的人压低声音，谨慎地回答了你的问题。"
+                ),
+                "claimed_fact_ids": [],
+                "suggested_actions": [],
+            }
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(output, ensure_ascii=False),
+                        }
+                    }
+                ]
+            },
+        )
+
+    client = QwenChatCompletionsJsonClient(
+        api_key="offline-test-key",
+        base_url="https://dashscope.example/compatible-mode/v1/",
+        model="qwen3.7-plus",
+        timeout_seconds=1,
+        transport=httpx.MockTransport(handler),
+    )
+    module = load_paper_chase()
+    state = conversation_state(module)
+    store = InMemoryEngineStore()
+    store.register_room(module_content=module, initial_state=state)
+    application = build_turn_application(
+        store,
+        RuleEngineService(store),
+        intent_model=PromptIntentModel(client),
+        narration_model=PromptNarrationModel(client),
+    )
+
+    output = await application.handle(
+        room_id=state.room_id,
+        player_id="player_1",
+        client_action_id="qwen-protocol-leak",
+        utterance="我询问眼前人的情况",
+    )
+
+    assert narration_calls == 2
+    assert output.payload.narration.text == "眼前的人压低声音，谨慎地回答了你的问题。"
+    assert "claimed_fact_ids" not in output.payload.narration.text
 
 
 async def test_deepseek_client_posts_compatible_json_mode_without_qwen_fields() -> None:

--- a/trpg-backend/tests/test_turn_orchestration.py
+++ b/trpg-backend/tests/test_turn_orchestration.py
@@ -66,25 +66,90 @@ class FailOnceNarration:
         return await self._fake.generate(context)
 
 
+class CountingEngine(RuleEngineService):
+    def __init__(self, store: InMemoryEngineStore) -> None:
+        super().__init__(store)
+        self.read_calls = 0
+        self.execute_calls = 0
+
+    async def read(self, player_input):
+        self.read_calls += 1
+        return await super().read(player_input)
+
+    async def execute(self, request):
+        self.execute_calls += 1
+        return await super().execute(request)
+
+
+class InvalidThenSafeNarration:
+    leaked_text = "托马斯看着你。 claimed_fact_ids: [],"
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.contexts: list[NarrationContext] = []
+        self._fake = FakeNarrationModel()
+
+    async def generate(self, context: NarrationContext):
+        self.calls += 1
+        self.contexts.append(context)
+        if self.calls == 1:
+            return {
+                "kind": "narration",
+                "text": self.leaked_text,
+                "claimed_fact_ids": [],
+                "suggested_actions": [],
+            }
+        return await self._fake.generate(context)
+
+
+class InvalidTwiceThenSafeNarration(InvalidThenSafeNarration):
+    async def generate(self, context: NarrationContext):
+        self.calls += 1
+        self.contexts.append(context)
+        if self.calls <= 2:
+            return {
+                "kind": "narration",
+                "text": self.leaked_text,
+                "claimed_fact_ids": [],
+                "suggested_actions": [],
+            }
+        return await self._fake.generate(context)
+
+
+class InvalidThenTimeoutNarration(InvalidThenSafeNarration):
+    async def generate(self, context: NarrationContext):
+        self.calls += 1
+        self.contexts.append(context)
+        if self.calls == 1:
+            return {
+                "kind": "narration",
+                "text": self.leaked_text,
+                "claimed_fact_ids": [],
+                "suggested_actions": [],
+            }
+        raise TimeoutError("provider timeout")
+
+
 def application(host_agent, narration_model):
     module = load_paper_chase()
     state = conversation_state(module).model_copy(update={"scene_id": "client_briefing"})
     store = InMemoryEngineStore()
     store.register_room(module_content=module, initial_state=state)
+    engine = CountingEngine(store)
     app = build_turn_application(
         store,
-        RuleEngineService(store),
+        engine,
         host_agent=host_agent,
         narration_model=narration_model,
     )
-    return app, store, state
+    return app, store, state, engine
 
 
 @pytest.mark.asyncio
 async def test_narrator_failure_retries_without_rerunning_host_or_state_change() -> None:
     host = CountingHostAgent()
     narration = FailOnceNarration()
-    app, store, state = application(host, narration)
+    app, store, state, engine = application(host, narration)
 
     prepared = await app.prepare(
         room_id=state.room_id,
@@ -108,13 +173,109 @@ async def test_narrator_failure_retries_without_rerunning_host_or_state_change()
     assert output.player_input.client_action_id == "narrator-retry"
     assert host.calls == 1
     assert narration.calls == 2
+    assert engine.execute_calls == 1
     assert store.inspect_state(state.room_id).event_sequence == 0
+
+
+@pytest.mark.asyncio
+async def test_invalid_narration_is_retried_once_with_same_safe_context() -> None:
+    host = CountingHostAgent()
+    narration = InvalidThenSafeNarration()
+    app, _, state, engine = application(host, narration)
+
+    prepared = await app.prepare(
+        room_id=state.room_id,
+        player_id="player_1",
+        client_action_id="narration-auto-retry",
+        utterance="我询问托马斯藏书的情况",
+    )
+    with capture_logs() as logs:
+        output = await app.complete(prepared)
+
+    assert output.narration.text != narration.leaked_text
+    assert narration.calls == 2
+    assert narration.contexts[0] is narration.contexts[1]
+    assert host.calls == 1
+    assert engine.execute_calls == 1
+    encoded = json.dumps(logs, ensure_ascii=False)
+    assert narration.leaked_text not in encoded
+    assert "narration_validation_rejected" in encoded
+    assert '"attempt": 1' in encoded
+    assert '"will_retry": true' in encoded
+
+
+@pytest.mark.asyncio
+async def test_two_invalid_narrations_fail_closed_and_manual_retry_skips_executor() -> None:
+    host = CountingHostAgent()
+    narration = InvalidTwiceThenSafeNarration()
+    app, store, state, engine = application(host, narration)
+    action_result_calls = 0
+
+    async def record_action_result(_):
+        nonlocal action_result_calls
+        action_result_calls += 1
+
+    prepared = await app.prepare(
+        room_id=state.room_id,
+        player_id="player_1",
+        client_action_id="narration-manual-retry",
+        utterance="我询问托马斯藏书的情况",
+    )
+    with capture_logs() as logs, pytest.raises(TurnExecutionError) as failed:
+        await app.complete(prepared, on_action_result=record_action_result)
+
+    assert failed.value.code == "NARRATION_INVALID"
+    assert failed.value.retryable is True
+    assert narration.calls == 2
+    assert host.calls == 1
+    assert engine.execute_calls == 1
+    assert action_result_calls == 1
+    assert store.inspect_completed_action(state.room_id, "narration-manual-retry") is not None
+    encoded = json.dumps(logs, ensure_ascii=False)
+    assert narration.leaked_text not in encoded
+    assert '"attempt": 2' in encoded
+    assert '"will_retry": false' in encoded
+
+    replayed = await app.prepare(
+        room_id=state.room_id,
+        player_id="player_1",
+        client_action_id="narration-manual-retry",
+        utterance="我询问托马斯藏书的情况",
+    )
+    output = await app.complete(replayed, on_action_result=record_action_result)
+
+    assert output.player_input.client_action_id == "narration-manual-retry"
+    assert narration.calls == 3
+    assert host.calls == 1
+    assert engine.execute_calls == 1
+    assert action_result_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_after_invalid_retry_maps_to_narrator_failed() -> None:
+    host = CountingHostAgent()
+    narration = InvalidThenTimeoutNarration()
+    app, _, state, engine = application(host, narration)
+
+    prepared = await app.prepare(
+        room_id=state.room_id,
+        player_id="player_1",
+        client_action_id="narration-invalid-then-timeout",
+        utterance="我询问托马斯藏书的情况",
+    )
+    with pytest.raises(TurnExecutionError) as failed:
+        await app.complete(prepared)
+
+    assert failed.value.code == "NARRATOR_FAILED"
+    assert narration.calls == 2
+    assert host.calls == 1
+    assert engine.execute_calls == 1
 
 
 @pytest.mark.asyncio
 async def test_invisible_target_fails_before_authoritative_engine_boundary() -> None:
     host = CountingHostAgent(target_id="module-secret-entity")
-    app, store, state = application(host, FakeNarrationModel())
+    app, store, state, _ = application(host, FakeNarrationModel())
 
     with pytest.raises(TurnExecutionError) as failed:
         await app.prepare(
@@ -134,7 +295,7 @@ async def test_invisible_target_fails_before_authoritative_engine_boundary() -> 
 @pytest.mark.asyncio
 async def test_host_observability_is_metadata_only_and_records_rejection_code() -> None:
     host = CountingHostAgent(target_id="module-secret-entity")
-    app, _, state = application(host, FakeNarrationModel())
+    app, _, state, _ = application(host, FakeNarrationModel())
 
     with capture_logs() as logs, pytest.raises(TurnExecutionError):
         await app.prepare(

--- a/trpg-backend/tests/test_turn_orchestration.py
+++ b/trpg-backend/tests/test_turn_orchestration.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import AsyncIterator
 
 import pytest
-from collaboration_framework.contracts import ContractError
+from collaboration_framework.contracts import ContractError, player_input_fingerprint
 from collaboration_framework.engine import InMemoryEngineStore, RuleEngineService
 from collaboration_framework.host.adapters.fakes import FakeNarrationModel
 from collaboration_framework.host.application import TurnExecutionError
@@ -249,6 +249,40 @@ async def test_two_invalid_narrations_fail_closed_and_manual_retry_skips_executo
     assert host.calls == 1
     assert engine.execute_calls == 1
     assert action_result_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_completed_action_rejects_same_id_with_different_player_input() -> None:
+    host = CountingHostAgent()
+    narration = InvalidTwiceThenSafeNarration()
+    app, store, state, engine = application(host, narration)
+
+    prepared = await app.prepare(
+        room_id=state.room_id,
+        player_id="player_1",
+        client_action_id="narration-conflicting-retry",
+        utterance="我询问托马斯藏书的情况",
+    )
+    with pytest.raises(TurnExecutionError, match="叙事未通过安全校验"):
+        await app.complete(prepared)
+
+    completed = store.inspect_completed_action(
+        state.room_id,
+        "narration-conflicting-retry",
+    )
+    assert completed.request.input_fingerprint == player_input_fingerprint(prepared.player_input)
+
+    with pytest.raises(ContractError, match="request_id 已用于不同"):
+        await app.prepare(
+            room_id=state.room_id,
+            player_id="player_1",
+            client_action_id="narration-conflicting-retry",
+            utterance="我攻击托马斯",
+        )
+
+    assert host.calls == 1
+    assert engine.execute_calls == 1
+    assert narration.calls == 2
 
 
 @pytest.mark.asyncio

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -580,6 +580,29 @@ def test_invalid_narration_fails_closed_then_original_request_recovers(
         )
         assert narration_model.leaked_text not in str(first_attempt_events)
 
+        ws.send_json(
+            {
+                **action,
+                "payload": {
+                    **action["payload"],
+                    "utterance": "我攻击托马斯",
+                },
+            }
+        )
+        conflict, conflict_events = receive_until(
+            ws,
+            lambda message: message.get("type") == "turn.failed",
+        )
+
+        assert conflict["payload"]["code"] == "ACTION_ID_CONFLICT"
+        assert conflict["payload"]["retryable"] is False
+        assert all(
+            message.get("message_type") != "turn.completed"
+            and message.get("type") not in {"check.request", "check.result", "narration.push"}
+            for message in conflict_events
+        )
+        assert narration_model.calls == 2
+
         ws.send_json(action)
         completed, retry_events = receive_until(
             ws,

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -1,7 +1,7 @@
 import pytest
 from collaboration_framework.contracts import JsonObject
 from collaboration_framework.host.adapters.fakes import FakeNarrationModel
-from collaboration_framework.host.schemas import IntentContext
+from collaboration_framework.host.schemas import IntentContext, NarrationContext
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
@@ -50,6 +50,36 @@ class _WsAttackThenPlainIntentModel:
             "check": {"route": "none"},
             "summary": context.player_input.utterance,
         }
+
+
+class _WsPlainIntentModel:
+    async def generate(self, context: IntentContext) -> JsonObject:
+        return {
+            "kind": "dialogue",
+            "verb": "talk",
+            "target": {"matched": True, "id": "thomas"},
+            "check": {"route": "none"},
+            "summary": context.player_input.utterance,
+        }
+
+
+class _WsInvalidTwiceThenSafeNarration:
+    leaked_text = "托马斯看着你。 claimed_fact_ids: [],"
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self._fake = FakeNarrationModel()
+
+    async def generate(self, context: NarrationContext) -> JsonObject:
+        self.calls += 1
+        if self.calls <= 2:
+            return {
+                "kind": "narration",
+                "text": self.leaked_text,
+                "claimed_fact_ids": [],
+                "suggested_actions": [],
+            }
+        return await self._fake.generate(context)
 
 
 @pytest.fixture
@@ -494,6 +524,92 @@ def test_action_submit_broadcasts_narration_to_room_only(sync_client: TestClient
     assert len(action_narrations) == 1
 
 
+def test_invalid_narration_fails_closed_then_original_request_recovers(
+    sync_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = register_and_login(sync_client, "narration_policy_host")
+    room = create_room(sync_client, token)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+    narration_model = _WsInvalidTwiceThenSafeNarration()
+    current_application = ws_controller.turn_application
+    monkeypatch.setattr(
+        ws_controller,
+        "turn_application",
+        build_turn_application(
+            current_application.store,
+            current_application.engine,
+            intent_model=_WsPlainIntentModel(),
+            narration_model=narration_model,
+        ),
+    )
+    action = {
+        "type": "action.submit",
+        "playerId": room["playerId"],
+        "payload": {
+            "clientActionId": "ws-narration-invalid-167",
+            "utterance": "我继续询问托马斯",
+        },
+    }
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        assert ws.receive_json()["type"] == "session.bound"
+        assert ws.receive_json()["type"] == "view.updated"
+
+        ws.send_json(action)
+        failed, first_attempt_events = receive_until(
+            ws,
+            lambda message: message.get("type") == "turn.failed",
+        )
+
+        assert failed["payload"]["code"] == "NARRATION_INVALID"
+        assert failed["payload"]["retryable"] is True
+        assert all(
+            message.get("message_type") != "turn.completed"
+            and message.get("type") not in {"view.updated", "narration.push"}
+            for message in first_attempt_events
+        )
+        assert narration_model.leaked_text not in str(first_attempt_events)
+
+        ws.send_json(action)
+        completed, retry_events = receive_until(
+            ws,
+            lambda message: message.get("message_type") == "turn.completed",
+        )
+        narration, _ = receive_until(
+            ws,
+            lambda message: message.get("type") == "narration.push",
+        )
+
+    assert completed["correlation_id"] == "ws-narration-invalid-167"
+    assert all(message.get("type") != "turn.failed" for message in retry_events)
+    assert narration_model.calls == 3
+    assert narration["payload"]["text"] != narration_model.leaked_text
+
+    replay = sync_client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/replay",
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    ).json()["data"]
+    narration_events = [
+        event
+        for event in replay
+        if event["eventType"] == "narration.push"
+        and event["payload"]["text"] == narration["payload"]["text"]
+    ]
+    assert len(narration_events) == 1
+    assert narration_events[0]["payload"]["text"] == narration["payload"]["text"]
+    assert narration_model.leaked_text not in str(replay)
+
+
 def test_skill_check_waits_for_player_selection_and_roll(
     sync_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -587,6 +703,103 @@ def test_skill_check_waits_for_player_selection_and_roll(
         "turn.phase_changed",
         "check.result",
     ]
+
+
+def test_invalid_check_narration_clears_pending_turn_and_reuses_completed_action(
+    sync_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = register_and_login(sync_client, "narration_check_retry_host")
+    room = create_room(sync_client, token)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+    narration_model = _WsInvalidTwiceThenSafeNarration()
+    current_application = ws_controller.turn_application
+    monkeypatch.setattr(
+        ws_controller,
+        "turn_application",
+        build_turn_application(
+            current_application.store,
+            current_application.engine,
+            intent_model=_WsCandidateIntentModel(),
+            narration_model=narration_model,
+        ),
+    )
+    action = {
+        "type": "action.submit",
+        "playerId": room["playerId"],
+        "payload": {
+            "clientActionId": "ws-check-narration-invalid-167",
+            "utterance": "尝试潜行查找资料",
+        },
+    }
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        assert ws.receive_json()["type"] == "session.bound"
+        assert ws.receive_json()["type"] == "view.updated"
+
+        ws.send_json(action)
+        request, _ = receive_until(
+            ws,
+            lambda message: message.get("type") == "check.request",
+        )
+        ws.send_json(
+            {
+                "type": "check.roll",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": request["payload"]["clientActionId"],
+                    "skill": "stealth",
+                    "rollValue": 7,
+                },
+            }
+        )
+        failed, failed_events = receive_until(
+            ws,
+            lambda message: message.get("type") == "turn.failed",
+        )
+
+        assert failed["payload"]["code"] == "NARRATION_INVALID"
+        assert sum(
+            message.get("type") == "check.result" for message in failed_events
+        ) == 1
+
+        ws.send_json(action)
+        completed, retry_events = receive_until(
+            ws,
+            lambda message: message.get("message_type") == "turn.completed",
+        )
+        narration, _ = receive_until(
+            ws,
+            lambda message: message.get("type") == "narration.push",
+        )
+
+    assert completed["correlation_id"] == "ws-check-narration-invalid-167"
+    assert all(message.get("type") != "check.request" for message in retry_events)
+    assert all(message.get("type") != "check.result" for message in retry_events)
+    assert narration_model.calls == 3
+    assert narration["payload"]["text"] != narration_model.leaked_text
+
+    replay = sync_client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/replay",
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    ).json()["data"]
+    check_results = [
+        event
+        for event in replay
+        if event["eventType"] == "check.result"
+        and event["payload"]["clientActionId"] == "ws-check-narration-invalid-167"
+    ]
+    assert len(check_results) == 1
+    assert narration_model.leaked_text not in str(replay)
 
 
 def test_terminal_attack_check_failure_releases_pending_turn(

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -768,9 +768,7 @@ def test_invalid_check_narration_clears_pending_turn_and_reuses_completed_action
         )
 
         assert failed["payload"]["code"] == "NARRATION_INVALID"
-        assert sum(
-            message.get("type") == "check.result" for message in failed_events
-        ) == 1
+        assert sum(message.get("type") == "check.result" for message in failed_events) == 1
 
         ws.send_json(action)
         completed, retry_events = receive_until(


### PR DESCRIPTION
## 背景与根因

真实 Qwen Narrator 的外层 `NarrationOutput` 可以通过结构校验，但模型可能把 `claimed_fact_ids: []`、`suggested_actions:` 或 Narration JSON/schema 片段再次写入玩家可见的 `text`。此前应用层只校验真正的 `claimed_fact_ids` 集合，WebSocket 随后会原样发送并持久化 `text`。

Closes #167

## 修改内容

- 将 Narrator 收口为唯一的不可信输出安全边界，统一执行外层 Pydantic、可见 fact ID 和玩家可见文本策略校验。
- 增加结构感知的协议残留检测，覆盖 snake/camel case 字段、半角/全角冒号、多行数组与对象、Narration JSON、Markdown fence 和 schema 尾巴，同时保留正常中文叙事与自然技术讨论。
- 强化共享 Narration Prompt；Provider Adapter 只返回不可信 JSON，不再复制应用校验。
- 对确定性的 `NarrationValidationError` 在同一安全上下文内自动重试一次；第二次仍非法时返回可重试的 `NARRATION_INVALID`。Provider/运行时故障仍使用 `NARRATOR_FAILED`，不自动重试。
- 手动重试原 `clientActionId` 时直接复用 `CompletedAction.execution.action_result`，跳过 Host Agent 和 `ActionExecutor.execute()`，避免重复投骰、状态变化、事实发现或 checkpoint 推进。
- 检定路径在最终 Narrator 失败后释放 pending turn；非法正文不会进入 `turn.completed`、`view.updated`、`narration.push` 或 replay/EventLog。
- 新增 Framework 策略矩阵、Qwen Mock、编排计数、普通 WebSocket 与检定恢复回归。

## 玩家与开发者影响

- 首次偶发格式污染会被服务端无感吸收；只有连续两次非法才向玩家返回安全错误。
- 现有 WebSocket/SDK payload 形状不变，仅新增稳定错误码 `NARRATION_INVALID`。
- 现有前端“使用原请求重试”流程可直接复用，无需前端正则清洗。
- 日志只记录 `correlation_id`、attempt、是否继续重试和安全拒绝分类，不记录模型正文或命中片段。

## 验证

- Backend 全量：195 passed
- Backend Ruff：通过
- Backend `ty check app tests`：通过
- Framework 本次相关测试：21 passed
- Framework Narrator 策略测试：通过
- Schema export：通过且无 Schema diff
- SDK：14 tests passed；typecheck、lint、build 通过
- Frontend：10 tests passed；lint、production build 通过
- `git diff --check`：通过

Framework 全量基线仍有 6 个与本 PR 无关的数据模型文档字段同步失败（`GetVisibleEntityResult`、`RuleSpec`、`SceneSpec`、`EntitySpec`、`CheckpointOutcomeSpec`、`ModuleContent`）；本 PR 未修改这些模型或文档。
