### PR TITLE
fix(room): 行动频道显示角色卡姓名

### DIFF
--- a/e2e/tests/discussion-chat.e2e.ts
+++ b/e2e/tests/discussion-chat.e2e.ts
@@ -170,8 +170,16 @@ test('🔴 所有人都能看到发起者的原话 + 守秘人回复（修"聊�
     if (echo.type === 'action.broadcast') {
       assert.equal(echo.payload.playerId, room.hostPlayerId)
       assert.ok(echo.payload.nickname.length > 0)
+      assert.equal(echo.payload.characterName, 'E2E 调查员')
     }
     await Promise.all([guestSeesNarration, completed])
+
+    const conversation = await room.host.sdk.rooms.listConversation(room.roomId, room.reconnectToken)
+    const action = conversation.find((event) => event.type === 'action.broadcast')
+    assert.ok(action)
+    if (action?.type === 'action.broadcast') {
+      assert.equal(action.payload.characterName, 'E2E 调查员')
+    }
   } finally {
     room.host.sdk.roomSocket.disconnect()
     guest.sdk.roomSocket.disconnect()

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -280,11 +280,13 @@ async def _send_check_result(
     if check_result is None:
         raise ContractError("Completed skill check did not return a check result")
     candidate = next(item for item in prepared.candidates if item.id == check_result.skill_id)
+    character_name = await room_service.get_player_character_name(db, player_id)
     payload = CheckResultPayload(
         player_id=player_id,
         client_action_id=prepared.player_input.client_action_id,
         skill=check_result.skill_id,
         skill_name=candidate.name,
+        character_name=character_name,
         roll_value=check_result.roll_value,
         target_value=check_result.target_value,
         difficulty=check_result.difficulty,
@@ -369,10 +371,12 @@ async def _broadcast_action_utterance(
 
     player = await room_service.get_player(db, player_id)
     nickname = player.nickname if player is not None else "玩家"
+    character_name = await room_service.get_player_character_name(db, player_id, fallback=nickname)
     payload = ActionBroadcastPayload(
         player_id=player_id,
         client_action_id=client_action_id,
         nickname=nickname,
+        character_name=character_name,
         utterance=utterance,
     )
     recorded = await room_service.record_event(

--- a/trpg-backend/app/dto/ws.py
+++ b/trpg-backend/app/dto/ws.py
@@ -161,6 +161,7 @@ class ActionBroadcastPayload(CamelModel):
     player_id: str
     client_action_id: str
     nickname: str
+    character_name: str | None = None
     utterance: str
 
 
@@ -277,6 +278,7 @@ class CheckResultPayload(CamelModel):
     client_action_id: str
     skill: str
     skill_name: str
+    character_name: str | None = None
     roll_value: int
     target_value: int
     difficulty: Literal["regular", "hard", "extreme"]

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -117,6 +117,33 @@ async def get_player_by_reconnect_token(db: AsyncSession, reconnect_token: str |
     return player
 
 
+async def get_player_character_name(
+    db: AsyncSession,
+    player_id: str,
+    fallback: str = "玩家",
+) -> str:
+    """解析玩家在行动频道里应显示的局内名字。
+
+    规则：已完成角色卡优先，其次回退到房间昵称，最后回退到通用占位名。
+    """
+    row = await db.execute(
+        select(Character.name, Character.status, Player.nickname)
+        .join(Player, Character.player_id == Player.id)
+        .where(Player.id == player_id)
+    )
+    result = row.first()
+    if result is None:
+        return fallback
+    character_name, status, nickname = result
+    if status == "complete" and isinstance(character_name, str):
+        stripped = character_name.strip()
+        if stripped:
+            return stripped
+    if isinstance(nickname, str) and nickname.strip():
+        return nickname
+    return fallback
+
+
 async def _require_host(db: AsyncSession, room: Room, reconnect_token: str | None) -> Player:
     player = await get_player_by_reconnect_token(db, reconnect_token)
     if player.room_id != room.id or player.id != room.host_player_id:

--- a/trpg-backend/tests/test_chat_ws.py
+++ b/trpg-backend/tests/test_chat_ws.py
@@ -177,6 +177,7 @@ def test_action_submit_broadcasts_utterance_then_narration(sync_client: TestClie
     assert echo["type"] == "action.broadcast"
     assert echo["payload"]["utterance"] == "我推开吱呀作响的木门"
     assert echo["payload"]["nickname"] == "房主"
+    assert echo["payload"]["characterName"] == "陈探员"
     assert echo["payload"]["playerId"] == room["playerId"]
     assert narration["type"] == "narration.push"
     assert narration["payload"]["text"]
@@ -405,6 +406,7 @@ def test_conversation_restores_action_discussion_and_narration(
         check_result, _ = receive_until(ws, lambda message: message.get("type") == "check.result")
         assert check_request["payload"]["clientActionId"] == "conv-action-1"
         assert check_result["payload"]["clientActionId"] == "conv-action-1"
+        assert check_result["payload"]["characterName"] == "陈探员"
         completed, _ = receive_until(
             ws, lambda message: message.get("message_type") == "turn.completed"
         )
@@ -426,7 +428,9 @@ def test_conversation_restores_action_discussion_and_narration(
     ]
     assert conversation[1]["channel"] == "discussion"
     assert conversation[2]["channel"] == "action"
+    assert conversation[2]["payload"]["characterName"] == "陈探员"
     assert conversation[3]["payload"]["clientActionId"] == "conv-action-1"
+    assert conversation[3]["payload"]["characterName"] == "陈探员"
     assert conversation[4]["payload"]["text"]
 
 

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -101,14 +101,19 @@ def join_as(client: TestClient, room_code: str, account: str, nickname: str = "�
     return result
 
 
-def complete_character(client: TestClient, room_id: str, reconnect_token: str) -> None:
+def complete_character(
+    client: TestClient,
+    room_id: str,
+    reconnect_token: str,
+    name: str = "陈探员",
+) -> None:
     headers = {"X-Reconnect-Token": reconnect_token}
     draft = client.post(f"{ROOMS_BASE}/{room_id}/characters", headers=headers)
     character_id = draft.json()["data"]["characterId"]
     client.patch(
         f"{ROOMS_BASE}/{room_id}/characters/{character_id}",
         json={
-            "name": "陈探员",
+            "name": name,
             "attributes": {
                 "STR": 50,
                 "CON": 50,
@@ -572,6 +577,7 @@ def test_skill_check_waits_for_player_selection_and_roll(
     assert result["type"] == "check.result"
     assert result["payload"]["skill"] == "stealth"
     assert result["payload"]["rollValue"] == 7
+    assert result["payload"]["characterName"] == "陈探员"
     assert completed["message_type"] == "turn.completed"
     assert completed["correlation_id"] == "ws-skill-check-146"
     assert narration["type"] == "narration.push"
@@ -653,6 +659,7 @@ def test_terminal_attack_check_failure_releases_pending_turn(
             lambda message: message.get("type") == "check.result",
         )
         assert check_result["payload"]["clientActionId"] == "attack-thomas-153"
+        assert check_result["payload"]["characterName"] == "陈探员"
         completed, _ = receive_until(
             ws,
             lambda message: message.get("message_type") == "turn.completed",

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -113,6 +113,7 @@ function conversationHistory(): RoomConversationEvent[] {
         playerId: 'player-1',
         clientActionId: 'act-1',
         nickname: '陈探员',
+        characterName: '杜调查员',
         utterance: '我查看书架',
       },
       createdAt: '2026-07-28T10:01:00Z',
@@ -125,6 +126,7 @@ function conversationHistory(): RoomConversationEvent[] {
         playerId: 'player-1',
         clientActionId: 'act-1',
         skillName: '图书馆使用',
+        characterName: '杜调查员',
         targetValue: 50,
         rollValue: 23,
         difficulty: 'regular',
@@ -179,6 +181,7 @@ describe('RoomPage conversation history', () => {
     expect(await screen.findByText('我查看书架')).toBeInTheDocument()
     expect(screen.getByText('你发现书架后有一个暗格。')).toBeInTheDocument()
     expect(screen.getByText('图书馆使用 50% · D100 23 · 成功')).toBeInTheDocument()
+    expect(screen.getByText('杜调查员 · 掷骰')).toBeInTheDocument()
     expect(mockListConversation).toHaveBeenCalledWith('room-1', 'reconnect-1')
 
     fireEvent.click(screen.getByRole('button', { name: '讨论区' }))
@@ -201,6 +204,7 @@ describe('RoomPage conversation history', () => {
         playerId: 'player-1',
         clientActionId: 'act-1',
         nickname: '陈探员',
+        characterName: '杜调查员',
         utterance: '我查看书架',
       },
     })
@@ -208,5 +212,61 @@ describe('RoomPage conversation history', () => {
     await waitFor(() => {
       expect(screen.getAllByText('我查看书架')).toHaveLength(1)
     })
+  })
+
+  it('falls back for legacy payloads when characterName is missing', async () => {
+    useCharacterStore.getState().setCharacter(
+      {
+        info: {
+          name: '杜调查员',
+          playerName: '陈探员',
+          age: '32',
+          gender: '男',
+          residence: '阿卡姆',
+          birthplace: '波士顿',
+          occupationId: null,
+        },
+        attr: {},
+        skillAlloc: {},
+        skillFinalValues: {},
+        equipment: '',
+        background: '',
+        notes: '',
+        derived: { hp: 10, san: 60, db: '0', move: 8 },
+      } as never,
+      'room-1',
+    )
+    mockListConversation.mockResolvedValue([])
+
+    renderRoomPage()
+
+    emitWsMessage({
+      type: 'action.broadcast',
+      payload: {
+        playerId: 'player-1',
+        clientActionId: 'legacy-act-1',
+        nickname: '房主',
+        utterance: '我查看书架',
+      },
+    })
+    expect(await screen.findByText('房主')).toBeInTheDocument()
+
+    emitWsMessage({
+      type: 'check.result',
+      payload: {
+        playerId: 'player-1',
+        clientActionId: 'legacy-act-2',
+        skill: 'library-use',
+        skillName: '图书馆使用',
+        targetValue: 50,
+        rollValue: 23,
+        difficulty: 'regular',
+        successLevel: 'regular',
+        passed: true,
+        result: 'regular',
+      },
+    })
+
+    expect(await screen.findByText('杜调查员 · 掷骰')).toBeInTheDocument()
   })
 })

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -99,6 +99,14 @@ function appendLiveMessage(current: Message[], message: Message): Message[] {
   return [...current, message]
 }
 
+function displayName(...candidates: Array<string | null | undefined>): string {
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim()
+    if (trimmed) return trimmed
+  }
+  return '玩家'
+}
+
 function conversationEventToMessage(
   event: RoomConversationEvent,
   selfPlayerId: string | null,
@@ -128,13 +136,14 @@ function conversationEventToMessage(
       playerId: string
       clientActionId: string
       nickname: string
+      characterName?: string | null
       utterance: string
     }
     return {
       type: 'player',
       channel: 'action',
       messageId: conversationMessageId(event.type, event.id),
-      sender: payload.nickname,
+      sender: displayName(payload.characterName, payload.nickname),
       content: payload.utterance,
       time: formatRoomTime(event.createdAt),
       isSelf: payload.playerId === selfPlayerId,
@@ -156,6 +165,7 @@ function conversationEventToMessage(
       playerId: string
       clientActionId: string
       skillName: string
+      characterName?: string | null
       targetValue: number
       rollValue: number
       difficulty: string
@@ -184,7 +194,10 @@ function conversationEventToMessage(
       type: 'dice',
       channel: 'action',
       messageId: conversationMessageId(event.type, event.id),
-      sender: payload.playerId === selfPlayerId ? senderName : '玩家',
+      sender: displayName(
+        payload.characterName,
+        payload.playerId === selfPlayerId ? senderName : null,
+      ),
       content: `${payload.skillName} ${payload.targetValue}% · D100 ${payload.rollValue} · ${outcomeLabel}`,
       time: formatRoomTime(event.createdAt),
       isSelf: payload.playerId === selfPlayerId,
@@ -727,7 +740,7 @@ export default function RoomPage() {
           type: 'player',
           channel: 'action',
           messageId: conversationMessageId('action.broadcast', envelope.payload.clientActionId),
-          sender: envelope.payload.nickname,
+          sender: displayName(envelope.payload.characterName, envelope.payload.nickname),
           content: envelope.payload.utterance,
           time: formatRoomTime(new Date()),
           isSelf: envelope.payload.playerId === playerId,
@@ -760,7 +773,10 @@ export default function RoomPage() {
           type: 'dice',
           channel: 'action',
           messageId: conversationMessageId('check.result', envelope.payload.clientActionId),
-          sender: envelope.payload.playerId === playerId ? senderName : '玩家',
+          sender: displayName(
+            envelope.payload.characterName,
+            envelope.payload.playerId === playerId ? senderName : null,
+          ),
           content: `${envelope.payload.skillName} ${envelope.payload.targetValue}% · D100 ${envelope.payload.rollValue} · ${outcomeLabel}`,
           time: formatRoomTime(new Date()),
           isSelf: envelope.payload.playerId === playerId,

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -16,6 +16,7 @@ export interface ActionBroadcastPayload {
   playerId: string;
   clientActionId: string;
   nickname: string;
+  characterName?: string | null;
   utterance: string;
 }
 
@@ -283,6 +284,7 @@ export interface CheckResultPayload {
   clientActionId: string;
   skill: string;
   skillName: string;
+  characterName?: string | null;
   rollValue: number;
   targetValue: number;
   difficulty: "regular" | "hard" | "extreme";

--- a/trpg-sdk/src/resources/room-socket.test.ts
+++ b/trpg-sdk/src/resources/room-socket.test.ts
@@ -66,6 +66,19 @@ test('isValidServerEvent：接受已知类型的合法事件', () => {
     isValidServerEvent({ type: 'session.bound', payload: { roomId: 'r1', playerId: 'p1' } }),
     true
   );
+  assert.equal(
+    isValidServerEvent({
+      type: 'action.broadcast',
+      payload: {
+        playerId: 'player-1',
+        clientActionId: 'action-1',
+        nickname: '房主',
+        characterName: '陈探员',
+        utterance: '我查看书架',
+      },
+    }),
+    true
+  );
   assert.equal(isValidServerEvent({ type: 'narration.push', payload: { text: 'hi' } }), true);
   assert.equal(
     isValidServerEvent({
@@ -102,6 +115,21 @@ test('isValidServerEvent：拒绝未知 type', () => {
   assert.equal(isValidServerEvent({ type: 'not.a.real.event', payload: {} }), false);
 });
 
+test('isValidServerEvent：接受缺少 characterName 的旧 action.broadcast', () => {
+  assert.equal(
+    isValidServerEvent({
+      type: 'action.broadcast',
+      payload: {
+        playerId: 'player-1',
+        clientActionId: 'action-1',
+        nickname: '房主',
+        utterance: '我查看书架',
+      },
+    }),
+    true
+  );
+});
+
 test('isValidServerEvent：拒绝缺 payload / payload 不是对象 / 顶层不是对象', () => {
   assert.equal(isValidServerEvent({ type: 'session.bound' }), false);
   assert.equal(isValidServerEvent({ type: 'session.bound', payload: 'nope' }), false);
@@ -123,6 +151,19 @@ test('isValidServerEvent：拒绝 payload 字段缺失或类型不对', () => {
   assert.equal(isValidServerEvent({ type: 'narration.push', payload: { text: 123 } }), false);
   assert.equal(
     isValidServerEvent({ type: 'session.bound', payload: { roomId: 'r1', playerId: 42 } }),
+    false
+  );
+  assert.equal(
+    isValidServerEvent({
+      type: 'action.broadcast',
+      payload: {
+        playerId: 'player-1',
+        clientActionId: 'action-1',
+        nickname: '房主',
+        characterName: 42,
+        utterance: '我查看书架',
+      },
+    }),
     false
   );
 });

--- a/trpg-sdk/src/resources/room-socket.ts
+++ b/trpg-sdk/src/resources/room-socket.ts
@@ -298,6 +298,9 @@ const PAYLOAD_VALIDATORS: {
     typeof p.clientActionId === 'string' &&
     typeof p.skill === 'string' &&
     typeof p.skillName === 'string' &&
+    (typeof p.characterName === 'string' ||
+      p.characterName === null ||
+      p.characterName === undefined) &&
     typeof p.rollValue === 'number' &&
     typeof p.targetValue === 'number' &&
     typeof p.difficulty === 'string' &&
@@ -315,6 +318,9 @@ const PAYLOAD_VALIDATORS: {
     typeof p.playerId === 'string' &&
     typeof p.clientActionId === 'string' &&
     typeof p.nickname === 'string' &&
+    (typeof p.characterName === 'string' ||
+      p.characterName === null ||
+      p.characterName === undefined) &&
     typeof p.utterance === 'string',
   'san.check.request': (p) => typeof p.playerId === 'string',
   'san.check.result': (p) =>


### PR DESCRIPTION
## 关联 Issue

Closes #179

## 主要改动

- 后端在 `action.broadcast` 与 `check.result` payload 中新增可选 `characterName`，并在事件落库时持久化角色卡姓名。
- 前端行动频道统一优先显示 `characterName`，旧事件继续回退到 `nickname` 或“玩家”；讨论区仍显示账号昵称。
- 同步 SDK 生成 DTO 与 WebSocket 运行时校验器，兼容缺少 `characterName` 的旧消息。
- 补充后端 WS、前端房间页、SDK 校验和多人 e2e 回归测试。

## 采用该方案的原因

行动频道需要表达局内角色身份，讨论区需要保留场外账号身份。把角色名写入后端生成并持久化的行动事件，可以保证实时广播、其他玩家视角和历史恢复使用同一数据来源；字段保持可选，旧事件无需迁移即可继续显示。

## 测试与验证

- [x] `uv run pytest tests/test_ws.py tests/test_chat_ws.py`：24 passed，1 个既有 Starlette deprecation warning。
- [x] `uv run ruff check app/controller/ws.py app/dto/ws.py app/service/room.py tests/test_ws.py tests/test_chat_ws.py`：All checks passed。
- [x] `npm test -- src/routes/games/trpg/RoomPage.test.tsx`：1 passed，3 tests passed。
- [x] `npm run build`（trpg-frontend）：通过。
- [x] `npm test -- src/resources/room-socket.test.ts`（trpg-sdk）：15 tests passed。
- [x] `npm run typecheck`（trpg-sdk）：通过。
- [x] `npm run build`（trpg-sdk）：通过。
- [x] `npm run lint`（trpg-sdk）：通过。
- [x] `npm run lint`（trpg-frontend）：通过。
- [x] `HOST_MODEL_PROVIDER=fake npm run test:e2e -- tests/discussion-chat.e2e.ts`：5 tests passed。

说明：直接运行 `npm run test:e2e -- tests/discussion-chat.e2e.ts` 时，本地环境将 `HOST_MODEL_PROVIDER` 覆盖为 `deepseek` 且未设置 `DEEPSEEK_API_KEY`，启动阶段按配置校验失败；显式使用 `HOST_MODEL_PROVIDER=fake` 后通过。

## 风险与回滚

- 风险：新字段只在新写入事件中存在，旧历史事件仍会使用昵称兜底，这是预期兼容行为。
- 回滚：回退本 PR 即恢复为行动频道显示账号昵称；无数据库迁移或数据回填需要撤销。

## UI 证据

未附截图；显示行为通过房间页单测和多人 e2e 覆盖，包括实时广播、历史恢复与旧 payload 兜底。

## AI 使用情况

本实现由 AI 辅助完成，人工核对了 Issue 范围、diff、生成物、测试结果和回滚风险。合并前仍需要维护者进行人工 Review。

## 自检

- [x] 改动范围符合 Issue
- [x] 不包含无关改动
- [x] 已包含必要的测试和文档
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查，等待人工 Review