### PR TITLE
fix(narrator): 规范化玩家可见叙事换行 (#188)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/application/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/__init__.py
@@ -5,7 +5,7 @@ from .host_agent_intent_resolver import (
     TurnExecutionError,
 )
 from .intent_parser import IntentParser, validate_intent_against_view
-from .narrator import NarrationValidationError, Narrator
+from .narrator import NarrationValidationError, Narrator, normalize_narration_text
 from .orchestrator import Orchestrator
 from .player_view_projector import PlayerViewProjector
 from .tool_registry import (
@@ -31,5 +31,6 @@ __all__ = [
     "ToolHandler",
     "ToolRegistry",
     "TurnExecutionError",
+    "normalize_narration_text",
     "validate_intent_against_view",
 ]

--- a/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
@@ -93,6 +93,12 @@ class NarrationValidationError(ContractError):
         self.reason = reason
 
 
+def normalize_narration_text(text: str) -> str:
+    """Convert model-emitted literal newline escapes to canonical LF characters."""
+
+    return text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\r", "\n")
+
+
 def narration_text_rejection_reason(
     text: str,
 ) -> Literal["protocol_tail", "schema_fragment"] | None:
@@ -133,6 +139,8 @@ class Narrator:
 
     async def narrate(self, context: NarrationContext) -> NarrationOutput:
         raw = await self._model.generate(context)
+        if isinstance(raw, dict) and isinstance(raw.get("text"), str):
+            raw = {**raw, "text": normalize_narration_text(raw["text"])}
         try:
             output = NarrationOutput.model_validate(raw)
         except (TypeError, ValueError) as exc:

--- a/agent-collaboration-framework/tests/test_narrator_policy.py
+++ b/agent-collaboration-framework/tests/test_narrator_policy.py
@@ -3,11 +3,37 @@ from __future__ import annotations
 import unittest
 
 from collaboration_framework.host.application.narrator import (
+    normalize_narration_text,
     narration_text_rejection_reason,
 )
 
 
 class NarrationTextPolicyTests(unittest.TestCase):
+    def test_normalizes_literal_newline_escapes_without_general_decoding(self) -> None:
+        cases = {
+            "第一段\\n第二段": "第一段\n第二段",
+            "第一段\\r\\n第二段": "第一段\n第二段",
+            "第一段\\r第二段": "第一段\n第二段",
+            "第一段\\n\\n第二段": "第一段\n\n第二段",
+            "第一段\n第二段": "第一段\n第二段",
+            "制表符\\t保持原样": "制表符\\t保持原样",
+            "C:\\temp\\file.txt": "C:\\temp\\file.txt",
+            "普通反斜杠\\\\保持原样": "普通反斜杠\\\\保持原样",
+        }
+
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                normalized = normalize_narration_text(text)
+                self.assertEqual(normalized, expected)
+                self.assertEqual(normalize_narration_text(normalized), expected)
+
+    def test_normalizes_before_protocol_tail_detection(self) -> None:
+        normalized = normalize_narration_text(
+            "托马斯说完便沉默。\\nclaimed_fact_ids: []"
+        )
+
+        self.assertEqual(narration_text_rejection_reason(normalized), "protocol_tail")
+
     def test_rejects_protocol_field_assignments_and_json_tails(self) -> None:
         cases = {
             "托马斯看着你。 claimed_fact_ids: [],": "protocol_tail",

--- a/agent-collaboration-framework/tests/test_workflow.py
+++ b/agent-collaboration-framework/tests/test_workflow.py
@@ -294,6 +294,38 @@ class UnifiedWorkflowTests(unittest.TestCase):
         self.assertEqual(failed.exception.reason, "fact_scope")
         self.assertEqual(engine.execute_calls, 1)
 
+    def test_narrator_normalizes_literal_newlines_before_returning_output(self) -> None:
+        narrator = StaticNarrationModel(
+            {
+                "kind": "narration",
+                "text": "第一段\\r\\n第二段\\n第三段\\r第四段",
+                "claimed_fact_ids": [],
+                "suggested_actions": [],
+            }
+        )
+        orchestrator, _, _ = self.application(narration_model=narrator)
+
+        output = self.run_turn(orchestrator)
+
+        self.assertEqual(output.narration.text, "第一段\n第二段\n第三段\n第四段")
+
+    def test_narrator_checks_protocol_tail_after_newline_normalization(self) -> None:
+        narrator = StaticNarrationModel(
+            {
+                "kind": "narration",
+                "text": "托马斯说完便沉默。\\nclaimed_fact_ids: []",
+                "claimed_fact_ids": [],
+                "suggested_actions": [],
+            }
+        )
+        orchestrator, engine, _ = self.application(narration_model=narrator)
+
+        with self.assertRaises(NarrationValidationError) as failed:
+            self.run_turn(orchestrator)
+
+        self.assertEqual(failed.exception.reason, "protocol_tail")
+        self.assertEqual(engine.execute_calls, 1)
+
     def test_host_semantic_checkpoint_choice_is_not_rejected_by_verb_equality(
         self,
     ) -> None:

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -38,7 +38,10 @@ import anyio
 import structlog
 from collaboration_framework.contracts import ActionResult, ContractError, PlayerView
 from collaboration_framework.engine import RevisionConflictError
-from collaboration_framework.host.application import TurnExecutionError
+from collaboration_framework.host.application import (
+    TurnExecutionError,
+    normalize_narration_text,
+)
 from collaboration_framework.host.schemas import TurnOutput
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
@@ -213,6 +216,7 @@ async def _broadcast_narration(
     /rooms/{roomId}/replay` 读的就是这里写入的数据（issue #77 才打通的
     EventLog 闭环，此前"不记 EventLog"是已知缺口）。
     """
+    text = normalize_narration_text(text)
     narration = NarrationPushPayload(text=text)
     envelope = ServerEnvelope(type="narration.push", payload=narration.model_dump(by_alias=True))
     await room_service.record_event(db, room_id, player_id, "narration.push", {"text": text})
@@ -237,6 +241,7 @@ async def _deliver_turn_narration(
 ) -> bool:
     """持久化去重成功后才发送一次动作叙事。"""
 
+    text = normalize_narration_text(text)
     recorded = await room_service.record_event(
         db,
         room_id,

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -19,6 +19,7 @@ from collaboration_framework.engine import (
     create_initial_game_state,
     require_runtime_capabilities,
 )
+from collaboration_framework.host.application import normalize_narration_text
 from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -908,6 +909,15 @@ async def get_module_detail(db: AsyncSession, module_id: str) -> ModuleDetailRea
 # ── 复盘 / 事件回放 ──────────────────────────────────────
 
 
+def _player_visible_event_payload(event_type: str, payload: dict) -> dict:
+    """Return a display-safe copy without rewriting the stored event payload."""
+
+    visible_payload = deepcopy(payload)
+    if event_type == "narration.push" and isinstance(visible_payload.get("text"), str):
+        visible_payload["text"] = normalize_narration_text(visible_payload["text"])
+    return visible_payload
+
+
 async def record_event(
     db: AsyncSession,
     room_id: str,
@@ -962,7 +972,15 @@ async def get_replay(
     result = await db.scalars(
         select(Event).where(Event.room_id == room_id).order_by(Event.created_at)
     )
-    return [ReplayEventRead.model_validate(e) for e in result]
+    replay: list[ReplayEventRead] = []
+    for event in result:
+        item = ReplayEventRead.model_validate(event)
+        replay.append(
+            item.model_copy(
+                update={"payload": _player_visible_event_payload(event.event_type, event.payload)}
+            )
+        )
+    return replay
 
 
 async def list_conversation_events(
@@ -1032,7 +1050,7 @@ async def list_conversation_events(
                     id=event.correlation_id or event.id,
                     type="narration.push",
                     channel="action",
-                    payload=event.payload,
+                    payload=_player_visible_event_payload(event.event_type, event.payload),
                     created_at=event.created_at,
                 )
             )

--- a/trpg-backend/tests/test_rooms.py
+++ b/trpg-backend/tests/test_rooms.py
@@ -8,8 +8,39 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.seed import BUILTIN_MODULE_ID, BUILTIN_SYSTEM_ID
 from app.models.content import Scenario
+from app.models.event import Event
 from app.models.room import Player
 from tests.helpers import ROOMS_BASE, bearer, create_room, join_room, reconnect, register
+
+
+async def test_legacy_narration_escapes_are_normalized_without_rewriting_event(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    room = await create_room(client)
+    event = Event(
+        room_id=room["roomId"],
+        player_id=room["playerId"],
+        event_type="narration.push",
+        payload={"text": "第一段\\r\\n第二段\\n第三段"},
+    )
+    db_session.add(event)
+    await db_session.commit()
+
+    headers = reconnect(room["reconnectToken"])
+    conversation = (
+        await client.get(f"{ROOMS_BASE}/{room['roomId']}/conversation", headers=headers)
+    ).json()["data"]
+    replay = (await client.get(f"{ROOMS_BASE}/{room['roomId']}/replay", headers=headers)).json()[
+        "data"
+    ]
+
+    expected = "第一段\n第二段\n第三段"
+    assert conversation[0]["payload"]["text"] == expected
+    assert replay[0]["payload"]["text"] == expected
+
+    await db_session.refresh(event)
+    assert event.payload["text"] == "第一段\\r\\n第二段\\n第三段"
 
 
 async def test_join_rejects_full_room(client: AsyncClient) -> None:

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -82,6 +82,16 @@ class _WsInvalidTwiceThenSafeNarration:
         return await self._fake.generate(context)
 
 
+class _WsEscapedNewlineNarration:
+    async def generate(self, context: NarrationContext) -> JsonObject:
+        return {
+            "kind": "narration",
+            "text": "第一段\\r\\n第二段\\n第三段",
+            "claimed_fact_ids": [],
+            "suggested_actions": [],
+        }
+
+
 @pytest.fixture
 def sync_client() -> TestClient:
     # 用同一个 app 实例的同步 TestClient——HTTP 部分照常发请求准备房间/角色
@@ -636,6 +646,71 @@ def test_invalid_narration_fails_closed_then_original_request_recovers(
     assert len(narration_events) == 1
     assert narration_events[0]["payload"]["text"] == narration["payload"]["text"]
     assert narration_model.leaked_text not in str(replay)
+
+
+def test_narration_newlines_are_normalized_before_turn_and_push(
+    sync_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = register_and_login(sync_client, "narration_newline_host")
+    room = create_room(sync_client, token)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+    current_application = ws_controller.turn_application
+    monkeypatch.setattr(
+        ws_controller,
+        "turn_application",
+        build_turn_application(
+            current_application.store,
+            current_application.engine,
+            intent_model=_WsPlainIntentModel(),
+            narration_model=_WsEscapedNewlineNarration(),
+        ),
+    )
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        assert ws.receive_json()["type"] == "session.bound"
+        assert ws.receive_json()["type"] == "view.updated"
+        ws.send_json(
+            {
+                "type": "action.submit",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "ws-narration-newline-188",
+                    "utterance": "我继续询问托马斯",
+                },
+            }
+        )
+        completed, _ = receive_until(
+            ws,
+            lambda message: message.get("message_type") == "turn.completed",
+        )
+        narration, _ = receive_until(
+            ws,
+            lambda message: message.get("type") == "narration.push",
+        )
+
+    expected = "第一段\n第二段\n第三段"
+    assert completed["payload"]["narration"]["text"] == expected
+    assert narration["payload"]["text"] == expected
+    replay = sync_client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/replay",
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    ).json()["data"]
+    persisted = [
+        event
+        for event in replay
+        if event["eventType"] == "narration.push" and event["payload"]["text"] == expected
+    ]
+    assert len(persisted) == 1
 
 
 def test_skill_check_waits_for_player_selection_and_roll(

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -219,6 +219,39 @@ describe('RoomPage conversation history', () => {
     })
   })
 
+  it('preserves real newlines in historical and realtime narration', async () => {
+    mockListConversation.mockResolvedValue([
+      {
+        id: 'narration-history-1',
+        type: 'narration.push',
+        channel: 'action',
+        payload: { text: '历史第一段\n历史第二段' },
+        createdAt: '2026-07-28T10:03:00Z',
+      },
+    ])
+
+    renderRoomPage()
+
+    const historical = await screen.findByText(
+      (_content, element) =>
+        element?.classList.contains('whitespace-pre-wrap') === true &&
+        element.textContent === '历史第一段\n历史第二段',
+    )
+    expect(historical).toHaveClass('whitespace-pre-wrap')
+
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { text: '实时第一段\n实时第二段' },
+    })
+
+    const realtime = await screen.findByText(
+      (_content, element) =>
+        element?.classList.contains('whitespace-pre-wrap') === true &&
+        element.textContent === '实时第一段\n实时第二段',
+    )
+    expect(realtime).toHaveClass('whitespace-pre-wrap')
+  })
+
   it('falls back for legacy payloads when characterName is missing', async () => {
     useCharacterStore.getState().setCharacter(
       {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1163,7 +1163,7 @@ export default function RoomPage() {
                 <div className={`
                   text-sm leading-[1.65] text-text-body inline-block max-w-full px-3.5 py-2.5
                   ${isPlayer ? 'bg-[#eef6ee] rounded-md' : ''}
-                  ${isNarr ? 'bg-[#fdfaf4] border-l-[3px] border-brass rounded-r-sm rounded-l-none italic text-[#4a4030] text-left' : ''}
+                  ${isNarr ? 'bg-[#fdfaf4] border-l-[3px] border-brass rounded-r-sm rounded-l-none italic text-[#4a4030] text-left whitespace-pre-wrap' : ''}
                   ${!isPlayer && !isNarr ? 'bg-panel rounded-md' : ''}
                 `}>
                   {msg.content}


### PR DESCRIPTION
## 关联 Issue

Closes #188

## 修改内容

- 在协作框架统一将叙事文本中的字面量换行转义规范为真实 LF，并在 Schema 与协议残留校验前执行
- 在后端持久化、日志与 WebSocket 广播边界做幂等兜底
- conversation 与 replay 读取旧事件时只规范化返回副本，不改写数据库
- 守秘人消息气泡保留真实换行，其他消息样式不变
- 补充框架、后端和前端回归测试

## 验证

- 协作框架相关测试：25 passed
- 后端新增定向测试：2 passed
- 后端 ruff check、ruff format --check、ty check：通过
- 前端 RoomPage 测试：8 passed
- 前端 lint：通过

## 已知基线问题

- 协作框架完整套件共 182 项，其中 6 项既有数据模型文档字段同步检查失败，与本次修改无关
- 后端既有 test_action_submit_broadcasts_narration_to_room_only 在本地独立运行时挂起；本次新增 WebSocket 用例通过
- 前端 build 仍被既有 TurnFailedError 联合类型的 correlationId 错误阻断；本次 RoomPage 实现仅改动守秘人气泡 CSS 类

## 风险与回滚

不修改 DTO、数据库结构或历史数据。回滚此提交即可恢复原行为。合并前请人工审查。