### PR TITLE
feat(frontend): 支持主持人语音朗读与音色选择 (#210)

### DIFF
--- a/trpg-frontend/src/hooks/useHostSpeech.test.ts
+++ b/trpg-frontend/src/hooks/useHostSpeech.test.ts
@@ -1,0 +1,197 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useHostSpeech } from './useHostSpeech'
+
+class FakeUtterance {
+  text: string
+  voice: SpeechSynthesisVoice | null = null
+  lang = ''
+  rate = 0
+  pitch = 0
+  volume = 0
+  onend: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(text: string) {
+    this.text = text
+  }
+}
+
+function fakeVoice(overrides: Partial<SpeechSynthesisVoice>): SpeechSynthesisVoice {
+  return {
+    default: false,
+    lang: 'en-US',
+    localService: true,
+    name: 'English',
+    voiceURI: 'english',
+    ...overrides,
+  }
+}
+
+function installSpeechApi(voices: SpeechSynthesisVoice[] = []) {
+  let voicesChanged: (() => void) | null = null
+  const spoken: FakeUtterance[] = []
+  const synthesis = {
+    getVoices: vi.fn(() => voices),
+    speak: vi.fn((utterance: FakeUtterance) => spoken.push(utterance)),
+    cancel: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    addEventListener: vi.fn((_event: string, listener: () => void) => { voicesChanged = listener }),
+    removeEventListener: vi.fn(),
+    emitVoicesChanged: () => voicesChanged?.(),
+  }
+  Object.defineProperty(window, 'speechSynthesis', { configurable: true, value: synthesis })
+  Object.defineProperty(window, 'SpeechSynthesisUtterance', { configurable: true, value: FakeUtterance })
+  return { synthesis, spoken }
+}
+
+describe('useHostSpeech', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    Object.defineProperty(window, 'speechSynthesis', { configurable: true, value: undefined })
+    Object.defineProperty(window, 'SpeechSynthesisUtterance', { configurable: true, value: undefined })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports unsupported browsers without throwing', () => {
+    const { result } = renderHook(() => useHostSpeech())
+
+    expect(result.current.supported).toBe(false)
+    expect(result.current.enabled).toBe(false)
+    act(() => {
+      result.current.enqueue('message-1', '文本')
+      result.current.replay('历史文本')
+    })
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('selects a stable Chinese default and starts disabled', () => {
+    installSpeechApi([
+      fakeVoice({ name: '中文乙', lang: 'zh-CN', voiceURI: 'zh-b' }),
+      fakeVoice({ name: '中文甲', lang: 'zh-Hans', voiceURI: 'zh-a' }),
+      fakeVoice({ name: 'English default', default: true, voiceURI: 'en-default' }),
+    ])
+    const { result: mounted } = renderHook(() => useHostSpeech())
+
+    expect(mounted.current.enabled).toBe(false)
+    expect(mounted.current.selectedVoiceURI).toBe('zh-a')
+    expect(mounted.current.voices.map((voice) => voice.voiceURI)).toEqual([
+      'zh-a',
+      'zh-b',
+      'en-default',
+    ])
+  })
+
+  it('falls back to the browser default voice when no Chinese voice exists', () => {
+    installSpeechApi([
+      fakeVoice({ name: 'Voice B', voiceURI: 'voice-b' }),
+      fakeVoice({ name: 'Voice A', default: true, voiceURI: 'voice-a' }),
+    ])
+    const { result } = renderHook(() => useHostSpeech())
+    expect(result.current.selectedVoiceURI).toBe('voice-a')
+  })
+
+  it('restores local settings and supports voice changes', () => {
+    localStorage.setItem('aidm-host-speech-settings', JSON.stringify({ enabled: true, voiceURI: 'voice-2' }))
+    installSpeechApi([
+      fakeVoice({ name: 'Voice 1', voiceURI: 'voice-1' }),
+      fakeVoice({ name: 'Voice 2', voiceURI: 'voice-2' }),
+    ])
+    const { result } = renderHook(() => useHostSpeech())
+
+    expect(result.current.enabled).toBe(true)
+    expect(result.current.selectedVoiceURI).toBe('voice-2')
+    act(() => result.current.setSelectedVoiceURI('voice-1'))
+    expect(JSON.parse(localStorage.getItem('aidm-host-speech-settings')!).voiceURI).toBe('voice-1')
+  })
+
+  it('plays an ordered, deduplicated automatic queue', () => {
+    const { spoken, synthesis } = installSpeechApi()
+    const { result } = renderHook(() => useHostSpeech())
+
+    act(() => {
+      result.current.setEnabled(true)
+      result.current.enqueue('message-1', '第一段')
+      result.current.enqueue('message-1', '重复第一段')
+      result.current.enqueue('message-2', '第二段')
+    })
+
+    expect(synthesis.speak).toHaveBeenCalledTimes(1)
+    expect(spoken[0]?.text).toBe('第一段')
+    expect(result.current.queueLength).toBe(1)
+
+    act(() => spoken[0]?.onend?.())
+    expect(spoken[1]?.text).toBe('第二段')
+    expect(result.current.queueLength).toBe(0)
+  })
+
+  it('allows manual replay while automatic speech is disabled', () => {
+    const { spoken } = installSpeechApi()
+    const { result } = renderHook(() => useHostSpeech())
+
+    act(() => result.current.replay('历史主持人消息'))
+    expect(spoken).toHaveLength(1)
+    expect(spoken[0]?.text).toBe('历史主持人消息')
+  })
+
+  it('applies the selected voice and fixed speech parameters', () => {
+    const voice = fakeVoice({ name: 'Voice 1', voiceURI: 'voice-1' })
+    const { spoken } = installSpeechApi([voice])
+    const { result } = renderHook(() => useHostSpeech())
+
+    act(() => {
+      result.current.setSelectedVoiceURI('voice-1')
+      result.current.replay('带音色的消息')
+    })
+
+    expect(spoken[0]?.voice).toBe(voice)
+    expect(spoken[0]?.lang).toBe('en-US')
+    expect(spoken[0]?.rate).toBe(1)
+    expect(spoken[0]?.pitch).toBe(1)
+    expect(spoken[0]?.volume).toBe(1)
+  })
+
+  it('supports pause, resume, stop and skips utterance errors', () => {
+    const { spoken, synthesis } = installSpeechApi()
+    const { result } = renderHook(() => useHostSpeech())
+
+    act(() => {
+      result.current.setEnabled(true)
+      result.current.enqueue('message-1', '第一段')
+      result.current.enqueue('message-2', '第二段')
+    })
+    act(() => result.current.pause())
+    expect(result.current.status).toBe('paused')
+    expect(synthesis.pause).toHaveBeenCalledTimes(1)
+    act(() => result.current.resume())
+    expect(result.current.status).toBe('speaking')
+    expect(synthesis.resume).toHaveBeenCalledTimes(1)
+
+    act(() => spoken[0]?.onerror?.())
+    expect(spoken[1]?.text).toBe('第二段')
+    act(() => result.current.stop())
+    expect(synthesis.cancel).toHaveBeenCalled()
+    expect(result.current.status).toBe('idle')
+    expect(result.current.queueLength).toBe(0)
+  })
+
+  it('refreshes voices and clears speech on unmount', async () => {
+    const { synthesis } = installSpeechApi([])
+    const { result, unmount } = renderHook(() => useHostSpeech())
+    expect(result.current.voices).toHaveLength(0)
+
+    const voice = fakeVoice({ name: '中文', lang: 'zh-CN', voiceURI: 'zh' })
+    synthesis.getVoices.mockReturnValue([voice])
+    act(() => synthesis.emitVoicesChanged())
+    await waitFor(() => expect(result.current.selectedVoiceURI).toBe('zh'))
+
+    act(() => result.current.replay('待清理'))
+    unmount()
+    expect(synthesis.cancel).toHaveBeenCalled()
+    expect(synthesis.removeEventListener).toHaveBeenCalled()
+  })
+})

--- a/trpg-frontend/src/hooks/useHostSpeech.test.ts
+++ b/trpg-frontend/src/hooks/useHostSpeech.test.ts
@@ -129,6 +129,20 @@ describe('useHostSpeech', () => {
     expect(result.current.queueLength).toBe(0)
   })
 
+  it('does not enqueue message ids already restored from history', () => {
+    const { spoken } = installSpeechApi()
+    const { result } = renderHook(() => useHostSpeech())
+
+    act(() => {
+      result.current.markSeen(['message-from-history'])
+      result.current.setEnabled(true)
+      result.current.enqueue('message-from-history', '历史消息的实时重放')
+    })
+
+    expect(spoken).toHaveLength(0)
+    expect(result.current.status).toBe('idle')
+  })
+
   it('allows manual replay while automatic speech is disabled', () => {
     const { spoken } = installSpeechApi()
     const { result } = renderHook(() => useHostSpeech())

--- a/trpg-frontend/src/hooks/useHostSpeech.ts
+++ b/trpg-frontend/src/hooks/useHostSpeech.ts
@@ -166,6 +166,13 @@ export function useHostSpeech() {
     selectedVoiceURIRef.current = voiceURI || null
   }, [])
 
+  const markSeen = useCallback((messageIds: readonly string[]) => {
+    for (const messageId of messageIds) {
+      const trimmed = messageId.trim()
+      if (trimmed) seenMessageIdsRef.current.add(trimmed)
+    }
+  }, [])
+
   const enqueue = useCallback((messageId: string | undefined, text: string) => {
     const trimmed = text.trim()
     if (!supportedRef.current || !enabledRef.current || !messageId || !trimmed) return
@@ -231,6 +238,7 @@ export function useHostSpeech() {
     setEnabled,
     selectedVoiceURI,
     setSelectedVoiceURI,
+    markSeen,
     status,
     queueLength,
     enqueue,

--- a/trpg-frontend/src/hooks/useHostSpeech.ts
+++ b/trpg-frontend/src/hooks/useHostSpeech.ts
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const STORAGE_KEY = 'aidm-host-speech-settings'
+const DEFAULT_RATE = 1
+const DEFAULT_PITCH = 1
+const DEFAULT_VOLUME = 1
+
+export type HostSpeechStatus = 'idle' | 'speaking' | 'paused'
+
+interface HostSpeechSettings {
+  enabled: boolean
+  voiceURI: string | null
+}
+
+interface SpeechQueueItem {
+  messageId?: string
+  text: string
+}
+
+function readSettings(): HostSpeechSettings {
+  if (typeof window === 'undefined') return { enabled: false, voiceURI: null }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { enabled: false, voiceURI: null }
+    const parsed = JSON.parse(raw) as Partial<HostSpeechSettings>
+    return {
+      enabled: parsed.enabled === true,
+      voiceURI: typeof parsed.voiceURI === 'string' && parsed.voiceURI ? parsed.voiceURI : null,
+    }
+  } catch {
+    return { enabled: false, voiceURI: null }
+  }
+}
+
+function writeSettings(settings: HostSpeechSettings): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+  } catch {
+    // localStorage may be unavailable in private browsing or restricted frames.
+  }
+}
+
+function getSpeechSynthesis(): SpeechSynthesis | null {
+  if (typeof window === 'undefined') return null
+  const synthesis = window.speechSynthesis
+  const utteranceCtor = (window as Window & {
+    SpeechSynthesisUtterance?: typeof SpeechSynthesisUtterance
+  }).SpeechSynthesisUtterance
+  return synthesis && utteranceCtor ? synthesis : null
+}
+
+function getUtteranceCtor(): typeof SpeechSynthesisUtterance | null {
+  if (typeof window === 'undefined') return null
+  return (window as Window & {
+    SpeechSynthesisUtterance?: typeof SpeechSynthesisUtterance
+  }).SpeechSynthesisUtterance ?? null
+}
+
+function sortVoices(voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice[] {
+  return [...voices].sort((left, right) =>
+    left.name.localeCompare(right.name, 'zh-CN') ||
+    left.lang.localeCompare(right.lang, 'zh-CN') ||
+    left.voiceURI.localeCompare(right.voiceURI, 'zh-CN'),
+  )
+}
+
+function isChineseVoice(voice: SpeechSynthesisVoice): boolean {
+  const lang = voice.lang.toLocaleLowerCase()
+  return lang === 'zh-cn' || lang === 'zh-hans' || lang.startsWith('zh-cn-') || lang.startsWith('zh-hans-')
+}
+
+function chooseDefaultVoice(voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null {
+  const sorted = sortVoices(voices)
+  return sorted.find(isChineseVoice) ?? voices.find((voice) => voice.default) ?? sorted[0] ?? null
+}
+
+export function useHostSpeech() {
+  const initialSettingsRef = useRef<HostSpeechSettings | null>(null)
+  if (initialSettingsRef.current === null) initialSettingsRef.current = readSettings()
+
+  const synthesisRef = useRef<SpeechSynthesis | null>(getSpeechSynthesis())
+  const utteranceCtorRef = useRef<typeof SpeechSynthesisUtterance | null>(getUtteranceCtor())
+  const supportedRef = useRef(synthesisRef.current !== null && utteranceCtorRef.current !== null)
+  const [supported] = useState(supportedRef.current)
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>(() => {
+    try {
+      return synthesisRef.current ? sortVoices(synthesisRef.current.getVoices()) : []
+    } catch {
+      return []
+    }
+  })
+  const [enabled, setEnabledState] = useState(() => initialSettingsRef.current?.enabled ?? false)
+  const [selectedVoiceURI, setSelectedVoiceURIState] = useState<string | null>(
+    () => initialSettingsRef.current?.voiceURI ?? null,
+  )
+  const [status, setStatus] = useState<HostSpeechStatus>('idle')
+  const [queueLength, setQueueLength] = useState(0)
+
+  const voicesRef = useRef(voices)
+  const selectedVoiceURIRef = useRef(selectedVoiceURI)
+  const enabledRef = useRef(enabled)
+  const queueRef = useRef<SpeechQueueItem[]>([])
+  const seenMessageIdsRef = useRef(new Set<string>())
+  const currentRef = useRef<SpeechQueueItem | null>(null)
+  const processQueueRef = useRef<() => void>(() => {})
+
+  voicesRef.current = voices
+  selectedVoiceURIRef.current = selectedVoiceURI
+  enabledRef.current = enabled
+
+  const processQueue = useCallback(() => {
+    const synthesis = synthesisRef.current
+    const Utterance = utteranceCtorRef.current
+    if (!synthesis || !Utterance || currentRef.current || queueRef.current.length === 0) {
+      if (!currentRef.current && queueRef.current.length === 0) setStatus('idle')
+      return
+    }
+
+    const item = queueRef.current.shift()!
+    currentRef.current = item
+    setQueueLength(queueRef.current.length)
+    setStatus('speaking')
+
+    const utterance = new Utterance(item.text)
+    const voice = voicesRef.current.find((candidate) => candidate.voiceURI === selectedVoiceURIRef.current)
+    if (voice) {
+      utterance.voice = voice
+      utterance.lang = voice.lang
+    }
+    utterance.rate = DEFAULT_RATE
+    utterance.pitch = DEFAULT_PITCH
+    utterance.volume = DEFAULT_VOLUME
+    const finish = () => {
+      currentRef.current = null
+      processQueueRef.current()
+    }
+    utterance.onend = finish
+    utterance.onerror = finish
+
+    try {
+      synthesis.speak(utterance)
+    } catch {
+      finish()
+    }
+  }, [])
+
+  processQueueRef.current = processQueue
+
+  const clearPlayback = useCallback(() => {
+    synthesisRef.current?.cancel()
+    queueRef.current = []
+    currentRef.current = null
+    setQueueLength(0)
+    setStatus('idle')
+  }, [])
+
+  const setEnabled = useCallback((nextEnabled: boolean) => {
+    setEnabledState(nextEnabled)
+    enabledRef.current = nextEnabled
+    if (!nextEnabled) clearPlayback()
+  }, [clearPlayback])
+
+  const setSelectedVoiceURI = useCallback((voiceURI: string) => {
+    setSelectedVoiceURIState(voiceURI || null)
+    selectedVoiceURIRef.current = voiceURI || null
+  }, [])
+
+  const enqueue = useCallback((messageId: string | undefined, text: string) => {
+    const trimmed = text.trim()
+    if (!supportedRef.current || !enabledRef.current || !messageId || !trimmed) return
+    if (seenMessageIdsRef.current.has(messageId)) return
+    seenMessageIdsRef.current.add(messageId)
+    queueRef.current.push({ messageId, text: trimmed })
+    setQueueLength(queueRef.current.length)
+    processQueueRef.current()
+  }, [])
+
+  const replay = useCallback((text: string) => {
+    const trimmed = text.trim()
+    if (!supportedRef.current || !trimmed) return
+    queueRef.current.push({ text: trimmed })
+    setQueueLength(queueRef.current.length)
+    processQueueRef.current()
+  }, [])
+
+  const pause = useCallback(() => {
+    if (status !== 'speaking') return
+    synthesisRef.current?.pause()
+    setStatus('paused')
+  }, [status])
+
+  const resume = useCallback(() => {
+    if (status !== 'paused') return
+    synthesisRef.current?.resume()
+    setStatus('speaking')
+  }, [status])
+
+  useEffect(() => {
+    writeSettings({ enabled, voiceURI: selectedVoiceURI })
+  }, [enabled, selectedVoiceURI])
+
+  useEffect(() => {
+    const synthesis = synthesisRef.current
+    if (!synthesis) return
+
+    const refreshVoices = () => {
+      try {
+        setVoices(sortVoices(synthesis.getVoices()))
+      } catch {
+        setVoices([])
+      }
+    }
+    refreshVoices()
+    synthesis.addEventListener('voiceschanged', refreshVoices)
+    return () => synthesis.removeEventListener('voiceschanged', refreshVoices)
+  }, [])
+
+  useEffect(() => {
+    if (voices.length === 0) return
+    if (selectedVoiceURI && voices.some((voice) => voice.voiceURI === selectedVoiceURI)) return
+    setSelectedVoiceURIState(chooseDefaultVoice(voices)?.voiceURI ?? null)
+  }, [selectedVoiceURI, voices])
+
+  useEffect(() => () => clearPlayback(), [clearPlayback])
+
+  return {
+    supported,
+    voices,
+    enabled,
+    setEnabled,
+    selectedVoiceURI,
+    setSelectedVoiceURI,
+    status,
+    queueLength,
+    enqueue,
+    replay,
+    pause,
+    resume,
+    stop: clearPlayback,
+  }
+}
+
+export { chooseDefaultVoice, sortVoices }

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -15,6 +15,37 @@ import { useAuthStore } from '@/stores/auth-store'
 import { useCharacterStore } from '@/stores/character-store'
 import { useRoomStore } from '@/stores/room-store'
 
+class RoomSpeechUtterance {
+  text: string
+  voice: SpeechSynthesisVoice | null = null
+  lang = ''
+  rate = 0
+  pitch = 0
+  volume = 0
+  onend: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(text: string) {
+    this.text = text
+  }
+}
+
+function installRoomSpeechApi() {
+  const spoken: RoomSpeechUtterance[] = []
+  const synthesis = {
+    getVoices: vi.fn(() => [] as SpeechSynthesisVoice[]),
+    speak: vi.fn((utterance: RoomSpeechUtterance) => spoken.push(utterance)),
+    cancel: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }
+  Object.defineProperty(window, 'speechSynthesis', { configurable: true, value: synthesis })
+  Object.defineProperty(window, 'SpeechSynthesisUtterance', { configurable: true, value: RoomSpeechUtterance })
+  return { synthesis, spoken }
+}
+
 const {
   emitWsMessage,
   mockGetOpeningMessageId,
@@ -201,6 +232,8 @@ describe('RoomPage conversation history', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     wsHandlers.clear()
+    Object.defineProperty(window, 'speechSynthesis', { configurable: true, value: undefined })
+    Object.defineProperty(window, 'SpeechSynthesisUtterance', { configurable: true, value: undefined })
     window.HTMLElement.prototype.scrollIntoView = vi.fn()
     localStorage.clear()
     sessionStorage.clear()
@@ -406,6 +439,90 @@ describe('RoomPage conversation history', () => {
         element.textContent === '实时第一段\n实时第二段',
     )
     expect(realtime).toHaveClass('whitespace-pre-wrap')
+  })
+
+  it('automatically speaks new final narration once by message id', async () => {
+    const { spoken } = installRoomSpeechApi()
+    localStorage.setItem('aidm-host-speech-settings', JSON.stringify({ enabled: true, voiceURI: null }))
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { messageId: 'narration-1', text: '新的主持人叙事' },
+    })
+    expect(await screen.findByText('新的主持人叙事')).toBeInTheDocument()
+    expect(spoken).toHaveLength(1)
+    expect(spoken[0]?.text).toBe('新的主持人叙事')
+
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { messageId: 'narration-1', text: '新的主持人叙事' },
+    })
+    await waitFor(() => expect(spoken).toHaveLength(1))
+  })
+
+  it('does not auto-speak restored history but supports manual replay', async () => {
+    const { spoken } = installRoomSpeechApi()
+    localStorage.setItem('aidm-host-speech-settings', JSON.stringify({ enabled: true, voiceURI: null }))
+    mockListConversation.mockResolvedValue([
+      {
+        id: 'history-narration',
+        type: 'narration.push',
+        channel: 'action',
+        payload: { messageId: 'history-narration', text: '历史主持人叙事' },
+        createdAt: '2026-07-28T10:03:00Z',
+      },
+    ])
+
+    renderRoomPage()
+    expect(await screen.findByText('历史主持人叙事')).toBeInTheDocument()
+    expect(spoken).toHaveLength(0)
+
+    fireEvent.click(screen.getByRole('button', { name: '重新朗读' }))
+    expect(spoken).toHaveLength(1)
+    expect(spoken[0]?.text).toBe('历史主持人叙事')
+  })
+
+  it('exposes speech controls and stops the queue when disabled', async () => {
+    const { spoken, synthesis } = installRoomSpeechApi()
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: '主持人语音' }))
+    const toggle = screen.getByRole('switch', { name: '主持人语音朗读' })
+    fireEvent.click(toggle)
+    expect(toggle).toBeChecked()
+
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { messageId: 'narration-controls-1', text: '控制面板测试' },
+    })
+    expect(await screen.findByText('控制面板测试')).toBeInTheDocument()
+    expect(spoken).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: '暂停朗读' }))
+    expect(synthesis.pause).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: '继续朗读' }))
+    expect(synthesis.resume).toHaveBeenCalledTimes(1)
+    fireEvent.click(toggle)
+    expect(toggle).not.toBeChecked()
+    expect(synthesis.cancel).toHaveBeenCalled()
+  })
+
+  it('keeps text readable and disables replay when speech is unsupported', async () => {
+    mockListConversation.mockResolvedValue([
+      {
+        id: 'unsupported-narration',
+        type: 'narration.push',
+        channel: 'action',
+        payload: { messageId: 'unsupported-narration', text: '纯文本主持人叙事' },
+        createdAt: '2026-07-28T10:03:00Z',
+      },
+    ])
+    renderRoomPage()
+    expect(await screen.findByText('纯文本主持人叙事')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '重新朗读' })).toBeDisabled()
   })
 
   it('falls back for legacy payloads when characterName is missing', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -479,6 +479,15 @@ describe('RoomPage conversation history', () => {
     expect(await screen.findByText('历史主持人叙事')).toBeInTheDocument()
     expect(spoken).toHaveLength(0)
 
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { messageId: 'history-narration', text: '历史主持人叙事' },
+    })
+    await waitFor(() => {
+      expect(screen.getAllByText('历史主持人叙事')).toHaveLength(1)
+      expect(spoken).toHaveLength(0)
+    })
+
     fireEvent.click(screen.getByRole('button', { name: '重新朗读' }))
     expect(spoken).toHaveLength(1)
     expect(spoken[0]?.text).toBe('历史主持人叙事')

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -756,6 +756,7 @@ export default function RoomPage() {
   const roomInfo = useRoomPlayers(roomCode)
   const hostSpeech = useHostSpeech()
   const enqueueHostSpeech = hostSpeech.enqueue
+  const markHostSpeechSeen = hostSpeech.markSeen
   const isHost = roomInfo?.players.find((p) => p.playerId === playerId)?.isHost ?? false
   const [roomPhase, setRoomPhase] = useState<string | null>(null)
   const [confirmEnd, setConfirmEnd] = useState(false)
@@ -810,6 +811,11 @@ export default function RoomPage() {
       const restored = history
         .map((event) => conversationEventToMessage(event, playerId, senderName))
         .filter((item): item is Message => item !== null)
+      markHostSpeechSeen(
+        restored.flatMap((item) =>
+          item.type === 'narr' && item.messageId ? [item.messageId] : [],
+        ),
+      )
       setMessages((current) => mergeHistoricalMessages(current, restored))
       if (
         restored.some(
@@ -822,7 +828,7 @@ export default function RoomPage() {
       }
     }).catch(() => {})
     return () => { cancelled = true }
-  }, [roomId, reconnectToken, playerId, senderName])
+  }, [markHostSpeechSeen, roomId, reconnectToken, playerId, senderName])
 
   useEffect(() => {
     // ★ block: 'nearest' 很关键——默认的 scrollIntoView 会尝试把目标"居中"，

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { RoomSocketServerError, TurnFailedError, type AgentPlayerView, type AgentTurnPhase, type CheckRequestPayload, type RoomConversationEvent } from 'trpg-sdk'
-import { ArrowLeft, Users, Map, BookOpen, ScrollText, Star, X, SendHorizontal, Dice6, Plus, Save, FlagOff, Heart } from 'lucide-react'
+import { ArrowLeft, Users, Map, BookOpen, ScrollText, Star, X, SendHorizontal, Dice6, Plus, Save, FlagOff, Heart, Volume2, Pause, Play, Square, RotateCcw } from 'lucide-react'
 import { useState, useRef, useEffect, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 import { useRoomStore } from '@/stores/room-store'
 import { useAuthStore } from '@/stores/auth-store'
@@ -9,6 +9,7 @@ import { connectWebSocket, waitForWsOpen, sdk, onWsMessage, disconnectWebSocket,
 import { endGame } from '@/services/room'
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 import { useRuleset } from '@/hooks/useRuleset'
+import { useHostSpeech } from '@/hooks/useHostSpeech'
 
 // `crypto.randomUUID()` 要求安全上下文（HTTPS 或 localhost）——CI Preview
 // 部署在纯 HTTP 的 IP:端口上（issue #200，域名/HTTPS 明确列在本期不做），
@@ -753,6 +754,8 @@ export default function RoomPage() {
   const senderName = character?.info.name || nickname || '你'
   const { ruleset } = useRuleset()
   const roomInfo = useRoomPlayers(roomCode)
+  const hostSpeech = useHostSpeech()
+  const enqueueHostSpeech = hostSpeech.enqueue
   const isHost = roomInfo?.players.find((p) => p.playerId === playerId)?.isHost ?? false
   const [roomPhase, setRoomPhase] = useState<string | null>(null)
   const [confirmEnd, setConfirmEnd] = useState(false)
@@ -858,16 +861,17 @@ export default function RoomPage() {
       if (envelope.type === 'narration.push') {
         setTyping(false)
         setProgressLabel(null)
+        const authoritativeId = envelope.payload.messageId?.trim()
+        const messageId = authoritativeId
+          ? conversationMessageId('narration.push', authoritativeId)
+          : pendingNarrationActionIdRef.current
+            ? conversationMessageId(
+                'narration.push',
+                pendingNarrationActionIdRef.current,
+              )
+            : undefined
+        enqueueHostSpeech(messageId, envelope.payload.text)
         setMessages(prev => {
-          const authoritativeId = envelope.payload.messageId?.trim()
-          const messageId = authoritativeId
-            ? conversationMessageId('narration.push', authoritativeId)
-            : pendingNarrationActionIdRef.current
-              ? conversationMessageId(
-                  'narration.push',
-                  pendingNarrationActionIdRef.current,
-                )
-              : undefined
           if (messageId && prev.some((item) => item.messageId === messageId)) {
             pendingNarrationActionIdRef.current = null
             return prev
@@ -998,7 +1002,7 @@ export default function RoomPage() {
       setProgressLabel('守秘人正在生成开场叙事')
     }
     return off
-  }, [playerId, senderName])
+  }, [enqueueHostSpeech, playerId, senderName])
 
   const submitPlayerAction = (action: { clientActionId: string; utterance: string }) => {
     if (!playerId || suspended) return
@@ -1083,6 +1087,7 @@ export default function RoomPage() {
     setEndError('')
     try {
       await endGame(roomId)
+      hostSpeech.stop()
       disconnectWebSocket()
       navigate('/home')
     } catch (err) {
@@ -1094,6 +1099,7 @@ export default function RoomPage() {
   // 退出（不是结束游戏）——只是自己离开，房间对其他人继续存在、phase 不变，
   // 之后可以从「我的游戏」用同一个身份重新进来（见 MyRoomsPage 的继续逻辑）。
   const handleExit = () => {
+    hostSpeech.stop()
     disconnectWebSocket()
     navigate('/home')
   }
@@ -1115,7 +1121,17 @@ export default function RoomPage() {
           </div>
         </div>
         <button
+          onClick={() => setOpenPanel(openPanel === 'speech' ? null : 'speech')}
+          aria-label="主持人语音"
+          title="主持人语音"
+          className={`w-8 h-8 rounded-full bg-card border border-border-light flex items-center justify-center active:bg-panel ${hostSpeech.status === 'speaking' ? 'text-brass-dark' : 'text-text-muted'}`}
+        >
+          <Volume2 className="w-4 h-4" strokeWidth={2.5} />
+        </button>
+        <button
           onClick={() => setOpenPanel(openPanel === 'members' ? null : 'members')}
+          aria-label="房间成员"
+          title="房间成员"
           className="w-8 h-8 rounded-full bg-card border border-border-light flex items-center justify-center active:bg-panel"
         >
           <Users className="w-4 h-4 text-text-muted" strokeWidth={2.5} />
@@ -1197,6 +1213,19 @@ export default function RoomPage() {
                   {msg.content}
                 </div>
                 <div className="text-[10px] text-text-dim mt-0.5">{msg.time}</div>
+                {isNarr && (
+                  <button
+                    type="button"
+                    aria-label="重新朗读"
+                    title="重新朗读"
+                    disabled={!hostSpeech.supported}
+                    onClick={() => hostSpeech.replay(msg.content)}
+                    className="mt-1 inline-flex items-center gap-1 text-[10px] text-text-muted disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    <RotateCcw className="w-3 h-3" strokeWidth={2} />
+                    重播
+                  </button>
+                )}
               </div>
             </div>
           )
@@ -1544,6 +1573,96 @@ export default function RoomPage() {
           className="w-full min-h-[180px] text-sm leading-[1.7] text-text-body bg-input border border-border-light rounded-md px-3.5 py-3 resize-none outline-none focus:border-brass transition-colors font-mono placeholder:text-text-dim"
         />
         <div className="text-[10px] text-text-dim mt-2 text-right">{lastSaved ? `最后保存: ${lastSaved}` : '尚未保存'}</div>
+      </BottomPanel>
+
+      {/* Panel: 主持人语音 */}
+      <BottomPanel open={openPanel === 'speech'} onClose={() => setOpenPanel(null)} title="主持人语音">
+        {!hostSpeech.supported ? (
+          <p className="text-sm text-text-dim py-6 text-center">
+            当前浏览器不支持语音朗读，文本消息仍可正常使用
+          </p>
+        ) : (
+          <div className="space-y-4">
+            <label className="flex items-center justify-between gap-3">
+              <span>
+                <span className="block text-sm font-semibold text-text-primary">主持人语音朗读</span>
+                <span className="block text-[11px] text-text-muted mt-0.5">新产生的最终主持人消息自动播放</span>
+              </span>
+              <input
+                type="checkbox"
+                role="switch"
+                aria-label="主持人语音朗读"
+                checked={hostSpeech.enabled}
+                onChange={(event) => hostSpeech.setEnabled(event.target.checked)}
+                className="h-5 w-9 accent-brass"
+              />
+            </label>
+
+            <label className="block">
+              <span className="block text-xs font-semibold text-text-muted mb-1.5">音色</span>
+              <select
+                aria-label="主持人音色"
+                value={hostSpeech.selectedVoiceURI ?? ''}
+                onChange={(event) => hostSpeech.setSelectedVoiceURI(event.target.value)}
+                disabled={hostSpeech.voices.length === 0}
+                className="w-full bg-input border border-border-light rounded-md px-3 py-2 text-sm text-text-primary disabled:opacity-50"
+              >
+                {hostSpeech.voices.length === 0 ? (
+                  <option value="">正在加载音色…</option>
+                ) : (
+                  hostSpeech.voices.map((voice) => (
+                    <option key={voice.voiceURI} value={voice.voiceURI}>
+                      {voice.name} · {voice.lang}
+                    </option>
+                  ))
+                )}
+              </select>
+            </label>
+
+            <div className="flex items-center justify-between text-[11px] text-text-muted">
+              <span>
+                {hostSpeech.status === 'speaking' ? '正在朗读' : hostSpeech.status === 'paused' ? '已暂停' : '空闲'}
+              </span>
+              <span>待播放 {hostSpeech.queueLength} 条</span>
+            </div>
+
+            <div className="flex gap-2">
+              <button
+                type="button"
+                aria-label="暂停朗读"
+                title="暂停朗读"
+                onClick={hostSpeech.pause}
+                disabled={hostSpeech.status !== 'speaking'}
+                className="flex-1 py-2 rounded-sm bg-panel border border-border-light text-text-muted text-xs font-medium flex items-center justify-center gap-1 disabled:opacity-40"
+              >
+                <Pause className="w-3.5 h-3.5" />
+                暂停
+              </button>
+              <button
+                type="button"
+                aria-label="继续朗读"
+                title="继续朗读"
+                onClick={hostSpeech.resume}
+                disabled={hostSpeech.status !== 'paused'}
+                className="flex-1 py-2 rounded-sm bg-panel border border-border-light text-text-muted text-xs font-medium flex items-center justify-center gap-1 disabled:opacity-40"
+              >
+                <Play className="w-3.5 h-3.5" />
+                继续
+              </button>
+              <button
+                type="button"
+                aria-label="停止朗读"
+                title="停止朗读"
+                onClick={hostSpeech.stop}
+                disabled={hostSpeech.status === 'idle' && hostSpeech.queueLength === 0}
+                className="flex-1 py-2 rounded-sm bg-panel border border-border-light text-text-muted text-xs font-medium flex items-center justify-center gap-1 disabled:opacity-40"
+              >
+                <Square className="w-3.5 h-3.5" />
+                停止
+              </button>
+            </div>
+          </div>
+        )}
       </BottomPanel>
 
       {/* Panel: 房间成员 */}


### PR DESCRIPTION
## 关联 Issue

Closes #210

## 主要改动

- 新增 useHostSpeech Hook，封装浏览器 Web Speech API。
- 支持主持人语音朗读开关、自动朗读队列、消息 ID 去重、暂停、继续、停止和手动重播。
- 实时 narration.push 只在最终文本确认后进入自动朗读队列。
- 历史主持人消息不会自动播放，但可以手动重新朗读。
- 支持浏览器音色选择：默认优先选择 zh-CN 或 zh-Hans，用户可以选择浏览器提供的其他音色，音色和开关状态保存在当前浏览器。
- 浏览器不支持 Web Speech API 或朗读失败时，继续使用纯文本，不影响游戏流程。
- 离开房间、结束游戏或组件卸载时停止朗读并清理队列。
- 新增 Hook 单元测试和 RoomPage 集成测试。

## 采用该方案的原因

语音朗读完全使用浏览器原生能力，保持前端闭环，不需要新增后端服务、WebSocket 字段、数据库迁移或第三方语音供应商配置。

自动朗读只依赖已有的 narration.push 最终消息和稳定 messageId，可以复用当前房间消息去重逻辑，并避免流式文本或重连场景重复播放。

音色设置采用浏览器本地持久化，不引入房间共享设置，避免扩大协议和权限范围。首次默认关闭，避免用户进入房间时产生非预期声音。

## 当前局限与后续方向

当前实现依赖浏览器原生 Web Speech API，存在以下限制：

- 可用音色数量取决于操作系统和浏览器，部分环境可选音色较少。
- 默认音色整体偏机械，情绪、语气和角色区分能力有限。
- 不同浏览器和系统的音色质量、中文发音和可用性存在差异。
- 当前只支持固定语速、音调和音量，不支持更细致的情绪化语音控制。
- 浏览器音色加载和播放行为可能受系统环境影响，难以保证所有设备表现一致。

后续可以抽象统一的 TTS Provider 接口，按需接入第三方语音服务，例如豆包、七牛 Linx 等，以获得更多音色、更自然的发音和更丰富的情绪表达。后续评估需要重点关注服务成本、网络延迟、API 密钥管理、用户隐私、文本传输范围和浏览器端降级策略。

第三方 TTS 接入不包含在本 PR 中。

## 测试与验证

- [x] npm test -- --run：5 个测试文件通过，36 个测试通过
- [x] npm run build
- [x] npm run lint
- [x] git diff --check
- [ ] 真实 Chrome/Safari 浏览器音色和播放联调

## 兼容性、迁移与风险

- 仅修改前端，不涉及后端、SDK、WebSocket 协议或数据库。
- 不支持 Web Speech API 的浏览器继续显示文本消息。
- 语音播放异常会被单条消息隔离，不会影响游戏状态、规则结算或历史记录。
- 用户设置保存在 localStorage，清除浏览器站点数据后会恢复为默认关闭。
- 回滚方式：回滚本次 Commit 即可移除语音功能，不需要数据迁移或兼容处理。

## UI 证据

当前已通过 RoomPage 集成测试验证交互逻辑，尚未采集真实浏览器截图或录屏；后续补充语音面板和消息重播按钮的截图。

## 自检

- [x] 改动范围符合 Issue #210
- [x] 不包含无关代码改动
- [x] 已包含必要测试
- [x] 未包含密钥、个人信息或非预期生成物
- [ ] 已完成维护者人工 Review