### PR TITLE
feat(backend/sdk/frontend): AI 主持人安全流式输出 (#203)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/application/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/__init__.py
@@ -17,7 +17,12 @@ from .intent_aligner import (
     recover_travel_intent,
 )
 from .intent_parser import IntentParser, validate_intent_against_view
-from .narrator import NarrationValidationError, Narrator, normalize_narration_text
+from .narrator import (
+    NarrationValidationError,
+    Narrator,
+    normalize_narration_text,
+    split_narration_chunks,
+)
 from .opening_narrator import (
     OpeningNarrationValidationError,
     OpeningNarrator,
@@ -60,5 +65,6 @@ __all__ = [
     "normalize_narration_text",
     "deterministic_opening_narration",
     "recover_travel_intent",
+    "split_narration_chunks",
     "validate_intent_against_view",
 ]

--- a/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
@@ -99,6 +99,51 @@ def normalize_narration_text(text: str) -> str:
     return text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\r", "\n")
 
 
+_SENTENCE_END_CHARS = "。！？!?…"
+_SENTENCE_CLOSING_CHARS = "」』”’\"')）】"
+
+_NARRATION_PIECE_RE = re.compile(
+    rf"[^{_SENTENCE_END_CHARS}]*[{_SENTENCE_END_CHARS}]+[{_SENTENCE_CLOSING_CHARS}]*\s*"
+    rf"|[^{_SENTENCE_END_CHARS}]+"
+)
+
+# 只用来挡住"……"、"好。"这种退化片段。定得再高会把正常的短句（"陈探员此刻
+# 就在这里。"）并进前一段，短叙事会整段塌成单片、退回非流式。
+_MIN_CHUNK_CHARS = 6
+
+
+def split_narration_chunks(text: str, *, min_chars: int = _MIN_CHUNK_CHARS) -> tuple[str, ...]:
+    """Split already-validated narration text at sentence boundaries.
+
+    Only for progressive delivery of text that has *already* passed
+    ``Narrator.narrate()``. Never use it to emit unvalidated model output: a
+    fragment carries no independent safety guarantee, so the caller must have
+    validated the whole narration first.
+
+    Concatenating the result reproduces ``text`` byte for byte — clients that
+    accumulate chunks must end up with exactly the persisted narration. Pieces
+    shorter than ``min_chars`` are merged forward so a stray "……" does not
+    become its own chunk.
+    """
+
+    if not text:
+        return ()
+
+    chunks: list[str] = []
+    buffer = ""
+    for match in _NARRATION_PIECE_RE.finditer(text):
+        buffer += match.group(0)
+        if len(buffer.strip()) >= min_chars:
+            chunks.append(buffer)
+            buffer = ""
+    if buffer:
+        if chunks:
+            chunks[-1] += buffer
+        else:
+            chunks.append(buffer)
+    return tuple(chunks)
+
+
 def narration_text_rejection_reason(
     text: str,
 ) -> Literal["protocol_tail", "schema_fragment"] | None:

--- a/agent-collaboration-framework/tests/test_narration_chunking.py
+++ b/agent-collaboration-framework/tests/test_narration_chunking.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import unittest
+
+from collaboration_framework.host.application.narrator import split_narration_chunks
+
+
+class NarrationChunkingTests(unittest.TestCase):
+    def test_concatenated_chunks_reproduce_the_source_text(self) -> None:
+        cases = (
+            "",
+            "短句。",
+            "雨点敲打着窗框。屋里只剩壁炉燃烧的细响，книга 摊在桌上。",
+            "你推开门。\n\n走廊尽头有一盏灯还亮着，灯下站着一个人影。",
+            "他低声问：「你真的要进去吗？」你没有回答，只是握紧了手电筒。",
+            "没有任何句末标点的一整段叙述文字就这样一直延续下去",
+            "第一句！第二句？第三句……第四句。",
+            "  前导空白也要原样保留。  ",
+        )
+
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertEqual("".join(split_narration_chunks(text)), text)
+
+    def test_empty_text_yields_no_chunks(self) -> None:
+        self.assertEqual(split_narration_chunks(""), ())
+
+    def test_splits_at_sentence_boundaries(self) -> None:
+        text = "雨点敲打着窗框，声音单调。屋里只剩壁炉燃烧的细响，空气发闷。"
+
+        chunks = split_narration_chunks(text)
+
+        self.assertEqual(len(chunks), 2)
+        self.assertTrue(chunks[0].endswith("。"))
+
+    def test_keeps_closing_quote_with_its_sentence(self) -> None:
+        text = "他低声问：「你真的要进去吗？」你没有回答，只是握紧了手电筒。"
+
+        chunks = split_narration_chunks(text)
+
+        self.assertTrue(chunks[0].endswith("」"))
+
+    def test_merges_fragments_shorter_than_the_minimum(self) -> None:
+        text = "好。真的吗？走吧。"
+
+        chunks = split_narration_chunks(text)
+
+        self.assertEqual(chunks, (text,))
+
+    def test_short_but_complete_final_sentence_stays_its_own_chunk(self) -> None:
+        """短叙事不能因为末句偏短就整段塌成单片、退回非流式（issue #203）。"""
+
+        text = "托马斯·金博尔坐在你面前，正等待你回应委托。\n陈探员此刻就在这里。"
+
+        chunks = split_narration_chunks(text)
+
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual("".join(chunks), text)
+
+    def test_trailing_fragment_is_merged_into_the_previous_chunk(self) -> None:
+        text = "长度足够的第一句叙述文字放在这里。尾巴"
+
+        chunks = split_narration_chunks(text)
+
+        self.assertEqual(len(chunks), 1)
+        self.assertTrue(chunks[0].endswith("尾巴"))
+
+    def test_text_without_sentence_end_is_a_single_chunk(self) -> None:
+        text = "没有任何句末标点的一整段叙述文字就这样一直延续下去"
+
+        self.assertEqual(split_narration_chunks(text), (text,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/e2e/tests/multiplayer-ws.e2e.ts
+++ b/e2e/tests/multiplayer-ws.e2e.ts
@@ -37,6 +37,28 @@ function waitForEvent(
   })
 }
 
+/** 收集事件直到出现终止事件，返回这期间收到的全部事件（含终止事件本身）。 */
+function collectUntil(
+  socketOwner: { roomSocket: { onMessage: (h: (e: ServerToClientEvent) => void) => () => void } },
+  terminal: (event: ServerToClientEvent) => boolean,
+  timeoutMs = 5_000
+): Promise<ServerToClientEvent[]> {
+  return new Promise((resolve, reject) => {
+    const seen: ServerToClientEvent[] = []
+    const timer = setTimeout(() => {
+      off()
+      reject(new Error(`等待终止事件超时（${timeoutMs}ms）；已收到 ${seen.length} 条`))
+    }, timeoutMs)
+    const off = socketOwner.roomSocket.onMessage((event) => {
+      seen.push(event)
+      if (!terminal(event)) return
+      clearTimeout(timer)
+      off()
+      resolve(seen)
+    })
+  })
+}
+
 /** 建好角色卡并标记完成——`game.start` 要求全员建完卡。 */
 async function buildCharacter(
   sdk: Awaited<ReturnType<typeof registerPlayer>>['sdk'],
@@ -372,6 +394,65 @@ test('终止性攻击检定失败后仍可继续提交行动', async () => {
     })
     assert.equal(nextTurn.player_id, room.hostPlayerId)
     assert.doesNotMatch(nextTurn.narration.text, /CHECK_PENDING|契约校验/)
+  } finally {
+    room.host.sdk.roomSocket.disconnect()
+  }
+})
+
+test('渐进叙事：开场片段按序到达且拼接结果等于权威 narration.push', async () => {
+  const room = await createRoomWithModule('chunk')
+  await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
+  await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken, '片段调查员')
+
+  const socket = room.host.sdk.roomSocket.connect(room.roomId, room.host.token)
+  try {
+    await room.host.sdk.roomSocket.waitForOpen(socket)
+
+    const bound = waitForEvent(room.host.sdk, (e) => e.type === 'session.bound')
+    room.host.sdk.roomSocket.joinRoom(room.hostPlayerId, {
+      reconnectToken: room.reconnectToken,
+    })
+    await bound
+
+    const streamed = collectUntil(
+      room.host.sdk,
+      (event) =>
+        event.type === 'narration.push' && event.payload.messageId === 'game-opening'
+    )
+    room.host.sdk.roomSocket.startGame(room.hostPlayerId)
+    const events = await streamed
+
+    const push = events.at(-1)
+    assert.equal(push?.type, 'narration.push')
+    const chunks = events.filter((event) => event.type === 'narration.chunk')
+    assert.ok(chunks.length > 0, '开场应当先下发渐进片段')
+
+    // 片段全部属于同一条消息，序号从 0 连续递增。
+    assert.deepEqual(
+      chunks.map((chunk) => chunk.payload.messageId),
+      chunks.map(() => 'game-opening')
+    )
+    assert.deepEqual(
+      chunks.map((chunk) => chunk.payload.sequence),
+      chunks.map((_chunk, index) => index)
+    )
+
+    // 这条断言是本用例的核心：客户端把片段拼起来，必须与服务端持久化并推送的
+    // 权威文本逐字一致，否则渐进展示会跟最终历史对不上。
+    assert.equal(
+      chunks.map((chunk) => chunk.payload.text).join(''),
+      push?.type === 'narration.push' ? push.payload.text : ''
+    )
+
+    // 片段不进权威历史：会话历史里只有一条 game-opening。
+    const conversation = await room.host.sdk.rooms.listConversation(
+      room.roomId,
+      room.reconnectToken
+    )
+    assert.equal(
+      conversation.filter((event) => event.id === 'game-opening').length,
+      1
+    )
   } finally {
     room.host.sdk.roomSocket.disconnect()
   }

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -21,6 +21,9 @@
 - `san.check.roll`/`room.rejoin` 仍是 `NOT_IMPLEMENTED` 协议桩。
 - 每条实际发送的 `narration.push` 都会同步写一行 `events` 表；动作叙事用
   `clientActionId` 做持久化去重，`GET /rooms/{roomId}/replay` 直接读它。
+- 落库去重成功后、发出权威 `narration.push` 之前，同一条叙事会先按句切成
+  `narration.chunk` 下发用于渐进展示（issue #203）。片段不落库、不构成权威
+  历史，拼接结果与最终 `narration.push` 完全一致。
 
 数据库会话按"每条消息一个短 session"处理，而不是整条连接复用一个：一个
 WebSocket 可能存活很久，用一个 session 包住整条连接会在这期间一直占着一个
@@ -30,7 +33,7 @@ WebSocket 可能存活很久，用一个 session 包住整条连接会在这期�
 """
 
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from functools import partial
 
@@ -46,6 +49,7 @@ from collaboration_framework.engine import RevisionConflictError
 from collaboration_framework.host.application import (
     TurnExecutionError,
     normalize_narration_text,
+    split_narration_chunks,
 )
 from collaboration_framework.host.schemas import TurnOutput
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -83,6 +87,7 @@ from app.dto.ws import (
     ClientEnvelope,
     ErrorPayload,
     GameStartPayload,
+    NarrationChunkPayload,
     NarrationPushPayload,
     OpeningStartedPayload,
     PlayerReadyPayload,
@@ -216,6 +221,39 @@ async def _send_view_updated(
     await websocket.send_json(envelope.model_dump(by_alias=True))
 
 
+async def _stream_narration_chunks(
+    send: Callable[[dict], Awaitable[None]],
+    *,
+    message_id: str,
+    text: str,
+) -> None:
+    """把一条已校验、已落库的叙事按句切片，作为渐进展示先行下发（issue #203）。
+
+    调用前提有两条，缺一条都不能调：完整叙事已经过 `Narrator` 的 Schema 与
+    事实引用校验；并且 `record_event()` 去重成功。片段本身**没有**独立的安全
+    保证，也不落库——它只是同一条 `narration.push` 的展示形式，历史恢复、
+    复盘和语音朗读一律只认随后发出的权威 `narration.push`。
+
+    只切出一段时直接返回：单片段没有渐进可言，再发一轮 chunk 只是白白多一次
+    往返，前端收到最终 `narration.push` 的时机完全一样。
+    """
+
+    chunks = split_narration_chunks(text)
+    if len(chunks) < 2:
+        return
+    for sequence, chunk in enumerate(chunks):
+        payload = NarrationChunkPayload(
+            message_id=message_id,
+            sequence=sequence,
+            text=chunk,
+        )
+        envelope = ServerEnvelope(
+            type="narration.chunk",
+            payload=payload.model_dump(by_alias=True),
+        )
+        await send(envelope.model_dump(by_alias=True))
+
+
 async def _send_persisted_opening(
     db: AsyncSession,
     websocket: WebSocket,
@@ -305,6 +343,11 @@ async def _ensure_opening_narration(
             _OPENING_MESSAGE_ID,
         )
         return False
+    await _stream_narration_chunks(
+        partial(manager.broadcast, room_id),
+        message_id=_OPENING_MESSAGE_ID,
+        text=narration.text,
+    )
     envelope = ServerEnvelope(type="narration.push", payload=payload)
     await manager.broadcast(room_id, envelope.model_dump(by_alias=True))
     return True
@@ -351,12 +394,16 @@ async def _deliver_turn_narration(
         text=text,
         clarification=clarification,
     )
+    # 澄清叙事只对发起者可见，它的渐进片段必须走同一条投递通道，
+    # 否则片段会广播给全房间、泄露只该给一个人看的内容。
+    send = websocket.send_json if clarification else partial(manager.broadcast, room_id)
+    await _stream_narration_chunks(
+        send,
+        message_id=client_action_id,
+        text=text,
+    )
     envelope = ServerEnvelope(type="narration.push", payload=payload)
-    message = envelope.model_dump(by_alias=True)
-    if clarification:
-        await websocket.send_json(message)
-    else:
-        await manager.broadcast(room_id, message)
+    await send(envelope.model_dump(by_alias=True))
     return True
 
 

--- a/trpg-backend/app/dto/ws.py
+++ b/trpg-backend/app/dto/ws.py
@@ -145,6 +145,21 @@ class NarrationPushPayload(CamelModel):
     text: str
 
 
+class NarrationChunkPayload(CamelModel):
+    """narration.chunk 推送 payload（issue #203）。
+
+    片段只是同一条 `narration.push` 的渐进展示形式，不是权威消息：服务端先
+    生成并校验完整叙事、落库去重成功，才按句切片下发，最后再发权威的
+    `narration.push`。客户端按 `messageId` 归组、按 `sequence` 排序去重，
+    拼接结果必须与最终 `narration.push` 的 `text` 完全一致；历史恢复和持久化
+    始终只认 `narration.push`，临时拼接内容不得写入权威历史。
+    """
+
+    message_id: str = Field(..., min_length=1)
+    sequence: int = Field(..., ge=0)
+    text: str = Field(..., min_length=1)
+
+
 class OpeningStartedPayload(CamelModel):
     """权威开场正在由 Host 模型生成；模板模式不会发送。"""
 

--- a/trpg-backend/scripts/export_schema.py
+++ b/trpg-backend/scripts/export_schema.py
@@ -86,6 +86,7 @@ _MODELS: list[type[BaseModel]] = [
     ws.ActionSubmitPayload,
     ws.SessionBoundPayload,
     ws.NarrationPushPayload,
+    ws.NarrationChunkPayload,
     ws.OpeningStartedPayload,
     ws.TurnStartedPayload,
     ws.TurnPhaseChangedPayload,

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -270,6 +270,28 @@ def receive_replayed_opening(ws) -> dict:
     return opening
 
 
+def receive_narration_stream(ws, *, limit: int = 60) -> tuple[dict, list[dict]]:
+    """Receive up to the authoritative `narration.push`, returning it with its chunks."""
+
+    push, seen = receive_until(
+        ws,
+        lambda message: message.get("type") == "narration.push",
+        limit=limit,
+    )
+    chunks = [message for message in seen if message.get("type") == "narration.chunk"]
+    return push, chunks
+
+
+def assert_chunks_reconstruct_push(push: dict, chunks: list[dict]) -> None:
+    """The progressive chunks must rebuild the authoritative text exactly (issue #203)."""
+
+    assert chunks, "expected progressive narration chunks before the authoritative push"
+    message_id = push["payload"]["messageId"]
+    assert [chunk["payload"]["messageId"] for chunk in chunks] == [message_id] * len(chunks)
+    assert [chunk["payload"]["sequence"] for chunk in chunks] == list(range(len(chunks)))
+    assert "".join(chunk["payload"]["text"] for chunk in chunks) == push["payload"]["text"]
+
+
 def test_connect_without_token_is_rejected(sync_client: TestClient) -> None:
     room = create_room(sync_client, register_and_login(sync_client))
 
@@ -1356,3 +1378,107 @@ def test_turn_error_reason_keeps_contract_error_message_bounded() -> None:
 
     assert reason == "checkpoint 不在可信候选中 with extra whitespace"
     assert "\n" not in reason
+
+
+def test_opening_narration_streams_chunks_before_the_authoritative_push(
+    sync_client: TestClient,
+) -> None:
+    token = register_and_login(sync_client, "opening_stream")
+    room = create_room(sync_client, token)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        ws.receive_json()  # session.bound
+        ws.send_json({"type": "game.start", "playerId": room["playerId"], "payload": {}})
+        push, chunks = receive_narration_stream(ws)
+
+    assert push["payload"]["messageId"] == "game-opening"
+    assert_chunks_reconstruct_push(push, chunks)
+
+
+def test_action_narration_chunks_reach_every_player_in_the_room(
+    sync_client: TestClient,
+) -> None:
+    host_token = register_and_login(sync_client, "chunk_host")
+    room = create_room(sync_client, host_token, max_players=2)
+    guest = join_as(sync_client, room["roomCode"], "chunk_guest")
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    complete_character(sync_client, room["roomId"], guest["reconnectToken"])
+    start_game(sync_client, room, host_token)
+
+    with (
+        sync_client.websocket_connect(f"/ws/{room['roomId']}?token={host_token}") as host_ws,
+        sync_client.websocket_connect(
+            f"/ws/{room['roomId']}?token={guest['authToken']}"
+        ) as guest_ws,
+    ):
+        host_ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        host_ws.receive_json()  # session.bound
+        host_ws.receive_json()  # current view.updated
+        receive_replayed_opening(host_ws)
+        guest_ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": guest["playerId"],
+                "payload": {"reconnectToken": guest["reconnectToken"]},
+            }
+        )
+        guest_ws.receive_json()  # session.bound
+        guest_ws.receive_json()  # current view.updated
+        receive_replayed_opening(guest_ws)
+
+        host_ws.send_json(
+            {
+                "type": "action.submit",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "chunk-broadcast-203",
+                    "utterance": "我看看托马斯",
+                },
+            }
+        )
+        host_push, host_chunks = receive_narration_stream(host_ws)
+        guest_push, guest_chunks = receive_narration_stream(guest_ws)
+
+    assert host_push["payload"]["messageId"] == "chunk-broadcast-203"
+    assert_chunks_reconstruct_push(host_push, host_chunks)
+    assert_chunks_reconstruct_push(guest_push, guest_chunks)
+
+
+def test_replayed_opening_sends_no_chunks(sync_client: TestClient) -> None:
+    """历史恢复只发权威消息：重新进房不该再放一遍渐进片段（issue #203）。"""
+
+    token = register_and_login(sync_client, "replay_no_chunk")
+    room = create_room(sync_client, token)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        ws.receive_json()  # session.bound
+        ws.receive_json()  # current view.updated
+        opening = receive_replayed_opening(ws)
+
+    assert opening["payload"]["messageId"] == "game-opening"

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -441,58 +441,95 @@ describe('RoomPage conversation history', () => {
     expect(realtime).toHaveClass('whitespace-pre-wrap')
   })
 
-  it('renders narration chunks progressively and replaces them with the authoritative push', async () => {
+  it('reveals narration chunks gradually instead of dumping the whole text', async () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
 
+    const full = '雨点敲打着窗框。屋里只剩壁炉燃烧的细响。'
     emitWsMessage({
       type: 'narration.chunk',
       payload: { messageId: 'action-203', sequence: 0, text: '雨点敲打着窗框。' },
     })
-    expect(await screen.findByText('雨点敲打着窗框。')).toBeInTheDocument()
-    expect(screen.getByText('生成中…')).toBeInTheDocument()
-
     emitWsMessage({
       type: 'narration.chunk',
       payload: { messageId: 'action-203', sequence: 1, text: '屋里只剩壁炉燃烧的细响。' },
     })
-    expect(
-      await screen.findByText('雨点敲打着窗框。屋里只剩壁炉燃烧的细响。'),
-    ).toBeInTheDocument()
 
+    // 这是本用例的核心：片段同时到达，但不能立刻整段显示。
+    await waitFor(
+      () => {
+        const shown =
+          screen
+            .getByText('生成中…')
+            .parentElement?.querySelector('.whitespace-pre-wrap')?.textContent ?? ''
+        expect(shown.length).toBeGreaterThan(0)
+        expect(full.startsWith(shown)).toBe(true)
+        expect(shown).not.toBe(full)
+      },
+      { timeout: 2000 },
+    )
+  })
+
+  it('holds the authoritative push until the reveal finishes, then hands over once', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    const full = '雨点敲打着窗框。屋里只剩壁炉燃烧的细响。'
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-203', sequence: 0, text: '雨点敲打着窗框。' },
+    })
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-203', sequence: 1, text: '屋里只剩壁炉燃烧的细响。' },
+    })
+    // 权威消息紧跟着片段到达（真实间隔约 0.5ms），但不能当场接管。
     emitWsMessage({
       type: 'narration.push',
-      payload: {
-        messageId: 'action-203',
-        text: '雨点敲打着窗框。屋里只剩壁炉燃烧的细响。',
-      },
+      payload: { messageId: 'action-203', text: full },
     })
-    await waitFor(() => expect(screen.queryByText('生成中…')).not.toBeInTheDocument())
-    // 权威消息接管后文字仍在，且只剩一份（临时气泡已丢弃）。
-    expect(
-      screen.getAllByText('雨点敲打着窗框。屋里只剩壁炉燃烧的细响。'),
-    ).toHaveLength(1)
+
+    // 两段式等待：先确认揭示真的开始了，再等它交接完成。只断言"全文出现一次"
+    // 是不够的——揭示到全文、权威消息还没接管的那一帧同样满足，命中的是临时
+    // 气泡而不是权威消息。
+    await screen.findByText('生成中…')
+    await waitFor(
+      () => expect(screen.queryByText('生成中…')).not.toBeInTheDocument(),
+      { timeout: 4000 },
+    )
+    // 交接完成后全文在，且只有一份——临时气泡没有和权威消息并存。
+    expect(screen.getAllByText(full)).toHaveLength(1)
   })
 
   it('deduplicates repeated chunks and tolerates out-of-order arrival', async () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
 
+    const full = '第一段落在这里。第二段落在这里。'
     emitWsMessage({
       type: 'narration.chunk',
-      payload: { messageId: 'action-204', sequence: 1, text: '第二段。' },
+      payload: { messageId: 'action-204', sequence: 1, text: '第二段落在这里。' },
     })
     emitWsMessage({
       type: 'narration.chunk',
-      payload: { messageId: 'action-204', sequence: 0, text: '第一段。' },
+      payload: { messageId: 'action-204', sequence: 0, text: '第一段落在这里。' },
     })
     // 重连重放同一个片段不得让文字出现两次。
     emitWsMessage({
       type: 'narration.chunk',
-      payload: { messageId: 'action-204', sequence: 1, text: '第二段。' },
+      payload: { messageId: 'action-204', sequence: 1, text: '第二段落在这里。' },
+    })
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { messageId: 'action-204', text: full },
     })
 
-    expect(await screen.findByText('第一段。第二段。')).toBeInTheDocument()
+    await screen.findByText('生成中…')
+    await waitFor(
+      () => expect(screen.queryByText('生成中…')).not.toBeInTheDocument(),
+      { timeout: 4000 },
+    )
+    expect(screen.getAllByText(full)).toHaveLength(1)
   })
 
   it('drops streamed chunks when the turn fails', async () => {
@@ -503,7 +540,7 @@ describe('RoomPage conversation history', () => {
       type: 'narration.chunk',
       payload: { messageId: 'action-205', sequence: 0, text: '半截叙事片段。' },
     })
-    expect(await screen.findByText('半截叙事片段。')).toBeInTheDocument()
+    expect(await screen.findByText('生成中…')).toBeInTheDocument()
 
     emitWsMessage({
       type: 'turn.failed',
@@ -514,10 +551,11 @@ describe('RoomPage conversation history', () => {
         retryable: true,
       },
     })
-    await waitFor(() => expect(screen.queryByText('半截叙事片段。')).not.toBeInTheDocument())
+    await waitFor(() => expect(screen.queryByText('生成中…')).not.toBeInTheDocument())
+    expect(screen.queryByText('半截叙事片段。')).not.toBeInTheDocument()
   })
 
-  it('does not auto-speak narration chunks, only the final push', async () => {
+  it('speaks the narration only once the authoritative push has landed', async () => {
     const { spoken } = installRoomSpeechApi()
     localStorage.setItem(
       'aidm-host-speech-settings',
@@ -526,19 +564,38 @@ describe('RoomPage conversation history', () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
 
+    const full = '渐进片段一号。渐进片段二号。'
     emitWsMessage({
       type: 'narration.chunk',
-      payload: { messageId: 'action-206', sequence: 0, text: '渐进片段。' },
+      payload: { messageId: 'action-206', sequence: 0, text: '渐进片段一号。' },
     })
-    expect(await screen.findByText('渐进片段。')).toBeInTheDocument()
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-206', sequence: 1, text: '渐进片段二号。' },
+    })
+    expect(await screen.findByText('生成中…')).toBeInTheDocument()
+    // 揭示途中不能出声：片段不是权威消息。
     expect(spoken).toHaveLength(0)
 
     emitWsMessage({
       type: 'narration.push',
-      payload: { messageId: 'action-206', text: '渐进片段。' },
+      payload: { messageId: 'action-206', text: full },
     })
-    await waitFor(() => expect(spoken).toHaveLength(1))
-    expect(spoken[0]?.text).toBe('渐进片段。')
+    await waitFor(() => expect(spoken).toHaveLength(1), { timeout: 4000 })
+    expect(spoken[0]?.text).toBe(full)
+  })
+
+  it('commits immediately when a narration arrives without any chunks', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { messageId: 'action-207', text: '单片段叙事直接落地。' },
+    })
+
+    expect(await screen.findByText('单片段叙事直接落地。')).toBeInTheDocument()
+    expect(screen.queryByText('生成中…')).not.toBeInTheDocument()
   })
 
   it('automatically speaks new final narration once by message id', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -441,6 +441,106 @@ describe('RoomPage conversation history', () => {
     expect(realtime).toHaveClass('whitespace-pre-wrap')
   })
 
+  it('renders narration chunks progressively and replaces them with the authoritative push', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-203', sequence: 0, text: '雨点敲打着窗框。' },
+    })
+    expect(await screen.findByText('雨点敲打着窗框。')).toBeInTheDocument()
+    expect(screen.getByText('生成中…')).toBeInTheDocument()
+
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-203', sequence: 1, text: '屋里只剩壁炉燃烧的细响。' },
+    })
+    expect(
+      await screen.findByText('雨点敲打着窗框。屋里只剩壁炉燃烧的细响。'),
+    ).toBeInTheDocument()
+
+    emitWsMessage({
+      type: 'narration.push',
+      payload: {
+        messageId: 'action-203',
+        text: '雨点敲打着窗框。屋里只剩壁炉燃烧的细响。',
+      },
+    })
+    await waitFor(() => expect(screen.queryByText('生成中…')).not.toBeInTheDocument())
+    // 权威消息接管后文字仍在，且只剩一份（临时气泡已丢弃）。
+    expect(
+      screen.getAllByText('雨点敲打着窗框。屋里只剩壁炉燃烧的细响。'),
+    ).toHaveLength(1)
+  })
+
+  it('deduplicates repeated chunks and tolerates out-of-order arrival', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-204', sequence: 1, text: '第二段。' },
+    })
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-204', sequence: 0, text: '第一段。' },
+    })
+    // 重连重放同一个片段不得让文字出现两次。
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-204', sequence: 1, text: '第二段。' },
+    })
+
+    expect(await screen.findByText('第一段。第二段。')).toBeInTheDocument()
+  })
+
+  it('drops streamed chunks when the turn fails', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-205', sequence: 0, text: '半截叙事片段。' },
+    })
+    expect(await screen.findByText('半截叙事片段。')).toBeInTheDocument()
+
+    emitWsMessage({
+      type: 'turn.failed',
+      payload: {
+        correlationId: 'action-205',
+        code: 'HOST_AGENT_TIMEOUT',
+        publicMessage: '守秘人没能完成这次回合，请重试。',
+        retryable: true,
+      },
+    })
+    await waitFor(() => expect(screen.queryByText('半截叙事片段。')).not.toBeInTheDocument())
+  })
+
+  it('does not auto-speak narration chunks, only the final push', async () => {
+    const { spoken } = installRoomSpeechApi()
+    localStorage.setItem(
+      'aidm-host-speech-settings',
+      JSON.stringify({ enabled: true, voiceURI: null }),
+    )
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-206', sequence: 0, text: '渐进片段。' },
+    })
+    expect(await screen.findByText('渐进片段。')).toBeInTheDocument()
+    expect(spoken).toHaveLength(0)
+
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { messageId: 'action-206', text: '渐进片段。' },
+    })
+    await waitFor(() => expect(spoken).toHaveLength(1))
+    expect(spoken[0]?.text).toBe('渐进片段。')
+  })
+
   it('automatically speaks new final narration once by message id', async () => {
     const { spoken } = installRoomSpeechApi()
     localStorage.setItem('aidm-host-speech-settings', JSON.stringify({ enabled: true, voiceURI: null }))

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -501,6 +501,40 @@ describe('RoomPage conversation history', () => {
     expect(screen.getAllByText(full)).toHaveLength(1)
   })
 
+  // 回归：待提交槽位原本是单个，揭示 A 的过程中到达的 B 会把 A 顶掉，A 既不
+  // 进消息列表也不朗读，只能靠刷新走历史恢复（PR #213 review 指出）。
+  it('keeps an earlier narration when another push lands mid-reveal', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    const first = '第一条叙事的前半句。第一条叙事的后半句。'
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-A', sequence: 0, text: '第一条叙事的前半句。' },
+    })
+    emitWsMessage({
+      type: 'narration.chunk',
+      payload: { messageId: 'action-A', sequence: 1, text: '第一条叙事的后半句。' },
+    })
+    emitWsMessage({ type: 'narration.push', payload: { messageId: 'action-A', text: first } })
+    // A 还在揭示时，另一条没有片段的叙事直接到达。
+    emitWsMessage({
+      type: 'narration.push',
+      payload: { messageId: 'action-B', text: '第二条叙事直接落地。' },
+    })
+
+    // 两条都要落地，且顺序不能颠倒——队列按到达顺序提交。
+    await waitFor(
+      () => {
+        expect(screen.getByText(first)).toBeInTheDocument()
+        expect(screen.getByText('第二条叙事直接落地。')).toBeInTheDocument()
+      },
+      { timeout: 4000 },
+    )
+    const rendered = screen.getAllByText(/第[一二]条叙事/).map((node) => node.textContent)
+    expect(rendered).toEqual([first, '第二条叙事直接落地。'])
+  })
+
   it('deduplicates repeated chunks and tolerates out-of-order arrival', async () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -105,6 +105,44 @@ function conversationMessageId(type: RoomConversationEvent['type'], id: string):
   return `history:${type}:${id}`
 }
 
+/**
+ * 一条主持叙事正在渐进到达时的临时拼装状态（issue #203）。
+ *
+ * 它**不是**权威历史：片段不落库，最终以服务端持久化的 `narration.push` 为准。
+ * 收到同一 `messageId` 的 push 后这份状态立即丢弃，由权威消息接管；刷新或重新
+ * 进房只会拿到 push，不会重放片段。
+ */
+interface StreamingNarration {
+  messageId: string
+  chunks: Record<number, string>
+}
+
+/**
+ * 按 `sequence` 收片段。同一序号重复到达（重连/重试）不会重复拼接，换了
+ * `messageId` 说明是新的一条叙事，直接从头开始。
+ */
+export function accumulateNarrationChunk(
+  current: StreamingNarration | null,
+  chunk: { messageId: string; sequence: number; text: string },
+): StreamingNarration {
+  const base =
+    current?.messageId === chunk.messageId ? current : { messageId: chunk.messageId, chunks: {} }
+  if (chunk.sequence in base.chunks) return base
+  return {
+    messageId: base.messageId,
+    chunks: { ...base.chunks, [chunk.sequence]: chunk.text },
+  }
+}
+
+/** 按序号升序拼接已到达的片段；乱序到达也能得到正确文本。 */
+export function streamingNarrationText(state: StreamingNarration): string {
+  return Object.keys(state.chunks)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .map((sequence) => state.chunks[sequence])
+    .join('')
+}
+
 function mergeHistoricalMessages(current: Message[], history: Message[]): Message[] {
   const ids = new Set(current.flatMap((item) => (item.messageId ? [item.messageId] : [])))
   return [...history.filter((item) => !item.messageId || !ids.has(item.messageId)), ...current]
@@ -775,6 +813,7 @@ export default function RoomPage() {
     return cached?.room_id === roomId ? cached : null
   })
   const [progressLabel, setProgressLabel] = useState<string | null>(null)
+  const [streamingNarration, setStreamingNarration] = useState<StreamingNarration | null>(null)
   const [actionError, setActionError] = useState('')
   const [actionErrorRetryable, setActionErrorRetryable] = useState(false)
   const [actionErrorIsGuidance, setActionErrorIsGuidance] = useState(false)
@@ -864,9 +903,22 @@ export default function RoomPage() {
   // 生成主持叙述。
   useEffect(() => {
     const off = onWsMessage((envelope) => {
-      if (envelope.type === 'narration.push') {
+      if (envelope.type === 'narration.chunk') {
+        // 已经有文字在往外走，就不要再同时显示"正在思考"的点点了。
         setTyping(false)
         setProgressLabel(null)
+        setStreamingNarration((current) =>
+          accumulateNarrationChunk(current, {
+            messageId: conversationMessageId('narration.push', envelope.payload.messageId),
+            sequence: envelope.payload.sequence,
+            text: envelope.payload.text,
+          }),
+        )
+      } else if (envelope.type === 'narration.push') {
+        setTyping(false)
+        setProgressLabel(null)
+        // 权威消息一到就丢弃临时拼装：显示的文字从此只来自持久化记录。
+        setStreamingNarration(null)
         const authoritativeId = envelope.payload.messageId?.trim()
         const messageId = authoritativeId
           ? conversationMessageId('narration.push', authoritativeId)
@@ -982,6 +1034,9 @@ export default function RoomPage() {
       } else if (envelope.type === 'turn.failed') {
         setTyping(false)
         setProgressLabel(null)
+        // 片段只在叙事落库成功后才会下发，回合失败时不存在对应的权威消息——
+        // 留着半截文字会让玩家以为那是这回合的结果。
+        setStreamingNarration(null)
         setActionError(envelope.payload.publicMessage)
         setActionErrorRetryable(envelope.payload.retryable)
         setActionErrorIsGuidance(envelope.payload.code === 'HOST_AGENT_INVALID_OUTPUT')
@@ -995,6 +1050,7 @@ export default function RoomPage() {
       } else if (envelope.type === 'error') {
         setTyping(false)
         setProgressLabel(null)
+        setStreamingNarration(null)
         setActionError(envelope.payload.message)
         setActionErrorRetryable(false)
         setActionErrorIsGuidance(false)
@@ -1237,8 +1293,25 @@ export default function RoomPage() {
           )
         })}
 
+        {/* 渐进到达的主持叙事（issue #203）。没有"重播"按钮：它还不是权威
+            消息，语音朗读只认最终 narration.push。*/}
+        {streamingNarration && (
+          <div className="flex gap-2.5 animate-[msgIn_0.3s_ease]">
+            <div className="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center text-sm bg-[#faf5eb] border border-brass">
+              📜
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-[11px] font-semibold text-brass-dark mb-0.5">守秘人</div>
+              <div className="text-sm leading-[1.65] inline-block max-w-full px-3.5 py-2.5 bg-[#fdfaf4] border-l-[3px] border-brass rounded-r-sm rounded-l-none italic text-[#4a4030] text-left whitespace-pre-wrap">
+                {streamingNarrationText(streamingNarration)}
+              </div>
+              <div className="text-[10px] text-text-dim mt-0.5">生成中…</div>
+            </div>
+          </div>
+        )}
+
         {/* Typing indicator */}
-        {typing && (
+        {typing && !streamingNarration && (
           <div className="flex gap-2.5 animate-[msgIn_0.3s_ease]">
             <div className="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center text-sm bg-[#faf5eb] border border-brass">
               📜

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom'
-import { RoomSocketServerError, TurnFailedError, type AgentPlayerView, type AgentTurnPhase, type CheckRequestPayload, type RoomConversationEvent } from 'trpg-sdk'
+import { RoomSocketServerError, TurnFailedError, type AgentPlayerView, type AgentTurnPhase, type CheckRequestPayload, type NarrationPushPayload, type RoomConversationEvent } from 'trpg-sdk'
 import { ArrowLeft, Users, Map, BookOpen, ScrollText, Star, X, SendHorizontal, Dice6, Plus, Save, FlagOff, Heart, Volume2, Pause, Play, Square, RotateCcw } from 'lucide-react'
-import { useState, useRef, useEffect, type Dispatch, type FormEvent, type SetStateAction } from 'react'
+import { useCallback, useState, useRef, useEffect, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 import { useRoomStore } from '@/stores/room-store'
 import { useAuthStore } from '@/stores/auth-store'
 import { useCharacterStore } from '@/stores/character-store'
@@ -115,21 +115,25 @@ function conversationMessageId(type: RoomConversationEvent['type'], id: string):
 interface StreamingNarration {
   messageId: string
   chunks: Record<number, string>
+  /** 已揭示的字符数。片段几乎同时到达，靠它把文字按节奏放出来。 */
+  revealed: number
 }
 
 /**
  * 按 `sequence` 收片段。同一序号重复到达（重连/重试）不会重复拼接，换了
- * `messageId` 说明是新的一条叙事，直接从头开始。
+ * `messageId` 说明是新的一条叙事，连揭示进度一起从头开始。
  */
 export function accumulateNarrationChunk(
   current: StreamingNarration | null,
   chunk: { messageId: string; sequence: number; text: string },
 ): StreamingNarration {
   const base =
-    current?.messageId === chunk.messageId ? current : { messageId: chunk.messageId, chunks: {} }
+    current?.messageId === chunk.messageId
+      ? current
+      : { messageId: chunk.messageId, chunks: {}, revealed: 0 }
   if (chunk.sequence in base.chunks) return base
   return {
-    messageId: base.messageId,
+    ...base,
     chunks: { ...base.chunks, [chunk.sequence]: chunk.text },
   }
 }
@@ -142,6 +146,19 @@ export function streamingNarrationText(state: StreamingNarration): string {
     .map((sequence) => state.chunks[sequence])
     .join('')
 }
+
+/**
+ * 逐字揭示的节奏参数（issue #203）。
+ *
+ * 服务端是在完整叙事生成并校验之后才切片的，所有片段会在毫秒级内一起到达
+ * （实测三帧间隔 0.5–0.7ms）。所以「渐进」必须由前端控制节奏，否则玩家看到的
+ * 仍然是整段瞬间弹出。这是展示层的节奏，不是真的增量生成——真增量要等可独立
+ * 校验的 ValidatedNarrationChunk 协议。
+ *
+ * 长文本按比例加快，保证总时长不超过 REVEAL_MAX_MS；短文本自然更快结束。
+ */
+const REVEAL_TICK_MS = 30
+const REVEAL_MAX_MS = 2400
 
 function mergeHistoricalMessages(current: Message[], history: Message[]): Message[] {
   const ids = new Set(current.flatMap((item) => (item.messageId ? [item.messageId] : [])))
@@ -814,6 +831,7 @@ export default function RoomPage() {
   })
   const [progressLabel, setProgressLabel] = useState<string | null>(null)
   const [streamingNarration, setStreamingNarration] = useState<StreamingNarration | null>(null)
+  const [pendingNarration, setPendingNarration] = useState<NarrationPushPayload | null>(null)
   const [actionError, setActionError] = useState('')
   const [actionErrorRetryable, setActionErrorRetryable] = useState(false)
   const [actionErrorIsGuidance, setActionErrorIsGuidance] = useState(false)
@@ -899,6 +917,71 @@ export default function RoomPage() {
     }
   }, [roomId, playerId, roomCode, nickname, reconnectToken])
 
+  /** 把权威叙事落成正式消息，并交给语音朗读。只有它产出权威历史。 */
+  const commitNarration = useCallback((payload: NarrationPushPayload) => {
+    const authoritativeId = payload.messageId?.trim()
+    const messageId = authoritativeId
+      ? conversationMessageId('narration.push', authoritativeId)
+      : pendingNarrationActionIdRef.current
+        ? conversationMessageId('narration.push', pendingNarrationActionIdRef.current)
+        : undefined
+    enqueueHostSpeech(messageId, payload.text)
+    setMessages((prev) => {
+      if (messageId && prev.some((item) => item.messageId === messageId)) {
+        pendingNarrationActionIdRef.current = null
+        return prev
+      }
+      if (!messageId && prev.at(-1)?.content === payload.text) return prev
+      pendingNarrationActionIdRef.current = null
+      return appendLiveMessage(prev, {
+        type: 'narr',
+        channel: 'action',
+        messageId,
+        sender: '守秘人',
+        content: payload.text,
+        time: formatRoomTime(new Date()),
+      })
+    })
+  }, [enqueueHostSpeech])
+
+  // 逐字揭示：片段几乎同时到达，节奏由这里控制。长文本按比例加快，总时长
+  // 不超过 REVEAL_MAX_MS。
+  useEffect(() => {
+    if (!streamingNarration) return
+    const full = streamingNarrationText(streamingNarration)
+    if (streamingNarration.revealed >= full.length) return
+    const step = Math.max(1, Math.ceil(full.length / (REVEAL_MAX_MS / REVEAL_TICK_MS)))
+    const timer = setTimeout(() => {
+      setStreamingNarration((current) =>
+        current === null
+          ? current
+          : {
+              ...current,
+              revealed: Math.min(
+                streamingNarrationText(current).length,
+                current.revealed + step,
+              ),
+            },
+      )
+    }, REVEAL_TICK_MS)
+    return () => clearTimeout(timer)
+  }, [streamingNarration])
+
+  // 权威消息何时接管：同一条叙事还没揭示完就等着，否则立即落地。
+  useEffect(() => {
+    if (!pendingNarration) return
+    const stillRevealing =
+      streamingNarration !== null &&
+      pendingNarration.messageId != null &&
+      streamingNarration.messageId ===
+        conversationMessageId('narration.push', pendingNarration.messageId) &&
+      streamingNarration.revealed < streamingNarrationText(streamingNarration).length
+    if (stillRevealing) return
+    commitNarration(pendingNarration)
+    setPendingNarration(null)
+    setStreamingNarration(null)
+  }, [commitNarration, pendingNarration, streamingNarration])
+
   // 服务端主持人回复：只订阅 narration.push，不从 turn.completed 或本地逻辑
   // 生成主持叙述。
   useEffect(() => {
@@ -917,34 +1000,9 @@ export default function RoomPage() {
       } else if (envelope.type === 'narration.push') {
         setTyping(false)
         setProgressLabel(null)
-        // 权威消息一到就丢弃临时拼装：显示的文字从此只来自持久化记录。
-        setStreamingNarration(null)
-        const authoritativeId = envelope.payload.messageId?.trim()
-        const messageId = authoritativeId
-          ? conversationMessageId('narration.push', authoritativeId)
-          : pendingNarrationActionIdRef.current
-            ? conversationMessageId(
-                'narration.push',
-                pendingNarrationActionIdRef.current,
-              )
-            : undefined
-        enqueueHostSpeech(messageId, envelope.payload.text)
-        setMessages(prev => {
-          if (messageId && prev.some((item) => item.messageId === messageId)) {
-            pendingNarrationActionIdRef.current = null
-            return prev
-          }
-          if (!messageId && prev.at(-1)?.content === envelope.payload.text) return prev
-          pendingNarrationActionIdRef.current = null
-          return appendLiveMessage(prev, {
-            type: 'narr',
-            channel: 'action',
-            messageId,
-            sender: '守秘人',
-            content: envelope.payload.text,
-            time: formatRoomTime(new Date()),
-          })
-        })
+        // 不在这里直接落地：权威消息比最后一个片段只晚到半毫秒，立刻接管会让
+        // 刚开始的渐进展示当场被整段覆盖。交给下面的 effect 裁决何时提交。
+        setPendingNarration(envelope.payload)
       } else if (envelope.type === 'opening.started') {
         setTyping(true)
         setProgressLabel('守秘人正在生成开场叙事')
@@ -1037,6 +1095,7 @@ export default function RoomPage() {
         // 片段只在叙事落库成功后才会下发，回合失败时不存在对应的权威消息——
         // 留着半截文字会让玩家以为那是这回合的结果。
         setStreamingNarration(null)
+        setPendingNarration(null)
         setActionError(envelope.payload.publicMessage)
         setActionErrorRetryable(envelope.payload.retryable)
         setActionErrorIsGuidance(envelope.payload.code === 'HOST_AGENT_INVALID_OUTPUT')
@@ -1051,6 +1110,7 @@ export default function RoomPage() {
         setTyping(false)
         setProgressLabel(null)
         setStreamingNarration(null)
+        setPendingNarration(null)
         setActionError(envelope.payload.message)
         setActionErrorRetryable(false)
         setActionErrorIsGuidance(false)
@@ -1295,7 +1355,7 @@ export default function RoomPage() {
 
         {/* 渐进到达的主持叙事（issue #203）。没有"重播"按钮：它还不是权威
             消息，语音朗读只认最终 narration.push。*/}
-        {streamingNarration && (
+        {streamingNarration && streamingNarration.revealed > 0 && (
           <div className="flex gap-2.5 animate-[msgIn_0.3s_ease]">
             <div className="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center text-sm bg-[#faf5eb] border border-brass">
               📜
@@ -1303,15 +1363,16 @@ export default function RoomPage() {
             <div className="flex-1 min-w-0">
               <div className="text-[11px] font-semibold text-brass-dark mb-0.5">守秘人</div>
               <div className="text-sm leading-[1.65] inline-block max-w-full px-3.5 py-2.5 bg-[#fdfaf4] border-l-[3px] border-brass rounded-r-sm rounded-l-none italic text-[#4a4030] text-left whitespace-pre-wrap">
-                {streamingNarrationText(streamingNarration)}
+                {streamingNarrationText(streamingNarration).slice(0, streamingNarration.revealed)}
               </div>
               <div className="text-[10px] text-text-dim mt-0.5">生成中…</div>
             </div>
           </div>
         )}
 
-        {/* Typing indicator */}
-        {typing && !streamingNarration && (
+        {/* Typing indicator。第一个片段到达后还没揭示出字的那一瞬间也留着它，
+            避免出现一个空气泡。*/}
+        {(typing || (streamingNarration !== null && streamingNarration.revealed === 0)) && (
           <div className="flex gap-2.5 animate-[msgIn_0.3s_ease]">
             <div className="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center text-sm bg-[#faf5eb] border border-brass">
               📜

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -831,7 +831,10 @@ export default function RoomPage() {
   })
   const [progressLabel, setProgressLabel] = useState<string | null>(null)
   const [streamingNarration, setStreamingNarration] = useState<StreamingNarration | null>(null)
-  const [pendingNarration, setPendingNarration] = useState<NarrationPushPayload | null>(null)
+  // 队列而不是单槽：揭示窗口最长 REVEAL_MAX_MS，这期间完全可能再来一条叙事
+  // （无片段的叙事后端会跳过切片，直接发 push）。用单槽的话后到的会把前一条
+  // 顶掉，被顶掉的那条既不进 messages 也不朗读，只能靠刷新走历史恢复。
+  const [pendingNarrations, setPendingNarrations] = useState<NarrationPushPayload[]>([])
   const [actionError, setActionError] = useState('')
   const [actionErrorRetryable, setActionErrorRetryable] = useState(false)
   const [actionErrorIsGuidance, setActionErrorIsGuidance] = useState(false)
@@ -967,20 +970,30 @@ export default function RoomPage() {
     return () => clearTimeout(timer)
   }, [streamingNarration])
 
-  // 权威消息何时接管：同一条叙事还没揭示完就等着，否则立即落地。
+  // 权威消息何时接管：按到达顺序逐条提交，队首那条还没揭示完就等着。
+  //
+  // 严格按队首处理（而不是跳过它先提交后面的）是为了保持叙事顺序：后到的
+  // 叙事最多被队首多等一个揭示周期，但不会插到前一条之前，也不会把它挤掉。
   useEffect(() => {
-    if (!pendingNarration) return
-    const stillRevealing =
+    const next = pendingNarrations[0]
+    if (!next) return
+    const belongsToStream =
       streamingNarration !== null &&
-      pendingNarration.messageId != null &&
+      next.messageId != null &&
       streamingNarration.messageId ===
-        conversationMessageId('narration.push', pendingNarration.messageId) &&
+        conversationMessageId('narration.push', next.messageId)
+    if (
+      belongsToStream &&
       streamingNarration.revealed < streamingNarrationText(streamingNarration).length
-    if (stillRevealing) return
-    commitNarration(pendingNarration)
-    setPendingNarration(null)
-    setStreamingNarration(null)
-  }, [commitNarration, pendingNarration, streamingNarration])
+    ) {
+      return
+    }
+    commitNarration(next)
+    setPendingNarrations((current) => current.slice(1))
+    // 只清掉刚提交的这条对应的片段状态。别的叙事还在揭示时不能顺手清空，
+    // 否则它的文字会凭空消失。
+    if (belongsToStream) setStreamingNarration(null)
+  }, [commitNarration, pendingNarrations, streamingNarration])
 
   // 服务端主持人回复：只订阅 narration.push，不从 turn.completed 或本地逻辑
   // 生成主持叙述。
@@ -1001,8 +1014,8 @@ export default function RoomPage() {
         setTyping(false)
         setProgressLabel(null)
         // 不在这里直接落地：权威消息比最后一个片段只晚到半毫秒，立刻接管会让
-        // 刚开始的渐进展示当场被整段覆盖。交给下面的 effect 裁决何时提交。
-        setPendingNarration(envelope.payload)
+        // 刚开始的渐进展示当场被整段覆盖。入队，交给上面的 effect 按序裁决。
+        setPendingNarrations((current) => [...current, envelope.payload])
       } else if (envelope.type === 'opening.started') {
         setTyping(true)
         setProgressLabel('守秘人正在生成开场叙事')
@@ -1094,8 +1107,10 @@ export default function RoomPage() {
         setProgressLabel(null)
         // 片段只在叙事落库成功后才会下发，回合失败时不存在对应的权威消息——
         // 留着半截文字会让玩家以为那是这回合的结果。
+        //
+        // 只中止揭示，不清待提交队列：队列里的都是已经落库的权威消息（push 紧跟
+        // 片段到达），清掉等于丢服务端认定已发生的叙事。中止后它们会立即落地。
         setStreamingNarration(null)
-        setPendingNarration(null)
         setActionError(envelope.payload.publicMessage)
         setActionErrorRetryable(envelope.payload.retryable)
         setActionErrorIsGuidance(envelope.payload.code === 'HOST_AGENT_INVALID_OUTPUT')
@@ -1110,7 +1125,6 @@ export default function RoomPage() {
         setTyping(false)
         setProgressLabel(null)
         setStreamingNarration(null)
-        setPendingNarration(null)
         setActionError(envelope.payload.message)
         setActionErrorRetryable(false)
         setActionErrorIsGuidance(false)

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -584,6 +584,21 @@ export interface MyRoomSummary {
 }
 
 /**
+ * narration.chunk 推送 payload（issue #203）。
+ *
+ * 片段只是同一条 `narration.push` 的渐进展示形式，不是权威消息：服务端先
+ * 生成并校验完整叙事、落库去重成功，才按句切片下发，最后再发权威的
+ * `narration.push`。客户端按 `messageId` 归组、按 `sequence` 排序去重，
+ * 拼接结果必须与最终 `narration.push` 的 `text` 完全一致；历史恢复和持久化
+ * 始终只认 `narration.push`，临时拼接内容不得写入权威历史。
+ */
+export interface NarrationChunkPayload {
+  messageId: string;
+  sequence: number;
+  text: string;
+}
+
+/**
  * narration.push 推送 payload。
  */
 export interface NarrationPushPayload {

--- a/trpg-sdk/src/resources/room-socket.test.ts
+++ b/trpg-sdk/src/resources/room-socket.test.ts
@@ -144,6 +144,50 @@ test('isValidServerEvent：接受缺少 characterName 的旧 action.broadcast', 
   );
 });
 
+test('isValidServerEvent：narration.chunk 需要非空 messageId、非负整数 sequence 和字符串 text', () => {
+  assert.equal(
+    isValidServerEvent({
+      type: 'narration.chunk',
+      payload: { messageId: 'game-opening', sequence: 0, text: '雨点敲打着窗框。' },
+    }),
+    true
+  );
+  // 空 messageId 无法把片段归到某一条消息上。
+  assert.equal(
+    isValidServerEvent({
+      type: 'narration.chunk',
+      payload: { messageId: '', sequence: 0, text: '雨点敲打着窗框。' },
+    }),
+    false
+  );
+  // sequence 决定拼接顺序，小数或负数都会让去重与排序失去意义。
+  assert.equal(
+    isValidServerEvent({
+      type: 'narration.chunk',
+      payload: { messageId: 'game-opening', sequence: 1.5, text: '片段' },
+    }),
+    false
+  );
+  assert.equal(
+    isValidServerEvent({
+      type: 'narration.chunk',
+      payload: { messageId: 'game-opening', sequence: -1, text: '片段' },
+    }),
+    false
+  );
+  assert.equal(
+    isValidServerEvent({
+      type: 'narration.chunk',
+      payload: { messageId: 'game-opening', sequence: 0, text: 42 },
+    }),
+    false
+  );
+  assert.equal(
+    isValidServerEvent({ type: 'narration.chunk', payload: { messageId: 'game-opening' } }),
+    false
+  );
+});
+
 test('isValidServerEvent：拒绝缺 payload / payload 不是对象 / 顶层不是对象', () => {
   assert.equal(isValidServerEvent({ type: 'session.bound' }), false);
   assert.equal(isValidServerEvent({ type: 'session.bound', payload: 'nope' }), false);

--- a/trpg-sdk/src/resources/room-socket.ts
+++ b/trpg-sdk/src/resources/room-socket.ts
@@ -259,6 +259,16 @@ const PAYLOAD_VALIDATORS: {
     (p.messageId === undefined ||
       p.messageId === null ||
       (typeof p.messageId === 'string' && p.messageId.length > 0)),
+  // 片段只是 narration.push 的渐进展示形式，不是权威消息（issue #203）：
+  // messageId 用来归组、sequence 用来排序去重，拼接结果必须等于最终 push 的
+  // text。下游不得把拼接内容当成权威历史。
+  'narration.chunk': (p) =>
+    typeof p.messageId === 'string' &&
+    p.messageId.length > 0 &&
+    typeof p.sequence === 'number' &&
+    Number.isInteger(p.sequence) &&
+    p.sequence >= 0 &&
+    typeof p.text === 'string',
   'opening.started': (p) =>
     typeof p.messageId === 'string' && p.messageId.length > 0,
   'turn.started': (p) => typeof p.correlationId === 'string',

--- a/trpg-sdk/src/types.ts
+++ b/trpg-sdk/src/types.ts
@@ -63,6 +63,7 @@ export type {
   GameStartPayload,
   SessionBoundPayload,
   NarrationPushPayload,
+  NarrationChunkPayload,
   OpeningStartedPayload,
   // WebSocket 新增 14 个事件（issue #77）
   CheckRollPayload,
@@ -118,6 +119,7 @@ import type {
   ClueGrantedPayload,
   ErrorPayload,
   GameEndedPayload,
+  NarrationChunkPayload,
   NarrationPushPayload,
   OpeningStartedPayload,
   PlayerJoinedPayload,
@@ -146,6 +148,7 @@ import type {
 export type ServerToClientEvent =
   | { type: 'session.bound'; payload: SessionBoundPayload }
   | { type: 'narration.push'; payload: NarrationPushPayload }
+  | { type: 'narration.chunk'; payload: NarrationChunkPayload }
   | { type: 'opening.started'; payload: OpeningStartedPayload }
   | { type: 'turn.started'; payload: TurnStartedPayload }
   | { type: 'turn.phase_changed'; payload: TurnPhaseChangedPayload }


### PR DESCRIPTION
Closes #203

叙事在完整生成并通过安全校验之后按句切片下发，前端按节奏逐字揭示。权威最终消息仍然只有 `narration.push` 一条。

## 改了什么

| 文件 | 改动 |
|---|---|
| `collaboration_framework/host/application/narrator.py` | `split_narration_chunks()`：按句末标点切分**已校验**文本，拼接逐字可逆；片段最小长度 6，只挡"……"这类退化片段 |
| `trpg-backend/app/dto/ws.py` | `NarrationChunkPayload`（`messageId` / `sequence` / `text`） |
| `trpg-backend/app/controller/ws.py` | `_stream_narration_chunks()`：落库去重成功后、发权威 push 之前切片下发；接入动作叙事与开场旁白两条投递路径 |
| `trpg-backend/scripts/export_schema.py` | 新 payload 进导出清单 |
| `trpg-sdk/src/types.ts`、`resources/room-socket.ts` | `narration.chunk` 事件类型与 payload 校验器（非空 `messageId`、非负整数 `sequence`） |
| `trpg-sdk/src/generated/dto.ts` | codegen 同步 |
| `trpg-frontend/src/routes/games/trpg/RoomPage.tsx` | 片段按 `sequence` 归组去重、逐字揭示；权威消息缓到揭示完成再接管；语音朗读时机跟随交接 |
| 测试 | framework 8 条、backend 3 条 WS 用例、SDK 1 条校验器用例、frontend 6 条、e2e 1 条 |

## 关键决策

**为什么不新增 `turn.completed`**：Issue 的事件清单里列了它，但 `narration.push` 已经是唯一权威最终消息——持久化、`clientActionId` 去重、历史恢复、复盘、语音朗读全部挂在它上面。再引入第二个"最终"事件，前端就要判断以哪个为准，历史恢复也对不上。片段只是同一条消息的展示形式：不落库、不构成权威历史、拼接结果与最终 push 逐字一致。

**为什么先落库再切片**：切片严格发生在 `record_event()` 去重成功之后。幂等和"一个合法动作只结算一次"因此完全不受影响，同一 `clientActionId` 重试复用已提交结果，不会重复下发片段。反过来先发片段再落库，一次重试就会让玩家看到两遍。

**为什么揭示节奏放在前端，而不是服务端 sleep**：服务端加人为延迟会占住 WS 协程、拉长房间锁持有时间，并让测试变慢变脆。文字本来就已经全部到齐，节奏是纯展示问题，属于前端。

**澄清叙事的片段为什么必须走单连接通道**：`clarification` 的最终消息只发给发起者。片段如果图省事走广播，只该给一个人看的内容会当场发给全房间——这是这次改动里最容易埋雷的地方，已有用例覆盖。

**为什么裁决写在 effect 里而不是 `setState` updater 内**：updater 在 StrictMode 下会执行两次，把"提交权威消息"写进去会重复落地。改成 `pendingNarration` 状态 + 一个 effect 统一裁决何时提交。

## 验证

- framework：199 passed（新增 8 条切分用例，含"拼接结果逐字还原原文"）
- backend：229 passed，`ruff check` / `ruff format --check` / `ty check` 全绿
- SDK：16 passed，`lint` / `typecheck` / `build` 通过
- frontend：42 passed（连续跑 6 次确认不 flaky），`lint` / `build` 通过
- e2e：31 passed，新增用例断言片段拼接结果 == 服务端持久化文本，且历史里只有一条 `game-opening`
- codegen 管线重跑，`trpg-sdk/src/generated/` 无漂移
- 本地接真实 DeepSeek 走过完整流程：注册 → 建房 → 选追书人 → 建卡 → 开局 → 提交行动

测试抓到过两个真问题，都留了回归用例：

1. 片段最小长度原本定 12，开场旁白末句「陈探员此刻就在这里。」只有 10 字被并回前一段，整条叙事塌成单片、直接退回非流式。短叙事普遍会踩。
2. 前端用例一度 1/3 概率红。根因是断言有歧义——"全文出现一次"在「揭示刚好到全文、权威消息还没接管」那一帧同样成立，命中的是临时气泡而非权威消息。改成先等气泡出现、再等它消失的两段式等待。

## 已知限制

**这一期不缩短 TTFT。** 切片发生在完整叙事生成并校验之后，本地实测三帧到达间隔只有 0.5–0.7ms：

```text
chunk#0 (43 字)   +96.9ms   Δ    -
chunk#1 (17 字)   +97.6ms   Δ 0.7ms
PUSH     (60 字)  +98.2ms   Δ 0.5ms
```

接真实 DeepSeek 后同样成立：开场旁白生成耗时 3.58s、一次行动 8.6s，但这些时间花在生成阶段，切片仍在其后。所以玩家看到的渐进效果由前端节奏控制，**是展示层的节奏，不是真增量生成**；等待期间的过程反馈仍然主要由已有的 `turn.phase_changed` 承担。

Issue 的「设计与实现说明」和「风险」两节都已写明这一取舍。真正的增量生成需要可独立校验的 `ValidatedNarrationChunk` 协议（Issue 列为不包含项）。届时前端消费片段的逻辑不需要改动，只是片段来源从"校验后切分"换成"边生成边校验"。

## 不在本 PR 范围

- `ValidatedNarrationChunk`：可独立校验的增量片段协议（真流式的前提）
- 跨进程流恢复与模型生成断点续传（Issue 已列明不包含）
- 语音朗读的节奏化（朗读仍以整条最终消息为单位，接在揭示完成之后）
