### PR TITLE
feat(frontend): 拆分背景故事分类填写

### DIFF
--- a/trpg-frontend/src/data/character-background.test.ts
+++ b/trpg-frontend/src/data/character-background.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  emptyCharacterBackground,
+  parseCharacterBackground,
+  serializeCharacterBackground,
+} from './character-background'
+
+describe('character background', () => {
+  it('serializes non-empty sections in fixed order with other last', () => {
+    const form = emptyCharacterBackground()
+    form.sections.personalDescription = '穿着旧风衣'
+    form.sections.significantPeople = '导师亨利'
+    form.other = '习惯随身带笔记本'
+
+    expect(serializeCharacterBackground(form)).toBe([
+      '形象描述：穿着旧风衣',
+      '重要之人：导师亨利',
+      '其他：习惯随身带笔记本',
+    ].join('\n'))
+  })
+
+  it('parses multiline Windows text and merges duplicate sections without overwriting', () => {
+    const parsed = parseCharacterBackground([
+      '重要之人：亨利是我的导师。',
+      '他在三年前失踪。',
+      '宝贵之物：一支钢笔。',
+      '重要之人：记者艾琳。',
+    ].join('\r\n'))
+
+    expect(parsed.sections.significantPeople).toBe([
+      '亨利是我的导师。',
+      '他在三年前失踪。',
+      '记者艾琳。',
+    ].join('\n'))
+    expect(parsed.sections.treasuredPossessions).toBe('一支钢笔。')
+  })
+
+  it('places legacy free text in other', () => {
+    const legacy = parseCharacterBackground('这是旧版背景。\n包含两行内容。')
+    expect(legacy.other).toBe('这是旧版背景。\n包含两行内容。')
+  })
+
+  it('round-trips categorized content', () => {
+    const form = emptyCharacterBackground()
+    form.sections.ideologyBeliefs = '真相总会留下痕迹。\n即使它并不体面。'
+    form.sections.phobiasManias = '害怕密闭空间'
+    form.other = '来自波士顿'
+
+    expect(parseCharacterBackground(serializeCharacterBackground(form))).toEqual(form)
+  })
+})

--- a/trpg-frontend/src/data/character-background.ts
+++ b/trpg-frontend/src/data/character-background.ts
@@ -1,0 +1,107 @@
+export const CHARACTER_BACKGROUND_MAX_LENGTH = 4000
+
+export const BACKGROUND_SECTION_DEFINITIONS = [
+  { key: 'personalDescription', label: '形象描述' },
+  { key: 'ideologyBeliefs', label: '思想与信念' },
+  { key: 'significantPeople', label: '重要之人' },
+  { key: 'meaningfulLocations', label: '意义非凡之地' },
+  { key: 'treasuredPossessions', label: '宝贵之物' },
+  { key: 'traits', label: '特质' },
+  { key: 'injuriesScars', label: '伤口和疤痕' },
+  { key: 'phobiasManias', label: '恐惧症和躁狂症' },
+] as const
+
+export type BackgroundSectionKey = typeof BACKGROUND_SECTION_DEFINITIONS[number]['key']
+export type BackgroundSections = Record<BackgroundSectionKey, string>
+
+export interface CharacterBackgroundForm {
+  sections: BackgroundSections
+  other: string
+}
+
+const SECTION_KEY_BY_LABEL = new Map<string, BackgroundSectionKey>(
+  BACKGROUND_SECTION_DEFINITIONS.map(section => [section.label, section.key])
+)
+
+export function emptyCharacterBackground(): CharacterBackgroundForm {
+  return {
+    sections: Object.fromEntries(
+      BACKGROUND_SECTION_DEFINITIONS.map(section => [section.key, ''])
+    ) as BackgroundSections,
+    other: '',
+  }
+}
+
+function normalizedLines(value: string): string[] {
+  return value.replace(/\r\n?/g, '\n').split('\n')
+}
+
+function cleanedBlock(lines: string[]): string {
+  let start = 0
+  let end = lines.length
+  while (start < end && lines[start].trim() === '') start += 1
+  while (end > start && lines[end - 1].trim() === '') end -= 1
+  return lines.slice(start, end).join('\n')
+}
+
+export function parseCharacterBackground(raw: string): CharacterBackgroundForm {
+  const result = emptyCharacterBackground()
+  if (!raw.trim()) return result
+
+  const sectionLines = Object.fromEntries(
+    BACKGROUND_SECTION_DEFINITIONS.map(section => [section.key, [] as string[]])
+  ) as Record<BackgroundSectionKey, string[]>
+  const otherLines: string[] = []
+  let currentTarget: BackgroundSectionKey | 'other' | null = null
+
+  const appendToCurrent = (line: string) => {
+    if (currentTarget === 'other') {
+      otherLines.push(line)
+    } else if (currentTarget) {
+      sectionLines[currentTarget].push(line)
+    } else {
+      otherLines.push(line)
+    }
+  }
+
+  for (const line of normalizedLines(raw)) {
+    const prefixed = line.match(/^([^：:\n]+)[：:](.*)$/)
+    if (!prefixed) {
+      appendToCurrent(line)
+      continue
+    }
+
+    const label = prefixed[1].trim()
+    const content = prefixed[2]
+    const sectionKey = SECTION_KEY_BY_LABEL.get(label)
+    if (sectionKey) {
+      currentTarget = sectionKey
+      sectionLines[sectionKey].push(content)
+      continue
+    }
+    if (label === '其他') {
+      currentTarget = 'other'
+      otherLines.push(content)
+      continue
+    }
+    appendToCurrent(line)
+  }
+
+  for (const section of BACKGROUND_SECTION_DEFINITIONS) {
+    result.sections[section.key] = cleanedBlock(sectionLines[section.key])
+  }
+  result.other = cleanedBlock(otherLines)
+  return result
+}
+
+export function serializeCharacterBackground(form: CharacterBackgroundForm): string {
+  const output: string[] = []
+  for (const section of BACKGROUND_SECTION_DEFINITIONS) {
+    const content = form.sections[section.key].replace(/\r\n?/g, '\n').trim()
+    if (content) output.push(`${section.label}：${content}`)
+  }
+
+  const other = form.other.replace(/\r\n?/g, '\n').trim()
+  if (other) output.push(`其他：${other}`)
+  return output.join('\n')
+}

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -111,6 +111,10 @@ vi.mock('@/services/character/character-api', () => mockCharacterApi)
 describe('CharacterPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCharacterApi.createCharacterDraft.mockResolvedValue('draft-1')
+    mockCharacterApi.saveCharacter.mockResolvedValue(undefined)
+    mockCharacterApi.completeCharacter.mockResolvedValue(undefined)
+    mockCharacterApi.fetchCharacter.mockResolvedValue({ attributes: {}, skills: {} })
     useRoomStore.getState().reset()
     useCharacterStore.getState().clear()
     useRoomStore.setState({
@@ -153,6 +157,18 @@ describe('CharacterPage', () => {
       fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
       expect(screen.getByText('属性分配')).toBeInTheDocument()
     })
+  }
+
+  async function advanceToBackgroundStep() {
+    fireEvent.change(screen.getByPlaceholderText('角色姓名'), { target: { value: '张三' } })
+    fireEvent.click(screen.getByText('会计师'))
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    await advanceToAttributesAfterOccupationPreview()
+
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    expect(await screen.findByLabelText('信用评级')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    expect(await screen.findByText('背景故事')).toBeInTheDocument()
   }
 
   it('blocks advancing until name and occupation are filled', async () => {
@@ -234,5 +250,103 @@ describe('CharacterPage', () => {
     fireEvent.click(occPlus)
     expect(screen.getByLabelText('会计 技能点')).toHaveValue(2)
     expect(occPlus).toBeDisabled()
+  })
+
+  it('renders all categorized background fields', async () => {
+    renderPage()
+    await advanceToBackgroundStep()
+
+    expect(screen.getByLabelText('形象描述')).toBeInTheDocument()
+    expect(screen.getByLabelText('恐惧症和躁狂症')).toBeInTheDocument()
+    expect(screen.getByLabelText('其他')).toBeInTheDocument()
+    expect(screen.queryByText('关键联结')).not.toBeInTheDocument()
+  })
+
+  it('submits and caches the same prefixed background string', async () => {
+    renderPage()
+    await advanceToBackgroundStep()
+
+    fireEvent.change(screen.getByLabelText('形象描述'), { target: { value: '穿着旧风衣' } })
+    fireEvent.change(screen.getByLabelText('重要之人'), { target: { value: '导师亨利' } })
+    fireEvent.change(screen.getByLabelText('其他'), { target: { value: '随身携带笔记本' } })
+    fireEvent.click(screen.getByRole('button', { name: /完成创建/ }))
+
+    const expectedBackground = [
+      '形象描述：穿着旧风衣',
+      '重要之人：导师亨利',
+      '其他：随身携带笔记本',
+    ].join('\n')
+    await waitFor(() => {
+      expect(mockCharacterApi.saveCharacter).toHaveBeenCalledWith(
+        'room-1',
+        'draft-1',
+        expect.objectContaining({ background: expectedBackground })
+      )
+    })
+    await waitFor(() => {
+      expect(useCharacterStore.getState().getForRoom('room-1')?.background).toBe(expectedBackground)
+    })
+  })
+
+  it('loads a legacy background into other and blocks an overlong submission', async () => {
+    useCharacterStore.getState().setCharacter(
+      {
+        info: {
+          name: '', playerName: '', age: '28', gender: '男',
+          residence: '阿卡姆', birthplace: '阿卡姆', occupationId: null,
+        },
+        attr: {},
+        skillAlloc: {},
+        skillFinalValues: {},
+        equipment: '',
+        background: '没有分类前缀的旧背景',
+        notes: '',
+        derived: { hp: 0, san: 0, mp: 0, db: '0', move: 0 },
+      },
+      'room-1'
+    )
+
+    renderPage()
+    await advanceToBackgroundStep()
+    expect(screen.getByLabelText('其他')).toHaveValue('没有分类前缀的旧背景')
+
+    fireEvent.change(screen.getByLabelText('其他'), { target: { value: '字'.repeat(4000) } })
+    expect(screen.getByText(/背景故事不能超过 4000 个字符/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /完成创建/ }))
+    expect(mockCharacterApi.saveCharacter).not.toHaveBeenCalled()
+  })
+
+  it('hydrates categorized background fields from the backend character', async () => {
+    useRoomStore.setState({ characterId: 'character-1' })
+    mockCharacterApi.fetchCharacter.mockResolvedValue({
+      name: '后端调查员',
+      age: 30,
+      gender: '女',
+      residence: '阿卡姆',
+      birthplace: '波士顿',
+      occupation: '会计师',
+      attributes: Object.fromEntries(mockRuleset.attributes.map(attribute => [attribute.key, 50])),
+      derivedStats: { HP: 10, SAN: 50, MP: 10, DB: '0', MOV: 8 },
+      skills: {},
+      equipment: [],
+      background: '思想与信念：真相总会留下痕迹\n其他：来自旧报社',
+      notes: '',
+    })
+
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('角色姓名')).toHaveValue('后端调查员')
+    })
+    await waitFor(() => {
+      expect(mockPreviewCharacter).toHaveBeenCalledWith(expect.objectContaining({ occupationId: 1 }))
+    })
+
+    await advanceToAttributesAfterOccupationPreview()
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    expect(await screen.findByLabelText('信用评级')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+
+    expect(await screen.findByLabelText('思想与信念')).toHaveValue('真相总会留下痕迹')
+    expect(screen.getByLabelText('其他')).toHaveValue('来自旧报社')
   })
 })

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -10,6 +10,13 @@ import { previewCharacter, translateCharacterValidationError } from '@/services/
 import { friendlyErrorMessage } from '@/services/api-client'
 import { useRuleset } from '@/hooks/useRuleset'
 import type { OccupationSpec, SkillSpec } from '@/data/types'
+import {
+  BACKGROUND_SECTION_DEFINITIONS,
+  CHARACTER_BACKGROUND_MAX_LENGTH,
+  parseCharacterBackground,
+  serializeCharacterBackground,
+} from '@/data/character-background'
+import type { BackgroundSectionKey } from '@/data/character-background'
 
 // 图标和配色是纯 UI 装饰，不是规则数据，留在前端；键用后端 ruleset 的属性键。
 // 「有哪些属性、哪些能加点、默认值多少、预算和上下限是什么」全部来自
@@ -22,6 +29,17 @@ const ATTR_ICONS: Record<string, typeof Heart> = {
 const ATTR_COLORS: Record<string, string> = {
   STR: '#c04040', CON: '#c08050', POW: '#7050a0', DEX: '#4a8a4a',
   APP: '#8a4070', SIZ: '#b8976a', INT: '#4a7098', EDU: '#6a6050',
+}
+
+const BACKGROUND_PLACEHOLDERS: Record<BackgroundSectionKey, string> = {
+  personalDescription: '外貌、衣着、举止或给人的第一印象……',
+  ideologyBeliefs: '角色坚持的原则、信仰或世界观……',
+  significantPeople: '对角色影响深远的人，以及彼此的关系……',
+  meaningfulLocations: '承载重要回忆或意义的地点……',
+  treasuredPossessions: '角色珍视的物品及其来历……',
+  traits: '性格特点、习惯或待人处事方式……',
+  injuriesScars: '身体或心理上留下的伤痕……',
+  phobiasManias: '角色恐惧、执着或难以控制的倾向……',
 }
 
 // 建卡阶段的衍生值面板用小写 key，后端 derivedStats 是 { HP, MP, SAN, DB,
@@ -266,7 +284,7 @@ export default function CharacterPage() {
           // 别把已选职业清成 null——那会连带清掉技能预算。
           ...(matched ? { occupationId: matched.id } : {}),
         }))
-        setBackground(saved.background ?? '')
+        setBackgroundForm(parseCharacterBackground(saved.background ?? ''))
         setNotes(saved.notes ?? '')
         setEquipment((saved.equipment ?? []).join('、'))
         setSkillAlloc(alloc)
@@ -310,8 +328,21 @@ export default function CharacterPage() {
 
   // Equipment & background
   const [equipment, setEquipment] = useState(existingCharacter?.equipment ?? '')
-  const [background, setBackground] = useState(existingCharacter?.background ?? '')
+  const [backgroundForm, setBackgroundForm] = useState(() =>
+    parseCharacterBackground(existingCharacter?.background ?? '')
+  )
   const [notes, setNotes] = useState(existingCharacter?.notes ?? '')
+  const serializedBackground = useMemo(
+    () => serializeCharacterBackground(backgroundForm),
+    [backgroundForm]
+  )
+
+  const updateBackgroundSection = (key: BackgroundSectionKey, value: string) => {
+    setBackgroundForm(previous => ({
+      ...previous,
+      sections: { ...previous.sections, [key]: value },
+    }))
+  }
 
   // UI state
   const [search, setSearch] = useState('')
@@ -642,6 +673,9 @@ export default function CharacterPage() {
     const issues: string[] = []
     if (!info.name.trim()) issues.push('角色姓名不能为空')
     if (info.occupationId == null) issues.push('请选择职业')
+    if (targetStep >= 4 && serializedBackground.length > CHARACTER_BACKGROUND_MAX_LENGTH) {
+      issues.push(`背景故事不能超过 ${CHARACTER_BACKGROUND_MAX_LENGTH} 个字符`)
+    }
     const needsReadyPreview = targetStep >= 1 && info.name.trim() && info.occupationId != null
     if (needsReadyPreview) {
       if (previewStatus === 'pending') {
@@ -719,7 +753,7 @@ export default function CharacterPage() {
         skillValues: skillsPayload,
         equipment,
         occupationName: selectedOcc?.name ?? null,
-        background,
+        background: serializedBackground,
         notes,
       })
       await completeCharacter(roomId, characterId)
@@ -729,7 +763,7 @@ export default function CharacterPage() {
           attr: { ...attr },
           skillAlloc: { ...skillAlloc },
           skillFinalValues,
-          equipment, background, notes,
+          equipment, background: serializedBackground, notes,
           derived: finalDerived,
         },
         roomId
@@ -1213,10 +1247,60 @@ export default function CharacterPage() {
 
               {/* Background */}
               <div className="bg-card border border-border-light rounded-md p-[18px] mb-3">
-                <h4 className="text-[12px] font-semibold text-brass-dark uppercase tracking-[0.08em] mb-3">背景故事</h4>
-                <textarea value={background} onChange={e => setBackground(e.target.value)}
-                  placeholder="简单描述你的角色背景…" rows={4}
-                  className="w-full px-3.5 py-2.5 rounded-[6px] bg-input border border-border-light text-text-primary text-[14px] outline-none focus:border-brass resize-none" />
+                <div className="flex items-start justify-between gap-3 mb-1.5">
+                  <h4 className="text-[12px] font-semibold text-brass-dark uppercase tracking-[0.08em]">背景故事</h4>
+                  <span className={`text-[11px] font-mono ${
+                    serializedBackground.length > CHARACTER_BACKGROUND_MAX_LENGTH
+                      ? 'text-[#c04040] font-semibold'
+                      : 'text-text-muted'
+                  }`}>
+                    {serializedBackground.length}/{CHARACTER_BACKGROUND_MAX_LENGTH}
+                  </span>
+                </div>
+                <p className="text-[11px] text-text-muted leading-relaxed mb-3">
+                  分项填写调查员的经历，所有内容均为选填。
+                </p>
+                <div className="space-y-2.5">
+                  {BACKGROUND_SECTION_DEFINITIONS.map(section => {
+                    const value = backgroundForm.sections[section.key]
+                    return (
+                      <div key={section.key} className="rounded-[6px] bg-input border border-border-light p-3">
+                        <label htmlFor={`background-${section.key}`} className="block text-[13px] font-semibold text-text-primary mb-2">
+                          {section.label}
+                        </label>
+                        <textarea
+                          id={`background-${section.key}`}
+                          aria-label={section.label}
+                          value={value}
+                          onChange={event => updateBackgroundSection(section.key, event.target.value)}
+                          placeholder={BACKGROUND_PLACEHOLDERS[section.key]}
+                          rows={2}
+                          className="w-full px-3 py-2 rounded-[6px] bg-card border border-border-light text-text-primary text-[14px] outline-none focus:border-brass resize-y"
+                        />
+                      </div>
+                    )
+                  })}
+
+                  <div className="rounded-[6px] bg-input border border-border-light p-3">
+                    <label htmlFor="background-other" className="block text-[13px] font-semibold text-text-primary mb-2">
+                      其他
+                    </label>
+                    <textarea
+                      id="background-other"
+                      aria-label="其他"
+                      value={backgroundForm.other}
+                      onChange={event => setBackgroundForm(previous => ({ ...previous, other: event.target.value }))}
+                      placeholder="未归类的背景补充；旧版背景故事也会显示在这里……"
+                      rows={3}
+                      className="w-full px-3 py-2 rounded-[6px] bg-card border border-border-light text-text-primary text-[14px] outline-none focus:border-brass resize-y"
+                    />
+                  </div>
+                </div>
+                {serializedBackground.length > CHARACTER_BACKGROUND_MAX_LENGTH && (
+                  <p className="mt-2 text-[11px] text-[#c04040] font-medium">
+                    背景故事不能超过 {CHARACTER_BACKGROUND_MAX_LENGTH} 个字符，请精简后再完成建卡。
+                  </p>
+                )}
               </div>
 
               {/* Notes */}

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -781,6 +781,39 @@ describe('RoomPage conversation history', () => {
     expect(await screen.findByText('杜调查员 · 掷骰')).toBeInTheDocument()
   })
 
+  it('preserves categorized background line breaks in the character sheet', async () => {
+    const background = '形象描述：穿着旧风衣\n重要之人：导师亨利'
+    useCharacterStore.getState().setCharacter(
+      {
+        info: {
+          name: '杜调查员',
+          playerName: '陈探员',
+          age: '32',
+          gender: '男',
+          residence: '阿卡姆',
+          birthplace: '波士顿',
+          occupationId: null,
+        },
+        attr: {},
+        skillAlloc: {},
+        skillFinalValues: {},
+        equipment: '',
+        background,
+        notes: '',
+        derived: { hp: 10, san: 60, mp: 10, db: '0', move: 8 },
+      },
+      'room-1',
+    )
+    mockListConversation.mockResolvedValue([])
+
+    renderRoomPage()
+    fireEvent.click(screen.getByRole('button', { name: '角色卡' }))
+    fireEvent.click(screen.getByRole('button', { name: '背景装备' }))
+
+    const renderedBackground = screen.getByText((_, element) => element?.textContent === background)
+    expect(renderedBackground).toHaveClass('whitespace-pre-wrap')
+  })
+
   it('keeps the first check result when reopening the modal before confirming', async () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1599,7 +1599,7 @@ export default function RoomPage() {
                 <h4 className="text-xs font-semibold text-brass-dark mb-2.5">装备</h4>
                 <p className="text-sm text-text-body leading-[1.7] mb-4">{character.equipment || '未填写装备'}</p>
                 <h4 className="text-xs font-semibold text-brass-dark mb-2.5">背景故事</h4>
-                <p className="text-sm text-text-body leading-[1.7] mb-4">{character.background || '未填写背景故事'}</p>
+                <p className="text-sm text-text-body leading-[1.7] mb-4 whitespace-pre-wrap">{character.background || '未填写背景故事'}</p>
                 <h4 className="text-xs font-semibold text-brass-dark mb-2.5">备注</h4>
                 <p className="text-sm text-text-body leading-[1.7]">{character.notes || '未填写备注'}</p>
               </>


### PR DESCRIPTION
## 关联 Issue

Closes #214

## 主要改动

- 将建卡页的单一背景故事输入拆分为八个 COC7 标准分类和一个“其他”输入框，所有项目保持选填。
- 新增集中的背景文本解析/序列化工具，提交前按固定中文前缀拼接为现有 `background: string`，不修改后端、数据库或 SDK 契约。
- 将没有分类前缀的旧版自由文本载入“其他”，支持分类多行内容、重复分类合并以及 4000 字符提交前校验。
- 角色准备页沿用现有换行展示，游戏内角色卡补充 `whitespace-pre-wrap`。
- 补充解析、序列化、旧数据水合、超长拦截、提交一致性和游戏内展示测试。

## 采用该方案的原因

本次目标是细化玩家填写体验，而不是重构角色卡数据模型。由前端在提交前完成前缀拼接，可以继续复用现有 `background` 字符串、权限边界和存储流程，避免数据库迁移及前后端兼容成本。

取舍：当正文某一行恰好以已知分类前缀开头时，解析器会将其视为新分类；该限制已在 #214 风险中记录。旧版自由文本不会自动猜测分类，而是无损进入“其他”。

## 测试与验证

- [x] `cd trpg-sdk && npm run build`：通过，用于刷新本地 SDK 构建产物，无 SDK 源码改动。
- [x] `cd trpg-frontend && npm test`：通过，6 个测试文件、52 个测试全部通过。
- [x] `cd trpg-frontend && npm run lint`：通过，0 warning。
- [x] `cd trpg-frontend && npm run build`：通过，TypeScript 与 Vite 生产构建成功。

## 兼容性、风险与回滚

- 兼容性：后端、数据库、DTO 和 SDK 均不变；旧版自由文本在下一次保存时转为 `其他：原内容`。
- 风险：正文行首与固定分类前缀重名时可能被拆分到对应分类；总长度继续受现有 4000 字符限制。
- 隐私：沿用现有背景故事访问边界，没有扩大其他玩家可见范围。
- 回滚：直接回退提交 `2fcedd6` 即可，不涉及数据迁移或服务端回滚。

## UI 证据

本地浏览器验证被登录态阻挡，未创建临时账号或修改浏览器身份数据，因此暂未附截图。分类字段、旧数据回填、超长拦截、提交和游戏内换行展示已由自动化 UI 测试覆盖。

Draft 转为 Ready 前应由具备测试房间的人工 Reviewer 走一遍建卡流程并补充桌面或手机截图。
<img width="350" height="520" alt="image" src="https://github.com/user-attachments/assets/c9af5885-188d-43a4-9183-e73c50f8a772" />

## AI 使用情况

AI 根据 #214 完成了以下工作：在不改变后端契约的前提下设计前缀文本解析/序列化，改造分类表单与长度校验，补充兼容和页面测试，并根据产品反馈移除了无实际规则作用的“关键联结”。

解析器及其边界行为属于 AI 辅助生成的核心逻辑，必须由至少一名人工 Reviewer 检查并批准；本 Draft PR 不应在人工 Review 和必要 CI 完成前合并。

## 自检

- [x] 改动范围符合 Issue #214
- [x] 不包含无关改动或 `tmp/` 临时内容
- [x] 已包含必要测试
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查和差异自审
- [x] 已补充 UI 截图
- [ ] 已完成至少一次人工 Review

