### PR TITLE
feat(character): 中文化衍生属性并支持职业自选技能

### DIFF
--- a/trpg-backend/alembic/versions/e4b6c8d0f2a1_add_character_occupation_choices.py
+++ b/trpg-backend/alembic/versions/e4b6c8d0f2a1_add_character_occupation_choices.py
@@ -1,0 +1,28 @@
+"""add explicit character occupation skill choices
+
+Revision ID: e4b6c8d0f2a1
+Revises: 3f8a1c2d4e5f
+Create Date: 2026-08-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e4b6c8d0f2a1"
+down_revision: str | Sequence[str] | None = "3f8a1c2d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "characters",
+        sa.Column("occupation_choice_skill_ids", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("characters", "occupation_choice_skill_ids")

--- a/trpg-backend/app/core/coc7_rules.py
+++ b/trpg-backend/app/core/coc7_rules.py
@@ -26,7 +26,7 @@ issue #112：此前本模块直接 import `app/core/coc7_content.py` 的模块�
 import re
 from dataclasses import dataclass, field
 
-from app.dto.game import OccupationSpec, RulesetRead
+from app.dto.game import OccupationSpec, RulesetRead, SkillSpec
 
 SKILL_CAP = 99
 
@@ -84,6 +84,7 @@ class ComputeResult:
     occupation_skill_points: SkillPointsBudget
     interest_skill_points: SkillPointsBudget
     skill_view: list[SkillView] = field(default_factory=list)
+    resolved_occupation_choice_skill_ids: list[str] = field(default_factory=list)
     validation: list[ValidationIssue] = field(default_factory=list)
 
 
@@ -191,11 +192,14 @@ def find_occupation_by_name(
     return match, match is None
 
 
-def _assign_choice_slots(occupation: OccupationSpec | None, candidates: dict[str, int]) -> set[str]:
-    """决定哪些「非固定本职技能」占用了职业的自选槽，返回被占用的技能 id 集合。
+def _match_choice_slots(
+    occupation: OccupationSpec | None, candidates: list[tuple[str, int]]
+) -> list[str]:
+    """把候选技能匹配到职业槽位，按展开后的槽位顺序返回技能 id。
 
-    `candidates` 是 {技能 id: 该技能分配到的点数}，只含加了点、且不在固定
-    `skill_ids` 里的技能。
+    `candidates` 是 ``[(技能 id, 权重)]``。旧角色传已加点技能并用分配点作
+    权重，得到使职业点覆盖最大的兼容结果；显式选择传相同权重，匹配只负责
+    判断整组选择是否能装入槽位。
 
     ## 为什么要"最大化"而不是随便挑一种分配
 
@@ -219,7 +223,7 @@ def _assign_choice_slots(occupation: OccupationSpec | None, candidates: dict[str
     赌错的代价是玩家的合法角色卡被拒，而且现象是莫名其妙的点数超支。
     """
     if occupation is None or not occupation.choice_slots:
-        return set()
+        return []
 
     # 把每个槽按容量摊成若干个"槽位"，匹配问题就变成简单的二分图匹配。
     # candidate_skill_ids 为 None 表示任意技能（规则书的"任意 N 项特长"）。
@@ -236,21 +240,115 @@ def _assign_choice_slots(occupation: OccupationSpec | None, candidates: dict[str
 
     def try_assign(skill_id: str, visited: set[int]) -> bool:
         """标准增广路径：找一个空槽位，或挤走某个槽位上的技能让它另寻他处。"""
+        # 先取直接可用的空槽，避免多个等价槽之间无意义地反复换位；没有空槽时
+        # 再走增广路径重排，仍然保持最大匹配能力。
+        for unit in range(len(slot_units)):
+            if unit in visited or not accepts(unit, skill_id) or unit in unit_taken_by:
+                continue
+            visited.add(unit)
+            unit_taken_by[unit] = skill_id
+            return True
         for unit in range(len(slot_units)):
             if unit in visited or not accepts(unit, skill_id):
                 continue
             visited.add(unit)
-            occupant = unit_taken_by.get(unit)
-            if occupant is None or try_assign(occupant, visited):
+            occupant = unit_taken_by[unit]
+            if try_assign(occupant, visited):
                 unit_taken_by[unit] = skill_id
                 return True
         return False
 
     # 点数降序：拟阵贪心要求先处理权重大的，这样得到的才是最大权解。
-    for skill_id, _points in sorted(candidates.items(), key=lambda kv: -kv[1]):
+    for skill_id, _points in sorted(candidates, key=lambda kv: -kv[1]):
         try_assign(skill_id, set())
 
-    return set(unit_taken_by.values())
+    return [unit_taken_by[unit] for unit in sorted(unit_taken_by)]
+
+
+def _resolve_explicit_choice_slots(
+    occupation: OccupationSpec | None,
+    choice_skill_ids: list[str],
+    skills_by_id: dict[str, SkillSpec],
+) -> tuple[set[str], list[str], list[ValidationIssue]]:
+    """校验并解析新版角色显式提交的职业自选技能。"""
+    issues: list[ValidationIssue] = []
+    expected_count = (
+        sum(max(0, slot.count) for slot in occupation.choice_slots) if occupation is not None else 0
+    )
+
+    seen: set[str] = set()
+    valid_candidates: list[tuple[str, int]] = []
+    fixed_ids = set(occupation.skill_ids) if occupation is not None else set()
+    for skill_id in choice_skill_ids:
+        if skill_id in seen:
+            issues.append(
+                ValidationIssue(
+                    code="OCCUPATION_CHOICE_DUPLICATE",
+                    field="occupationChoiceSkillIds",
+                    message=f"职业自选技能不能重复选择：{skill_id}",
+                )
+            )
+            continue
+        seen.add(skill_id)
+        if occupation is None:
+            issues.append(
+                ValidationIssue(
+                    code="OCCUPATION_CHOICE_INVALID",
+                    field="occupationChoiceSkillIds",
+                    message="未选择职业时不能设置职业自选技能",
+                )
+            )
+        elif skill_id not in skills_by_id:
+            issues.append(
+                ValidationIssue(
+                    code="OCCUPATION_CHOICE_INVALID",
+                    field="occupationChoiceSkillIds",
+                    message=f"未知的职业自选技能：{skill_id}",
+                )
+            )
+        elif skill_id in fixed_ids:
+            issues.append(
+                ValidationIssue(
+                    code="OCCUPATION_CHOICE_INVALID",
+                    field="occupationChoiceSkillIds",
+                    message=f"{skill_id} 已经是固定职业技能，不能重复占用自选槽",
+                )
+            )
+        elif skill_id == "credit-rating" or skill_id in NON_ALLOCATABLE_SKILL_IDS:
+            issues.append(
+                ValidationIssue(
+                    code="OCCUPATION_CHOICE_INVALID",
+                    field="occupationChoiceSkillIds",
+                    message=f"{skill_id} 不能作为职业自选技能",
+                )
+            )
+        else:
+            valid_candidates.append((skill_id, 0))
+
+    resolved = _match_choice_slots(occupation, valid_candidates)
+    unmatched = {skill_id for skill_id, _ in valid_candidates} - set(resolved)
+    for skill_id in sorted(unmatched):
+        issues.append(
+            ValidationIssue(
+                code="OCCUPATION_CHOICE_INVALID",
+                field="occupationChoiceSkillIds",
+                message=f"{skill_id} 不符合当前职业的自选槽范围",
+            )
+        )
+
+    if len(choice_skill_ids) != expected_count:
+        issues.append(
+            ValidationIssue(
+                code="OCCUPATION_CHOICES_INCOMPLETE",
+                field="occupationChoiceSkillIds",
+                message=(
+                    f"职业自选技能需要选择 {expected_count} 项，"
+                    f"当前已选择 {len(choice_skill_ids)} 项"
+                ),
+            )
+        )
+
+    return set(resolved), resolved, issues
 
 
 def _validate_attributes(
@@ -367,6 +465,7 @@ def _compute(
     *,
     occupation_not_found: bool,
     generation_method: str = GENERATION_POINT_BUY,
+    occupation_choice_skill_ids: list[str] | None = None,
 ) -> ComputeResult:
     issues: list[ValidationIssue] = []
     if occupation_not_found:
@@ -386,6 +485,7 @@ def _compute(
             occupation_skill_points=SkillPointsBudget(budget=0, spent=0, remaining=0),
             interest_skill_points=SkillPointsBudget(budget=0, spent=0, remaining=0),
             skill_view=[],
+            resolved_occupation_choice_skill_ids=[],
             validation=issues,
         )
 
@@ -406,7 +506,7 @@ def _compute(
     skill_view: list[SkillView] = []
 
     # 先把每项技能的分配量算出来，再决定自选槽归属，最后才记账——三件事必须
-    # 分开：占槽是个全局最优化问题（见 `_assign_choice_slots`），边遍历边定
+    # 分开：占槽是个全局最优化问题（见 `_match_choice_slots`），边遍历边定
     # 归属等于用"先来后到"当分配策略，会把合法卡判死。
     allocations: dict[str, int] = {}
     for spec in ruleset.skills:
@@ -415,7 +515,20 @@ def _compute(
         if allocated > 0 and spec.id != "credit-rating" and spec.id not in occupation_skill_ids:
             allocations[spec.id] = allocated
 
-    slot_occupied_ids = _assign_choice_slots(occupation, allocations)
+    if occupation_choice_skill_ids is None:
+        resolved_choice_skill_ids = _match_choice_slots(occupation, list(allocations.items()))
+        slot_occupied_ids = set(resolved_choice_skill_ids)
+    else:
+        (
+            slot_occupied_ids,
+            resolved_choice_skill_ids,
+            choice_issues,
+        ) = _resolve_explicit_choice_slots(
+            occupation,
+            occupation_choice_skill_ids,
+            skills_by_id,
+        )
+        issues.extend(choice_issues)
 
     # 遍历技能表里的全部技能（不只是草稿里提到的那些），这样 `compute_preview`
     # 能一次性把完整的 base/cap 都带给前端渲染，草稿没提到的技能视为
@@ -546,6 +659,7 @@ def _compute(
             remaining=interest_budget - interest_spent,
         ),
         skill_view=skill_view,
+        resolved_occupation_choice_skill_ids=resolved_choice_skill_ids,
         validation=issues,
     )
 
@@ -556,6 +670,7 @@ def compute_preview(
     occupation_id: int | None,
     skills: dict[str, int],
     generation_method: str = GENERATION_POINT_BUY,
+    occupation_choice_skill_ids: list[str] | None = None,
 ) -> ComputeResult:
     """`POST /systems/{systemId}/character/preview` 的计算核心：职业按 id 查。
 
@@ -574,6 +689,7 @@ def compute_preview(
         skills,
         occupation_not_found=not_found,
         generation_method=generation_method,
+        occupation_choice_skill_ids=occupation_choice_skill_ids,
     )
 
 
@@ -583,6 +699,7 @@ def validate_character(
     occupation_name: str | None,
     skills: dict[str, int],
     generation_method: str = GENERATION_POINT_BUY,
+    occupation_choice_skill_ids: list[str] | None = None,
 ) -> list[ValidationIssue]:
     """`complete_character` 的校验核心：角色卡存的是职业名字符串，按名字查。
 
@@ -599,4 +716,5 @@ def validate_character(
         skills,
         occupation_not_found=not_found,
         generation_method=generation_method,
+        occupation_choice_skill_ids=occupation_choice_skill_ids,
     ).validation

--- a/trpg-backend/app/dto/character.py
+++ b/trpg-backend/app/dto/character.py
@@ -31,6 +31,7 @@ class CharacterUpdateBody(CamelModel):
     attributes: dict[str, int]
     derived_stats: dict[str, int]
     skills: dict[str, int]
+    occupation_choice_skill_ids: list[str] | None = None
     equipment: list[EquipmentItem] = Field(default_factory=list)
     occupation: str | None = None
     background: str = Field(default="", max_length=4000)
@@ -60,6 +61,7 @@ class CharacterRead(CamelModel):
     attributes: dict[str, int] = Field(default_factory=dict)
     derived_stats: dict[str, int | str] = Field(default_factory=dict)
     skills: dict[str, int] = Field(default_factory=dict)
+    occupation_choice_skill_ids: list[str] | None = None
     equipment: list[str] = Field(default_factory=list)
     occupation: str | None = None
     background: str = ""
@@ -131,6 +133,7 @@ class CharacterPreviewRequest(CamelModel):
     attributes: dict[str, int]
     occupation_id: int | None = None
     skills: dict[str, int] = Field(default_factory=dict)
+    occupation_choice_skill_ids: list[str] | None = None
 
 
 class SkillPointsBudgetView(CamelModel):
@@ -167,4 +170,5 @@ class CharacterComputeResult(CamelModel):
     occupation_skill_points: SkillPointsBudgetView
     interest_skill_points: SkillPointsBudgetView
     skill_view: list[SkillComputeView]
+    resolved_occupation_choice_skill_ids: list[str] = Field(default_factory=list)
     validation: list[ValidationIssueView]

--- a/trpg-backend/app/models/room.py
+++ b/trpg-backend/app/models/room.py
@@ -190,6 +190,9 @@ class Character(Base):
     attributes: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     derived_stats: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     skills: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    # None 表示 issue #140 之前创建、仍使用“按已加点技能自动占槽”的旧角色；
+    # list 表示玩家已经显式确认的职业自选技能（空列表对无自选槽职业合法）。
+    occupation_choice_skill_ids: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
     equipment: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
     background: Mapped[str] = mapped_column(Text, nullable=False, default="")
     notes: Mapped[str] = mapped_column(Text, nullable=False, default="")

--- a/trpg-backend/app/service/character.py
+++ b/trpg-backend/app/service/character.py
@@ -96,6 +96,11 @@ def _character_template_data(character: Character) -> dict[str, object]:
         "birthplace": character.birthplace or "",
         "attributes": dict(character.attributes or {}),
         "skills": dict(character.skills or {}),
+        "occupation_choice_skill_ids": (
+            list(character.occupation_choice_skill_ids)
+            if character.occupation_choice_skill_ids is not None
+            else None
+        ),
         "equipment": list(character.equipment or []),
         "occupation": character.occupation,
         "background": character.background or "",
@@ -202,6 +207,7 @@ async def update_character(
     character.attributes = payload.attributes
     character.derived_stats = payload.derived_stats
     character.skills = payload.skills
+    character.occupation_choice_skill_ids = payload.occupation_choice_skill_ids
     character.equipment = [item.name for item in payload.equipment]
     character.occupation = payload.occupation
     character.background = payload.background
@@ -248,6 +254,7 @@ async def complete_character(
         attributes=character.attributes or {},
         occupation_name=character.occupation,
         skills=character.skills or {},
+        occupation_choice_skill_ids=character.occupation_choice_skill_ids,
         generation_method=character.generation_method,
     )
     if issues:
@@ -301,6 +308,7 @@ async def get_character(
         attributes=character.attributes or {},
         derived_stats=character.derived_stats or {},
         skills=character.skills or {},
+        occupation_choice_skill_ids=character.occupation_choice_skill_ids,
         equipment=list(character.equipment or []),
         occupation=character.occupation,
         background=character.background or "",
@@ -323,6 +331,7 @@ def compute_character_preview(
         attributes=payload.attributes,
         occupation_id=payload.occupation_id,
         skills=payload.skills,
+        occupation_choice_skill_ids=payload.occupation_choice_skill_ids,
     )
     return CharacterComputeResult(**asdict(result))
 

--- a/trpg-backend/tests/test_character_preview.py
+++ b/trpg-backend/tests/test_character_preview.py
@@ -90,6 +90,28 @@ async def test_preview_returns_authoritative_compute_result(client: AsyncClient)
     assert data["validation"] == []
 
 
+async def test_preview_accepts_and_resolves_explicit_occupation_choices(
+    client: AsyncClient,
+) -> None:
+    session = await register(client)
+
+    response = await client.post(
+        PREVIEW_URL,
+        json={
+            "attributes": ATTRS,
+            "occupationId": 1,
+            "skills": {"credit-rating": 30},
+            "occupationChoiceSkillIds": ["climb", "swim"],
+        },
+        headers=bearer(session["token"]),
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["resolvedOccupationChoiceSkillIds"] == ["climb", "swim"]
+    assert data["validation"] == []
+
+
 async def test_preview_surfaces_issues_for_invalid_draft(client: AsyncClient) -> None:
     """预览接口即使卡不合法也应该返回 200 + 校验报告，不是抛错——它是渲染用
     的接口，前端要能实时看到"哪里超了"，不是等 complete 才知道。"""

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -347,6 +347,48 @@ async def test_get_character_reads_back_saved_card(client: AsyncClient) -> None:
     assert data["occupation"] == BUILT_CHARACTER["occupation"]
     # 默认是点数购买法——迁移前建的卡和前端建卡向导走的都是这条路径
     assert data["generationMethod"] == "pointbuy"
+    assert data["occupationChoiceSkillIds"] is None
+
+
+async def test_character_persists_explicit_occupation_choices(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    room = await create_room(client)
+    headers = reconnect(room["reconnectToken"])
+    draft = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters",
+        headers=headers,
+    )
+    character_id = draft.json()["data"]["characterId"]
+    payload = {
+        **BUILT_CHARACTER,
+        "occupationChoiceSkillIds": ["charm", "climb"],
+    }
+
+    saved = await client.patch(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
+        json=payload,
+        headers=headers,
+    )
+    completed = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/complete",
+        headers=headers,
+    )
+    response = await client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
+        headers=headers,
+    )
+
+    assert saved.status_code == 200
+    assert completed.status_code == 200
+    assert response.json()["data"]["occupationChoiceSkillIds"] == ["charm", "climb"]
+    stored_character = await db_session.get(Character, character_id)
+    assert stored_character is not None
+    assert stored_character.based_on_template_id is not None
+    template = await db_session.get(UserCharacterTemplate, stored_character.based_on_template_id)
+    assert template is not None
+    assert template.data["occupation_choice_skill_ids"] == ["charm", "climb"]
 
 
 async def test_roll_attributes_marks_card_as_rolled(client: AsyncClient) -> None:

--- a/trpg-backend/tests/test_coc7_rules.py
+++ b/trpg-backend/tests/test_coc7_rules.py
@@ -596,6 +596,118 @@ def test_choice_slot_assignment_is_optimal_not_first_come_first_served() -> None
     assert issues == []
 
 
+def test_explicit_choice_slots_are_resolved_and_charge_occupation_points() -> None:
+    ruleset, occupation = _detective_with_slots()
+    choices = ["climb", "swim", "persuade"]
+
+    result = compute_preview(
+        ruleset,
+        SLOT_ATTRS,
+        occupation.id,
+        {"credit-rating": 25, "climb": 95},
+        occupation_choice_skill_ids=choices,
+    )
+
+    assert result.validation == []
+    assert result.resolved_occupation_choice_skill_ids == choices
+    assert result.occupation_skill_points.spent == 9 + 75
+    assert result.interest_skill_points.spent == 25 - 9
+
+
+def test_explicit_choice_slots_require_all_slots_to_be_filled() -> None:
+    ruleset, occupation = _detective_with_slots()
+
+    result = compute_preview(
+        ruleset,
+        SLOT_ATTRS,
+        occupation.id,
+        {"credit-rating": 25},
+        occupation_choice_skill_ids=["climb"],
+    )
+
+    assert [issue.code for issue in result.validation] == ["OCCUPATION_CHOICES_INCOMPLETE"]
+
+
+def test_explicit_choice_slots_reject_duplicate_fixed_and_non_allocatable_skills() -> None:
+    ruleset, occupation = _detective_with_slots()
+
+    duplicate = compute_preview(
+        ruleset,
+        SLOT_ATTRS,
+        occupation.id,
+        {"credit-rating": 25},
+        occupation_choice_skill_ids=["climb", "climb", "persuade"],
+    )
+    fixed = compute_preview(
+        ruleset,
+        SLOT_ATTRS,
+        occupation.id,
+        {"credit-rating": 25},
+        occupation_choice_skill_ids=["psychology", "climb", "persuade"],
+    )
+    forbidden = compute_preview(
+        ruleset,
+        SLOT_ATTRS,
+        occupation.id,
+        {"credit-rating": 25},
+        occupation_choice_skill_ids=["cthulhu-mythos", "climb", "persuade"],
+    )
+    unknown = compute_preview(
+        ruleset,
+        SLOT_ATTRS,
+        occupation.id,
+        {"credit-rating": 25},
+        occupation_choice_skill_ids=["not-a-skill", "climb", "persuade"],
+    )
+
+    assert "OCCUPATION_CHOICE_DUPLICATE" in [issue.code for issue in duplicate.validation]
+    assert "OCCUPATION_CHOICE_INVALID" in [issue.code for issue in fixed.validation]
+    assert "OCCUPATION_CHOICE_INVALID" in [issue.code for issue in forbidden.validation]
+    assert "OCCUPATION_CHOICE_INVALID" in [issue.code for issue in unknown.validation]
+
+
+def test_explicit_choice_slots_reject_skill_outside_constrained_slot() -> None:
+    ruleset, occupation = _detective_with_slots()
+    occupation.choice_slots = [
+        SkillChoiceSlot(
+            count=1,
+            candidate_skill_ids=["charm", "fast-talk", "intimidate", "persuade"],
+            label="一项社交技能",
+        )
+    ]
+
+    result = compute_preview(
+        ruleset,
+        SLOT_ATTRS,
+        occupation.id,
+        {"credit-rating": 25},
+        occupation_choice_skill_ids=["climb"],
+    )
+
+    assert [issue.code for issue in result.validation] == ["OCCUPATION_CHOICE_INVALID"]
+
+
+def test_legacy_null_choices_keep_automatic_weighted_assignment() -> None:
+    ruleset, occupation = _detective_with_slots()
+
+    result = compute_preview(
+        ruleset,
+        SLOT_ATTRS,
+        occupation.id,
+        {
+            "credit-rating": 25,
+            "persuade": 90,
+            "climb": 95,
+            "swim": 95,
+            "ride": 95,
+        },
+        occupation_choice_skill_ids=None,
+    )
+
+    assert result.validation == []
+    assert set(result.resolved_occupation_choice_skill_ids) == {"persuade", "climb", "ride"}
+
+
 def test_skill_outside_every_slot_still_costs_interest_points() -> None:
     """槽是有限的：塞不进任何槽的技能照样吃兴趣点，超了要拦。
 

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -9,7 +9,7 @@ from pathlib import Path
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
 ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
-HEAD_REVISION = "3f8a1c2d4e5f"
+HEAD_REVISION = "e4b6c8d0f2a1"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -91,6 +91,7 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
     }.issubset(_foreign_keys(database, "game_sessions"))
     assert "module_version" in _column_names(database, "rooms")
     assert "version" in _column_names(database, "characters")
+    assert "occupation_choice_skill_ids" in _column_names(database, "characters")
     assert "correlation_id" in _column_names(database, "events")
     assert {
         "visibility",
@@ -105,6 +106,7 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
     assert "room_sessions" in _table_names(database)
     assert "module_versions" not in _table_names(database)
     assert "version" not in _column_names(database, "characters")
+    assert "occupation_choice_skill_ids" not in _column_names(database, "characters")
     assert "correlation_id" not in _column_names(database, "events")
 
     _upgrade_or_fail(database, "head")

--- a/trpg-frontend/src/data/derived-stats.test.ts
+++ b/trpg-frontend/src/data/derived-stats.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { DERIVED_STAT_DEFINITIONS, normalizeDerivedStats } from './derived-stats'
+
+describe('derived stats display', () => {
+  it('normalizes all server derived stat keys', () => {
+    expect(normalizeDerivedStats({
+      HP: 12,
+      SAN: 55,
+      MP: 11,
+      DB: '+1D4',
+      Build: '+1D4',
+      MOV: 8,
+    })).toEqual({
+      hp: 12,
+      san: 55,
+      mp: 11,
+      db: '+1D4',
+      build: '+1D4',
+      move: 8,
+    })
+  })
+
+  it('defines six Chinese-first labels in display order', () => {
+    expect(DERIVED_STAT_DEFINITIONS.map(item => [item.label, item.abbreviation])).toEqual([
+      ['生命值', 'HP'],
+      ['理智值', 'SAN'],
+      ['魔法值', 'MP'],
+      ['伤害加值', 'DB'],
+      ['体格', 'Build'],
+      ['移动力', 'MOV'],
+    ])
+  })
+})

--- a/trpg-frontend/src/data/derived-stats.ts
+++ b/trpg-frontend/src/data/derived-stats.ts
@@ -1,0 +1,39 @@
+export interface DerivedStatsView {
+  hp: number
+  san: number
+  mp: number
+  db: string
+  build?: string
+  move: number
+}
+
+export type DerivedStatKey = keyof DerivedStatsView
+
+export const DERIVED_STAT_DEFINITIONS: ReadonlyArray<{
+  key: DerivedStatKey
+  label: string
+  abbreviation: string
+  color: string
+}> = [
+  { key: 'hp', label: '生命值', abbreviation: 'HP', color: '#4a8a4a' },
+  { key: 'san', label: '理智值', abbreviation: 'SAN', color: '#7050a0' },
+  { key: 'mp', label: '魔法值', abbreviation: 'MP', color: '#4a7098' },
+  { key: 'db', label: '伤害加值', abbreviation: 'DB', color: '#6a6050' },
+  { key: 'build', label: '体格', abbreviation: 'Build', color: '#b8976a' },
+  { key: 'move', label: '移动力', abbreviation: 'MOV', color: '#c08050' },
+]
+
+export function normalizeDerivedStats(
+  derived: Record<string, number | string> | undefined,
+): DerivedStatsView {
+  const numberValue = (value: unknown) => (typeof value === 'number' ? value : 0)
+  const stringValue = (value: unknown) => (value == null ? '0' : String(value))
+  return {
+    hp: numberValue(derived?.HP),
+    san: numberValue(derived?.SAN),
+    mp: numberValue(derived?.MP),
+    db: stringValue(derived?.DB),
+    build: stringValue(derived?.Build),
+    move: numberValue(derived?.MOV),
+  }
+}

--- a/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
+++ b/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from '@/stores/auth-store'
 import { connectWebSocket, disconnectWebSocket, sdk, waitForWsOpen } from '@/services/api-client'
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 import { useRuleset } from '@/hooks/useRuleset'
+import { DERIVED_STAT_DEFINITIONS, normalizeDerivedStats } from '@/data/derived-stats'
 
 const SHEET_PAGES = [
   { key: 'info', label: '基本信息' },
@@ -70,17 +71,15 @@ function CharacterSheetModal({ character, onClose }: { character: NonNullable<Re
                   <span className="text-sm font-medium text-text-primary">{character.info.birthplace || '—'}</span>
                 </div>
               </div>
-              <div className="flex gap-2">
-                {[
-                  { label: 'HP', value: `${character.derived.hp}`, color: 'text-mold' },
-                  { label: 'SAN', value: `${character.derived.san}`, color: 'text-[#7050a0]' },
-                  { label: 'MP', value: `${character.derived.mp}`, color: 'text-[#4a7098]' },
-                  { label: 'DB', value: character.derived.db, color: 'text-text-muted' },
-                  { label: 'MOV', value: `${character.derived.move}`, color: 'text-text-muted' },
-                ].map(pill => (
-                  <div key={pill.label} className="flex-1 bg-panel rounded-md px-2.5 py-2 text-center">
-                    <div className="text-[10px] text-text-muted font-semibold">{pill.label}</div>
-                    <div className={`text-[16px] font-bold font-mono ${pill.color}`}>{pill.value}</div>
+              <div className="grid grid-cols-3 gap-2" data-testid="derived-stats-grid">
+                {DERIVED_STAT_DEFINITIONS.map(definition => (
+                  <div key={definition.key} className="bg-panel rounded-md px-2.5 py-2 text-center">
+                    <div className="text-[10px] text-text-muted font-semibold">
+                      {definition.label} <span className="font-mono text-text-dim">{definition.abbreviation}</span>
+                    </div>
+                    <div className="text-[16px] font-bold font-mono" style={{ color: definition.color }}>
+                      {character.derived[definition.key] ?? '—'}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -171,8 +170,7 @@ export default function CharacterReadyPage() {
         if (cancelled || !saved.name) return
         const occupationId =
           readyRuleset.occupations.find((o) => o.name === saved.occupation)?.id ?? null
-        const derived = saved.derivedStats ?? {}
-        const num = (v: unknown) => (typeof v === 'number' ? v : 0)
+        const derived = normalizeDerivedStats(saved.derivedStats ?? {})
         setRemoteCharacter({
           info: {
             name: saved.name,
@@ -186,16 +184,11 @@ export default function CharacterReadyPage() {
           attr: { ...saved.attributes },
           skillAlloc: {},
           skillFinalValues: { ...saved.skills },
+          occupationChoiceSkillIds: saved.occupationChoiceSkillIds ?? [],
           equipment: (saved.equipment ?? []).join('、'),
           background: saved.background ?? '',
           notes: saved.notes ?? '',
-          derived: {
-            hp: num(derived.HP),
-            san: num(derived.SAN),
-            mp: num(derived.MP),
-            db: derived.DB == null ? '0' : String(derived.DB),
-            move: num(derived.MOV),
-          },
+          derived,
         })
       })
       .catch(() => {

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -24,6 +24,9 @@ const { mockRuleset, mockPreviewCharacter, mockCharacterApi } = vi.hoisted(() =>
     skills: [
       { id: 'accounting', name: '会计', nameEn: 'accounting', base: 0, category: 'occupation' },
       { id: 'stealth', name: '潜行', nameEn: 'stealth', base: 0, category: 'interest' },
+      { id: 'charm', name: '取悦', nameEn: 'charm', base: 0, category: 'social' },
+      { id: 'climb', name: '攀爬', nameEn: 'climb', base: 0, category: 'physical' },
+      { id: 'cthulhu-mythos', name: '克苏鲁神话', nameEn: 'cthulhu mythos', base: 0, category: 'special' },
       { id: 'credit-rating', name: '信用评级', nameEn: 'credit-rating', base: 0, category: 'special' },
     ],
     occupationCategories: [
@@ -43,6 +46,21 @@ const { mockRuleset, mockPreviewCharacter, mockCharacterApi } = vi.hoisted(() =>
         categories: ['法律金融'],
       },
       {
+        id: 2,
+        name: '记者',
+        creditMin: 0,
+        creditMax: 70,
+        skillPointsFormula: 'EDU*4',
+        skillIds: ['accounting'],
+        choiceSlots: [
+          { count: 1, candidateSkillIds: ['charm'], label: '一项社交技能' },
+          { count: 1, candidateSkillIds: null, label: '任意一项其他技能' },
+        ],
+        description: '带职业自选槽的测试职业',
+        icon: '📰',
+        categories: ['法律金融'],
+      },
+      {
         id: 31,
         name: '罪犯-欺诈师',
         creditMin: 10,
@@ -56,13 +74,21 @@ const { mockRuleset, mockPreviewCharacter, mockCharacterApi } = vi.hoisted(() =>
     ],
   }
 
-  const mockPreviewCharacter = vi.fn(async ({ occupationId, skills }: { occupationId: number | null; skills: Record<string, number> }) => {
+  const mockPreviewCharacter = vi.fn(async ({
+    occupationId,
+    skills,
+    occupationChoiceSkillIds,
+  }: {
+    occupationId: number | null
+    skills: Record<string, number>
+    occupationChoiceSkillIds?: string[] | null
+  }) => {
     const accounting = skills.accounting ?? 0
     const stealth = skills.stealth ?? 0
     const credit = skills['credit-rating'] ?? 0
     const creditMin = occupationId === 1 ? 0 : 0
     return {
-      derivedStats: { HP: 10, SAN: 50, MP: 10, DB: '0', MOV: 8 },
+      derivedStats: { HP: 10, SAN: 50, MP: 10, DB: '0', Build: '0', MOV: 8 },
       occupationSkillPoints: {
         budget: 2,
         spent: accounting + creditMin,
@@ -80,7 +106,14 @@ const { mockRuleset, mockPreviewCharacter, mockCharacterApi } = vi.hoisted(() =>
         current: skills[skill.id] ?? 0,
         cap: skill.id === 'credit-rating' ? 70 : 99,
       })),
-      validation: [],
+      resolvedOccupationChoiceSkillIds: occupationChoiceSkillIds ?? [],
+      validation: occupationId === 2 && (occupationChoiceSkillIds?.length ?? 0) < 2
+        ? [{
+            code: 'OCCUPATION_CHOICES_INCOMPLETE',
+            field: 'occupationChoiceSkillIds',
+            message: '职业自选技能需要选择 2 项',
+          }]
+        : [],
     }
   })
 
@@ -171,6 +204,21 @@ describe('CharacterPage', () => {
     expect(await screen.findByText('背景故事')).toBeInTheDocument()
   }
 
+  async function advanceToReporterSkills() {
+    fireEvent.change(screen.getByPlaceholderText('角色姓名'), { target: { value: '张三' } })
+    fireEvent.click(screen.getByText('记者'))
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    await waitFor(() => {
+      expect(mockPreviewCharacter).toHaveBeenCalledWith(expect.objectContaining({ occupationId: 2 }))
+    })
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+      expect(screen.getByText('属性分配')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    expect(await screen.findByTestId('occupation-choice-panel')).toBeInTheDocument()
+  }
+
   it('blocks advancing until name and occupation are filled', async () => {
     renderPage()
 
@@ -215,6 +263,118 @@ describe('CharacterPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '详情' }))
 
     expect(screen.getByText('测试用职业')).toBeInTheDocument()
+  })
+
+  it('renders all six derived stats in a three-column grid', async () => {
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText('角色姓名'), { target: { value: '张三' } })
+    fireEvent.click(screen.getByText('会计师'))
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    await advanceToAttributesAfterOccupationPreview()
+
+    const grid = screen.getByTestId('derived-stats-grid')
+    expect(grid).toHaveClass('grid-cols-3')
+    for (const label of ['生命值', '理智值', '魔法值', '伤害加值', '体格', '移动力']) {
+      expect(screen.getByText(new RegExp(label))).toBeInTheDocument()
+    }
+  })
+
+  it('selects, submits, and caches explicit occupation choice skills', async () => {
+    renderPage()
+    await advanceToReporterSkills()
+
+    fireEvent.click(screen.getAllByRole('button', { name: /选择技能/ })[0])
+    fireEvent.click(screen.getByRole('button', { name: /取悦/ }))
+    fireEvent.click(screen.getByRole('button', { name: /选择技能/ }))
+    expect(screen.queryByText('克苏鲁神话')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /攀爬/ }))
+
+    expect(screen.getByLabelText('取悦 技能点')).toBeInTheDocument()
+    expect(screen.getByLabelText('攀爬 技能点')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(mockPreviewCharacter).toHaveBeenCalledWith(expect.objectContaining({
+        occupationChoiceSkillIds: ['charm', 'climb'],
+      }))
+    })
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+      expect(screen.getByText('背景故事')).toBeInTheDocument()
+    })
+    expect(await screen.findByText('背景故事')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /完成创建/ }))
+
+    await waitFor(() => {
+      expect(mockCharacterApi.saveCharacter).toHaveBeenCalledWith(
+        'room-1',
+        'draft-1',
+        expect.objectContaining({ occupationChoiceSkillIds: ['charm', 'climb'] }),
+      )
+    })
+    expect(useCharacterStore.getState().getForRoom('room-1')?.occupationChoiceSkillIds)
+      .toEqual(['charm', 'climb'])
+  })
+
+  it('hydrates legacy automatic choices from the preview result', async () => {
+    const inferredPreview = await mockPreviewCharacter({
+      occupationId: 2,
+      skills: { charm: 40, climb: 30 },
+      occupationChoiceSkillIds: ['charm', 'climb'],
+    })
+    mockPreviewCharacter.mockClear()
+    mockPreviewCharacter.mockResolvedValueOnce({
+      ...inferredPreview,
+      resolvedOccupationChoiceSkillIds: ['charm', 'climb'],
+      validation: [],
+    })
+    useRoomStore.setState({ characterId: 'legacy-character' })
+    mockCharacterApi.fetchCharacter.mockResolvedValue({
+      name: '旧卡调查员',
+      age: 30,
+      gender: '男',
+      residence: '阿卡姆',
+      birthplace: '波士顿',
+      occupation: '记者',
+      attributes: Object.fromEntries(mockRuleset.attributes.map(attribute => [attribute.key, 50])),
+      derivedStats: { HP: 10, SAN: 50, MP: 10 },
+      skills: { charm: 40, climb: 30 },
+      occupationChoiceSkillIds: null,
+      equipment: [],
+      background: '',
+      notes: '',
+    })
+
+    renderPage()
+    await waitFor(() => expect(screen.getByPlaceholderText('角色姓名')).toHaveValue('旧卡调查员'))
+    await waitFor(() => {
+      expect(mockPreviewCharacter).toHaveBeenCalledWith(expect.objectContaining({
+        occupationId: 2,
+        occupationChoiceSkillIds: null,
+      }))
+    })
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+      expect(screen.getByText('属性分配')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+
+    expect(await screen.findByLabelText('取消职业自选技能 取悦')).toBeInTheDocument()
+    expect(screen.getByLabelText('取消职业自选技能 攀爬')).toBeInTheDocument()
+  })
+
+  it('requires allocated occupation choice skills to be cleared before removal', async () => {
+    renderPage()
+    await advanceToReporterSkills()
+    fireEvent.click(screen.getAllByRole('button', { name: /选择技能/ })[0])
+    fireEvent.click(screen.getByRole('button', { name: /取悦/ }))
+
+    fireEvent.click(screen.getByLabelText('取悦 增加技能点'))
+    fireEvent.click(screen.getByLabelText('取消职业自选技能 取悦'))
+    expect(screen.getByText('请先将「取悦」的加点清零')).toBeInTheDocument()
+    expect(screen.getByLabelText('取消职业自选技能 取悦')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('取悦 减少技能点'))
+    fireEvent.click(screen.getByLabelText('取消职业自选技能 取悦'))
+    expect(screen.queryByLabelText('取消职业自选技能 取悦')).not.toBeInTheDocument()
   })
 
   it('lets credit be typed directly and keeps occupation and interest pools separate', async () => {

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -17,6 +17,10 @@ import {
   serializeCharacterBackground,
 } from '@/data/character-background'
 import type { BackgroundSectionKey } from '@/data/character-background'
+import {
+  DERIVED_STAT_DEFINITIONS,
+  normalizeDerivedStats,
+} from '@/data/derived-stats'
 
 // 图标和配色是纯 UI 装饰，不是规则数据，留在前端；键用后端 ruleset 的属性键。
 // 「有哪些属性、哪些能加点、默认值多少、预算和上下限是什么」全部来自
@@ -42,20 +46,7 @@ const BACKGROUND_PLACEHOLDERS: Record<BackgroundSectionKey, string> = {
   phobiasManias: '角色恐惧、执着或难以控制的倾向……',
 }
 
-// 建卡阶段的衍生值面板用小写 key，后端 derivedStats 是 { HP, MP, SAN, DB,
-// Build, MOV } 这种大写 key 的松散字典（不是固定字段的 DTO），这里做一次
-// 归一化，纯粹是取值/改大小写，不是规则计算。
-function normalizeDerivedStats(d: CharacterComputeResult['derivedStats'] | undefined) {
-  const num = (v: unknown) => (typeof v === 'number' ? v : 0)
-  const str = (v: unknown) => (v == null ? '0' : String(v))
-  return {
-    hp: num(d?.HP),
-    san: num(d?.SAN),
-    mp: num(d?.MP),
-    db: str(d?.DB),
-    move: num(d?.MOV),
-  }
-}
+const EMPTY_CHOICE_SELECTIONS: string[][] = []
 
 function occupationIcon(occupation: Pick<OccupationSpec, 'icon'>): string {
   return occupation.icon ?? '·'
@@ -69,8 +60,14 @@ async function previewWithAllocations(
   attributes: Attributes,
   occupationId: number | null,
   allocations: Record<string, number>,
+  occupationChoiceSkillIds: string[],
 ) {
-  const basePreview = await previewCharacter({ attributes, occupationId, skills: {} })
+  const basePreview = await previewCharacter({
+    attributes,
+    occupationId,
+    skills: {},
+    occupationChoiceSkillIds,
+  })
   const allocatedSkills = Object.entries(allocations).filter(([, points]) => points > 0)
   if (allocatedSkills.length === 0) {
     return { preview: basePreview, skillValues: {} }
@@ -80,8 +77,27 @@ async function previewWithAllocations(
   const skillValues = Object.fromEntries(
     allocatedSkills.map(([id, points]) => [id, (baseBySkill.get(id) ?? 0) + points])
   )
-  const preview = await previewCharacter({ attributes, occupationId, skills: skillValues })
+  const preview = await previewCharacter({
+    attributes,
+    occupationId,
+    skills: skillValues,
+    occupationChoiceSkillIds,
+  })
   return { preview, skillValues }
+}
+
+type OccupationChoiceSlot = NonNullable<OccupationSpec['choiceSlots']>[number]
+
+function splitChoiceSkillIds(
+  slots: OccupationChoiceSlot[],
+  skillIds: string[],
+): string[][] {
+  let offset = 0
+  return slots.map(slot => {
+    const selected = skillIds.slice(offset, offset + slot.count)
+    offset += slot.count
+    return selected
+  })
 }
 
 // ─── SkillRow Component ──────────────────────────────
@@ -188,6 +204,14 @@ export default function CharacterPage() {
   // Attributes
   const [attr, setAttr] = useState<Attributes>(() => ({ ...existingCharacter?.attr }))
 
+  // 职业自选技能按槽位分组保存在表单中；提交时再按槽位顺序压平成 API 的
+  // occupationChoiceSkillIds。occupationId 跟选择放在同一份状态里，避免异步
+  // 水合或切换职业时把上一职业的槽位误套到新职业。
+  const [occupationChoiceState, setOccupationChoiceState] = useState<{
+    occupationId: number | null
+    selections: string[][]
+  }>({ occupationId: null, selections: [] })
+
   // 可用点数购买的属性键（幸运不在其中——COC7 里它只能掷）。这份名单来自
   // 后端 ruleset 的 pointBuy 标志，前端不再自己维护（issue #96）。
   const pointBuyAttributes = useMemo(
@@ -236,15 +260,23 @@ export default function CharacterPage() {
           attributes: savedAttrs,
           occupationId: matched?.id ?? null,
           skills: saved.skills ?? {},
+          occupationChoiceSkillIds: saved.occupationChoiceSkillIds ?? null,
         })
         if (cancelled) return
+
+        const hydratedChoiceSkillIds = saved.occupationChoiceSkillIds
+          ?? view.resolvedOccupationChoiceSkillIds
+          ?? []
 
         // skillAlloc 和 interestAlloc 两份状态都要重建（PR #97 review [4]）：
         // 兴趣技能的行和计数器读的是 interestAlloc，只重建 skillAlloc 的话，
         // 清掉本地缓存后兴趣技能显示成 0 点、兴趣预算 bar 也是空的。
         // 拆分口径跟后端记账保持一致（coc7_rules：职业技能上的点数全算职业点、
         // 其余全算兴趣点），所以从最终值可以无歧义地还原出这两份状态。
-        const occIds = new Set(matched?.skillIds ?? [])
+        const occIds = new Set([
+          ...(matched?.skillIds ?? []),
+          ...hydratedChoiceSkillIds,
+        ])
         const alloc: Record<string, number> = {}
         const interest: Record<string, number> = {}
         for (const v of view.skillView) {
@@ -289,6 +321,10 @@ export default function CharacterPage() {
         setEquipment((saved.equipment ?? []).join('、'))
         setSkillAlloc(alloc)
         setInterestAlloc(interest)
+        setOccupationChoiceState({
+          occupationId: matched?.id ?? null,
+          selections: splitChoiceSkillIds(matched?.choiceSlots ?? [], hydratedChoiceSkillIds),
+        })
         // 后端那份已经是权威，别再让 localStorage 那条重建逻辑覆盖回去。
         interestAllocInitialized.current = true
       })
@@ -350,11 +386,70 @@ export default function CharacterPage() {
   const [skillTab, setSkillTab] = useState<'occupation' | 'interest'>('occupation')
   const [showGroupPicker, setShowGroupPicker] = useState(false)
   const [detailOcc, setDetailOcc] = useState<OccupationSpec | null>(null)
+  const [choicePickerSlotIndex, setChoicePickerSlotIndex] = useState<number | null>(null)
+  const [choiceSkillSearch, setChoiceSkillSearch] = useState('')
+  const [choiceActionError, setChoiceActionError] = useState('')
 
   const selectedOcc = useMemo(() => {
     if (!ruleset || info.occupationId == null) return null
     return ruleset.occupations.find(o => o.id === info.occupationId) ?? null
   }, [ruleset, info.occupationId])
+
+  useEffect(() => {
+    if (!selectedOcc) {
+      if (occupationChoiceState.occupationId !== null) {
+        setOccupationChoiceState({ occupationId: null, selections: [] })
+      }
+      return
+    }
+    if (occupationChoiceState.occupationId === selectedOcc.id) return
+    const cachedSkillIds = existingCharacter?.info.occupationId === selectedOcc.id
+      ? (existingCharacter.occupationChoiceSkillIds ?? [])
+      : []
+    setOccupationChoiceState({
+      occupationId: selectedOcc.id,
+      selections: splitChoiceSkillIds(selectedOcc.choiceSlots ?? [], cachedSkillIds),
+    })
+  }, [existingCharacter, occupationChoiceState.occupationId, selectedOcc])
+
+  const occupationChoiceSelections = selectedOcc
+    && occupationChoiceState.occupationId === selectedOcc.id
+    ? occupationChoiceState.selections
+    : EMPTY_CHOICE_SELECTIONS
+  const occupationChoiceSkillIds = useMemo(
+    () => occupationChoiceSelections.flat(),
+    [occupationChoiceSelections]
+  )
+  const selectedChoiceSkillIdSet = useMemo(
+    () => new Set(occupationChoiceSkillIds),
+    [occupationChoiceSkillIds]
+  )
+  const occupationChoicesComplete = (selectedOcc?.choiceSlots ?? []).every(
+    (slot, index) => (occupationChoiceSelections[index]?.length ?? 0) === slot.count
+  )
+
+  const selectOccupation = (occupationId: number | null) => {
+    if (occupationId === info.occupationId) return
+    const occupation = ruleset?.occupations.find(item => item.id === occupationId) ?? null
+    const fixedIds = new Set(occupation?.skillIds ?? [])
+    const nextInterest: Record<string, number> = {}
+    for (const [skillId, points] of Object.entries(skillAlloc)) {
+      if (skillId !== 'credit-rating' && !fixedIds.has(skillId) && points > 0) {
+        nextInterest[skillId] = points
+      }
+    }
+    setInfo(previous => ({ ...previous, occupationId }))
+    setOccupationChoiceState({
+      occupationId,
+      selections: (occupation?.choiceSlots ?? []).map(() => []),
+    })
+    setInterestAlloc(nextInterest)
+    setPendingOccupationDelta(0)
+    setPendingInterestDelta(0)
+    setChoicePickerSlotIndex(null)
+    setChoiceSkillSearch('')
+    setChoiceActionError('')
+  }
 
   const selectedOccupationSkillPreview = useMemo(() => {
     if (!ruleset || !selectedOcc) return []
@@ -410,8 +505,9 @@ export default function CharacterPage() {
   // Occupation skill IDs（保留职业技能清单里定义的顺序，不是技能表里的顺序）
   const occSkillIds = useMemo(() => {
     if (!ruleset || info.occupationId == null) return []
-    return ruleset.occupations.find(o => o.id === info.occupationId)?.skillIds ?? []
-  }, [ruleset, info.occupationId])
+    const fixed = ruleset.occupations.find(o => o.id === info.occupationId)?.skillIds ?? []
+    return [...fixed, ...occupationChoiceSkillIds]
+  }, [ruleset, info.occupationId, occupationChoiceSkillIds])
 
   const occSkills = useMemo(() => {
     if (!ruleset) return []
@@ -434,7 +530,7 @@ export default function CharacterPage() {
   // issue #114 之前这里刻意只在属性/职业变化时请求、不带 skills：那时"已花"是
   // 「occSkillIds 里的算职业点、其余算兴趣点」这种平凡算术，前端本地算即可。但
   // 职业技能 = 固定 + 自选槽后，某个技能的点数算职业还是兴趣，取决于后端的全局
-  // 最优占槽（_assign_choice_slots，尤其开放槽任何技能都可能占），前端无法在不
+  // 最优占槽（后端匹配器会处理开放槽与限定槽重叠），前端无法在不
   // 复刻规则的前提下算对。所以现在**把当前 skillAlloc 一起发过去、并在它变化时
   // （防抖）重新预演**，"已花"直接读后端返回的 occupationSkillPoints.spent /
   // interestSkillPoints.spent。代价是加点后数字有 ~400ms 防抖延迟。
@@ -461,7 +557,12 @@ export default function CharacterPage() {
     setPreviewStatus('pending')
     const timer = setTimeout(() => {
       const gen = ++previewGenRef.current
-      previewWithAllocations(attr, info.occupationId, skillAlloc)
+      previewWithAllocations(
+        attr,
+        info.occupationId,
+        skillAlloc,
+        occupationChoiceSkillIds,
+      )
         .then(({ preview: result }) => {
           if (gen !== previewGenRef.current) return
           setPreview(result)
@@ -477,7 +578,7 @@ export default function CharacterPage() {
         })
     }, 400)
     return () => clearTimeout(timer)
-  }, [ruleset, attr, info.occupationId, skillAlloc])
+  }, [ruleset, attr, info.occupationId, skillAlloc, occupationChoiceSkillIds])
 
   const skillComputeMap = useMemo(() => {
     const map = new Map<string, SkillComputeView>()
@@ -501,7 +602,10 @@ export default function CharacterPage() {
     if (!ruleset || !existingCharacter || interestAllocInitialized.current) return
     interestAllocInitialized.current = true
     const occIds = new Set(
-      ruleset.occupations.find(o => o.id === existingCharacter.info.occupationId)?.skillIds ?? []
+      [
+        ...(ruleset.occupations.find(o => o.id === existingCharacter.info.occupationId)?.skillIds ?? []),
+        ...(existingCharacter.occupationChoiceSkillIds ?? []),
+      ]
     )
     const out: Record<string, number> = {}
     for (const [id, pts] of Object.entries(existingCharacter.skillAlloc)) {
@@ -577,6 +681,71 @@ export default function CharacterPage() {
     const appliedDelta = clamped - prevOcc
     if (appliedDelta !== 0) setPendingOccupationDelta(d => Math.max(0, d + appliedDelta))
   }
+
+  const addOccupationChoice = (slotIndex: number, skillId: string) => {
+    if (!selectedOcc || selectedChoiceSkillIdSet.has(skillId)) return
+    const slot = selectedOcc.choiceSlots?.[slotIndex]
+    if (!slot || (occupationChoiceSelections[slotIndex]?.length ?? 0) >= slot.count) return
+    setOccupationChoiceState(previous => {
+      if (previous.occupationId !== selectedOcc.id) return previous
+      const selections = (selectedOcc.choiceSlots ?? []).map((_, index) => [
+        ...(previous.selections[index] ?? []),
+      ])
+      selections[slotIndex].push(skillId)
+      return { occupationId: previous.occupationId, selections }
+    })
+    // 原本作为兴趣技能加过点时保留总分配量，但移出兴趣池的本地镜像；后端
+    // preview 会按新的显式职业选择重新给两条预算记账。
+    setInterestAlloc(previous => {
+      const next = { ...previous }
+      delete next[skillId]
+      return next
+    })
+    setPendingOccupationDelta(0)
+    setPendingInterestDelta(0)
+    setChoiceActionError('')
+    if ((occupationChoiceSelections[slotIndex]?.length ?? 0) + 1 >= slot.count) {
+      setChoicePickerSlotIndex(null)
+      setChoiceSkillSearch('')
+    }
+  }
+
+  const removeOccupationChoice = (slotIndex: number, skillId: string) => {
+    if ((skillAlloc[skillId] ?? 0) > 0) {
+      setChoiceActionError(`请先将「${occupationSkillLabel(skillId, ruleset?.skills ?? [])}」的加点清零`)
+      return
+    }
+    setOccupationChoiceState(previous => {
+      if (!selectedOcc || previous.occupationId !== selectedOcc.id) return previous
+      const selections = previous.selections.map((selection, index) => (
+        index === slotIndex ? selection.filter(id => id !== skillId) : [...selection]
+      ))
+      return { occupationId: previous.occupationId, selections }
+    })
+    setPendingOccupationDelta(0)
+    setPendingInterestDelta(0)
+    setChoiceActionError('')
+  }
+
+  const activeChoiceSlot = choicePickerSlotIndex == null
+    ? null
+    : selectedOcc?.choiceSlots?.[choicePickerSlotIndex] ?? null
+  const choiceCandidateSkills = useMemo(() => {
+    if (!ruleset || !selectedOcc || !activeChoiceSlot) return []
+    const fixedIds = new Set(selectedOcc.skillIds)
+    const allowedIds = activeChoiceSlot.candidateSkillIds
+      ? new Set(activeChoiceSlot.candidateSkillIds)
+      : null
+    const query = choiceSkillSearch.trim().toLowerCase()
+    return ruleset.skills.filter(skill => {
+      if (skill.id === 'credit-rating' || skill.id === 'cthulhu-mythos') return false
+      if (fixedIds.has(skill.id) || selectedChoiceSkillIdSet.has(skill.id)) return false
+      if (allowedIds && !allowedIds.has(skill.id)) return false
+      if (!query) return true
+      return skill.name.toLowerCase().includes(query)
+        || (skill.nameEn ?? '').toLowerCase().includes(query)
+    })
+  }, [activeChoiceSlot, choiceSkillSearch, ruleset, selectedChoiceSkillIdSet, selectedOcc])
 
   // 信用评级 +/- ：直接夹在所选职业的 [creditMin, creditMax] 内。信用的
   // base 固定是 0（见后端 SkillSpec），所以 skillAlloc['credit-rating']
@@ -673,6 +842,12 @@ export default function CharacterPage() {
     const issues: string[] = []
     if (!info.name.trim()) issues.push('角色姓名不能为空')
     if (info.occupationId == null) issues.push('请选择职业')
+    if (targetStep >= 3 && selectedOcc && !occupationChoicesComplete) {
+      const missingSlot = (selectedOcc.choiceSlots ?? []).find(
+        (slot, index) => (occupationChoiceSelections[index]?.length ?? 0) < slot.count
+      )
+      issues.push(missingSlot ? `请完成职业自选技能：${missingSlot.label}` : '请完成职业自选技能')
+    }
     if (targetStep >= 4 && serializedBackground.length > CHARACTER_BACKGROUND_MAX_LENGTH) {
       issues.push(`背景故事不能超过 ${CHARACTER_BACKGROUND_MAX_LENGTH} 个字符`)
     }
@@ -685,7 +860,9 @@ export default function CharacterPage() {
       } else if (previewStatus !== 'ready') {
         issues.push('规则预览尚未准备好，请稍后')
       } else {
-        issues.push(...previewValidationIssues.map(issue => issue.message))
+        issues.push(...previewValidationIssues
+          .filter(issue => issue.code !== 'OCCUPATION_CHOICES_INCOMPLETE')
+          .map(issue => issue.message))
       }
     }
     return issues
@@ -726,7 +903,12 @@ export default function CharacterPage() {
       // 已分配点数换算成"最终值"，连同属性/职业一起发给后端拿回完整的
       // skillView（79 项技能的最终值）和衍生值，两边都以这次结果为准落库。
       const { preview: finalPreview, skillValues: skillsPayload } =
-        await previewWithAllocations(attr, info.occupationId, skillAlloc)
+        await previewWithAllocations(
+          attr,
+          info.occupationId,
+          skillAlloc,
+          occupationChoiceSkillIds,
+        )
       const finalDerived = normalizeDerivedStats(finalPreview.derivedStats)
       const skillFinalValues = Object.fromEntries(
         finalPreview.skillView.map(v => [v.id, v.current])
@@ -751,6 +933,7 @@ export default function CharacterPage() {
         attr,
         derived: { hp: finalDerived.hp, san: finalDerived.san, mp: finalDerived.mp },
         skillValues: skillsPayload,
+        occupationChoiceSkillIds,
         equipment,
         occupationName: selectedOcc?.name ?? null,
         background: serializedBackground,
@@ -763,6 +946,7 @@ export default function CharacterPage() {
           attr: { ...attr },
           skillAlloc: { ...skillAlloc },
           skillFinalValues,
+          occupationChoiceSkillIds: [...occupationChoiceSkillIds],
           equipment, background: serializedBackground, notes,
           derived: finalDerived,
         },
@@ -777,11 +961,14 @@ export default function CharacterPage() {
   }
 
   const currentNavigationIssues = validationAttempted ? getBlockingIssues(step < 3 ? step + 1 : 4) : []
-  const previewIssuesBanner = previewStatus === 'ready' && previewValidationIssues.length > 0 ? (
+  const visiblePreviewIssues = previewValidationIssues.filter(
+    issue => issue.code !== 'OCCUPATION_CHOICES_INCOMPLETE'
+  )
+  const previewIssuesBanner = previewStatus === 'ready' && visiblePreviewIssues.length > 0 ? (
     <div className="mt-3 rounded-[6px] border border-[#e0a0a0] bg-[#fff5f5] px-3 py-2 text-[11px] text-[#c04040]">
       <div className="font-semibold mb-1">当前人物卡有校验问题</div>
       <div className="space-y-0.5">
-        {previewValidationIssues.map((issue) => (
+        {visiblePreviewIssues.map((issue) => (
           <div key={`${issue.field}-${issue.code}`}>{issue.message}</div>
         ))}
       </div>
@@ -938,7 +1125,7 @@ export default function CharacterPage() {
                               className="text-[11px] text-brass-dark underline">
                               详情
                             </button>
-                            <button onClick={() => setInfo(i => ({ ...i, occupationId: null }))}
+                            <button onClick={() => selectOccupation(null)}
                               className="text-[11px] text-text-dim underline">
                               取消选择
                             </button>
@@ -980,7 +1167,7 @@ export default function CharacterPage() {
                         >
                           <Info className="w-3 h-3" />
                         </button>
-                        <div onClick={() => setInfo(i => ({ ...i, occupationId: occ.id }))} className="h-full flex flex-col items-center justify-center">
+                        <div onClick={() => selectOccupation(occ.id)} className="h-full flex flex-col items-center justify-center">
                           <div className="text-[20px] mb-1">{occupationIcon(occ)}</div>
                           <div className="text-[12px] font-semibold text-text-primary leading-[1.3]">{occ.name}</div>
                           {selected && (
@@ -1086,17 +1273,15 @@ export default function CharacterPage() {
               <div className="bg-card border border-border-light rounded-md p-[18px] mt-3">
                 <h4 className="text-[12px] font-semibold text-brass-dark uppercase tracking-[0.08em] mb-3">衍生属性</h4>
                 {previewError && <p className="text-[11px] text-[#c04040] mb-2">{previewError}</p>}
-                <div className="flex gap-2">
-                  {[
-                    { label: 'HP', value: `${derived.hp}`, color: '#4a8a4a' },
-                    { label: 'SAN', value: `${derived.san}`, color: '#7050a0' },
-                    { label: 'MP', value: `${derived.mp}`, color: '#4a7098' },
-                    { label: 'DB', value: derived.db, color: '#b8976a' },
-                    { label: 'MOV', value: `${derived.move}`, color: '#c08050' },
-                  ].map(pill => (
-                    <div key={pill.label} className="flex-1 bg-panel rounded-md px-2.5 py-2 text-center">
-                      <div className="text-[10px] text-text-muted font-semibold">{pill.label}</div>
-                      <div className="text-[16px] font-bold font-mono" style={{ color: pill.color }}>{pill.value}</div>
+                <div className="grid grid-cols-3 gap-2" data-testid="derived-stats-grid">
+                  {DERIVED_STAT_DEFINITIONS.map(definition => (
+                    <div key={definition.key} className="bg-panel rounded-md px-2.5 py-2 text-center">
+                      <div className="text-[10px] text-text-muted font-semibold">
+                        {definition.label} <span className="font-mono text-text-dim">{definition.abbreviation}</span>
+                      </div>
+                      <div className="text-[16px] font-bold font-mono" style={{ color: definition.color }}>
+                        {derived[definition.key]}
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -1132,6 +1317,71 @@ export default function CharacterPage() {
                 </div>
               </div>
               {previewIssuesBanner}
+
+              {selectedOcc && (selectedOcc.choiceSlots?.length ?? 0) > 0 && (
+                <div className="bg-card border border-border-light rounded-md p-3.5 my-3" data-testid="occupation-choice-panel">
+                  <div className="flex items-start justify-between gap-3 mb-3">
+                    <div>
+                      <h4 className="text-[12px] font-semibold text-brass-dark">职业自选技能</h4>
+                      <p className="text-[10px] text-text-muted mt-0.5">选中的技能将使用职业技能点</p>
+                    </div>
+                    <span className={`text-[11px] font-mono font-semibold ${
+                      occupationChoicesComplete ? 'text-mold' : 'text-[#c08050]'
+                    }`}>
+                      {occupationChoiceSkillIds.length}/
+                      {(selectedOcc.choiceSlots ?? []).reduce((sum, slot) => sum + slot.count, 0)}
+                    </span>
+                  </div>
+
+                  <div className="space-y-2.5">
+                    {(selectedOcc.choiceSlots ?? []).map((slot, slotIndex) => {
+                      const selectedIds = occupationChoiceSelections[slotIndex] ?? []
+                      return (
+                        <div key={`${slot.label}-${slotIndex}`} className="rounded-[6px] bg-input border border-border-light p-3">
+                          <div className="flex items-center justify-between gap-2 mb-2">
+                            <div className="text-[12px] font-medium text-text-primary">{slot.label}</div>
+                            <span className="text-[10px] font-mono text-text-muted">{selectedIds.length}/{slot.count}</span>
+                          </div>
+                          <div className="flex flex-wrap gap-1.5">
+                            {selectedIds.map(skillId => (
+                              <button
+                                key={skillId}
+                                type="button"
+                                onClick={() => removeOccupationChoice(slotIndex, skillId)}
+                                className="flex items-center gap-1 px-2 py-1 rounded-[4px] bg-card border border-brass text-[11px] text-text-body"
+                                aria-label={`取消职业自选技能 ${occupationSkillLabel(skillId, ruleset?.skills ?? [])}`}
+                              >
+                                {occupationSkillLabel(skillId, ruleset?.skills ?? [])}
+                                <X className="w-3 h-3" />
+                              </button>
+                            ))}
+                            {selectedIds.length < slot.count && (
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setChoicePickerSlotIndex(slotIndex)
+                                  setChoiceSkillSearch('')
+                                  setChoiceActionError('')
+                                }}
+                                className="flex items-center gap-1 px-2 py-1 rounded-[4px] border border-dashed border-brass text-[11px] text-brass-dark"
+                              >
+                                <Plus className="w-3 h-3" /> 选择技能
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+
+                  {choiceActionError && (
+                    <p className="mt-2 text-[11px] text-[#c04040]">{choiceActionError}</p>
+                  )}
+                  {validationAttempted && !occupationChoicesComplete && (
+                    <p className="mt-2 text-[11px] text-[#c04040]">请填满全部职业自选技能槽位</p>
+                  )}
+                </div>
+              )}
 
               {/* Credit Rating — 后端必填技能，值须落在所选职业信用区间内，
                   单独给一张显眼卡片，不跟普通技能混在职业/兴趣两个 tab 里。 */}
@@ -1372,11 +1622,65 @@ export default function CharacterPage() {
                   </div>
 
                   <button
-                    onClick={() => { setInfo(i => ({ ...i, occupationId: detailOcc.id })); setDetailOcc(null) }}
+                    onClick={() => { selectOccupation(detailOcc.id); setDetailOcc(null) }}
                     className="mt-4 w-full flex items-center justify-center gap-2 py-3 rounded-sm bg-brass text-white text-sm font-semibold active:bg-brass-dark transition-all"
                   >
                     选择 {detailOcc.name}
                   </button>
+                </div>
+              </div>
+            </>
+          )}
+
+          {activeChoiceSlot && choicePickerSlotIndex != null && (
+            <>
+              <div
+                className="fixed inset-0 bg-black/50 z-40 animate-fade-in"
+                onClick={() => setChoicePickerSlotIndex(null)}
+              />
+              <div className="fixed inset-x-0 bottom-0 z-50 mx-auto max-w-[430px] bg-page border border-border-light rounded-t-xl px-5 pt-5 pb-8 max-h-[75vh] flex flex-col">
+                <div className="flex items-start justify-between gap-3 mb-3">
+                  <div>
+                    <h3 className="text-[16px] font-bold text-text-primary">选择职业技能</h3>
+                    <p className="text-[11px] text-text-muted mt-0.5">{activeChoiceSlot.label}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setChoicePickerSlotIndex(null)}
+                    className="w-8 h-8 rounded-full bg-card border border-border-light flex items-center justify-center text-text-muted"
+                    aria-label="关闭职业技能选择"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+                <div className="relative mb-3">
+                  <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-text-dim" />
+                  <input
+                    value={choiceSkillSearch}
+                    onChange={event => setChoiceSkillSearch(event.target.value)}
+                    placeholder="搜索技能…"
+                    aria-label="搜索职业自选技能"
+                    className="w-full pl-9 pr-3 py-2.5 rounded-[6px] bg-input border border-border-light text-[13px] text-text-primary outline-none focus:border-brass"
+                  />
+                </div>
+                <div className="overflow-y-auto space-y-1.5">
+                  {choiceCandidateSkills.map(skill => (
+                    <button
+                      key={skill.id}
+                      type="button"
+                      onClick={() => addOccupationChoice(choicePickerSlotIndex, skill.id)}
+                      className="w-full flex items-center justify-between gap-3 px-3 py-2.5 rounded-[6px] bg-card border border-border-light text-left active:bg-panel"
+                    >
+                      <span className="min-w-0">
+                        <span className="block text-[13px] font-medium text-text-primary">{skill.name}</span>
+                        <span className="block text-[10px] font-mono text-text-dim">{skill.nameEn}</span>
+                      </span>
+                      <Plus className="w-4 h-4 text-brass flex-shrink-0" />
+                    </button>
+                  ))}
+                  {choiceCandidateSkills.length === 0 && (
+                    <p className="py-8 text-center text-sm text-text-muted">没有可选技能</p>
+                  )}
                 </div>
               </div>
             </>

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -121,7 +121,24 @@ vi.mock('@/hooks/useRoomPlayers', () => ({
 
 vi.mock('@/hooks/useRuleset', () => ({
   useRuleset: () => ({
-    ruleset: { attributes: [], skills: [], occupations: [] },
+    ruleset: {
+      attributes: [],
+      skills: [
+        { id: 'accounting', name: '会计', nameEn: 'accounting', base: 5, category: 'occupation' },
+        { id: 'charm', name: '取悦', nameEn: 'charm', base: 15, category: 'social' },
+        { id: 'stealth', name: '潜行', nameEn: 'stealth', base: 20, category: 'interest' },
+      ],
+      occupations: [{
+        id: 1,
+        name: '记者',
+        creditMin: 0,
+        creditMax: 70,
+        skillPointsFormula: 'EDU*4',
+        skillIds: ['accounting'],
+        choiceSlots: [{ count: 1, candidateSkillIds: null, label: '任意一项技能' }],
+        description: '',
+      }],
+    },
     loading: false,
     error: '',
   }),
@@ -792,15 +809,16 @@ describe('RoomPage conversation history', () => {
           gender: '男',
           residence: '阿卡姆',
           birthplace: '波士顿',
-          occupationId: null,
+          occupationId: 1,
         },
         attr: {},
         skillAlloc: {},
-        skillFinalValues: {},
+        skillFinalValues: { accounting: 40, charm: 50, stealth: 30 },
+        occupationChoiceSkillIds: ['charm'],
         equipment: '',
         background,
         notes: '',
-        derived: { hp: 10, san: 60, mp: 10, db: '0', move: 8 },
+        derived: { hp: 10, san: 60, mp: 10, db: '0', build: '0', move: 8 },
       },
       'room-1',
     )
@@ -808,10 +826,44 @@ describe('RoomPage conversation history', () => {
 
     renderRoomPage()
     fireEvent.click(screen.getByRole('button', { name: '角色卡' }))
+    for (const label of ['生命值', '理智值', '魔法值', '伤害加值', '体格', '移动力']) {
+      expect(screen.getByText(new RegExp(label))).toBeInTheDocument()
+    }
     fireEvent.click(screen.getByRole('button', { name: '背景装备' }))
 
     const renderedBackground = screen.getByText((_, element) => element?.textContent === background)
     expect(renderedBackground).toHaveClass('whitespace-pre-wrap')
+  })
+
+  it('shows explicit occupation choice skills in the occupation tab', () => {
+    useCharacterStore.getState().setCharacter(
+      {
+        info: {
+          name: '杜调查员', playerName: '陈探员', age: '32', gender: '男',
+          residence: '阿卡姆', birthplace: '波士顿', occupationId: 1,
+        },
+        attr: {},
+        skillAlloc: {},
+        skillFinalValues: { accounting: 40, charm: 50, stealth: 30 },
+        occupationChoiceSkillIds: ['charm'],
+        equipment: '',
+        background: '',
+        notes: '',
+        derived: { hp: 10, san: 60, mp: 10, db: '0', build: '0', move: 8 },
+      },
+      'room-1',
+    )
+    mockListConversation.mockResolvedValue([])
+
+    renderRoomPage()
+    fireEvent.click(screen.getByRole('button', { name: '技能' }))
+    expect(screen.getByText('会计')).toBeInTheDocument()
+    expect(screen.getByText('取悦')).toBeInTheDocument()
+    expect(screen.queryByText('潜行')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '兴趣技能' }))
+    expect(screen.getByText('潜行')).toBeInTheDocument()
+    expect(screen.queryByText('取悦')).not.toBeInTheDocument()
   })
 
   it('keeps the first check result when reopening the modal before confirming', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -10,6 +10,7 @@ import { endGame } from '@/services/room'
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 import { useRuleset } from '@/hooks/useRuleset'
 import { useHostSpeech } from '@/hooks/useHostSpeech'
+import { DERIVED_STAT_DEFINITIONS } from '@/data/derived-stats'
 
 // `crypto.randomUUID()` 要求安全上下文（HTTPS 或 localhost）——CI Preview
 // 部署在纯 HTTP 的 IP:端口上（issue #200，域名/HTTPS 明确列在本期不做），
@@ -1437,14 +1438,14 @@ export default function RoomPage() {
         <div className="flex items-center gap-4 px-4 py-2 border-t border-border-light bg-page flex-shrink-0">
           <div className="flex items-center gap-1.5 flex-1 min-w-0">
             <Heart className="w-3 h-3 text-mold flex-shrink-0" strokeWidth={2.5} />
-            <span className="text-[10px] font-semibold text-text-muted flex-shrink-0">HP</span>
+            <span className="text-[10px] font-semibold text-text-muted flex-shrink-0">生命</span>
             <div className="flex-1 h-1.5 rounded-full bg-border-light overflow-hidden">
               <div className="h-full rounded-full bg-mold" style={{ width: '100%' }} />
             </div>
             <span className="text-[11px] font-bold font-mono text-mold flex-shrink-0">{currentHp}</span>
           </div>
           <div className="flex items-center gap-1.5 flex-1 min-w-0">
-            <span className="text-[10px] font-semibold text-text-muted flex-shrink-0">SAN</span>
+            <span className="text-[10px] font-semibold text-text-muted flex-shrink-0">理智</span>
             <div className="flex-1 h-1.5 rounded-full bg-border-light overflow-hidden">
               <div className="h-full rounded-full bg-[#7050a0]" style={{ width: `${Math.min(100, currentSan)}%` }} />
             </div>
@@ -1562,17 +1563,15 @@ export default function RoomPage() {
                   </div>
                 </div>
 
-                <div className="flex gap-2 mb-4">
-                  {[
-                    { label: 'HP', value: `${character.derived.hp}`, color: 'text-mold' },
-                    { label: 'SAN', value: `${character.derived.san}`, color: 'text-[#7050a0]' },
-                    { label: 'MP', value: `${character.derived.mp}`, color: 'text-[#4a7098]' },
-                    { label: 'DB', value: character.derived.db, color: 'text-text-muted' },
-                    { label: 'MOV', value: `${character.derived.move}`, color: 'text-text-muted' },
-                  ].map((pill) => (
-                    <div key={pill.label} className="flex-1 bg-panel rounded-md px-2.5 py-2 text-center">
-                      <div className="text-[10px] text-text-muted font-medium">{pill.label}</div>
-                      <div className={`text-base font-bold font-mono ${pill.color}`}>{pill.value}</div>
+                <div className="grid grid-cols-3 gap-2 mb-4" data-testid="derived-stats-grid">
+                  {DERIVED_STAT_DEFINITIONS.map((definition) => (
+                    <div key={definition.key} className="bg-panel rounded-md px-2.5 py-2 text-center">
+                      <div className="text-[10px] text-text-muted font-medium">
+                        {definition.label} <span className="font-mono text-text-dim">{definition.abbreviation}</span>
+                      </div>
+                      <div className="text-base font-bold font-mono" style={{ color: definition.color }}>
+                        {character.derived[definition.key] ?? '—'}
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -1628,7 +1627,10 @@ export default function RoomPage() {
             <div className="space-y-2">
               {(() => {
                 const occSkillIds = character.info.occupationId
-                  ? ruleset?.occupations.find(o => o.id === character.info.occupationId)?.skillIds ?? []
+                  ? [
+                      ...(ruleset?.occupations.find(o => o.id === character.info.occupationId)?.skillIds ?? []),
+                      ...(character.occupationChoiceSkillIds ?? []),
+                    ]
                   : []
                 const list = (ruleset?.skills ?? [])
                   .filter((skill) => skillsTab === 'occupation' ? occSkillIds.includes(skill.id) : !occSkillIds.includes(skill.id))

--- a/trpg-frontend/src/services/character/character-api.ts
+++ b/trpg-frontend/src/services/character/character-api.ts
@@ -14,6 +14,7 @@ export interface BuiltCharacter {
   attr: Record<string, number>; // 后端属性键，如 { STR: 50, CON: 60, ... }
   derived: { hp: number; san: number; mp: number };
   skillValues: Record<string, number>; // skillId -> 最终值（base+分配）
+  occupationChoiceSkillIds: string[];
   equipment: string;
   occupationName: string | null;
   background: string;
@@ -49,6 +50,7 @@ export async function saveCharacter(
       attributes: built.attr,
       derivedStats: { HP: built.derived.hp, SAN: built.derived.san, MP: built.derived.mp },
       skills: built.skillValues,
+      occupationChoiceSkillIds: built.occupationChoiceSkillIds,
       equipment: built.equipment
         ? built.equipment
             .split(/[,，\n]/)

--- a/trpg-frontend/src/services/character/ruleset-api.ts
+++ b/trpg-frontend/src/services/character/ruleset-api.ts
@@ -77,6 +77,7 @@ const VALIDATION_FIELD_LABELS: Record<string, string> = {
   skills: '技能',
   equipment: '装备',
   occupation: '职业',
+  occupationChoiceSkillIds: '职业自选技能',
   background: '背景故事',
   notes: '备注',
 }

--- a/trpg-frontend/src/stores/character-store.ts
+++ b/trpg-frontend/src/stores/character-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import type { Attributes, InvestigatorInfo } from '@/data/character-model'
+import type { DerivedStatsView } from '@/data/derived-stats'
 
 export interface CompletedCharacter {
   info: InvestigatorInfo
@@ -11,10 +12,13 @@ export interface CompletedCharacter {
   // 渲染这份数据，不用再拿 skillAlloc 现场重算（issue #84 S3：规则计算全部
   // 交给后端，前端只存/渲染结果）。
   skillFinalValues: Record<string, number>
+  // 可选是为了兼容 issue #140 之前写入 localStorage 的旧缓存；新保存的角色
+  // 始终写入数组，后端的 null 兼容路径负责旧角色推断。
+  occupationChoiceSkillIds?: string[]
   equipment: string
   background: string
   notes: string
-  derived: { hp: number; san: number; mp: number; db: string; move: number }
+  derived: DerivedStatsView
 }
 
 interface CharacterState {

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -133,6 +133,7 @@ export interface CharacterComputeResult {
   occupationSkillPoints: SkillPointsBudgetView;
   interestSkillPoints: SkillPointsBudgetView;
   skillView: SkillComputeView[];
+  resolvedOccupationChoiceSkillIds?: string[];
   validation: ValidationIssueView[];
 }
 
@@ -155,6 +156,7 @@ export interface CharacterPreviewRequest {
   skills?: {
     [k: string]: number;
   };
+  occupationChoiceSkillIds?: string[] | null;
 }
 
 /**
@@ -186,6 +188,7 @@ export interface CharacterRead {
   skills?: {
     [k: string]: number;
   };
+  occupationChoiceSkillIds?: string[] | null;
   equipment?: string[];
   occupation?: string | null;
   background?: string;
@@ -235,6 +238,7 @@ export interface CharacterUpdateBody {
   skills: {
     [k: string]: number;
   };
+  occupationChoiceSkillIds?: string[] | null;
   equipment?: EquipmentItem[];
   occupation?: string | null;
   background?: string;


### PR DESCRIPTION

Closes #140

## 改动摘要

- 将建卡页、准备页和游戏内角色卡的六项衍生属性统一为中文名称 + 英文缩写，并改为三列两行布局。
- 在技能步骤增加按职业槽位显式选择的「职业自选技能」面板，支持限定/开放候选、搜索、容量限制、分类重算和离开技能步骤时校验。
- 新角色保存显式选择；旧角色的 `null` 仍走现有加点自动匹配路径，并由预览结果回填。
- 后端增加显式选择的重复、未知、固定职业技能、不可分配技能、候选范围和槽位数量校验。

## 迁移与兼容

- 新增 nullable JSON 字段 `characters.occupation_choice_skill_ids`。
- Alembic: `3f8a1c2d4e5f -> e4b6c8d0f2a1`。
- 升级保留旧数据为 `null`；降级删除新字段。
- 已使用一次性 SQLite 数据库验证 `upgrade -> downgrade -> upgrade`。

## 验证结果

- Backend: `ruff check` ✓, `ruff format --check` ✓, `ty check` ✓, `pytest` ✓ (`236 passed, 3 skipped`)
- SDK: `codegen` ✓, `lint` ✓, `test` ✓ (`16 passed`), `build` ✓
- Frontend: `npm test` ✓ (`59 passed`), `npm run lint` ✓, `npm run build` ✓
- 本地真实前后端联调验证了六项衍生属性布局和职业自选面板。

## UI 截图

### 中文衍生属性（三列两行）
<img width="1280" height="720" alt="derived-stats" src="https://github.com/user-attachments/assets/e1c45db6-18bc-43a2-9c51-6c7d996d9ecf" />

### 职业自选技能面板
<img width="1280" height="720" alt="occupation-choices" src="https://github.com/user-attachments/assets/ede9cf28-4ef6-48b0-a40b-0f2f2ee4e9ac" />

## 人工 Review 待办

- [ ] 检查手机尺寸下职业自选面板与底部选择器的可用性
- [ ] 核对限定槽与开放槽重叠时的后端最终匹配顺序
- [ ] 用真实旧角色数据验证 `null` 自动回填的兼容体验
