### PR TITLE
feat(frontend): 技能检定与自由掷骰改用 Three.js 真 3D 骰子 (#217)

### DIFF
--- a/trpg-frontend/package-lock.json
+++ b/trpg-frontend/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.18.1",
+        "three": "^0.185.1",
         "trpg-sdk": "file:../trpg-sdk",
         "zustand": "^5.0.14"
       },
@@ -21,6 +22,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
+        "@types/three": "^0.185.3",
         "@vitejs/plugin-react": "^5.1.0",
         "autoprefixer": "^10.5.2",
         "eslint": "^9.39.5",
@@ -566,6 +568,13 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
@@ -1767,6 +1776,13 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1870,6 +1886,35 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.3",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.3.tgz",
+      "integrity": "sha512-8TqTn1+fjPWuJ4mR6Igtg56DCf9b5EeAlwhb5xaa6WlBrsg7SvG0NQbyctGRkHCKwg0uftfCspOEsTXelgktMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.64.0",
@@ -3251,6 +3296,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3809,6 +3861,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4820,6 +4879,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/trpg-frontend/package.json
+++ b/trpg-frontend/package.json
@@ -15,6 +15,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.18.1",
+    "three": "^0.185.1",
     "trpg-sdk": "file:../trpg-sdk",
     "zustand": "^5.0.14"
   },
@@ -24,6 +25,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
+    "@types/three": "^0.185.3",
     "@vitejs/plugin-react": "^5.1.0",
     "autoprefixer": "^10.5.2",
     "eslint": "^9.39.5",

--- a/trpg-frontend/src/features/dice3d/Dice3DStage.tsx
+++ b/trpg-frontend/src/features/dice3d/Dice3DStage.tsx
@@ -1,0 +1,98 @@
+/**
+ * 3D 骰子的 React 封装（issue #217）。
+ *
+ * three 走**动态 import**：只有真的要渲染 3D 骰子时才加载，不进首屏包。
+ * 因此这里对引擎只能用 `import type`，任何值层面的引用都必须在 `import()` 之后。
+ */
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+
+import type { DiceStage } from './engine'
+import { supports3DDice } from './support'
+import type { DiceKind } from './types'
+
+export interface Dice3DHandle {
+  /** 掷一次。引擎还没加载完时会记下来，加载完立刻补掷。 */
+  roll: () => void
+}
+
+interface Dice3DStageProps {
+  kind: DiceKind
+  /** 骰子停稳、结果可读时调用一次。 */
+  onSettled: (value: number) => void
+  /** 环境不支持 3D（无 WebGL / 用户要求减少动效）时调用，调用方据此回退 2D。 */
+  onUnsupported?: () => void
+  className?: string
+}
+
+export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function Dice3DStage(
+  { kind, onSettled, onUnsupported, className },
+  ref,
+) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const stageRef = useRef<DiceStage | null>(null)
+  // 引擎异步加载期间收到的掷骰请求先记下来，加载完补上——否则首次点击会丢。
+  const pendingRollRef = useRef(false)
+  const [failed, setFailed] = useState(false)
+
+  // 回调放进 ref：它们的引用变化不应该触发引擎重建（重建会丢掉画面上的骰子）。
+  const onSettledRef = useRef(onSettled)
+  onSettledRef.current = onSettled
+  const onUnsupportedRef = useRef(onUnsupported)
+  onUnsupportedRef.current = onUnsupported
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    if (!supports3DDice()) {
+      setFailed(true)
+      onUnsupportedRef.current?.()
+      return
+    }
+
+    let cancelled = false
+    void import('./engine')
+      .then(({ createDiceStage }) => {
+        if (cancelled) return
+        const stage = createDiceStage({
+          container,
+          kind,
+          onSettled: (value) => onSettledRef.current(value),
+        })
+        stageRef.current = stage
+        if (pendingRollRef.current) {
+          pendingRollRef.current = false
+          stage.roll()
+        }
+      })
+      .catch(() => {
+        if (cancelled) return
+        // 加载或初始化失败同样退回 2D，不能把检定卡死在这里。
+        setFailed(true)
+        onUnsupportedRef.current?.()
+      })
+
+    return () => {
+      cancelled = true
+      pendingRollRef.current = false
+      stageRef.current?.dispose()
+      stageRef.current = null
+    }
+  }, [kind])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      roll() {
+        if (failed) return
+        const stage = stageRef.current
+        if (stage) stage.roll()
+        else pendingRollRef.current = true
+      },
+    }),
+    [failed],
+  )
+
+  if (failed) return null
+  return <div ref={containerRef} className={className} data-testid="dice-3d-stage" />
+})

--- a/trpg-frontend/src/features/dice3d/engine.ts
+++ b/trpg-frontend/src/features/dice3d/engine.ts
@@ -294,11 +294,17 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
   let lastFrame = performance.now()
   let disposed = false
 
+  // 让 three 同时写 canvas 的 CSS 尺寸（setSize 的第三参默认 true）。
+  // 原型里用的是 setSize(w, h, false)，靠它自己页面的 CSS 把 canvas 拉成 100%；
+  // 这里没有那段 CSS，不写 style 的话 canvas 会按绘制缓冲尺寸当 CSS 像素显示
+  // ——在 dpr=2 的屏上就是 2 倍大小，父容器 overflow-hidden 只露出左上四分之一。
+  renderer.domElement.style.display = 'block'
+
   const resize = () => {
     const w = container.clientWidth
     const h = container.clientHeight
     if (w === 0 || h === 0) return
-    renderer.setSize(w, h, false)
+    renderer.setSize(w, h)
     camera.aspect = w / h
     camera.updateProjectionMatrix()
   }

--- a/trpg-frontend/src/features/dice3d/engine.ts
+++ b/trpg-frontend/src/features/dice3d/engine.ts
@@ -1,0 +1,488 @@
+/**
+ * 3D 骰子舞台：构建骰子、跑物理、自然定格取值（issue #217）。
+ *
+ * 与 React 无关，只认一个容器元素和一个回调，方便单独调试与替换。
+ * 这个模块会 import three，所以调用方应当**动态 import 它**，不要静态引入
+ * ——否则 three 会进首屏包。
+ *
+ * ## 结果怎么来的
+ * 不预先挑结果面，而是让骰子自然停下、读此刻朝上的那一面。这样数字与肉眼看到
+ * 的面永远一致；原型第一版是"先定值再把目标面掰上来"，表现为动画放完后骰子突然
+ * 又转一下，很突兀。
+ *
+ * 均匀性由 `shuffle()` 保证（见该文件注释），与物理是否有偏无关。
+ */
+import {
+  AmbientLight,
+  BufferGeometry,
+  Color,
+  DirectionalLight,
+  Euler,
+  Float32BufferAttribute,
+  Group,
+  Mesh,
+  MeshPhysicalMaterial,
+  MeshStandardMaterial,
+  PCFSoftShadowMap,
+  PerspectiveCamera,
+  PlaneGeometry,
+  PointLight,
+  Quaternion,
+  SRGBColorSpace,
+  Scene,
+  ShadowMaterial,
+  Vector3,
+  WebGLRenderer,
+} from 'three'
+
+import { faceNormal, polyhedronFaces } from './geometry'
+import { shuffle } from './shuffle'
+import { PALETTES, makeFaceTexture, type Palette } from './textures'
+import type { DiceKind, PolyhedronKind } from './types'
+
+const GRAVITY = -14
+const ARENA = { halfX: 2.9, halfZ: 1.35, floorY: 0 }
+/** 安全上限，防止物理异常时永远不结束。 */
+const MAX_TUMBLE_SECONDS = 4.5
+const SETTLE_SECONDS = 0.55
+
+interface FaceInfo {
+  value: number
+  normal: Vector3
+}
+
+interface Die {
+  group: Group
+  /** 静止时质心离地高度：以面着地，取内切半径。 */
+  restY: number
+  faces: FaceInfo[]
+}
+
+interface DiceActor {
+  die: Die
+  value: number | null
+  vel: Vector3
+  angAxis: Vector3
+  angSpeed: number
+  qStart?: Quaternion
+  qTarget?: Quaternion
+  pStart?: Vector3
+  pTarget?: Vector3
+}
+
+function rand(min: number, max: number): number {
+  return Math.random() * (max - min) + min
+}
+
+/** 构建一颗骰子：逐面独立网格 + 贴图，外加一个内芯防止面片缝隙透光。 */
+function buildDie(
+  kind: PolyhedronKind,
+  palette: Palette,
+  values: number[],
+  labels: string[],
+): Die {
+  const polys = polyhedronFaces(kind)
+  const group = new Group()
+  const faces: FaceInfo[] = []
+  const coreTris: number[] = []
+  let minInradius = Infinity
+  const usePips = kind === 'd6'
+
+  polys.forEach((verts, faceIndex) => {
+    // 保证顶点绕序让法线朝外。
+    const normal = faceNormal(verts)
+    const centroid = new Vector3()
+    for (const v of verts) centroid.add(v)
+    centroid.divideScalar(verts.length)
+    if (normal.dot(centroid) < 0) {
+      verts.reverse()
+      normal.negate()
+    }
+    minInradius = Math.min(minInradius, Math.abs(centroid.dot(normal)))
+
+    // UV：把面投影到它自己的平面基上，再归一化到 0–1 并留边距。
+    const u = new Vector3().subVectors(verts[1], verts[0]).normalize()
+    const w = new Vector3().crossVectors(normal, u).normalize()
+    const flat = verts.map((v) => {
+      const d = new Vector3().subVectors(v, verts[0])
+      return [d.dot(u), d.dot(w)] as [number, number]
+    })
+    const xs = flat.map((p) => p[0])
+    const ys = flat.map((p) => p[1])
+    const minX = Math.min(...xs)
+    const maxX = Math.max(...xs)
+    const minY = Math.min(...ys)
+    const maxY = Math.max(...ys)
+    const pad = 0.07
+    const uvPoly = flat.map(
+      ([px, py]) =>
+        [
+          pad + ((px - minX) / (maxX - minX || 1)) * (1 - 2 * pad),
+          pad + ((py - minY) / (maxY - minY || 1)) * (1 - 2 * pad),
+        ] as [number, number],
+    )
+
+    // 扇形三角化。
+    const positions: number[] = []
+    const uvs: number[] = []
+    for (let t = 1; t < verts.length - 1; t += 1) {
+      for (const idx of [0, t, t + 1]) {
+        positions.push(verts[idx].x, verts[idx].y, verts[idx].z)
+        uvs.push(uvPoly[idx][0], uvPoly[idx][1])
+        coreTris.push(verts[idx].x, verts[idx].y, verts[idx].z)
+      }
+    }
+    const geom = new BufferGeometry()
+    geom.setAttribute('position', new Float32BufferAttribute(positions, 3))
+    geom.setAttribute('uv', new Float32BufferAttribute(uvs, 2))
+    geom.computeVertexNormals()
+
+    const tex = makeFaceTexture(
+      palette,
+      labels[faceIndex],
+      uvPoly,
+      usePips ? values[faceIndex] : undefined,
+    )
+    const mesh = new Mesh(
+      geom,
+      new MeshPhysicalMaterial({
+        map: tex,
+        roughness: 0.32,
+        metalness: 0.05,
+        clearcoat: 0.7,
+        clearcoatRoughness: 0.25,
+      }),
+    )
+    mesh.castShadow = true
+    group.add(mesh)
+
+    faces.push({ value: values[faceIndex], normal: normal.clone() })
+  })
+
+  const coreGeom = new BufferGeometry()
+  coreGeom.setAttribute('position', new Float32BufferAttribute(coreTris, 3))
+  coreGeom.computeVertexNormals()
+  const core = new Mesh(
+    coreGeom,
+    new MeshStandardMaterial({
+      color: new Color(palette.base).multiplyScalar(0.55),
+      roughness: 0.6,
+    }),
+  )
+  core.scale.setScalar(0.985)
+  group.add(core)
+
+  return { group, restY: minInradius, faces }
+}
+
+function disposeGroup(group: Group): void {
+  group.traverse((obj) => {
+    const mesh = obj as Mesh
+    if (mesh.geometry) mesh.geometry.dispose()
+    const material = mesh.material
+    if (!material) return
+    for (const m of Array.isArray(material) ? material : [material]) {
+      const mapped = m as MeshPhysicalMaterial
+      if (mapped.map) mapped.map.dispose()
+      m.dispose()
+    }
+  })
+}
+
+/** 每颗骰子的面值表与摆放位置。D100 = 十位骰 + 个位骰。 */
+function diceDefinitions(kind: DiceKind): {
+  poly: PolyhedronKind
+  palette: Palette
+  values: number[]
+  labels: string[]
+  restX: number
+}[] {
+  if (kind === 'd100') {
+    const tens = shuffle([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+    const units = shuffle([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    return [
+      {
+        poly: 'd10',
+        palette: PALETTES.d100tens,
+        values: tens,
+        labels: tens.map((v) => (v === 0 ? '00' : String(v))),
+        restX: -1.05,
+      },
+      {
+        poly: 'd10',
+        palette: PALETTES.d100units,
+        values: units,
+        labels: units.map(String),
+        restX: 1.05,
+      },
+    ]
+  }
+  const sides = kind === 'd20' ? 20 : 6
+  const values = shuffle(Array.from({ length: sides }, (_, i) => i + 1))
+  return [
+    {
+      poly: kind,
+      palette: kind === 'd20' ? PALETTES.d20 : PALETTES.d6,
+      values,
+      labels: values.map(String),
+      restX: 0,
+    },
+  ]
+}
+
+export interface DiceStage {
+  /** 掷一次。正在掷的时候重复调用会被忽略。 */
+  roll: () => void
+  /** 释放 WebGL 资源并停掉动画循环。 */
+  dispose: () => void
+}
+
+export interface DiceStageOptions {
+  container: HTMLElement
+  kind: DiceKind
+  /** 骰子完全停稳、结果可读时调用一次。 */
+  onSettled: (value: number) => void
+}
+
+export function createDiceStage({ container, kind, onSettled }: DiceStageOptions): DiceStage {
+  const renderer = new WebGLRenderer({ antialias: true, alpha: true })
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+  renderer.shadowMap.enabled = true
+  renderer.shadowMap.type = PCFSoftShadowMap
+  // 原型用的是 r128 的 outputEncoding = sRGBEncoding。
+  renderer.outputColorSpace = SRGBColorSpace
+  container.appendChild(renderer.domElement)
+
+  const scene = new Scene()
+  const camera = new PerspectiveCamera(38, 1, 0.1, 60)
+  camera.position.set(0, 5.4, 7.0)
+  camera.lookAt(0, 0.1, 0)
+
+  scene.add(new AmbientLight(0xd8e2dc, 0.55))
+  const key = new DirectionalLight(0xffffff, 0.95)
+  key.position.set(3.5, 7, 4)
+  key.castShadow = true
+  key.shadow.mapSize.set(1024, 1024)
+  key.shadow.camera.left = -5
+  key.shadow.camera.right = 5
+  key.shadow.camera.top = 5
+  key.shadow.camera.bottom = -5
+  key.shadow.radius = 4
+  scene.add(key)
+  const rim = new PointLight(0x4fd1a5, 0.5, 20)
+  rim.position.set(-4, 2.5, -3)
+  scene.add(rim)
+  const warm = new PointLight(0xc9a227, 0.22, 18)
+  warm.position.set(4, 1.5, 3)
+  scene.add(warm)
+
+  // 地面只承接阴影，本身透明。
+  const groundGeom = new PlaneGeometry(24, 24)
+  const groundMat = new ShadowMaterial({ opacity: 0.38 })
+  const ground = new Mesh(groundGeom, groundMat)
+  ground.rotation.x = -Math.PI / 2
+  ground.position.y = ARENA.floorY
+  ground.receiveShadow = true
+  scene.add(ground)
+
+  let actors: DiceActor[] = []
+  let phase: 'idle' | 'tumble' | 'align' = 'idle'
+  let elapsed = 0
+  let alignProgress = 0
+  let minTumble = 1.35
+  let frame = 0
+  let lastFrame = performance.now()
+  let disposed = false
+
+  const resize = () => {
+    const w = container.clientWidth
+    const h = container.clientHeight
+    if (w === 0 || h === 0) return
+    renderer.setSize(w, h, false)
+    camera.aspect = w / h
+    camera.updateProjectionMatrix()
+  }
+  resize()
+
+  const observer =
+    typeof ResizeObserver === 'function' ? new ResizeObserver(() => resize()) : null
+  observer?.observe(container)
+
+  const clearActors = () => {
+    for (const actor of actors) {
+      scene.remove(actor.die.group)
+      disposeGroup(actor.die.group)
+    }
+    actors = []
+  }
+
+  /** 找出此刻法线最朝上的面——就是玩家看到的那一面。 */
+  const findTopFace = (die: Die): FaceInfo => {
+    let best = -Infinity
+    let bestFace = die.faces[0]
+    for (const face of die.faces) {
+      const worldY = face.normal.clone().applyQuaternion(die.group.quaternion).y
+      if (worldY > best) {
+        best = worldY
+        bestFace = face
+      }
+    }
+    return bestFace
+  }
+
+  const readValue = (): number => {
+    if (kind === 'd100') {
+      const tens = actors[0]?.value ?? 0
+      const units = actors[1]?.value ?? 0
+      const total = tens + units
+      return total === 0 ? 100 : total
+    }
+    return actors[0]?.value ?? 1
+  }
+
+  const enterAlign = () => {
+    phase = 'align'
+    alignProgress = 0
+    for (const actor of actors) {
+      actor.qStart = actor.die.group.quaternion.clone()
+      actor.pStart = actor.die.group.position.clone()
+      const top = findTopFace(actor.die)
+      actor.value = top.value
+      // 只做最短弧修正：这一面本来就接近朝上，不会出现大幅突转。
+      actor.qTarget = new Quaternion().setFromUnitVectors(
+        top.normal.clone(),
+        new Vector3(0, 1, 0),
+      )
+      const target = actor.die.group.position.clone()
+      target.y = actor.die.restY
+      actor.pTarget = target
+    }
+  }
+
+  const step = (dt: number) => {
+    if (phase === 'tumble') {
+      elapsed += dt
+      // 前 0.5 秒放开翻滚，之后逐渐加大阻尼让它自己停下来。
+      const damp = elapsed > 0.5 ? Math.min((elapsed - 0.5) / 0.8, 1) : 0
+      let allResting = true
+
+      for (const actor of actors) {
+        const g = actor.die.group
+        actor.vel.y += GRAVITY * dt
+        g.position.addScaledVector(actor.vel, dt)
+
+        if (g.position.y < actor.die.restY) {
+          g.position.y = actor.die.restY
+          actor.vel.y = Math.abs(actor.vel.y) * 0.42
+          actor.vel.x *= 0.7
+          actor.vel.z *= 0.7
+          actor.angSpeed *= 0.7
+          actor.angAxis.set(rand(-1, 1), rand(-1, 1), rand(-1, 1)).normalize()
+          if (actor.vel.y < 0.8) actor.vel.y = 0
+        }
+        if (g.position.x > ARENA.halfX) {
+          g.position.x = ARENA.halfX
+          actor.vel.x = -Math.abs(actor.vel.x) * 0.6
+        }
+        if (g.position.x < -ARENA.halfX) {
+          g.position.x = -ARENA.halfX
+          actor.vel.x = Math.abs(actor.vel.x) * 0.6
+        }
+        if (g.position.z > ARENA.halfZ) {
+          g.position.z = ARENA.halfZ
+          actor.vel.z = -Math.abs(actor.vel.z) * 0.6
+        }
+        if (g.position.z < -ARENA.halfZ) {
+          g.position.z = -ARENA.halfZ
+          actor.vel.z = Math.abs(actor.vel.z) * 0.6
+        }
+
+        if (damp > 0) {
+          actor.angSpeed *= Math.pow(0.06, dt * damp)
+          const pk = Math.pow(0.12, dt * damp)
+          actor.vel.x *= pk
+          actor.vel.z *= pk
+        }
+
+        g.quaternion.premultiply(
+          new Quaternion().setFromAxisAngle(actor.angAxis, actor.angSpeed * dt),
+        )
+
+        // 只看速度会在弹跳顶点误判为静止，必须同时要求真的贴着地面。
+        const grounded = Math.abs(g.position.y - actor.die.restY) < 0.03
+        if (
+          actor.angSpeed > 0.15 ||
+          Math.abs(actor.vel.y) > 0.05 ||
+          Math.abs(actor.vel.x) > 0.05 ||
+          Math.abs(actor.vel.z) > 0.05 ||
+          !grounded
+        ) {
+          allResting = false
+        }
+      }
+
+      if ((allResting && elapsed >= minTumble) || elapsed >= MAX_TUMBLE_SECONDS) {
+        enterAlign()
+      }
+    } else if (phase === 'align') {
+      alignProgress += dt / SETTLE_SECONDS
+      const k = Math.min(alignProgress, 1)
+      const ease = 1 - Math.pow(1 - k, 3)
+      for (const actor of actors) {
+        if (!actor.qStart || !actor.qTarget || !actor.pStart || !actor.pTarget) continue
+        actor.die.group.quaternion.slerpQuaternions(actor.qStart, actor.qTarget, ease)
+        actor.die.group.position.lerpVectors(actor.pStart, actor.pTarget, ease)
+      }
+      if (k >= 1) {
+        phase = 'idle'
+        onSettled(readValue())
+      }
+    }
+  }
+
+  const loop = (now: number) => {
+    if (disposed) return
+    frame = requestAnimationFrame(loop)
+    const dt = Math.min((now - lastFrame) / 1000, 0.05)
+    lastFrame = now
+    step(dt)
+    renderer.render(scene, camera)
+  }
+  frame = requestAnimationFrame(loop)
+
+  return {
+    roll() {
+      if (disposed || phase !== 'idle') return
+      clearActors()
+      diceDefinitions(kind).forEach((def, index) => {
+        const die = buildDie(def.poly, def.palette, def.values, def.labels)
+        die.group.position.set(def.restX + rand(-0.6, 0.6), 3.4 + index * 0.7, rand(-0.4, 0.4))
+        die.group.quaternion.setFromEuler(
+          new Euler(rand(0, 6.28), rand(0, 6.28), rand(0, 6.28)),
+        )
+        scene.add(die.group)
+        actors.push({
+          die,
+          value: null,
+          vel: new Vector3(rand(-2.4, 2.4), rand(-1, 0.5), rand(-1.4, 1.4)),
+          angAxis: new Vector3(rand(-1, 1), rand(-1, 1), rand(-1, 1)).normalize(),
+          angSpeed: rand(11, 19),
+        })
+      })
+      elapsed = 0
+      minTumble = rand(1.2, 1.5)
+      phase = 'tumble'
+    },
+    dispose() {
+      if (disposed) return
+      disposed = true
+      cancelAnimationFrame(frame)
+      observer?.disconnect()
+      clearActors()
+      groundGeom.dispose()
+      groundMat.dispose()
+      renderer.dispose()
+      renderer.domElement.remove()
+    },
+  }
+}

--- a/trpg-frontend/src/features/dice3d/geometry.ts
+++ b/trpg-frontend/src/features/dice3d/geometry.ts
@@ -1,0 +1,88 @@
+/**
+ * 骰子多面体几何（issue #217，移植自本地 Three.js 原型）。
+ *
+ * 逐面构建而不是直接用内置几何体：每个面要贴一张独立的、带数字的贴图，
+ * 所以必须先把「面」这个概念从三角形汤里还原出来。
+ */
+import { IcosahedronGeometry, Vector3, type BufferGeometry } from 'three'
+
+import type { PolyhedronKind } from './types'
+
+/** Newell 法求面法线：对凹凸不敏感，比取前三点叉积稳。 */
+export function faceNormal(verts: Vector3[]): Vector3 {
+  const n = new Vector3()
+  for (let i = 0; i < verts.length; i += 1) {
+    const a = verts[i]
+    const b = verts[(i + 1) % verts.length]
+    n.x += (a.y - b.y) * (a.z + b.z)
+    n.y += (a.z - b.z) * (a.x + b.x)
+    n.z += (a.x - b.x) * (a.y + b.y)
+  }
+  return n.normalize()
+}
+
+/** 从内置几何体里按三角形提取面（二十面体每面就是一个三角形）。 */
+export function extractTriangleFaces(geom: BufferGeometry): Vector3[][] {
+  const pos = geom.attributes.position.array
+  const faces: Vector3[][] = []
+  for (let i = 0; i < pos.length; i += 9) {
+    faces.push([
+      new Vector3(pos[i], pos[i + 1], pos[i + 2]),
+      new Vector3(pos[i + 3], pos[i + 4], pos[i + 5]),
+      new Vector3(pos[i + 6], pos[i + 7], pos[i + 8]),
+    ])
+  }
+  return faces
+}
+
+/** 立方体六个面，顶点按面内顺序给出。 */
+export function cubeFaces(): Vector3[][] {
+  const v = (x: number, y: number, z: number) => new Vector3(x, y, z)
+  return [
+    [v(-1, 1, -1), v(-1, 1, 1), v(1, 1, 1), v(1, 1, -1)], // 顶
+    [v(-1, -1, -1), v(1, -1, -1), v(1, -1, 1), v(-1, -1, 1)], // 底
+    [v(-1, -1, 1), v(1, -1, 1), v(1, 1, 1), v(-1, 1, 1)], // 前
+    [v(1, -1, -1), v(-1, -1, -1), v(-1, 1, -1), v(1, 1, -1)], // 后
+    [v(1, -1, 1), v(1, -1, -1), v(1, 1, -1), v(1, 1, 1)], // 右
+    [v(-1, -1, -1), v(-1, -1, 1), v(-1, 1, 1), v(-1, 1, -1)], // 左
+  ]
+}
+
+/**
+ * 五角偏方面体——真实 D10 的形状，three 没有内置，手写。
+ *
+ * 上下各 5 个风筝形面：两圈交错的腰顶点（A/B，相位差 36°）分别与上下极点围成面。
+ */
+export function trapezohedronFaces(): Vector3[][] {
+  const waistY = 0.42
+  const apexY = 1.28
+  const radius = 1
+  const upper: Vector3[] = []
+  const lower: Vector3[] = []
+  for (let i = 0; i < 5; i += 1) {
+    const a1 = ((i * 72) * Math.PI) / 180
+    const a2 = ((i * 72 + 36) * Math.PI) / 180
+    upper.push(new Vector3(Math.cos(a1) * radius, waistY, Math.sin(a1) * radius))
+    lower.push(new Vector3(Math.cos(a2) * radius, -waistY, Math.sin(a2) * radius))
+  }
+  const top = new Vector3(0, apexY, 0)
+  const bottom = new Vector3(0, -apexY, 0)
+  const faces: Vector3[][] = []
+  for (let j = 0; j < 5; j += 1) {
+    const n = (j + 1) % 5
+    faces.push([top, upper[j], lower[j], upper[n]])
+    faces.push([bottom, lower[n], upper[n], lower[j]])
+  }
+  return faces
+}
+
+export function polyhedronFaces(kind: PolyhedronKind): Vector3[][] {
+  switch (kind) {
+    case 'd6':
+      return cubeFaces()
+    case 'd10':
+      return trapezohedronFaces()
+    case 'd20':
+      return extractTriangleFaces(new IcosahedronGeometry(1.15))
+  }
+}

--- a/trpg-frontend/src/features/dice3d/index.ts
+++ b/trpg-frontend/src/features/dice3d/index.ts
@@ -1,0 +1,4 @@
+export { Dice3DStage, type Dice3DHandle } from './Dice3DStage'
+export { supports3DDice, isWebGLAvailable, prefersReducedMotion } from './support'
+export { shuffle } from './shuffle'
+export type { DiceKind } from './types'

--- a/trpg-frontend/src/features/dice3d/shuffle.test.ts
+++ b/trpg-frontend/src/features/dice3d/shuffle.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { shuffle } from './shuffle'
+
+/** 可复现的 LCG，避免用 Math.random 让统计断言变成 flaky 测试。 */
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0
+    return state / 0x100000000
+  }
+}
+
+describe('shuffle', () => {
+  it('返回原集合的一个排列，且不改动入参', () => {
+    const input = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    const snapshot = [...input]
+
+    const out = shuffle(input, seededRandom(1))
+
+    expect(out).toHaveLength(input.length)
+    expect([...out].sort((a, b) => a - b)).toEqual(snapshot)
+    expect(input).toEqual(snapshot)
+  })
+
+  it('空数组与单元素数组不出错', () => {
+    expect(shuffle([])).toEqual([])
+    expect(shuffle([7])).toEqual([7])
+  })
+
+  /**
+   * 这条是 issue #217 的硬性验收点。
+   *
+   * 3D 骰子的结果 = 物理停下后朝上那一面所带的点数，所以结果分布**完全**取决于
+   * 「点数→面」这个排列是否均匀。原型里用的 `sort(() => Math.random() - 0.5)`
+   * 不是均匀排列，会让检定骰的点数分布偏斜。
+   */
+  it('每个点数落到每个位置的频率都接近均匀', () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const trials = 20000
+    const random = seededRandom(20260804)
+    // counts[position][value] = 出现次数
+    const counts = Array.from({ length: values.length }, () =>
+      new Array<number>(values.length).fill(0),
+    )
+
+    for (let t = 0; t < trials; t += 1) {
+      const out = shuffle(values, random)
+      out.forEach((value, position) => {
+        counts[position][values.indexOf(value)] += 1
+      })
+    }
+
+    const expected = trials / values.length
+    // ±8% 相对偏差：均匀洗牌在 2 万次下远低于此，有偏洗牌（元素倾向留在原位）
+    // 在对角线上会超出一大截。
+    const tolerance = expected * 0.08
+    for (const row of counts) {
+      for (const observed of row) {
+        expect(Math.abs(observed - expected)).toBeLessThan(tolerance)
+      }
+    }
+  })
+})

--- a/trpg-frontend/src/features/dice3d/shuffle.ts
+++ b/trpg-frontend/src/features/dice3d/shuffle.ts
@@ -1,0 +1,22 @@
+/**
+ * Fisher–Yates 均匀洗牌（issue #217）。
+ *
+ * 为什么必须是均匀的：3D 骰子的结果取自「物理停下后朝上的那一面」，而点数是在
+ * 掷骰前被洗到各个面上的。设物理落面为 F（分布可能有偏），面→点数的映射为独立
+ * 的随机排列 V，则 P(V[F] = v) = 1/n 对任意 v 成立**当且仅当** V 是均匀排列。
+ * 也就是说，结果的均匀性完全由这里保证，与物理是否有偏无关。
+ *
+ * 原型里用的是 `arr.sort(() => Math.random() - 0.5)`，那不是均匀排列——比较器
+ * 返回随机值时，排序结果取决于具体排序算法的比较顺序，元素明显倾向于留在原位。
+ * 对判定成败的检定骰来说这是正确性问题，不是风格问题。
+ */
+export function shuffle<T>(items: readonly T[], random: () => number = Math.random): T[] {
+  const out = items.slice()
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1))
+    const tmp = out[i]
+    out[i] = out[j]
+    out[j] = tmp
+  }
+  return out
+}

--- a/trpg-frontend/src/features/dice3d/support.test.ts
+++ b/trpg-frontend/src/features/dice3d/support.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isWebGLAvailable, prefersReducedMotion, supports3DDice } from './support'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  Reflect.deleteProperty(window, 'matchMedia')
+})
+
+describe('3D 骰子可用性探测', () => {
+  it('取不到 WebGL context 时判定不可用', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+
+    expect(isWebGLAvailable()).toBe(false)
+    expect(supports3DDice()).toBe(false)
+  })
+
+  it('取 context 抛异常时也判定不可用，而不是让异常冒出去', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => {
+      throw new Error('WebGL blocked')
+    })
+
+    expect(() => isWebGLAvailable()).not.toThrow()
+    expect(isWebGLAvailable()).toBe(false)
+  })
+
+  it('用户要求减少动效时不走 3D，即使 WebGL 可用', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      {} as unknown as RenderingContext,
+    )
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({ matches: query.includes('reduce') }) as MediaQueryList,
+    })
+
+    expect(isWebGLAvailable()).toBe(true)
+    expect(prefersReducedMotion()).toBe(true)
+    expect(supports3DDice()).toBe(false)
+  })
+
+  it('没有 matchMedia 的环境按"不要求减少动效"处理', () => {
+    expect(prefersReducedMotion()).toBe(false)
+  })
+})

--- a/trpg-frontend/src/features/dice3d/support.ts
+++ b/trpg-frontend/src/features/dice3d/support.ts
@@ -1,0 +1,36 @@
+/**
+ * 3D 骰子的可用性探测（issue #217）。
+ *
+ * 检定是主流程的一环，不能因为渲染能力缺失就卡住。这两个判断决定是否回退到
+ * 原有的 2D 数字展示——回退路径必须始终可用。
+ *
+ * 这里不 import three：调用方要先用它决定「值不值得动态加载 three」，
+ * 所以它自己必须是零依赖的。
+ */
+
+/** WebGL 是否可用。老旧移动端浏览器、部分隐私模式下会拿不到 context。 */
+export function isWebGLAvailable(): boolean {
+  if (typeof document === 'undefined') return false
+  try {
+    const canvas = document.createElement('canvas')
+    const gl =
+      canvas.getContext('webgl2') ??
+      canvas.getContext('webgl') ??
+      canvas.getContext('experimental-webgl')
+    return gl !== null
+  } catch {
+    // 某些环境下取 context 会直接抛异常，等同不可用。
+    return false
+  }
+}
+
+/** 用户是否要求减少动态效果（无障碍偏好）。 */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/** 三者合一：当前环境是否应该走 3D。 */
+export function supports3DDice(): boolean {
+  return isWebGLAvailable() && !prefersReducedMotion()
+}

--- a/trpg-frontend/src/features/dice3d/textures.ts
+++ b/trpg-frontend/src/features/dice3d/textures.ts
@@ -1,0 +1,177 @@
+/**
+ * 程序化骰面贴图（issue #217，移植自本地 Three.js 原型）。
+ *
+ * 每个面一张 Canvas 贴图：大理石纹底 + 棱线 + 凹刻数字（D6 用点数）。
+ * 走程序化而不是美术图，是为了不往仓库塞二进制资源，也方便按骰型换配色。
+ */
+import { CanvasTexture, SRGBColorSpace } from 'three'
+
+export interface Palette {
+  /** 底色 */
+  base: string
+  /** 浅色纹理，"r,g,b" */
+  light: string
+  /** 深色纹理，"r,g,b" */
+  dark: string
+}
+
+export const PALETTES = {
+  d6: { base: '#6e7d8f', light: '200,215,230', dark: '22,30,40' },
+  d20: { base: '#157a55', light: '120,230,190', dark: '2,40,26' },
+  /** D100 十位骰 */
+  d100tens: { base: '#96231a', light: '255,150,130', dark: '48,6,4' },
+  /** D100 个位骰 */
+  d100units: { base: '#c04331', light: '255,180,160', dark: '70,14,8' },
+} as const satisfies Record<string, Palette>
+
+export type PaletteKey = keyof typeof PALETTES
+
+const SIZE = 256
+
+/** D6 的点数面。 */
+function drawPips(ctx: CanvasRenderingContext2D, cx: number, cy: number, count: number): void {
+  const off = SIZE * 0.16
+  const r = SIZE * 0.055
+  const layouts: Record<number, [number, number][]> = {
+    1: [[0, 0]],
+    2: [[-1, -1], [1, 1]],
+    3: [[-1, -1], [0, 0], [1, 1]],
+    4: [[-1, -1], [1, -1], [-1, 1], [1, 1]],
+    5: [[-1, -1], [1, -1], [0, 0], [-1, 1], [1, 1]],
+    6: [[-1, -1], [1, -1], [-1, 0], [1, 0], [-1, 1], [1, 1]],
+  }
+  const spots = layouts[count] ?? layouts[1]
+  for (const [sx, sy] of spots) {
+    const px = cx + sx * off
+    const py = cy + sy * off
+    // 先画错位的深色再画白色，做出凹刻的错觉。
+    ctx.beginPath()
+    ctx.arc(px, py + 2, r, 0, Math.PI * 2)
+    ctx.fillStyle = 'rgba(0,0,0,0.5)'
+    ctx.fill()
+    ctx.beginPath()
+    ctx.arc(px, py, r, 0, Math.PI * 2)
+    ctx.fillStyle = '#f4f6f2'
+    ctx.fill()
+  }
+}
+
+/**
+ * 生成一张骰面贴图。
+ *
+ * @param uvPoly 该面在贴图空间里的多边形轮廓（0–1），用来画棱线并定位数字。
+ * @param pips   传了就画点数（D6），否则画 label 数字。
+ */
+export function makeFaceTexture(
+  palette: Palette,
+  label: string,
+  uvPoly: [number, number][],
+  pips?: number,
+): CanvasTexture {
+  const canvas = document.createElement('canvas')
+  canvas.width = SIZE
+  canvas.height = SIZE
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('无法获取 2D 绘图上下文，骰面贴图生成失败')
+
+  ctx.fillStyle = palette.base
+  ctx.fillRect(0, 0, SIZE, SIZE)
+
+  // 大理石纹：十几块半透明模糊椭圆叠出来的随机纹理。
+  for (let i = 0; i < 12; i += 1) {
+    const tint = i % 2 === 0 ? palette.light : palette.dark
+    ctx.fillStyle = `rgba(${tint},${(0.1 + Math.random() * 0.14).toFixed(2)})`
+    // filter 在个别浏览器不支持，纹理会略平，不影响可用性。
+    try {
+      ctx.filter = `blur(${SIZE / 16}px)`
+    } catch {
+      ctx.filter = 'none'
+    }
+    ctx.beginPath()
+    ctx.ellipse(
+      Math.random() * SIZE,
+      Math.random() * SIZE,
+      SIZE * (0.14 + Math.random() * 0.3),
+      SIZE * (0.06 + Math.random() * 0.18),
+      Math.random() * Math.PI,
+      0,
+      Math.PI * 2,
+    )
+    ctx.fill()
+  }
+  try {
+    ctx.filter = 'none'
+  } catch {
+    // 同上，忽略。
+  }
+
+  // 左上柔光。
+  const grad = ctx.createRadialGradient(
+    SIZE * 0.3, SIZE * 0.24, SIZE * 0.05,
+    SIZE * 0.3, SIZE * 0.24, SIZE * 0.9,
+  )
+  grad.addColorStop(0, 'rgba(255,255,255,0.16)')
+  grad.addColorStop(0.5, 'rgba(255,255,255,0.02)')
+  grad.addColorStop(1, 'rgba(0,0,0,0.20)')
+  ctx.fillStyle = grad
+  ctx.fillRect(0, 0, SIZE, SIZE)
+
+  const tracePoly = () => {
+    ctx.beginPath()
+    uvPoly.forEach(([ux, uy], idx) => {
+      const px = ux * SIZE
+      const py = (1 - uy) * SIZE
+      if (idx === 0) ctx.moveTo(px, py)
+      else ctx.lineTo(px, py)
+    })
+    ctx.closePath()
+  }
+
+  // 棱线：外圈暗、内圈亮。
+  ctx.lineJoin = 'round'
+  tracePoly()
+  ctx.strokeStyle = 'rgba(0,0,0,0.32)'
+  ctx.lineWidth = SIZE * 0.05
+  ctx.stroke()
+  tracePoly()
+  ctx.strokeStyle = 'rgba(255,255,255,0.10)'
+  ctx.lineWidth = SIZE * 0.02
+  ctx.stroke()
+
+  // 质心 = 数字落点。
+  let cx = 0
+  let cy = 0
+  for (const [ux, uy] of uvPoly) {
+    cx += ux
+    cy += uy
+  }
+  cx = (cx / uvPoly.length) * SIZE
+  cy = (1 - cy / uvPoly.length) * SIZE
+
+  if (pips !== undefined) {
+    drawPips(ctx, cx, cy, pips)
+  } else {
+    const fontSize = SIZE * (label.length >= 2 ? 0.34 : 0.44)
+    ctx.font = `900 ${fontSize}px Georgia, serif`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillStyle = 'rgba(0,0,0,0.5)'
+    ctx.fillText(label, cx, cy + SIZE * 0.018)
+    ctx.fillStyle = '#f4f6f2'
+    ctx.fillText(label, cx, cy)
+    // 6 和 9 加下划线——真实骰子的惯例，否则倒过来看会读错。
+    if (label === '6' || label === '9') {
+      const w = ctx.measureText(label).width
+      ctx.fillStyle = 'rgba(0,0,0,0.5)'
+      ctx.fillRect(cx - w * 0.32, cy + fontSize * 0.52 + 2, w * 0.64, SIZE * 0.02)
+      ctx.fillStyle = '#f4f6f2'
+      ctx.fillRect(cx - w * 0.32, cy + fontSize * 0.52, w * 0.64, SIZE * 0.02)
+    }
+  }
+
+  const tex = new CanvasTexture(canvas)
+  tex.anisotropy = 4
+  // 原型用的是 r128 的 tex.encoding = sRGBEncoding，新版本改成了 colorSpace。
+  tex.colorSpace = SRGBColorSpace
+  return tex
+}

--- a/trpg-frontend/src/features/dice3d/types.ts
+++ b/trpg-frontend/src/features/dice3d/types.ts
@@ -1,0 +1,9 @@
+/**
+ * 骰型定义。刻意不 import three——React 侧要能只引类型而不把 three 拖进首屏包。
+ */
+
+/** 本项目用到的骰型。D100 由两颗 D10 组成，几何上没有 d100。 */
+export type DiceKind = 'd100' | 'd20' | 'd6'
+
+/** 实际存在的多面体。 */
+export type PolyhedronKind = 'd10' | 'd20' | 'd6'

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -814,6 +814,31 @@ describe('RoomPage conversation history', () => {
     expect(renderedBackground).toHaveClass('whitespace-pre-wrap')
   })
 
+  // jsdom 没有 WebGL，supports3DDice() 为 false —— 正好覆盖降级路径：
+  // 渲染能力缺失时不能把检定卡住（issue #217）。
+  it('falls back to the 2D dice display when WebGL is unavailable', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    await act(async () => {
+      emitWsMessage({
+        type: 'check.request',
+        payload: {
+          playerId: 'player-1',
+          clientActionId: 'check-fallback',
+          summary: '检查旧报纸',
+          difficulty: 'regular',
+          skills: [{ id: 'library', name: '图书馆使用', targetValue: 60 }],
+        },
+      })
+    })
+
+    expect(await screen.findByText('图书馆使用')).toBeInTheDocument()
+    expect(screen.queryByTestId('dice-3d-stage')).not.toBeInTheDocument()
+    expect(screen.getByText('十位')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '掷骰' })).toBeInTheDocument()
+  })
+
   it('keeps the first check result when reopening the modal before confirming', async () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
@@ -841,11 +866,10 @@ describe('RoomPage conversation history', () => {
       .mockReturnValueOnce(0.2)
       .mockReturnValueOnce(0.3)
 
-    fireEvent.mouseDown(screen.getByTestId('dice-table'))
-    fireEvent.mouseUp(screen.getByTestId('dice-table'))
+    fireEvent.click(screen.getByRole('button', { name: '掷骰' }))
 
     await act(async () => {
-      vi.advanceTimersByTime(600)
+      vi.advanceTimersByTime(800)
     })
 
     expect(screen.getByText('23')).toBeInTheDocument()
@@ -896,11 +920,10 @@ describe('RoomPage conversation history', () => {
       .mockReturnValueOnce(0.4)
       .mockReturnValueOnce(0.1)
 
-    fireEvent.mouseDown(screen.getByTestId('dice-table'))
-    fireEvent.mouseUp(screen.getByTestId('dice-table'))
+    fireEvent.click(screen.getByRole('button', { name: '掷骰' }))
 
     await act(async () => {
-      vi.advanceTimersByTime(600)
+      vi.advanceTimersByTime(800)
     })
 
     fireEvent.click(screen.getByRole('button', { name: '确认并发送' }))
@@ -938,11 +961,10 @@ describe('RoomPage conversation history', () => {
     })
 
     expect(screen.getByText('侦查')).toBeInTheDocument()
-    fireEvent.mouseDown(screen.getByTestId('dice-table'))
-    fireEvent.mouseUp(screen.getByTestId('dice-table'))
+    fireEvent.click(screen.getByRole('button', { name: '掷骰' }))
 
     await act(async () => {
-      vi.advanceTimersByTime(600)
+      vi.advanceTimersByTime(800)
     })
 
     expect(screen.getByText('41')).toBeInTheDocument()

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -57,10 +57,12 @@ const {
   mockSubmitAction,
   mockWaitForWsOpen,
   wsHandlers,
+  dice3dSupported,
 } = vi.hoisted(() => {
   const handlers = new Set<(event: ServerToClientEvent) => void>()
   return {
     wsHandlers: handlers,
+    dice3dSupported: { value: false },
     emitWsMessage: (event: ServerToClientEvent) => {
       for (const handler of handlers) handler(event)
     },
@@ -102,6 +104,29 @@ vi.mock('@/services/api-client', () => ({
 vi.mock('@/services/room', () => ({
   endGame: vi.fn(),
 }))
+
+/**
+ * 3D 骰子在 jsdom 里跑不了（没有 WebGL），默认按"不支持"处理，与真实 jsdom
+ * 行为一致，不影响其余用例。
+ *
+ * `dice3dSupported` 置 true 时启用一个只做一件事的假舞台：被调用 roll() 就触发
+ * `onUnsupported` —— 模拟"玩家已经点了掷骰、引擎 chunk 这时才加载失败"。
+ */
+vi.mock('@/features/dice3d', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react')
+  return {
+    supports3DDice: () => dice3dSupported.value,
+    Dice3DStage: forwardRef(
+      (
+        { onUnsupported }: { onUnsupported?: () => void },
+        ref: React.Ref<{ roll: () => void }>,
+      ) => {
+        useImperativeHandle(ref, () => ({ roll: () => onUnsupported?.() }), [onUnsupported])
+        return <div data-testid="dice-3d-stage" />
+      },
+    ),
+  }
+})
 
 vi.mock('@/hooks/useRoomPlayers', () => ({
   useRoomPlayers: () => ({
@@ -232,6 +257,7 @@ describe('RoomPage conversation history', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     wsHandlers.clear()
+    dice3dSupported.value = false
     Object.defineProperty(window, 'speechSynthesis', { configurable: true, value: undefined })
     Object.defineProperty(window, 'SpeechSynthesisUtterance', { configurable: true, value: undefined })
     window.HTMLElement.prototype.scrollIntoView = vi.fn()
@@ -837,6 +863,47 @@ describe('RoomPage conversation history', () => {
     expect(screen.queryByTestId('dice-3d-stage')).not.toBeInTheDocument()
     expect(screen.getByText('十位')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '掷骰' })).toBeInTheDocument()
+  })
+
+  // 回归：3D 引擎在玩家点了「掷骰」之后才加载失败时，只翻 use3D 会让 rolling
+  // 永远不清 —— 检定卡在「骰子还在滚」，既没有结果也没有重掷入口，恰好是这套
+  // 降级本该防住的情况（PR #219 review 指出）。
+  it('completes the roll when the 3D engine fails to load after the tap', async () => {
+    dice3dSupported.value = true
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    await act(async () => {
+      emitWsMessage({
+        type: 'check.request',
+        payload: {
+          playerId: 'player-1',
+          clientActionId: 'check-3d-fail',
+          summary: '检查旧报纸',
+          difficulty: 'regular',
+          skills: [{ id: 'library', name: '图书馆使用', targetValue: 60 }],
+        },
+      })
+    })
+    expect(await screen.findByText('图书馆使用')).toBeInTheDocument()
+    expect(screen.getByTestId('dice-3d-stage')).toBeInTheDocument()
+
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0.2).mockReturnValueOnce(0.3)
+
+    // 点击掷骰 → 假舞台立刻触发 onUnsupported，模拟 chunk 加载失败。
+    fireEvent.click(screen.getByRole('button', { name: '掷骰' }))
+    await act(async () => {
+      vi.advanceTimersByTime(800)
+    })
+    vi.useRealTimers()
+
+    // 这一次掷骰必须被补完：结果出来、能确认发送，而不是永远停在"骰子还在滚"。
+    expect(screen.getByText('23')).toBeInTheDocument()
+    expect(screen.queryByText('🎲 骰子还在滚……')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '确认并发送' })).toBeInTheDocument()
+    // 已经退回 2D 展示。
+    expect(screen.queryByTestId('dice-3d-stage')).not.toBeInTheDocument()
   })
 
   it('keeps the first check result when reopening the modal before confirming', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -10,6 +10,7 @@ import { endGame } from '@/services/room'
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 import { useRuleset } from '@/hooks/useRuleset'
 import { useHostSpeech } from '@/hooks/useHostSpeech'
+import { Dice3DStage, supports3DDice, type Dice3DHandle } from '@/features/dice3d'
 
 // `crypto.randomUUID()` 要求安全上下文（HTTPS 或 localhost）——CI Preview
 // 部署在纯 HTTP 的 IP:端口上（issue #200，域名/HTTPS 明确列在本期不做），
@@ -290,7 +291,6 @@ type DiceType = typeof DICE_OPTIONS[number]['id']
 type PendingCheckDiceState = {
   clientActionId: string
   selectedSkillId: string | null
-  shakeLevel: number
   result: number | null
   rolling: boolean
   showResult: boolean
@@ -303,7 +303,6 @@ function createPendingCheckDiceState(checkRequest: CheckRequestPayload): Pending
   return {
     clientActionId: checkRequest.clientActionId,
     selectedSkillId: checkRequest.skills[0]?.id ?? null,
-    shakeLevel: 0,
     result: null,
     rolling: false,
     showResult: false,
@@ -311,6 +310,12 @@ function createPendingCheckDiceState(checkRequest: CheckRequestPayload): Pending
     ones: 0,
     submitted: false,
   }
+}
+
+/** D100 结果拆成十位/个位用于展示。100 由「00 + 0」得来，两位都是 0。 */
+function splitD100(value: number): { tens: number; ones: number } {
+  if (value === 100) return { tens: 0, ones: 0 }
+  return { tens: Math.floor(value / 10), ones: value % 10 }
 }
 
 const DIFFICULTY_COLORS: Record<string, string> = {
@@ -378,18 +383,16 @@ function DiceModal({
   setCheckDiceState: Dispatch<SetStateAction<PendingCheckDiceState | null>>
 }) {
   const [freeDiceType, setFreeDiceType] = useState<DiceType>('d100')
-  const [freeShakeLevel, setFreeShakeLevel] = useState(0)
   const [freeResult, setFreeResult] = useState<number | null>(null)
   const [freeRolling, setFreeRolling] = useState(false)
   const [freeShowResult, setFreeShowResult] = useState(false)
   const [freeTens, setFreeTens] = useState(0)
   const [freeOnes, setFreeOnes] = useState(0)
-  const tableRef = useRef<HTMLDivElement>(null)
-  const isGrabbed = useRef(false)
-  const directionChanges = useRef(0)
-  const lastDirX = useRef(0)
-  const lastDirY = useRef(0)
   const submitLockRef = useRef(false)
+  const dice3dRef = useRef<Dice3DHandle>(null)
+  // 3D 不可用（无 WebGL / 用户要求减少动效 / 引擎加载失败）时退回原来的 2D 展示。
+  // 检定是主流程的一环，不能因为渲染能力缺失就卡住。
+  const [use3D, setUse3D] = useState(() => supports3DDice())
 
   useEffect(() => {
     if (!checkRequest) {
@@ -407,7 +410,6 @@ function DiceModal({
   useEffect(() => {
     if (open && !checkRequest) {
       setFreeDiceType('d100')
-      setFreeShakeLevel(0)
       setFreeResult(null)
       setFreeRolling(false)
       setFreeShowResult(false)
@@ -420,7 +422,6 @@ function DiceModal({
   const isCheckMode = Boolean(checkRequest)
   const activeCheckDice = checkRequest ? checkDiceState : null
   const activeDiceType: DiceType = isCheckMode ? 'd100' : freeDiceType
-  const activeShakeLevel = isCheckMode ? activeCheckDice?.shakeLevel ?? 0 : freeShakeLevel
   const activeResult = isCheckMode ? activeCheckDice?.result ?? null : freeResult
   const activeRolling = isCheckMode ? activeCheckDice?.rolling ?? false : freeRolling
   const activeShowResult = isCheckMode ? activeCheckDice?.showResult ?? false : freeShowResult
@@ -442,120 +443,57 @@ function DiceModal({
     })
   }
 
-  const roll = (power: number) => {
+  /** 结果落地：3D 由动画定格回调进来，2D 由本地随机 + 定时器进来，两条路共用。 */
+  const settle = (value: number, requestId: string | null) => {
+    const { tens, ones } = activeDiceType === 'd100' ? splitD100(value) : { tens: 0, ones: 0 }
+    if (requestId !== null) {
+      setCheckDiceState((current) => {
+        if (!current || current.clientActionId !== requestId) return current
+        return { ...current, result: value, showResult: true, rolling: false, tens, ones }
+      })
+      return
+    }
+    setFreeTens(tens)
+    setFreeOnes(ones)
+    setFreeResult(value)
+    setFreeShowResult(true)
+    setFreeRolling(false)
+  }
+
+  const roll = () => {
+    const requestId = isCheckMode ? checkRequest?.clientActionId ?? null : null
     if (isCheckMode) {
       if (!checkRequest || !activeCheckDice || activeCheckDice.result !== null || activeCheckDice.submitted || activeCheckDice.rolling) return
-      const requestId = checkRequest.clientActionId
-      updateCheckDiceState((current) => ({
-        ...current,
-        rolling: true,
-        showResult: false,
-      }))
+      updateCheckDiceState((current) => ({ ...current, rolling: true, showResult: false }))
+    } else {
+      if (freeRolling) return
+      setFreeRolling(true)
+      setFreeShowResult(false)
+    }
 
-      const tens = Math.floor(Math.random() * 10)
-      const ones = Math.floor(Math.random() * 10)
-      let finalResult = tens * 10 + ones
-      if (finalResult === 0) finalResult = 100
-
-      const dur = 500 + power * 100
-      setTimeout(() => {
-        setCheckDiceState((current) => {
-          if (!current || current.clientActionId !== requestId) return current
-          return {
-            ...current,
-            result: finalResult,
-            showResult: true,
-            rolling: false,
-            tens,
-            ones,
-          }
-        })
-      }, dur)
+    // 3D：值来自物理定格后朝上的那一面（面上的点数已由 Fisher–Yates 均匀洗过），
+    // 所以这里不预先取值，等 onSettled 回调。
+    if (use3D) {
+      dice3dRef.current?.roll()
       return
     }
 
-    setFreeRolling(true)
-    setFreeShowResult(false)
-
+    // 2D 回退：本地随机 + 固定时长的假动画，与改造前一致。
     let finalResult: number
-    let tens = 0
-    let ones = 0
-
-    if (freeDiceType === 'd100') {
-      tens = Math.floor(Math.random() * 10)
-      ones = Math.floor(Math.random() * 10)
+    if (activeDiceType === 'd100') {
+      const tens = Math.floor(Math.random() * 10)
+      const ones = Math.floor(Math.random() * 10)
       finalResult = tens * 10 + ones
       if (finalResult === 0) finalResult = 100
-      setFreeTens(tens)
-      setFreeOnes(ones)
-    } else if (freeDiceType === 'd20') {
+    } else if (activeDiceType === 'd20') {
       finalResult = Math.floor(Math.random() * 20) + 1
     } else {
       finalResult = Math.floor(Math.random() * 6) + 1
     }
-
-    const dur = 500 + power * 100
-    setTimeout(() => {
-      setFreeResult(finalResult)
-      setFreeShowResult(true)
-      setFreeRolling(false)
-    }, dur)
+    setTimeout(() => settle(finalResult, requestId), 700)
   }
 
-  const handleMouseDown = () => {
-    if (activeRolling || activeShowResult || (isCheckMode && activeResult !== null)) return
-    isGrabbed.current = true
-    directionChanges.current = 0
-    lastDirX.current = 0
-    lastDirY.current = 0
-    if (isCheckMode) {
-      updateCheckDiceState((current) => ({
-        ...current,
-        shakeLevel: 0,
-      }))
-    } else {
-      setFreeShakeLevel(0)
-    }
-  }
-
-  const handleMouseMove = (e: React.MouseEvent | React.TouchEvent) => {
-    if (!isGrabbed.current) return
-    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX
-    const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY
-
-    if (tableRef.current) {
-      const rect = tableRef.current.getBoundingClientRect()
-      const dx = clientX - (rect.left + rect.width / 2)
-      const dy = clientY - (rect.top + rect.height / 2)
-      const dirX = Math.sign(dx)
-      const dirY = Math.sign(dy)
-
-      if (lastDirX.current !== 0 && dirX !== lastDirX.current) directionChanges.current++
-      if (lastDirY.current !== 0 && dirY !== lastDirY.current) directionChanges.current++
-      lastDirX.current = dirX
-      lastDirY.current = dirY
-
-      const level = Math.min(5, Math.floor(directionChanges.current / 2.5))
-      if (isCheckMode) {
-        updateCheckDiceState((current) => ({
-          ...current,
-          shakeLevel: level,
-        }))
-      } else {
-        setFreeShakeLevel(level)
-      }
-    }
-  }
-
-  const handleMouseUp = () => {
-    if (!isGrabbed.current) return
-    isGrabbed.current = false
-    if (activeShakeLevel >= 1) {
-      roll(activeShakeLevel)
-    } else {
-      roll(1)
-    }
-  }
+  const canRoll = !activeRolling && !activeShowResult && activeResult === null && !activeCheckDice?.submitted
 
   const confirmResult = () => {
     if (isCheckMode) {
@@ -577,9 +515,20 @@ function DiceModal({
   }
 
   const renderDiceDisplay = () => {
+    if (use3D) {
+      return (
+        <Dice3DStage
+          ref={dice3dRef}
+          kind={activeDiceType}
+          className="w-full h-48"
+          onSettled={(value) => settle(value, isCheckMode ? checkRequest?.clientActionId ?? null : null)}
+          onUnsupported={() => setUse3D(false)}
+        />
+      )
+    }
     const glow = activeRolling ? 'opacity-40' : ''
     return (
-      <div ref={tableRef} className={`relative w-full h-48 flex items-center justify-center select-none ${isGrabbed.current ? 'cursor-grabbing' : 'cursor-grab'} ${glow}`}>
+      <div className={`relative w-full h-48 flex items-center justify-center select-none ${glow}`}>
         {activeDiceType === 'd100' ? (
           <div className="flex items-center gap-6">
             <div className="text-center">
@@ -598,7 +547,7 @@ function DiceModal({
           </div>
         ) : (
           <div
-            className={`text-[64px] font-bold font-mono text-[#eeead8] ${isGrabbed.current ? 'scale-105' : ''} transition-transform duration-150`}
+            className="text-[64px] font-bold font-mono text-[#eeead8] transition-transform duration-150"
             style={{
               clipPath: activeDiceType === 'd20' ? 'polygon(50% 0%, 95% 25%, 95% 75%, 50% 100%, 5% 75%, 5% 25%)' : undefined,
               background: 'linear-gradient(145deg, #2a2630, #1a1620)',
@@ -641,7 +590,6 @@ function DiceModal({
                   setFreeDiceType(opt.id)
                   setFreeResult(null)
                   setFreeShowResult(false)
-                  setFreeShakeLevel(0)
                   setFreeTens(0)
                   setFreeOnes(0)
                 }
@@ -671,7 +619,6 @@ function DiceModal({
                     selectedSkillId: skill.id,
                     result: null,
                     showResult: false,
-                    shakeLevel: 0,
                     tens: 0,
                     ones: 0,
                     submitted: false,
@@ -706,50 +653,22 @@ function DiceModal({
       <div
         data-testid="dice-table"
         className="rounded-md bg-[#1a1620] px-4 pt-5 pb-4 flex flex-col items-center relative overflow-hidden"
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
-        onTouchStart={handleMouseDown}
-        onTouchMove={handleMouseMove}
-        onTouchEnd={handleMouseUp}
       >
-        {activeShakeLevel >= 2 && !activeRolling && !activeShowResult && (
-          <div
-            className="absolute w-52 h-52 rounded-full pointer-events-none transition-all duration-200"
-            style={{
-              background: `radial-gradient(circle, rgba(184,151,106,${0.04 + activeShakeLevel * 0.04}) 0%, transparent 70%)`,
-              transform: `scale(${1 + activeShakeLevel * 0.05})`,
-            }}
-          />
-        )}
-
         {renderDiceDisplay()}
 
-        {!activeRolling && !activeShowResult && (
-          <div className="text-center mt-2">
-            <span className="text-xs text-[#9088a0]">
-              {activeShakeLevel === 0 ? '👆 按住这里来回拖动 · 摇动后松手' :
-               activeShakeLevel <= 2 ? '⚡ 再用力一点……' :
-               activeShakeLevel <= 4 ? '🔥 快了！' :
-               '💥 松手投出！'}
-            </span>
-          </div>
-        )}
-
-        {!activeRolling && !activeShowResult && (
-          <div className="flex gap-1 mt-3">
-            {[0, 1, 2, 3, 4].map((i) => (
-              <div key={i} className={`w-6 h-1 rounded-full transition-all duration-200 ${
-                i < activeShakeLevel ? (i >= 3 ? 'bg-brass' : 'bg-[rgba(184,151,106,0.5)]') : 'bg-[rgba(255,255,255,0.08)]'
-              }`} />
-            ))}
-          </div>
+        {canRoll && (
+          <button
+            type="button"
+            onClick={roll}
+            className="mt-3 px-8 py-2.5 rounded-sm bg-brass text-white text-sm font-semibold active:bg-brass-dark active:scale-[0.97] transition-all"
+          >
+            掷骰
+          </button>
         )}
 
         {activeRolling && (
-          <div className="text-center mt-2 text-xs text-[#9088a0] animate-pulse">
-            🎲 骰子飞出去了……
+          <div className="text-center mt-3 text-xs text-[#9088a0] animate-pulse">
+            🎲 骰子还在滚……
           </div>
         )}
       </div>

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -443,8 +443,18 @@ function DiceModal({
     })
   }
 
+  /**
+   * 已经交给 3D、但还没定格的那次掷骰。
+   *
+   * 用 ref 而不是读 state：3D 失败回调可能与 `roll()` 在同一个同步流程里发生，
+   * 那时 `rolling` 的 setState 还没生效，读 state 会拿到旧值、判断成"没有掷骰
+   * 在进行"，等于没修。
+   */
+  const inFlight3DRollRef = useRef<{ requestId: string | null } | null>(null)
+
   /** 结果落地：3D 由动画定格回调进来，2D 由本地随机 + 定时器进来，两条路共用。 */
   const settle = (value: number, requestId: string | null) => {
+    inFlight3DRollRef.current = null
     const { tens, ones } = activeDiceType === 'd100' ? splitD100(value) : { tens: 0, ones: 0 }
     if (requestId !== null) {
       setCheckDiceState((current) => {
@@ -460,25 +470,10 @@ function DiceModal({
     setFreeRolling(false)
   }
 
-  const roll = () => {
-    const requestId = isCheckMode ? checkRequest?.clientActionId ?? null : null
-    if (isCheckMode) {
-      if (!checkRequest || !activeCheckDice || activeCheckDice.result !== null || activeCheckDice.submitted || activeCheckDice.rolling) return
-      updateCheckDiceState((current) => ({ ...current, rolling: true, showResult: false }))
-    } else {
-      if (freeRolling) return
-      setFreeRolling(true)
-      setFreeShowResult(false)
-    }
+  const currentRequestId = () => (isCheckMode ? checkRequest?.clientActionId ?? null : null)
 
-    // 3D：值来自物理定格后朝上的那一面（面上的点数已由 Fisher–Yates 均匀洗过），
-    // 所以这里不预先取值，等 onSettled 回调。
-    if (use3D) {
-      dice3dRef.current?.roll()
-      return
-    }
-
-    // 2D 回退：本地随机 + 固定时长的假动画，与改造前一致。
+  /** 2D 回退掷骰：本地随机 + 固定时长的假动画，与改造前一致。 */
+  const roll2D = (requestId: string | null) => {
     let finalResult: number
     if (activeDiceType === 'd100') {
       const tens = Math.floor(Math.random() * 10)
@@ -491,6 +486,42 @@ function DiceModal({
       finalResult = Math.floor(Math.random() * 6) + 1
     }
     setTimeout(() => settle(finalResult, requestId), 700)
+  }
+
+  const roll = () => {
+    const requestId = currentRequestId()
+    if (isCheckMode) {
+      if (!checkRequest || !activeCheckDice || activeCheckDice.result !== null || activeCheckDice.submitted || activeCheckDice.rolling) return
+      updateCheckDiceState((current) => ({ ...current, rolling: true, showResult: false }))
+    } else {
+      if (freeRolling) return
+      setFreeRolling(true)
+      setFreeShowResult(false)
+    }
+
+    // 3D：值来自物理定格后朝上的那一面（面上的点数已由 Fisher–Yates 均匀洗过），
+    // 所以这里不预先取值，等 onSettled 回调。
+    if (use3D) {
+      inFlight3DRollRef.current = { requestId }
+      dice3dRef.current?.roll()
+      return
+    }
+    roll2D(requestId)
+  }
+
+  /**
+   * 3D 不可用。可能在掷骰之前（环境不支持），也可能在掷骰之后——懒加载 chunk
+   * 是一个网络请求，移动端抖一下就会失败。
+   *
+   * 后者必须把这一次掷骰补完：`roll()` 已经置了 rolling 并走 3D 分支返回，没有
+   * 排任何定时器。只翻 use3D 的话 rolling 永远不清，检定会卡在"骰子还在滚"，
+   * 既没有结果也没有重掷入口——恰好是这套降级本该防住的情况（PR #219 review）。
+   */
+  const handle3DUnsupported = () => {
+    const pending = inFlight3DRollRef.current
+    inFlight3DRollRef.current = null
+    setUse3D(false)
+    if (pending) roll2D(pending.requestId)
   }
 
   const canRoll = !activeRolling && !activeShowResult && activeResult === null && !activeCheckDice?.submitted
@@ -521,8 +552,8 @@ function DiceModal({
           ref={dice3dRef}
           kind={activeDiceType}
           className="w-full h-48"
-          onSettled={(value) => settle(value, isCheckMode ? checkRequest?.clientActionId ?? null : null)}
-          onUnsupported={() => setUse3D(false)}
+          onSettled={(value) => settle(value, currentRequestId())}
+          onUnsupported={handle3DUnsupported}
         />
       )
     }

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -652,7 +652,14 @@ function DiceModal({
 
       <div
         data-testid="dice-table"
-        className="rounded-md bg-[#1a1620] px-4 pt-5 pb-4 flex flex-col items-center relative overflow-hidden"
+        className="rounded-md px-4 pt-5 pb-4 flex flex-col items-center relative overflow-hidden"
+        style={{
+          // 暖调骰盘而不是冷近黑：骰子是亮面树脂材质，深底才有对比；
+          // 中心略亮、边缘压暗，配合内阴影读起来像一个打着光的托盘。
+          background:
+            'radial-gradient(120% 95% at 50% 30%, #3d3327 0%, #262019 55%, #171310 100%)',
+          boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06), inset 0 -14px 28px rgba(0,0,0,0.45)',
+        }}
       >
         {renderDiceDisplay()}
 


### PR DESCRIPTION
Closes #217

D100（双 D10 百分骰）/ D20 / D6 改为 Three.js 真 3D：重力翻滚、落底弹跳、自然定格，结果就是停下时朝上那一面。检定与自由掷骰共用同一套渲染，协议与后端零改动。

## 改了什么

| 文件 | 改动 |
|---|---|
| `features/dice3d/geometry.ts` | 立方体、五角偏方面体（真实 D10 形状，three 无内置，手写）、二十面体的逐面提取；Newell 法求面法线 |
| `features/dice3d/textures.ts` | 程序化骰面贴图：大理石纹 + 棱线 + 凹刻数字，D6 走点数；6/9 加下划线 |
| `features/dice3d/engine.ts` | 逐面独立网格 + 内芯、灯光与阴影、物理翻滚、`findTopFace` 自然定格、资源释放。与 React 无关，只认容器和回调 |
| `features/dice3d/shuffle.ts` | Fisher–Yates。结果分布完全由它保证，见「关键决策」 |
| `features/dice3d/support.ts` | WebGL 与 `prefers-reduced-motion` 探测，零依赖（要先用它决定值不值得加载 three） |
| `features/dice3d/Dice3DStage.tsx` | React 封装，动态 `import()` 引擎；加载期间的掷骰请求会排队补发 |
| `routes/games/trpg/RoomPage.tsx` | `DiceModal` 接入 3D；删掉拖拽摇晃改为点按；`splitD100` 把结果拆回十位/个位用于展示 |
| 测试 | 洗牌均匀性（固定种子 LCG，2 万次）、可用性探测 4 例、检定降级到 2D 的回归 |

## 关键决策

**为什么结果取自物理定格，而不是先取值再把目标面转上来**：后者在翻滚结束时骰子姿态是随机的，要把指定面掰到朝上需要一大段额外旋转，表现为「动画放完后骰子突然又动一下，数字很突兀」。改成读此刻朝上的面之后，数字与肉眼看到的面永远一致，定格只需要一个最短弧的极小修正。

**均匀性为什么由洗牌保证，而不是由物理保证**：每次掷骰前用均匀随机排列把点数分配到各个面上。设物理落面为 `F`（分布可能有偏）、面→点数的映射为独立的均匀排列 `V`，则 `P(V[F] = v) = 1/n` 对任意 `v` 成立——结果均匀与物理是否有偏无关。

这条推理的前提是排列必须均匀，所以原型里的 `sort(() => Math.random() - 0.5)` 必须换掉：它不是均匀排列，而结果分布**完全**取决于它。变异检验把 Fisher–Yates 换回这个写法后，2 万次采样下单格偏差 **1853**，容差 160（期望每格 2000）——不是理论瑕疵，是能被玩家感知的分布倾斜。对判定成败的检定骰属于正确性问题。

**为什么 three 走动态 import**：移动端首屏体积敏感。骰子面板不是进房就打开的，没理由让所有玩家在首屏付出 three 的体积。改造后主 chunk 253.90 KB（改造前 253.89 KB，基本不变），three 落到独立的 523 KB / gzip 133 KB 懒加载块，打开面板才拉。为此 `Dice3DStage` 对引擎只能用 `import type`，`DiceKind` 也单独放在不 import three 的 `types.ts` 里。

**为什么直接删掉摇晃手势而不是接到物理上**：原来的 `shakeLevel` 只影响 `setTimeout(500 + power * 100)` 的时长，既不影响结果也没有物理含义，摇得狠只是等得久一点，是没有反馈的假交互。3D 化后若要保留就得把力度接进初速度，交互分支和测试面都会变大。本期先做点按这条确定路径，手感需要「用力掷」的话再单开 issue。

**为什么降级不删掉原来的 2D 实现**：WebGL 在部分老旧移动端浏览器和某些隐私模式下不可用，`prefers-reduced-motion` 是无障碍要求。检定是主流程的一环，不能因为渲染能力缺失就卡住，所以 2D 展示保留为回退路径而不是被替换。引擎动态加载失败同样回退。

**骰盘为什么是深色**：骰子是亮面树脂材质，靠高光与凹刻阴影出质感，浅底会把这两者一起洗掉、还得连灯光重做。原来的 `#1a1620` 是冷调近黑，在米白面板里像挖了个洞，换成暖棕径向渐变 + 内阴影，读起来像打着光的骰盘。

## 验证

- 前端：60 passed、`lint`、`build` 全绿
- **变异检验**：洗牌换回有偏的 `sort(() => Math.random() - 0.5)` 后，均匀性用例立刻报红（偏差 1853 / 容差 160）
- **浏览器内实跑引擎**（页面隐藏时 rAF 不触发，改用手动泵帧驱动物理循环）：
  - d100 / d20 / d6 取值全部落在合法区间，约 2 秒、120 帧左右自然收敛（远低于 4.5 秒的安全上限）
  - `dispose()` 后 canvas 归零，无 context 泄漏
- **几何校验**：d6/d10/d20 分别 6/10/20 面，法线全唯一，无重复面或破洞；另确认新版 three 的 `IcosahedronGeometry` 仍是非索引化的（否则按 position 每 9 个数取三角形的做法会错）
- 真机走通检定全流程（DeepSeek provider，追书人「心理学」检定）

过程中抓到一个真 bug，已修并写进 commit：canvas 被以 2 倍尺寸显示，父容器 `overflow-hidden` 只露出左上四分之一，表现为「只看得到一颗骰子且特别大」。根因是 `setSize(w, h, false)` 的第三参表示不写 canvas 的 CSS 尺寸——原型靠自己页面的 CSS 把 canvas 拉成 100%，移植时没有那段 CSS，于是 canvas 按绘制缓冲尺寸当 CSS 像素显示（dpr=2 时 716×384，而容器只有 358×192）。修后实测内容包围盒 `x 0.17–0.90 / y 0.31–0.79`，两颗骰子都在画面内且未贴边裁切。

## 已知限制

- **视觉细节没有精修**：骰子大小、镜头角度、材质亮度、配色都还是原型的参数，只保证「看得全、读得清」。后续单开 issue 打磨。
- `npm run build` 会对 523 KB 的懒加载块报一条体积警告。没有加 `chunkSizeWarningLimit` 压掉——它是按需加载的块，这条警告本身是有用的提醒。
- 三种骰型的定格时长都在 2 秒上下，比原来的 0.5–1 秒假动画慢。这是真实物理收敛的代价，实测不影响检定节奏。

## 不在本 PR 范围

- 掷骰音效、震动反馈
- 多人同步观看别人掷骰的动画（当前只有本人看得到）
- 骰子外观自定义 / 皮肤
- D4 / D8 / D12（游戏里用不到）
- 把摇晃力度接进物理初速度
