### PR TITLE
修复持续集成：外部仓库合并请求关闭时跳过无效的预览环境回收

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,7 +10,8 @@ name: PR Preview
 # 和目录会永久遗留、PR 评论也不会更新成"已回收"（fennoai review 抓到的
 # 真问题）。改成 workflow 本身总是对 opened/synchronize/reopened/closed
 # 触发，路径判断挪到 job 内部（见 changes job），只门控是否需要真的构建
-# 部署；teardown job 不受这个判断影响，只要事件是 closed 就一定跑。
+# 部署；teardown job 不受路径判断影响，但只回收同仓库 PR——fork PR 本来
+# 就不会部署，也拿不到仓库 Secrets，关闭时继续尝试 SSH 只会产生误报。
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
@@ -248,8 +249,12 @@ jobs:
 
   teardown:
     # 不依赖 changes job（那个 job 对 closed 事件根本不跑），也不看
-    # paths——只要是 closed 事件就一定尝试回收，见文件顶部的说明。
-    if: github.event.action == 'closed'
+    # paths。同仓库 PR 才可能跑过 deploy，也只有它们的 pull_request 事件
+    # 能拿到 PREVIEW_SSH_* Secrets；fork PR 关闭时无需回收，必须在 job 级
+    # 直接跳过，否则空 SSH_PORT 会导致 `Bad port ''` 并把已合并 PR 标红。
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## 修改概要

- 仅对同仓库分支的 closed PR 执行 Preview teardown；
- 外部仓库 PR 本来就会跳过 deploy，关闭时不再尝试使用不可用的 Preview SSH Secrets；
- 更新工作流注释，明确外部仓库 PR 的部署与回收边界。

## 问题根因

PR #205、#211、#213、#216、#218、#219、#223 都来自外部 fork 仓库。GitHub 的 `pull_request` 工作流不会向 fork PR 提供仓库 Secrets，因此 teardown 中的 `PREVIEW_SSH_HOST`、`PREVIEW_SSH_USER`、`PREVIEW_SSH_PORT` 和 SSH key 均为空。

回收步骤最终执行空端口 SSH 命令，并以 `Bad port`、退出码 255 失败。由于 fork PR 的 deploy job 已经通过来源仓库条件跳过，这些 PR 实际没有创建 Preview 环境，也不需要回收。

## 代码范围

- `.github/workflows/pr-preview.yml`
  - teardown job 增加同仓库 PR 判断；
  - 更新工作流注释，说明部署和回收边界。

不修改前端、后端、SDK、数据库、服务器配置或 Preview Secrets。

## 验证结果

- [x] `actionlint -ignore SC2087 .github/workflows/pr-preview.yml`
- [x] `git diff --check`
- [x] 核对七次失败 run，均发生在 fork PR 的 closed 事件
- [x] 抽查 #219、#223 日志，Secret source 均为 None
- [x] 更新分支后的 PR Preview CI 通过

Closes #232
Related to #200
