### PR TITLE
优化 COC 新手规则引导与建卡规则说明

### DIFF
--- a/trpg-frontend/src/features/onboarding/OnboardingLayer.tsx
+++ b/trpg-frontend/src/features/onboarding/OnboardingLayer.tsx
@@ -1,9 +1,10 @@
 import { ChevronLeft, ChevronRight, X } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useAuthStore } from '@/stores/auth-store'
 import { useRoomStore } from '@/stores/room-store'
 import {
+  firstReplayStepForPath,
   firstStepForPath,
   stepsForAudience,
   type OnboardingStep,
@@ -14,11 +15,11 @@ import {
   type OnboardingState,
 } from './storage'
 import { calculateSpotlightRect, type Rect } from './geometry'
+import { useOnboardingController } from './controller'
 
-const GUIDE_ROUTES = new Set(['/room/lobby', '/room/story', '/room/character', '/room/ready', '/room/play'])
+const GUIDE_ROUTES = new Set(['/room/character', '/room/ready', '/room/play'])
 const SPOTLIGHT_GAP = 12
 const SPOTLIGHT_PADDING = 4
-const MAX_SPOTLIGHT_HEIGHT = 280
 const TOOLTIP_ESTIMATED_HEIGHT = 180
 const TARGET_SETTLE_DELAY = 900
 
@@ -50,7 +51,6 @@ function toRootRect(element: Element): Rect | null {
       clientWidth: root.clientWidth,
       clientHeight: root.clientHeight,
     },
-    MAX_SPOTLIGHT_HEIGHT,
   )
 }
 
@@ -58,6 +58,16 @@ function findStepIndex(steps: OnboardingStep[], stepId: string | null): number {
   if (!stepId) return 0
   const index = steps.findIndex((step) => step.id === stepId)
   return index >= 0 ? index : 0
+}
+
+export function preparePreviousStepTarget(step: OnboardingStep, pathname: string): boolean {
+  if (step.route !== pathname) return false
+  if (document.querySelector(`[data-onboarding-target="${step.target}"]`)) return true
+
+  const pageBack = document.querySelector<HTMLButtonElement>('[data-onboarding-page-back]')
+  if (!pageBack) return false
+  pageBack.click()
+  return true
 }
 
 function useTargetRect(target: string | null, pathname: string): Rect | null {
@@ -79,26 +89,46 @@ function useTargetRect(target: string | null, pathname: string): Rect | null {
   useEffect(() => {
     setRect(null)
     if (!target) return
-    const element = document.querySelector(`[data-onboarding-target="${target}"]`)
-    if (element) {
+    const selector = `[data-onboarding-target="${target}"]`
+    let observedElement: Element | null = null
+
+    const scrollTargetIntoView = (element: Element) => {
       const root = document.querySelector<HTMLElement>('#root')
       const block = root && element.getBoundingClientRect().height > root.clientHeight * 0.55
         ? 'start'
         : 'center'
       element.scrollIntoView({ block, behavior: 'smooth' })
     }
-    const retry = window.setTimeout(measure, 120)
-    const observer = element && typeof ResizeObserver !== 'undefined'
+
+    const resizeObserver = typeof ResizeObserver !== 'undefined'
       ? new ResizeObserver(measure)
       : null
-    const mutationObserver = new MutationObserver(measure)
-    if (element) observer?.observe(element)
+    const syncTarget = () => {
+      const element = document.querySelector(selector)
+      if (!element) {
+        setRect(null)
+        return
+      }
+      if (element !== observedElement) {
+        if (observedElement) resizeObserver?.unobserve(observedElement)
+        observedElement = element
+        resizeObserver?.observe(element)
+        // 建卡页的后续步骤会在当前引导目标已经激活后才挂载。
+        // 目标首次出现时必须重新滚动，否则高亮会停在视口边缘。
+        scrollTargetIntoView(element)
+      }
+      measure()
+    }
+
+    const retry = window.setTimeout(syncTarget, 120)
+    const mutationObserver = new MutationObserver(syncTarget)
+    syncTarget()
     mutationObserver.observe(document.body, { childList: true, subtree: true })
     window.addEventListener('resize', measure)
     document.addEventListener('scroll', measure, true)
     return () => {
       window.clearTimeout(retry)
-      observer?.disconnect()
+      resizeObserver?.disconnect()
       mutationObserver.disconnect()
       window.removeEventListener('resize', measure)
       document.removeEventListener('scroll', measure, true)
@@ -132,13 +162,13 @@ function IntroDialog({ onStart, onSkip }: { onStart: () => void; onSkip: () => v
         className="relative w-full max-w-[340px] rounded-lg border border-brass/50 bg-card p-5 shadow-2xl"
       >
         <div className="mb-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-brass-dark">
-          新手指引
+          COC 规则指引
         </div>
         <h2 id="onboarding-intro-title" className="text-lg font-bold text-text-primary">
-          一起完成第一次游戏
+          快速了解调查员规则
         </h2>
         <p className="mt-2 text-sm leading-relaxed text-text-body">
-          接下来会带你完成创建调查员、准备房间和进入游戏的关键步骤，整个过程可以随时跳过。
+          接下来会说明人物卡、玩家准备、行动和游戏工具等关键规则，整个过程可以随时跳过。
         </p>
         <div className="mt-5 flex gap-2">
           <button
@@ -217,6 +247,7 @@ function Tooltip({
   total,
   rect,
   onPrevious,
+  canGoPrevious,
   onNext,
   onSkip,
 }: {
@@ -225,6 +256,7 @@ function Tooltip({
   total: number
   rect: Rect
   onPrevious: () => void
+  canGoPrevious: boolean
   onNext: () => void
   onSkip: () => void
 }) {
@@ -235,9 +267,16 @@ function Tooltip({
   const left = clamp(rect.left + rect.width / 2 - tooltipWidth / 2, 12, rootWidth - tooltipWidth - 12)
   const spaceAbove = rect.top
   const spaceBelow = rootHeight - rect.top - rect.height
-  const below = spaceBelow >= TOOLTIP_ESTIMATED_HEIGHT + SPOTLIGHT_GAP || spaceBelow >= spaceAbove
-  const top = below ? rect.top + rect.height + SPOTLIGHT_GAP : undefined
-  const bottom = below ? undefined : rootHeight - rect.top + SPOTLIGHT_GAP
+  const canPlaceBelow = spaceBelow >= TOOLTIP_ESTIMATED_HEIGHT + SPOTLIGHT_GAP
+  const canPlaceAbove = spaceAbove >= TOOLTIP_ESTIMATED_HEIGHT + SPOTLIGHT_GAP
+  const overlapsTarget = !canPlaceBelow && !canPlaceAbove
+  const below = canPlaceBelow || (!canPlaceAbove && spaceBelow >= spaceAbove)
+  const naturalTop = below
+    ? rect.top + rect.height + SPOTLIGHT_GAP
+    : rect.top - TOOLTIP_ESTIMATED_HEIGHT - SPOTLIGHT_GAP
+  const top = overlapsTarget
+    ? Math.max(12, rootHeight - TOOLTIP_ESTIMATED_HEIGHT - 20)
+    : clamp(naturalTop, 12, rootHeight - TOOLTIP_ESTIMATED_HEIGHT - 12)
   const arrowLeft = clamp(rect.left + rect.width / 2 - left - 7, 16, tooltipWidth - 20)
 
   return (
@@ -246,12 +285,14 @@ function Tooltip({
       aria-label="新手指引"
       aria-live="polite"
       className="fixed z-[102] pointer-events-auto"
-      style={{ left, top, bottom, width: tooltipWidth }}
+      style={{ left, top, width: tooltipWidth }}
     >
-      <div
-        className={`absolute -top-2 h-4 w-4 rotate-45 border-l border-t border-brass/50 bg-card ${below ? '' : 'top-auto -bottom-2 rotate-[225deg]'}`}
-        style={{ left: arrowLeft }}
-      />
+      {!overlapsTarget && (
+        <div
+          className={`absolute -top-2 h-4 w-4 rotate-45 border-l border-t border-brass/50 bg-card ${below ? '' : 'top-auto -bottom-2 rotate-[225deg]'}`}
+          style={{ left: arrowLeft }}
+        />
+      )}
       <div className="relative rounded-lg border border-brass/50 bg-card p-4 shadow-2xl">
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -266,7 +307,7 @@ function Tooltip({
         </div>
         <p className="mt-2 text-xs leading-relaxed text-text-body">{step.description}</p>
         <div className="mt-4 flex items-center justify-between gap-2">
-          <button type="button" onClick={onPrevious} disabled={index === 0} className="flex items-center gap-1 text-xs text-text-muted disabled:opacity-35">
+          <button type="button" onClick={onPrevious} disabled={!canGoPrevious} className="flex items-center gap-1 text-xs text-text-muted disabled:opacity-35">
             <ChevronLeft className="h-3.5 w-3.5" /> 上一步
           </button>
           <button type="button" onClick={onNext} className="flex items-center gap-1 rounded-sm bg-brass px-3 py-2 text-xs font-semibold text-white active:bg-brass-dark">
@@ -283,6 +324,8 @@ export default function OnboardingLayer() {
   const userId = useAuthStore((state) => state.userId)
   const roomId = useRoomStore((state) => state.roomId)
   const isHost = useRoomStore((state) => state.isHost)
+  const replayRequest = useOnboardingController((state) => state.replayRequest)
+  const handledReplayRequest = useRef(replayRequest)
   const [state, setState] = useState<OnboardingState | null>(null)
   const [introOpen, setIntroOpen] = useState(false)
   const [confirmSkipOpen, setConfirmSkipOpen] = useState(false)
@@ -292,8 +335,15 @@ export default function OnboardingLayer() {
   const steps = useMemo(() => stepsForAudience(isHost), [isHost])
   const activeIndex = findStepIndex(steps, state?.stepId ?? null)
   const activeStep = state?.status === 'active' ? steps[activeIndex] ?? null : null
+  const previousStep = activeIndex > 0 ? steps[activeIndex - 1] ?? null : null
+  const canGoPrevious = Boolean(previousStep?.route === pathname)
   const targetRect = useTargetRect(activeStep?.route === pathname ? activeStep.target : null, pathname)
-  const fallbackVisible = useDelayedFallback(Boolean(activeStep && activeStep.route === pathname && !targetRect))
+  const fallbackVisible = useDelayedFallback(Boolean(
+    activeStep &&
+    activeStep.route === pathname &&
+    !activeStep.waitForTarget &&
+    !targetRect,
+  ))
 
   useEffect(() => {
     if (!userId || !roomId || !isGuideRoute(pathname)) {
@@ -316,6 +366,27 @@ export default function OnboardingLayer() {
     setState(null)
     setIntroOpen(true)
   }, [isHost, pathname, roomId, userId])
+
+  useEffect(() => {
+    if (!replayRequest || replayRequest === handledReplayRequest.current) return
+    handledReplayRequest.current = replayRequest
+    if (!userId || !roomId || !isGuideRoute(pathname)) return
+
+    const first = firstReplayStepForPath(
+      pathname,
+      isHost,
+      (target) => Boolean(document.querySelector(`[data-onboarding-target="${target}"]`)),
+    ) ?? firstStepForPath(pathname, isHost)
+    if (!first) return
+
+    const nextState = { status: 'active' as const, stepId: first.id }
+    setState(nextState)
+    writeOnboardingState(userId, nextState)
+    setIntroOpen(false)
+    setConfirmSkipOpen(false)
+    setCompletionOpen(false)
+    setDismissedFallbackStep(null)
+  }, [isHost, pathname, replayRequest, roomId, userId])
 
   useEffect(() => {
     if (!userId || state?.status !== 'active' || !activeStep) return
@@ -382,7 +453,10 @@ export default function OnboardingLayer() {
       setCompletionOpen(true)
       return
     }
-    const nextState = { status: 'active' as const, stepId: steps[Math.max(0, nextIndex)].id }
+    const nextStep = steps[Math.max(0, nextIndex)]
+    if (!nextStep) return
+    if (delta < 0 && !preparePreviousStepTarget(nextStep, pathname)) return
+    const nextState = { status: 'active' as const, stepId: nextStep.id }
     setState(nextState)
     writeOnboardingState(userId, nextState)
     setDismissedFallbackStep(null)
@@ -422,6 +496,7 @@ export default function OnboardingLayer() {
         total={steps.length}
         rect={targetRect}
         onPrevious={() => move(-1)}
+        canGoPrevious={canGoPrevious}
         onNext={() => move(1)}
         onSkip={() => setConfirmSkipOpen(true)}
       />

--- a/trpg-frontend/src/features/onboarding/OnboardingTrigger.tsx
+++ b/trpg-frontend/src/features/onboarding/OnboardingTrigger.tsx
@@ -1,0 +1,27 @@
+import { CircleHelp } from 'lucide-react'
+import { useRoomStore } from '@/stores/room-store'
+import { useOnboardingController } from './controller'
+
+interface OnboardingTriggerProps {
+  className?: string
+}
+
+export default function OnboardingTrigger({ className = '' }: OnboardingTriggerProps) {
+  const roomId = useRoomStore((state) => state.roomId)
+  const requestReplay = useOnboardingController((state) => state.requestReplay)
+
+  if (!roomId) return null
+
+  return (
+    <button
+      type="button"
+      onClick={requestReplay}
+      aria-label="重新观看 COC 规则指引"
+      title="重新观看 COC 规则指引"
+      className={`h-8 flex-shrink-0 rounded-full border border-border-light bg-card px-2.5 text-[11px] font-semibold text-text-muted flex items-center justify-center gap-1.5 active:bg-panel active:scale-[0.96] transition-all ${className}`}
+    >
+      <CircleHelp className="h-4 w-4" strokeWidth={2.25} />
+      <span>规则指引</span>
+    </button>
+  )
+}

--- a/trpg-frontend/src/features/onboarding/controller.ts
+++ b/trpg-frontend/src/features/onboarding/controller.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface OnboardingControllerState {
+  replayRequest: number
+  requestReplay: () => void
+}
+
+export const useOnboardingController = create<OnboardingControllerState>((set) => ({
+  replayRequest: 0,
+  requestReplay: () => set((state) => ({ replayRequest: state.replayRequest + 1 })),
+}))

--- a/trpg-frontend/src/features/onboarding/geometry.ts
+++ b/trpg-frontend/src/features/onboarding/geometry.ts
@@ -15,7 +15,6 @@ interface RootFrame extends Rect {
 export function calculateSpotlightRect(
   target: Rect,
   root: RootFrame,
-  maxHeight: number,
 ): Rect | null {
   const rootLeft = root.left + root.borderLeft
   const rootTop = root.top + root.borderTop
@@ -32,6 +31,6 @@ export function calculateSpotlightRect(
     left: visibleLeft,
     top: visibleTop,
     width: visibleRight - visibleLeft,
-    height: Math.min(visibleBottom - visibleTop, maxHeight),
+    height: visibleBottom - visibleTop,
   }
 }

--- a/trpg-frontend/src/features/onboarding/index.ts
+++ b/trpg-frontend/src/features/onboarding/index.ts
@@ -1,3 +1,4 @@
 export { default as OnboardingLayer } from './OnboardingLayer'
+export { default as OnboardingTrigger } from './OnboardingTrigger'
 export * from './steps'
 export * from './storage'

--- a/trpg-frontend/src/features/onboarding/onboarding.test.ts
+++ b/trpg-frontend/src/features/onboarding/onboarding.test.ts
@@ -1,12 +1,24 @@
-import { describe, expect, it, beforeEach } from 'vitest'
+import { createElement } from 'react'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { calculateSpotlightRect } from './geometry'
-import { firstStepForPath, stepsForAudience } from './steps'
+import { firstReplayStepForPath, firstStepForPath, stepsForAudience } from './steps'
+import { useOnboardingController } from './controller'
+import OnboardingLayer, { preparePreviousStepTarget } from './OnboardingLayer'
 import {
   onboardingStorageKey,
   readOnboardingState,
   resetOnboardingState,
   writeOnboardingState,
 } from './storage'
+import { useAuthStore } from '@/stores/auth-store'
+import { useRoomStore } from '@/stores/room-store'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
 
 describe('onboarding geometry', () => {
   it('uses the inner border edge as the fixed-position coordinate origin', () => {
@@ -22,28 +34,174 @@ describe('onboarding geometry', () => {
         clientWidth: 374,
         clientHeight: 804,
       },
-      280,
     )
 
-    expect(rect).toEqual({ left: 20, top: 156, width: 334, height: 280 })
+    expect(rect).toEqual({ left: 20, top: 156, width: 334, height: 438 })
+  })
+
+  it('highlights the full visible portion of a target that extends past the viewport', () => {
+    const rect = calculateSpotlightRect(
+      { left: 20, top: 100, width: 350, height: 900 },
+      {
+        left: 0,
+        top: 0,
+        width: 390,
+        height: 820,
+        borderLeft: 0,
+        borderTop: 0,
+        clientWidth: 390,
+        clientHeight: 820,
+      },
+    )
+
+    expect(rect).toEqual({ left: 20, top: 100, width: 350, height: 720 })
   })
 })
 
 describe('onboarding steps', () => {
-  it('filters host-only and player-only steps by room role', () => {
+  it('keeps the focused rules guide short for both room roles', () => {
     const hostSteps = stepsForAudience(true)
     const playerSteps = stepsForAudience(false)
 
-    expect(hostSteps.some((step) => step.id === 'lobby-start-story')).toBe(true)
-    expect(hostSteps.some((step) => step.id === 'lobby-ready')).toBe(false)
-    expect(playerSteps.some((step) => step.id === 'lobby-ready')).toBe(true)
-    expect(playerSteps.some((step) => step.id === 'start-game')).toBe(false)
+    expect(hostSteps).toEqual(playerSteps)
+    expect(hostSteps).toHaveLength(9)
+    expect(hostSteps.some((step) => step.route === '/room/lobby')).toBe(false)
+    expect(hostSteps.some((step) => step.id === 'start-game')).toBe(false)
   })
 
   it('finds the first step for a route after a saved position', () => {
     expect(firstStepForPath('/room/character', false)?.id).toBe('character-progress')
-    expect(firstStepForPath('/room/ready', true)?.id).toBe('character-summary')
+    expect(firstStepForPath('/room/ready', true)?.id).toBe('player-status')
     expect(firstStepForPath('/home', false)).toBeNull()
+  })
+
+  it('starts replay at the first target available on the current page', () => {
+    const availableTargets = new Set(['character-progress', 'skill-editor'])
+
+    expect(
+      firstReplayStepForPath(
+        '/room/character',
+        false,
+        (target) => availableTargets.has(target),
+      )?.id,
+    ).toBe('skill-editor')
+  })
+
+  it('waits silently for controls on later character-building stages', () => {
+    const waitingStepIds = stepsForAudience(false)
+      .filter((step) => step.waitForTarget)
+      .map((step) => step.id)
+
+    expect(waitingStepIds).toEqual([
+      'attribute-editor',
+      'skill-editor',
+      'credit-rating',
+      'character-submit',
+    ])
+  })
+
+  it('explains COC credit rating as a separate guided rule', () => {
+    const creditStep = stepsForAudience(false).find((step) => step.id === 'credit-rating')
+
+    expect(creditStep?.target).toBe('credit-rating-editor')
+    expect(creditStep?.description).toContain('职业技能点')
+    expect(creditStep?.description).toContain('兴趣技能点')
+    expect(creditStep?.description).toContain('社会地位')
+  })
+
+  it('explains the asymmetric COC skill point pools in beginner language', () => {
+    const skillStep = stepsForAudience(false).find((step) => step.id === 'skill-editor')
+
+    expect(skillStep?.description).toContain('两份建卡预算')
+    expect(skillStep?.description).toContain('职业点用完后')
+    expect(skillStep?.description).toContain('兴趣列表里的技能则只能花兴趣点')
+  })
+
+  it('points the attribute step at the inline COC attribute explanation', () => {
+    const attributeStep = stepsForAudience(false).find((step) => step.id === 'attribute-editor')
+
+    expect(attributeStep?.target).toBe('attribute-example-row')
+    expect(attributeStep?.description).toContain('圆形说明按钮')
+    expect(attributeStep?.description).toContain('幸运')
+  })
+
+  it('requests an immediate replay through the shared controller', () => {
+    useOnboardingController.setState({ replayRequest: 0 })
+    useOnboardingController.getState().requestReplay()
+
+    expect(useOnboardingController.getState().replayRequest).toBe(1)
+  })
+})
+
+describe('onboarding delayed target alignment', () => {
+  it('scrolls a target into view when the next page stage mounts it later', async () => {
+    const scrollIntoView = vi.fn()
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    })
+    useAuthStore.setState({ userId: 'user-a' })
+    useRoomStore.setState({ roomId: 'room-a', isHost: false })
+    writeOnboardingState('user-a', { status: 'active', stepId: 'attribute-editor' })
+
+    const tree = (targetMounted: boolean) => createElement(
+      MemoryRouter,
+      { initialEntries: ['/room/character'] },
+      createElement(
+        'div',
+        { id: 'root' },
+        createElement(OnboardingLayer),
+        targetMounted
+          ? createElement('div', { 'data-onboarding-target': 'attribute-example-row' })
+          : null,
+      ),
+    )
+    const view = render(tree(false))
+
+    expect(scrollIntoView).not.toHaveBeenCalled()
+    view.rerender(tree(true))
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'center', behavior: 'smooth' })
+    })
+  })
+})
+
+describe('onboarding previous-step navigation', () => {
+  it('moves the character builder back when the previous target is on an earlier stage', () => {
+    const pageBack = document.createElement('button')
+    pageBack.setAttribute('data-onboarding-page-back', '')
+    const click = vi.fn()
+    pageBack.addEventListener('click', click)
+    document.body.appendChild(pageBack)
+    const attributeStep = stepsForAudience(false).find((step) => step.id === 'attribute-editor')!
+
+    expect(preparePreviousStepTarget(attributeStep, '/room/character')).toBe(true)
+    expect(click).toHaveBeenCalledOnce()
+    pageBack.remove()
+  })
+
+  it('does not change page stage when the previous target is already mounted', () => {
+    const pageBack = document.createElement('button')
+    pageBack.setAttribute('data-onboarding-page-back', '')
+    const click = vi.fn()
+    pageBack.addEventListener('click', click)
+    document.body.appendChild(pageBack)
+    const target = document.createElement('div')
+    target.setAttribute('data-onboarding-target', 'skill-editor')
+    document.body.appendChild(target)
+    const skillStep = stepsForAudience(false).find((step) => step.id === 'skill-editor')!
+
+    expect(preparePreviousStepTarget(skillStep, '/room/character')).toBe(true)
+    expect(click).not.toHaveBeenCalled()
+    target.remove()
+    pageBack.remove()
+  })
+
+  it('rejects a previous step that belongs to a different route', () => {
+    const submitStep = stepsForAudience(false).find((step) => step.id === 'character-submit')!
+
+    expect(preparePreviousStepTarget(submitStep, '/room/ready')).toBe(false)
   })
 })
 

--- a/trpg-frontend/src/features/onboarding/steps.ts
+++ b/trpg-frontend/src/features/onboarding/steps.ts
@@ -7,59 +7,16 @@ export interface OnboardingStep {
   title: string
   description: string
   audience?: OnboardingAudience
+  waitForTarget?: boolean
 }
 
 export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
-  {
-    id: 'lobby-players',
-    route: '/room/lobby',
-    target: 'lobby-players',
-    title: '先确认房间成员',
-    description: '这里会显示已经加入房间的玩家。房主和玩家都从同一个大厅开始准备。',
-  },
-  {
-    id: 'lobby-ready',
-    route: '/room/lobby',
-    target: 'lobby-ready',
-    title: '表达你的准备状态',
-    description: '普通玩家点击“标记为已就绪”，房主会在所有玩家准备好后开始故事。',
-    audience: 'player',
-  },
-  {
-    id: 'lobby-start-story',
-    route: '/room/lobby',
-    target: 'lobby-start-story',
-    title: '房主开始准备流程',
-    description: '房主确认所有玩家就绪后，点击这里进入故事介绍和角色创建。',
-    audience: 'host',
-  },
-  {
-    id: 'story-content',
-    route: '/room/story',
-    target: 'story-content',
-    title: '先了解案件背景',
-    description: '阅读模组的背景和当前处境。理解发生了什么，会更容易决定调查员接下来要做什么。',
-  },
-  {
-    id: 'story-continue',
-    route: '/room/story',
-    target: 'story-continue',
-    title: '进入角色创建',
-    description: '阅读完成后点击“继续”，开始创建这次冒险要使用的调查员。',
-  },
   {
     id: 'character-progress',
     route: '/room/character',
     target: 'character-progress',
     title: '按四步完成角色卡',
-    description: '角色卡分为信息、属性、技能和完成四步。已填写的内容会保留，也可以返回修改。',
-  },
-  {
-    id: 'character-info',
-    route: '/room/character',
-    target: 'character-info',
-    title: '填写调查员信息',
-    description: '姓名、年龄和出身让调查员成为一个具体的人物；姓名会显示在游戏对话中。',
+    description: '角色卡分为信息、属性、技能和完成四步。先填写姓名等身份信息，已填写的内容会保留，也可以返回修改。',
   },
   {
     id: 'occupation-picker',
@@ -71,59 +28,41 @@ export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
   {
     id: 'attribute-editor',
     route: '/room/character',
-    target: 'attribute-editor',
-    title: '分配基础属性',
-    description: '属性代表调查员的基础能力。调整时可以同时查看 HP、SAN、MP 等派生属性的变化。',
+    target: 'attribute-example-row',
+    title: '先了解属性，再分配点数',
+    description: '点击属性名旁的圆形说明按钮，可以查看每项属性的用途，幸运也可以查看。了解后再用 +/- 调整数值，并留意 HP、SAN、MP 等衍生属性的变化。',
+    waitForTarget: true,
   },
   {
     id: 'skill-editor',
     route: '/room/character',
     target: 'skill-editor',
-    title: '把点数分给技能',
-    description: '技能会影响调查和检定。优先强化与你选择的职业或想尝试的玩法相关的技能即可。',
+    title: '认清两种技能点',
+    description: '上方两种点数是两份建卡预算。职业列表里的技能可以先花职业点，职业点用完后还能继续花兴趣点；兴趣列表里的技能则只能花兴趣点。优先强化符合职业或玩法方向的技能即可。',
+    waitForTarget: true,
   },
   {
-    id: 'background-editor',
+    id: 'credit-rating',
     route: '/room/character',
-    target: 'background-editor',
-    title: '补充背景和装备',
-    description: '背景故事和装备帮助你代入角色，本阶段可以留空，之后仍能在角色卡中查看。',
+    target: 'credit-rating-editor',
+    title: '单独设置信用评级',
+    description: '信用评级代表调查员的经济状况与社会地位，必须落在当前职业标出的范围内。职业下限会占用职业技能点；高于下限的部分会占用兴趣技能点。',
+    waitForTarget: true,
   },
   {
     id: 'character-submit',
     route: '/room/character',
     target: 'character-submit',
     title: '完成并保存角色卡',
-    description: '点击这里提交角色卡。保存成功后会进入角色准备页，等待其他玩家。',
-  },
-  {
-    id: 'character-summary',
-    route: '/room/ready',
-    target: 'character-summary',
-    title: '检查你的角色卡',
-    description: '准备页会显示角色完成状态。你可以查看或编辑自己的角色卡，直到房主开始游戏。',
+    description: '背景和装备可以留空。确认关键信息后提交角色卡，保存成功会进入玩家准备页。',
+    waitForTarget: true,
   },
   {
     id: 'player-status',
     route: '/room/ready',
     target: 'player-status',
-    title: '等待全员完成建卡',
-    description: '角色卡内容对其他玩家保密，但大家可以看到谁已经完成。房主会在全员完成后开始游戏。',
-  },
-  {
-    id: 'start-game',
-    route: '/room/ready',
-    target: 'start-game',
-    title: '房主进入游戏',
-    description: '房主确认全员完成后点击“开始游戏”，所有玩家会进入同一个游戏房间。',
-    audience: 'host',
-  },
-  {
-    id: 'scene-header',
-    route: '/room/play',
-    target: 'scene-header',
-    title: '这是当前调查现场',
-    description: '顶部显示模组和当前场景。先阅读主持人的叙事，再决定调查员要采取的行动。',
+    title: '确认玩家准备状态',
+    description: '这里能查看谁已完成建卡；自己的角色卡可以查看或编辑。全员完成后由房主开始游戏。',
   },
   {
     id: 'action-input',
@@ -133,18 +72,11 @@ export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
     description: '你可以直接输入“检查门锁”“询问侦探”或“前往走廊”等行动，不限于固定选项。',
   },
   {
-    id: 'dice-button',
-    route: '/room/play',
-    target: 'dice-button',
-    title: '需要时使用骰子',
-    description: '需要检定时，系统会提示你选择技能并掷骰。最终结果由规则引擎负责结算。',
-  },
-  {
     id: 'tool-bar',
     route: '/room/play',
     target: 'tool-bar',
-    title: '随时查看调查工具',
-    description: '角色卡、技能、地图和速记本都可以从底部打开，不需要离开当前游戏页面。',
+    title: '随时使用游戏工具',
+    description: '底部可以打开角色卡、技能、地图和速记；需要主动掷骰时，使用输入框左侧的骰子按钮。',
   },
 ] as const
 
@@ -160,4 +92,22 @@ export function firstStepForPath(
 ): OnboardingStep | null {
   const steps = stepsForAudience(isHost)
   return steps.find((step, index) => index >= startAt && step.route === pathname) ?? null
+}
+
+export function firstReplayStepForPath(
+  pathname: string,
+  isHost: boolean,
+  isTargetAvailable: (target: string) => boolean,
+): OnboardingStep | null {
+  const availableSteps = stepsForAudience(isHost).filter(
+    (step) => step.route === pathname && isTargetAvailable(step.target),
+  )
+
+  if (pathname === '/room/character') {
+    return availableSteps.find((step) => step.id !== 'character-progress')
+      ?? availableSteps[0]
+      ?? null
+  }
+
+  return availableSteps[0] ?? null
 }

--- a/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
+++ b/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
@@ -9,6 +9,7 @@ import { connectWebSocket, disconnectWebSocket, sdk, waitForWsOpen } from '@/ser
 import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 import { useRuleset } from '@/hooks/useRuleset'
 import { DERIVED_STAT_DEFINITIONS, normalizeDerivedStats } from '@/data/derived-stats'
+import { OnboardingTrigger } from '@/features/onboarding'
 
 const SHEET_PAGES = [
   { key: 'info', label: '基本信息' },
@@ -264,12 +265,15 @@ export default function CharacterReadyPage() {
   return (
     <div className="animate-screen-in px-5 pt-6">
       {/* Header */}
-      <button
-        onClick={handleGoBack}
-        className="w-[34px] h-[34px] rounded-full bg-card border border-border-light flex items-center justify-center flex-shrink-0 active:bg-panel active:scale-[0.94] transition-all duration-150 mb-3"
-      >
-        <ArrowLeft className="w-[18px] h-[18px] text-text-muted" strokeWidth={2.5} />
-      </button>
+      <div className="mb-3 flex items-center justify-between">
+        <button
+          onClick={handleGoBack}
+          className="w-[34px] h-[34px] rounded-full bg-card border border-border-light flex items-center justify-center flex-shrink-0 active:bg-panel active:scale-[0.94] transition-all duration-150"
+        >
+          <ArrowLeft className="w-[18px] h-[18px] text-text-muted" strokeWidth={2.5} />
+        </button>
+        <OnboardingTrigger />
+      </div>
 
       <div className="flex items-center justify-center gap-2 mb-1">
         <span className="font-mono text-2xl font-bold text-text-primary tracking-[0.15em] bg-card border border-dashed border-border-mid px-4 py-1.5 rounded-sm">

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -235,6 +235,26 @@ describe('CharacterPage', () => {
     await advanceToAttributesAfterOccupationPreview()
   })
 
+  it('explains each COC attribute and luck from an inline info button', async () => {
+    renderPage()
+
+    fireEvent.change(screen.getByPlaceholderText('角色姓名'), { target: { value: '张三' } })
+    fireEvent.click(screen.getByText('会计师'))
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    await advanceToAttributesAfterOccupationPreview()
+
+    const strengthHelp = screen.getByRole('button', { name: '了解力量' })
+    fireEvent.click(strengthHelp)
+    expect(strengthHelp).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText(/衡量肌肉力量与爆发力/)).toBeInTheDocument()
+
+    const luckHelp = screen.getByRole('button', { name: '了解幸运' })
+    fireEvent.click(luckHelp)
+    expect(luckHelp).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.queryByText(/衡量肌肉力量与爆发力/)).not.toBeInTheDocument()
+    expect(screen.getByText(/不由个人能力决定的偶然运气/)).toBeInTheDocument()
+  })
+
   it('renders occupation icons and filters from backend ruleset metadata', () => {
     renderPage()
 
@@ -377,7 +397,7 @@ describe('CharacterPage', () => {
     expect(screen.queryByLabelText('取消职业自选技能 取悦')).not.toBeInTheDocument()
   })
 
-  it('lets credit be typed directly and keeps occupation and interest pools separate', async () => {
+  it('lets credit be typed directly and clamps it to the occupation range', async () => {
     renderPage()
 
     fireEvent.change(screen.getByPlaceholderText('角色姓名'), { target: { value: '张三' } })
@@ -386,6 +406,8 @@ describe('CharacterPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
     expect(await screen.findByLabelText('信用评级')).toBeInTheDocument()
+    expect(screen.getByLabelText('信用评级').closest('[data-onboarding-target="credit-rating-editor"]'))
+      .toBeInTheDocument()
 
     const creditInput = screen.getByLabelText('信用评级')
     fireEvent.change(creditInput, { target: { value: '66' } })
@@ -397,19 +419,55 @@ describe('CharacterPage', () => {
     fireEvent.blur(creditInput)
     await waitForPreviewWithSkill('credit-rating', 70)
     expect(screen.getByLabelText('信用评级')).toHaveValue(70)
+  })
+
+  it('lets occupation skills use interest points after occupation points run out', async () => {
+    renderPage()
+
+    fireEvent.change(screen.getByPlaceholderText('角色姓名'), { target: { value: '张三' } })
+    fireEvent.click(screen.getByText('会计师'))
+    await advanceToAttributesAfterOccupationPreview()
+
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    expect(await screen.findByLabelText('信用评级')).toBeInTheDocument()
+
+    const occPlus = screen.getByLabelText('会计 增加技能点')
+    fireEvent.click(occPlus)
+    fireEvent.click(occPlus)
+    expect(screen.getByLabelText('会计 技能点')).toHaveValue(2)
+    expect(occPlus).toBeEnabled()
+
+    fireEvent.click(occPlus)
+    fireEvent.click(occPlus)
+    expect(screen.getByLabelText('会计 技能点')).toHaveValue(4)
+    expect(occPlus).toBeDisabled()
+    await waitForPreviewWithSkill('accounting', 4)
+    await waitFor(() => expect(screen.getAllByText('2/2')).toHaveLength(2))
 
     fireEvent.click(screen.getByRole('button', { name: /兴趣技能/ }))
     expect(screen.getByLabelText('潜行 增加技能点')).toBeDisabled()
     expect(screen.getByLabelText('潜行 技能点')).toHaveValue(0)
+  })
+
+  it('does not let non-occupation skills borrow unused occupation points', async () => {
+    renderPage()
+
+    fireEvent.change(screen.getByPlaceholderText('角色姓名'), { target: { value: '张三' } })
+    fireEvent.click(screen.getByText('会计师'))
+    await advanceToAttributesAfterOccupationPreview()
+
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    expect(await screen.findByLabelText('信用评级')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /兴趣技能/ }))
+
+    const interestPlus = screen.getByLabelText('潜行 增加技能点')
+    fireEvent.click(interestPlus)
+    fireEvent.click(interestPlus)
+    expect(screen.getByLabelText('潜行 技能点')).toHaveValue(2)
+    expect(interestPlus).toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: /职业技能/ }))
-    const occPlus = screen.getByLabelText('会计 增加技能点')
-    fireEvent.click(occPlus)
-    expect(screen.getByLabelText('会计 技能点')).toHaveValue(1)
-
-    fireEvent.click(occPlus)
-    expect(screen.getByLabelText('会计 技能点')).toHaveValue(2)
-    expect(occPlus).toBeDisabled()
+    expect(screen.getByLabelText('会计 增加技能点')).toBeEnabled()
   })
 
   it('renders all categorized background fields', async () => {

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -21,6 +21,7 @@ import {
   DERIVED_STAT_DEFINITIONS,
   normalizeDerivedStats,
 } from '@/data/derived-stats'
+import { OnboardingTrigger } from '@/features/onboarding'
 
 // 图标和配色是纯 UI 装饰，不是规则数据，留在前端；键用后端 ruleset 的属性键。
 // 「有哪些属性、哪些能加点、默认值多少、预算和上下限是什么」全部来自
@@ -33,6 +34,20 @@ const ATTR_ICONS: Record<string, typeof Heart> = {
 const ATTR_COLORS: Record<string, string> = {
   STR: '#c04040', CON: '#c08050', POW: '#7050a0', DEX: '#4a8a4a',
   APP: '#8a4070', SIZ: '#b8976a', INT: '#4a7098', EDU: '#6a6050',
+}
+
+// 这些是 COC 新手教学文案，不参与规则计算；属性集合、点数限制和生成公式
+// 仍然以后端 ruleset 为准。
+const ATTRIBUTE_HELP: Record<string, string> = {
+  STR: '衡量肌肉力量与爆发力。常用于推、拉、举起、攀住目标和近战力量对抗，也参与伤害加值与体格计算。',
+  CON: '衡量健康程度与持久力。它会影响生命值，也常用于抵抗疾病、毒素、疲劳和昏迷。',
+  POW: '衡量意志与精神力量。它决定初始理智和魔法值，也常用于抵抗精神影响或进行意志对抗。',
+  DEX: '衡量反应速度与身体协调。它常影响行动顺序，并用于闪避、敏捷动作和精细操作。',
+  APP: '衡量外貌、气质与第一印象。它会影响陌生人的初始态度，但不能代替取悦、说服等社交技能。',
+  SIZ: '综合表示调查员的身高与体重。它参与生命值、伤害加值和体格计算；体型大不等于力量高。',
+  INT: '衡量理解、推理与临场判断。它决定兴趣技能点，也常用于灵感和线索联想相关的判断。',
+  EDU: '衡量正式教育与知识积累。它常参与职业技能点计算，也反映调查员可以调用的常识与专业知识。',
+  LUCK: '表示不由个人能力决定的偶然运气，用于幸运检定。它不占属性点，按 COC 规则独立生成。',
 }
 
 const BACKGROUND_PLACEHOLDERS: Record<BackgroundSectionKey, string> = {
@@ -203,6 +218,7 @@ export default function CharacterPage() {
 
   // Attributes
   const [attr, setAttr] = useState<Attributes>(() => ({ ...existingCharacter?.attr }))
+  const [attributeHelpKey, setAttributeHelpKey] = useState<string | null>(null)
 
   // 职业自选技能按槽位分组保存在表单中；提交时再按槽位顺序压平成 API 的
   // occupationChoiceSkillIds。occupationId 跟选择放在同一份状态里，避免异步
@@ -591,7 +607,8 @@ export default function CharacterPage() {
 
   const previewValidationIssues = preview?.validation ?? []
 
-  // 本期建卡页按分类独立记账：职业技能只吃职业池，兴趣技能只吃兴趣池。
+  // 兴趣技能的局部分配量需要单独保存；职业技能可以先吃职业池，再按 COC7
+  // 规则使用剩余兴趣点，因此它们只保存在总分配 skillAlloc 中。
   const [interestAlloc, setInterestAlloc] = useState<Record<string, number>>({})
   const interestAllocInitialized = useRef(false)
 
@@ -617,16 +634,26 @@ export default function CharacterPage() {
     setInterestAlloc(out)
   }, [ruleset, existingCharacter])
 
-  // 两条预算 bar 的"已花"直接取后端 preview 的权威记账，**不在前端本地重算**。
-  //
-  // 后端 compute_preview 返回的 spent 已经把固定技能、信用分账全算进去了（见
-  // coc7_rules._compute），前端只渲染，不叠加。预算闸门仍然走 preview 的总
-  // 结果，但每个技能的编辑只会作用于自己所在的那个池。
-  const occPointsSpent = preview?.occupationSkillPoints.spent ?? 0
-  const interestPointsSpent = preview?.interestSkillPoints.spent ?? 0
+  // 后端把所有职业技能投入都记在 occupation.spent 中，即使它已经超过职业预算；
+  // 超出的部分在 COC7 中实际由兴趣点承担。显示和前端闸门在这里做同一份转换，
+  // 让两条进度条展示玩家真正还剩下的两份预算。
+  const rawOccupationPointsSpent = preview?.occupationSkillPoints.spent ?? 0
+  const rawInterestPointsSpent = preview?.interestSkillPoints.spent ?? 0
+  const confirmedOccupationOverflow = Math.max(0, rawOccupationPointsSpent - occPointsTotal)
+  const occPointsSpent = Math.min(rawOccupationPointsSpent, occPointsTotal)
+  const interestPointsSpent = rawInterestPointsSpent + confirmedOccupationOverflow
 
-  const occupationPointsRemaining = Math.max(0, occPointsTotal - occPointsSpent - pendingOccupationDelta)
-  const interestPointsRemaining = Math.max(0, interestPointsTotal - interestPointsSpent - pendingInterestDelta)
+  const projectedOccupationSpent = rawOccupationPointsSpent + pendingOccupationDelta
+  const projectedInterestSpent = rawInterestPointsSpent + pendingInterestDelta
+  const projectedOccupationOverflow = Math.max(0, projectedOccupationSpent - occPointsTotal)
+  const combinedPointsRemaining = Math.max(
+    0,
+    occPointsTotal + interestPointsTotal - projectedOccupationSpent - projectedInterestSpent,
+  )
+  const interestPointsRemaining = Math.max(
+    0,
+    interestPointsTotal - projectedInterestSpent - projectedOccupationOverflow,
+  )
 
   const derived = useMemo(() => normalizeDerivedStats(preview?.derivedStats), [preview])
 
@@ -661,10 +688,12 @@ export default function CharacterPage() {
     if (appliedDelta !== 0) setPendingInterestDelta(d => Math.max(0, d + appliedDelta))
   }
 
-  // 职业技能页签：只动职业点数池，不再让职业技能自动借兴趣池。
+  // 职业技能先使用职业预算，超过职业预算的部分按 COC7 规则由兴趣预算承担。
+  // 因此这里用总剩余点数做闸门；非职业技能仍由上面的 interestPointsRemaining
+  // 单独限制，不能反过来借职业点。
   const handleOccSkillChange = (skillId: string, delta: number) => {
     if (delta > 0) {
-      if (occupationPointsRemaining <= 0) return
+      if (combinedPointsRemaining <= 0) return
       setSkillAlloc(prev => ({ ...prev, [skillId]: (prev[skillId] || 0) + 1 }))
       setPendingOccupationDelta(d => Math.max(0, d + 1))
     } else if (delta < 0) {
@@ -676,7 +705,7 @@ export default function CharacterPage() {
   const handleOccSkillSet = (skillId: string, newTotalAllocation: number) => {
     const prevOcc = skillAlloc[skillId] || 0
     let clamped = Math.max(0, newTotalAllocation)
-    if (clamped > prevOcc) clamped = Math.min(clamped, prevOcc + occupationPointsRemaining)
+    if (clamped > prevOcc) clamped = Math.min(clamped, prevOcc + combinedPointsRemaining)
     setSkillAlloc(prev => ({ ...prev, [skillId]: clamped }))
     const appliedDelta = clamped - prevOcc
     if (appliedDelta !== 0) setPendingOccupationDelta(d => Math.max(0, d + appliedDelta))
@@ -1000,6 +1029,7 @@ export default function CharacterPage() {
                 <ArrowLeft className="w-[18px] h-[18px] text-text-muted" strokeWidth={2.5} />
               </button>
               <h2 className="text-lg font-bold text-text-primary">创建角色</h2>
+              <OnboardingTrigger className="ml-auto" />
             </div>
             {/* Progress */}
             <div data-onboarding-target="character-progress" className="flex gap-1.5 px-5 py-3">
@@ -1190,7 +1220,7 @@ export default function CharacterPage() {
           {/* ═══════════════ Step 1: Attributes ═══════════════ */}
           {step === 1 && (
             <div className="px-5 pb-20 animate-screen-in">
-              <div data-onboarding-target="attribute-editor" className="bg-card border border-border-light rounded-md p-[18px]">
+              <div className="bg-card border border-border-light rounded-md p-[18px]">
                 <h4 className="text-[12px] font-semibold text-brass-dark uppercase tracking-[0.08em] mb-1.5">属性分配</h4>
                 <p className="text-[11px] text-text-muted mb-2">点击 +/- 调整属性值（范围 {pointBuyRules?.minValue ?? '—'}-{pointBuyRules?.maxValue ?? '—'}，每次 ±5）</p>
                 <div className="bg-panel rounded-md px-3.5 py-2 mb-3 flex items-center gap-3">
@@ -1211,40 +1241,66 @@ export default function CharacterPage() {
                     const Icon = ATTR_ICONS[key] || Shield
                     const color = ATTR_COLORS[key] || '#b8976a'
                     const val = attr[key] ?? 0
+                    const helpOpen = attributeHelpKey === key
                     return (
-                      <div key={key} className="flex items-center gap-3 px-3 py-2.5 bg-input border border-border-light rounded-[6px]">
-                        <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: color + '18' }}>
-                          <Icon className="w-4 h-4" style={{ color }} />
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          <div className="text-[13px] font-semibold text-text-primary flex items-center gap-1.5">
-                            {attribute.label}
-                            <span className="text-[10px] font-mono text-text-dim font-normal">{key}</span>
+                      <div
+                        key={key}
+                        data-onboarding-target={key === pointBuyAttributes[0]?.key ? 'attribute-example-row' : undefined}
+                        className="px-3 py-2.5 bg-input border border-border-light rounded-[6px]"
+                      >
+                        <div className="flex items-center gap-3">
+                          <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: color + '18' }}>
+                            <Icon className="w-4 h-4" style={{ color }} />
                           </div>
-                          <div className="w-full h-1.5 rounded-full bg-border-light mt-1 overflow-hidden">
-                            <div className="h-full rounded-full transition-all" style={{ width: `${Math.min(100, val)}%`, backgroundColor: color }} />
+                          <div className="flex-1 min-w-0">
+                            <div className="text-[13px] font-semibold text-text-primary flex items-center gap-1.5">
+                              {attribute.label}
+                              <span className="text-[10px] font-mono text-text-dim font-normal">{key}</span>
+                              <button
+                                type="button"
+                                onClick={() => setAttributeHelpKey(helpOpen ? null : key)}
+                                aria-label={`了解${attribute.label}`}
+                                aria-expanded={helpOpen}
+                                aria-controls={`attribute-help-${key}`}
+                                title={`了解${attribute.label}`}
+                                className="w-4.5 h-4.5 rounded-full border border-border-mid text-text-muted flex items-center justify-center active:bg-panel transition-colors"
+                              >
+                                <Info className="w-2.5 h-2.5" strokeWidth={2.5} />
+                              </button>
+                            </div>
+                            <div className="w-full h-1.5 rounded-full bg-border-light mt-1 overflow-hidden">
+                              <div className="h-full rounded-full transition-all" style={{ width: `${Math.min(100, val)}%`, backgroundColor: color }} />
+                            </div>
                           </div>
+                          <button onClick={() => handleAttrChange(key, -5)}
+                            aria-label={`减少${attribute.label}`}
+                            className="w-7 h-7 rounded-full bg-card border border-border-light text-text-muted flex items-center justify-center active:bg-panel active:scale-90 transition-all"
+                          >
+                            <Minus className="w-3.5 h-3.5" />
+                          </button>
+                          <input
+                            type="number"
+                            inputMode="numeric"
+                            aria-label={`${attribute.label}数值`}
+                            min={pointBuyRules?.minValue}
+                            max={pointBuyRules?.maxValue}
+                            value={attrInputs[key]}
+                            onChange={e => setAttrInputs(inputs => ({ ...inputs, [key]: e.target.value }))}
+                            onBlur={() => commitAttrInput(key)}
+                            className="text-[17px] font-bold font-mono text-text-primary min-w-[36px] w-[36px] text-center bg-transparent outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                          />
+                          <button onClick={() => handleAttrChange(key, 5)}
+                            aria-label={`增加${attribute.label}`}
+                            className="w-7 h-7 rounded-full bg-card border border-border-light text-text-muted flex items-center justify-center active:bg-panel active:scale-90 transition-all"
+                          >
+                            <Plus className="w-3.5 h-3.5" />
+                          </button>
                         </div>
-                        <button onClick={() => handleAttrChange(key, -5)}
-                          className="w-7 h-7 rounded-full bg-card border border-border-light text-text-muted flex items-center justify-center active:bg-panel active:scale-90 transition-all"
-                        >
-                          <Minus className="w-3.5 h-3.5" />
-                        </button>
-                        <input
-                          type="number"
-                          inputMode="numeric"
-                          min={pointBuyRules?.minValue}
-                          max={pointBuyRules?.maxValue}
-                          value={attrInputs[key]}
-                          onChange={e => setAttrInputs(inputs => ({ ...inputs, [key]: e.target.value }))}
-                          onBlur={() => commitAttrInput(key)}
-                          className="text-[17px] font-bold font-mono text-text-primary min-w-[36px] w-[36px] text-center bg-transparent outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                        />
-                        <button onClick={() => handleAttrChange(key, 5)}
-                          className="w-7 h-7 rounded-full bg-card border border-border-light text-text-muted flex items-center justify-center active:bg-panel active:scale-90 transition-all"
-                        >
-                          <Plus className="w-3.5 h-3.5" />
-                        </button>
+                        {helpOpen && (
+                          <p id={`attribute-help-${key}`} className="mt-2 border-t border-border-light pt-2 text-[11px] leading-relaxed text-text-muted">
+                            {ATTRIBUTE_HELP[key] ?? `${attribute.label}是当前规则系统定义的基础属性。`}
+                          </p>
+                        )}
                       </div>
                     )
                   })}
@@ -1252,21 +1308,42 @@ export default function CharacterPage() {
 
                 {/* 不参与点数购买的属性（COC7 里就是幸运：只能掷、不能用属性点买）。
                     同样由 ruleset 驱动，不写死是哪一项——换个规则系统这里自然跟着变。 */}
-                {(ruleset?.attributes ?? []).filter(a => !a.pointBuy).map(attribute => (
-                  <div key={attribute.key} className="flex items-center gap-3 px-3 py-2.5 mt-2 bg-panel border border-border-light rounded-[6px]">
-                    <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: '#4a8a4a18' }}>
-                      <Clover className="w-4 h-4" style={{ color: '#4a8a4a' }} />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="text-[13px] font-semibold text-text-primary flex items-center gap-1.5">
-                        {attribute.label}
-                        <span className="text-[10px] font-mono text-text-dim font-normal">{attribute.key}</span>
+                {(ruleset?.attributes ?? []).filter(a => !a.pointBuy).map(attribute => {
+                  const helpOpen = attributeHelpKey === attribute.key
+                  return (
+                    <div key={attribute.key} className="px-3 py-2.5 mt-2 bg-panel border border-border-light rounded-[6px]">
+                      <div className="flex items-center gap-3">
+                        <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: '#4a8a4a18' }}>
+                          <Clover className="w-4 h-4" style={{ color: '#4a8a4a' }} />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-[13px] font-semibold text-text-primary flex items-center gap-1.5">
+                            {attribute.label}
+                            <span className="text-[10px] font-mono text-text-dim font-normal">{attribute.key}</span>
+                            <button
+                              type="button"
+                              onClick={() => setAttributeHelpKey(helpOpen ? null : attribute.key)}
+                              aria-label={`了解${attribute.label}`}
+                              aria-expanded={helpOpen}
+                              aria-controls={`attribute-help-${attribute.key}`}
+                              title={`了解${attribute.label}`}
+                              className="w-4.5 h-4.5 rounded-full border border-border-mid text-text-muted flex items-center justify-center active:bg-input transition-colors"
+                            >
+                              <Info className="w-2.5 h-2.5" strokeWidth={2.5} />
+                            </button>
+                          </div>
+                          <div className="text-[10px] text-text-dim mt-0.5">不占属性点数（规则为独立掷 {attribute.generation}，掷骰生成待接入，暂为默认值）</div>
+                        </div>
+                        <span className="text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{attr[attribute.key] ?? '—'}</span>
                       </div>
-                      <div className="text-[10px] text-text-dim mt-0.5">不占属性点数（规则为独立掷 {attribute.generation}，掷骰生成待接入，暂为默认值）</div>
+                      {helpOpen && (
+                        <p id={`attribute-help-${attribute.key}`} className="mt-2 border-t border-border-light pt-2 text-[11px] leading-relaxed text-text-muted">
+                          {ATTRIBUTE_HELP[attribute.key] ?? `${attribute.label}是当前规则系统定义的基础属性。`}
+                        </p>
+                      )}
                     </div>
-                    <span className="text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{attr[attribute.key] ?? '—'}</span>
-                  </div>
-                ))}
+                  )
+                })}
               </div>
 
               {/* Derived Stats */}
@@ -1386,7 +1463,10 @@ export default function CharacterPage() {
               {/* Credit Rating — 后端必填技能，值须落在所选职业信用区间内，
                   单独给一张显眼卡片，不跟普通技能混在职业/兴趣两个 tab 里。 */}
               {selectedOcc && (
-                <div className="bg-[#fdfaf4] border border-brass rounded-md p-3.5 mb-3">
+                <div
+                  data-onboarding-target="credit-rating-editor"
+                  className="bg-[#fdfaf4] border border-brass rounded-md p-3.5 mb-3"
+                >
                   <div className="flex items-center justify-between mb-1">
                     <h4 className="text-[12px] font-semibold text-brass-dark">
                       信用评级 (Credit Rating) · <span className="text-[#c04040]">必填</span>
@@ -1446,7 +1526,7 @@ export default function CharacterPage() {
                       请先在上一步中选择职业
                     </div>
                   ) : occSkills.map(skill => {
-                    // 职业技能现在只记职业池，不再允许跨池溢出。
+                    // 职业技能优先吃职业池，超出部分由兴趣池承担。
                     const totalAllocation = skillAlloc[skill.id] || 0
                     const compute = skillComputeMap.get(skill.id)
                     const base = compute?.base ?? (typeof skill.base === 'number' ? skill.base : 0)
@@ -1456,14 +1536,13 @@ export default function CharacterPage() {
                         poolAllocation={totalAllocation}
                         onChange={(d) => handleOccSkillChange(skill.id, d)}
                         onSetAllocation={(v) => handleOccSkillSet(skill.id, v)}
-                        maxPoints={totalAllocation + occupationPointsRemaining}
+                        maxPoints={totalAllocation + combinedPointsRemaining}
                         minPoints={0}
                       />
                     )
                   })
                 ) : (
-                  // 兴趣技能页签只列非职业技能——职业技能那边已经能自动溢出用兴趣点数了，
-                  // 不需要在这里重复出现。这里纯粹是兴趣点数池，加点只碰 interestAlloc。
+                  // 兴趣页只列非职业技能；它们只能使用兴趣预算，不会占用职业点。
                   interestSkills.map(skill => {
                     const interestAllocation = interestAlloc[skill.id] || 0
                     const compute = skillComputeMap.get(skill.id)
@@ -1694,7 +1773,9 @@ export default function CharacterPage() {
               </p>
             )}
             <div className="flex gap-2.5">
-              <button onClick={() => step > 0 ? setStep(s => s - 1) : navigate(-1)}
+              <button
+                data-onboarding-page-back
+                onClick={() => step > 0 ? setStep(s => s - 1) : navigate(-1)}
                 className="flex-1 flex items-center justify-center gap-1.5 px-5 py-3 rounded-sm text-sm font-semibold transition-all border border-border-mid bg-card text-text-body active:bg-panel active:scale-[0.97]">
                 上一步
               </button>

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -12,6 +12,7 @@ import { useRuleset } from '@/hooks/useRuleset'
 import { useHostSpeech } from '@/hooks/useHostSpeech'
 import { Dice3DStage, supports3DDice, type Dice3DHandle } from '@/features/dice3d'
 import { DERIVED_STAT_DEFINITIONS } from '@/data/derived-stats'
+import { OnboardingTrigger } from '@/features/onboarding'
 
 // `crypto.randomUUID()` 要求安全上下文（HTTPS 或 localhost）——CI Preview
 // 部署在纯 HTTP 的 IP:端口上（issue #200，域名/HTTPS 明确列在本期不做），
@@ -1214,6 +1215,7 @@ export default function RoomPage() {
             {playerView?.scene.name || (roomInfo ? `${roomInfo.players.length} 位调查员` : '克苏鲁的呼唤')}
           </div>
         </div>
+        <OnboardingTrigger />
         <button
           onClick={() => setOpenPanel(openPanel === 'speech' ? null : 'speech')}
           aria-label="主持人语音"

--- a/trpg-frontend/src/routes/profile/ProfilePage.tsx
+++ b/trpg-frontend/src/routes/profile/ProfilePage.tsx
@@ -1,17 +1,15 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ArrowLeft, LogOut, RotateCcw } from 'lucide-react'
+import { ArrowLeft, LogOut } from 'lucide-react'
 import { useAuthStore } from '@/stores/auth-store'
 import { useRoomStore } from '@/stores/room-store'
 import { useCharacterStore } from '@/stores/character-store'
 import { updateProfile, fetchMe, logout as logoutFromServer } from '@/services/auth'
 import { friendlyErrorMessage } from '@/services/api-client'
-import { resetOnboardingState } from '@/features/onboarding'
 
 export default function ProfilePage() {
   const navigate = useNavigate()
   const [account, setAccount] = useState('')
-  const userId = useAuthStore((s) => s.userId)
   const nickname = useAuthStore((s) => s.nickname)
   const setNickname = useAuthStore((s) => s.setNickname)
   const clearAuthStore = useAuthStore((s) => s.logout)
@@ -21,7 +19,6 @@ export default function ProfilePage() {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [saved, setSaved] = useState(false)
-  const [guideReset, setGuideReset] = useState(false)
 
   useEffect(() => {
     fetchMe().then((me) => { if (me) setAccount(me.account) })
@@ -54,19 +51,6 @@ export default function ProfilePage() {
     resetRoomStore()
     clearCharacterStore()
     navigate('/auth/login')
-  }
-
-  const handleResetOnboarding = () => {
-    setError('')
-    setSaved(false)
-    setGuideReset(false)
-
-    if (!userId || !resetOnboardingState(userId)) {
-      setError('新手指引重置失败，请稍后重试')
-      return
-    }
-
-    setGuideReset(true)
   }
 
   return (
@@ -110,18 +94,6 @@ export default function ProfilePage() {
         >
           {saving ? '保存中…' : '保存'}
         </button>
-
-        <button
-          onClick={handleResetOnboarding}
-          className="w-full py-3.5 rounded-sm text-sm font-semibold border border-border-light text-text-dim flex items-center justify-center gap-2 active:bg-panel active:scale-[0.97] transition-all"
-        >
-          <RotateCcw className="w-[16px] h-[16px]" /> 重新观看新手指引
-        </button>
-        {guideReset && (
-          <p className="text-[11px] text-brass-dark text-center">
-            已重置，下次进入房间流程时会重新显示
-          </p>
-        )}
 
         <button
           onClick={handleLogout}


### PR DESCRIPTION
## 关联 Issue

- Closes #233
- 关联 #222 功能模块表第 4 项

## 改动说明

- 将新手引导由 19 步精简为 9 步，聚焦建卡、玩家准备、自然语言行动和游戏工具
- 在建卡、准备和游戏页面增加明显的“规则指引”入口，支持随时重新观看
- 为基础属性与幸运增加可点击的 COC 规则说明
- 为信用评级增加独立引导，说明其在职业与社会背景中的作用
- 说明职业技能点和兴趣技能点的分配规则
- 修复职业技能使用兴趣技能点时的前端分账限制与预算显示
- 修复引导高亮定位、延迟目标自动滚动和目标范围不完整的问题
- 修复点击“上一步”时引导步骤与建卡页面阶段不同步的问题
- 保留跳过引导与进度保存能力

## 代码范围

- `trpg-frontend/src/features/onboarding/**`
- `trpg-frontend/src/routes/games/trpg/CharacterPage.tsx`
- `trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx`
- `trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx`
- `trpg-frontend/src/routes/games/trpg/RoomPage.tsx`
- `trpg-frontend/src/routes/profile/ProfilePage.tsx`

## 验证结果

- ESLint 检查通过
- 11 个测试文件、90 项测试通过
- TypeScript 与生产构建通过
- 390px 移动端浏览器实测通过
- 浏览器控制台无错误

## 界面截图

<img width="439" height="840" alt="截屏2026-08-05 下午3 47 56" src="https://github.com/user-attachments/assets/e8219b90-21ab-4625-af6f-6e20454f41a3" />
