### PR TITLE
支持预览环境切换 AI 主持模型服务商

### DIFF
--- a/.github/workflows/main-preview.yml
+++ b/.github/workflows/main-preview.yml
@@ -78,11 +78,25 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
           DEEPSEEK_API_KEY: ${{ secrets.PREVIEW_DEEPSEEK_API_KEY }}
+          DEEPSEEK_BASE_URL: ${{ vars.PREVIEW_DEEPSEEK_BASE_URL }}
+          DEEPSEEK_MODEL: ${{ vars.PREVIEW_DEEPSEEK_MODEL }}
           DOUBAO_TTS_API_KEY: ${{ secrets.PREVIEW_DOUBAO_TTS_API_KEY }}
           DOUBAO_TTS_VOICES: ${{ secrets.PREVIEW_DOUBAO_TTS_VOICES }}
           DOUBAO_TTS_DEFAULT_VOICE_TYPE: ${{ secrets.PREVIEW_DOUBAO_TTS_DEFAULT_VOICE_TYPE }}
         run: |
           if [ -n "$DEEPSEEK_API_KEY" ]; then
+            if [ -z "$DEEPSEEK_BASE_URL" ] || [ -z "$DEEPSEEK_MODEL" ]; then
+              echo "::error::已配置 Preview 模型密钥，但缺少 PREVIEW_DEEPSEEK_BASE_URL 或 PREVIEW_DEEPSEEK_MODEL"
+              exit 1
+            fi
+            if [[ ! "$DEEPSEEK_BASE_URL" =~ ^https?://[^/[:space:]]+(/.*)?$ ]]; then
+              echo "::error::PREVIEW_DEEPSEEK_BASE_URL 必须是包含主机名的 HTTP(S) 根地址"
+              exit 1
+            fi
+            if [[ "$DEEPSEEK_BASE_URL" == */chat/completions* ]]; then
+              echo "::error::PREVIEW_DEEPSEEK_BASE_URL 应填写 API 根地址，不能包含 /chat/completions"
+              exit 1
+            fi
             HOST_MODEL_PROVIDER=deepseek
           else
             HOST_MODEL_PROVIDER=fake
@@ -92,10 +106,18 @@ jobs:
           else
             HOST_SPEECH_PROVIDER=disabled
           fi
+          DEEPSEEK_API_KEY_B64=$(printf '%s' "$DEEPSEEK_API_KEY" | base64 | tr -d '\n')
+          DEEPSEEK_BASE_URL_B64=$(printf '%s' "$DEEPSEEK_BASE_URL" | base64 | tr -d '\n')
+          DEEPSEEK_MODEL_B64=$(printf '%s' "$DEEPSEEK_MODEL" | base64 | tr -d '\n')
+          if [ -n "$DEEPSEEK_API_KEY_B64" ]; then
+            echo "::add-mask::$DEEPSEEK_API_KEY_B64"
+          fi
           DOUBAO_TTS_API_KEY_B64=$(printf '%s' "$DOUBAO_TTS_API_KEY" | base64 | tr -d '\n')
           DOUBAO_TTS_VOICES_B64=$(printf '%s' "$DOUBAO_TTS_VOICES" | base64 | tr -d '\n')
           DOUBAO_TTS_DEFAULT_VOICE_TYPE_B64=$(printf '%s' "$DOUBAO_TTS_DEFAULT_VOICE_TYPE" | base64 | tr -d '\n')
 
+          # runner 需先展开部署参数与编码后的配置，不能给 heredoc delimiter 加引号。
+          # shellcheck disable=SC2087
           ssh -p "$SSH_PORT" -i ~/.ssh/preview_deploy_key "$SSH_USER@$SSH_HOST" bash -s <<EOF
             set -e
             mkdir -p ~/trpg-previews/main
@@ -106,7 +128,9 @@ jobs:
             export FRONTEND_IMAGE="$FRONTEND_IMAGE"
             export PREVIEW_PORT=80
             export HOST_MODEL_PROVIDER="$HOST_MODEL_PROVIDER"
-            export DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY"
+            export DEEPSEEK_API_KEY="\$(printf '%s' '$DEEPSEEK_API_KEY_B64' | base64 -d)"
+            export DEEPSEEK_BASE_URL="\$(printf '%s' '$DEEPSEEK_BASE_URL_B64' | base64 -d)"
+            export DEEPSEEK_MODEL="\$(printf '%s' '$DEEPSEEK_MODEL_B64' | base64 -d)"
             export HOST_SPEECH_PROVIDER="$HOST_SPEECH_PROVIDER"
             # 编码后穿过未加引号的 SSH heredoc，避免 token/JSON 中的 shell
             # 元字符在部署机上被二次解析；解码结果只作为赋值结果，不会重新执行。

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -155,6 +155,8 @@ jobs:
           GHCR_ACTOR: ${{ github.actor }}
           # Preview 专用 key，跟本地/生产用的 key 分开管理，方便单独限额/吊销。
           DEEPSEEK_API_KEY: ${{ secrets.PREVIEW_DEEPSEEK_API_KEY }}
+          DEEPSEEK_BASE_URL: ${{ vars.PREVIEW_DEEPSEEK_BASE_URL }}
+          DEEPSEEK_MODEL: ${{ vars.PREVIEW_DEEPSEEK_MODEL }}
           DOUBAO_TTS_API_KEY: ${{ secrets.PREVIEW_DOUBAO_TTS_API_KEY }}
           DOUBAO_TTS_VOICES: ${{ secrets.PREVIEW_DOUBAO_TTS_VOICES }}
           DOUBAO_TTS_DEFAULT_VOICE_TYPE: ${{ secrets.PREVIEW_DOUBAO_TTS_DEFAULT_VOICE_TYPE }}
@@ -163,6 +165,18 @@ jobs:
           # README「主持模型配置」一节已说明）——这个判断必须在部署前做，
           # 不能让 compose 直接把空字符串当 key 传给 deepseek provider。
           if [ -n "$DEEPSEEK_API_KEY" ]; then
+            if [ -z "$DEEPSEEK_BASE_URL" ] || [ -z "$DEEPSEEK_MODEL" ]; then
+              echo "::error::已配置 Preview 模型密钥，但缺少 PREVIEW_DEEPSEEK_BASE_URL 或 PREVIEW_DEEPSEEK_MODEL"
+              exit 1
+            fi
+            if [[ ! "$DEEPSEEK_BASE_URL" =~ ^https?://[^/[:space:]]+(/.*)?$ ]]; then
+              echo "::error::PREVIEW_DEEPSEEK_BASE_URL 必须是包含主机名的 HTTP(S) 根地址"
+              exit 1
+            fi
+            if [[ "$DEEPSEEK_BASE_URL" == */chat/completions* ]]; then
+              echo "::error::PREVIEW_DEEPSEEK_BASE_URL 应填写 API 根地址，不能包含 /chat/completions"
+              exit 1
+            fi
             HOST_MODEL_PROVIDER=deepseek
           else
             HOST_MODEL_PROVIDER=fake
@@ -171,6 +185,12 @@ jobs:
             HOST_SPEECH_PROVIDER=doubao
           else
             HOST_SPEECH_PROVIDER=disabled
+          fi
+          DEEPSEEK_API_KEY_B64=$(printf '%s' "$DEEPSEEK_API_KEY" | base64 | tr -d '\n')
+          DEEPSEEK_BASE_URL_B64=$(printf '%s' "$DEEPSEEK_BASE_URL" | base64 | tr -d '\n')
+          DEEPSEEK_MODEL_B64=$(printf '%s' "$DEEPSEEK_MODEL" | base64 | tr -d '\n')
+          if [ -n "$DEEPSEEK_API_KEY_B64" ]; then
+            echo "::add-mask::$DEEPSEEK_API_KEY_B64"
           fi
           DOUBAO_TTS_API_KEY_B64=$(printf '%s' "$DOUBAO_TTS_API_KEY" | base64 | tr -d '\n')
           DOUBAO_TTS_VOICES_B64=$(printf '%s' "$DOUBAO_TTS_VOICES" | base64 | tr -d '\n')
@@ -186,6 +206,7 @@ jobs:
           # 固定 compose 模板（~/trpg-previews/compose-template/，这份文件
           # 只由有服务器访问权限的人手动维护，不经过 CI）——PR 能决定"用
           # 哪个镜像"，决定不了"以什么权限、挂载什么运行这个镜像"。
+          # shellcheck disable=SC2087
           ssh -p "$SSH_PORT" -i ~/.ssh/preview_deploy_key "$SSH_USER@$SSH_HOST" bash -s <<EOF
             set -e
             mkdir -p ~/trpg-previews/pr-$PR
@@ -212,7 +233,9 @@ jobs:
             export FRONTEND_IMAGE="$FRONTEND_IMAGE"
             export PREVIEW_PORT="$PORT"
             export HOST_MODEL_PROVIDER="$HOST_MODEL_PROVIDER"
-            export DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY"
+            export DEEPSEEK_API_KEY="\$(printf '%s' '$DEEPSEEK_API_KEY_B64' | base64 -d)"
+            export DEEPSEEK_BASE_URL="\$(printf '%s' '$DEEPSEEK_BASE_URL_B64' | base64 -d)"
+            export DEEPSEEK_MODEL="\$(printf '%s' '$DEEPSEEK_MODEL_B64' | base64 -d)"
             export HOST_SPEECH_PROVIDER="$HOST_SPEECH_PROVIDER"
             # base64 只负责安全穿过 SSH heredoc，不是加密；GitHub 日志仍由
             # secrets 掩码保护，应用日志则永远不记录这些字段。
@@ -301,6 +324,7 @@ jobs:
         run: |
           # 同上：故意不加引号，$PR 要在 runner 这一侧展开（这里没有
           # secret，纯粹是为了跟部署脚本保持同一套写法）。
+          # shellcheck disable=SC2087
           ssh -p "$SSH_PORT" -i ~/.ssh/preview_deploy_key "$SSH_USER@$SSH_HOST" bash -s <<EOF
             set -e
             if [ -d ~/trpg-previews/pr-$PR ]; then

--- a/README.md
+++ b/README.md
@@ -299,6 +299,51 @@ Host Agent 工具调用和结构化 Narrator 都使用 OpenAI-compatible Chat Co
 其他厂商如果遵循同一协议，可复用这组配置和 adapter；使用私有协议时应新增独立
 provider adapter，而不是把私有字段混入通用请求。
 
+#### Preview 环境切换兼容 Provider
+
+PR Preview 和 Main Preview 共用一套 Preview 专用模型配置。API key 使用 GitHub
+Repository Secret，非敏感的 API 根地址和模型名使用 Repository Variables：
+
+| GitHub 配置 | 类型 | 示例值 |
+| --- | --- | --- |
+| `PREVIEW_DEEPSEEK_API_KEY` | Repository Secret | 新服务商签发的 Preview 专用 key（不要写入仓库或日志） |
+| `PREVIEW_DEEPSEEK_BASE_URL` | Repository Variable | `https://api.qnaigc.com/v1` |
+| `PREVIEW_DEEPSEEK_MODEL` | Repository Variable | `deepseek/deepseek-v4-pro-202606` |
+
+`PREVIEW_DEEPSEEK_BASE_URL` 必须是 OpenAI-compatible API 根地址，不能填完整的
+`https://api.qnaigc.com/v1/chat/completions`；客户端会自行追加 `/chat/completions`。
+
+两份 Preview workflow 遵循同一配置规则：
+
+- key 为空时使用 `HOST_MODEL_PROVIDER=fake`，其余预览功能仍可验证；
+- key 非空时 Base URL 和模型名必须同时存在，否则部署立即失败；
+- 配置真实 provider 时不会静默使用代码中的旧厂商默认值；
+- fork PR 不执行部署 job，也不能读取 Repository Secret。
+
+部署服务器不会直接执行仓库中的 `docker-compose.preview.yml`，而是复制受信任的
+固定模板 `~/trpg-previews/compose-template/docker-compose.yml`。模板中的 backend
+service 必须透传相同配置：
+
+```yaml
+environment:
+  HOST_MODEL_PROVIDER: ${HOST_MODEL_PROVIDER:-fake}
+  DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+  DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.deepseek.com}
+  DEEPSEEK_MODEL: ${DEEPSEEK_MODEL:-deepseek-chat}
+```
+
+切换或轮换服务商时按以下顺序操作，避免 workflow 已更新但外部配置尚未就绪：
+
+1. 先更新服务器固定 compose 模板，确认三项 `DEEPSEEK_*` 环境变量都会进入 backend。
+2. 在主仓库创建或更新 `PREVIEW_DEEPSEEK_BASE_URL`、`PREVIEW_DEEPSEEK_MODEL`。
+3. 将 `PREVIEW_DEEPSEEK_API_KEY` 替换为新服务商的 Preview 专用 key。
+4. 合并 workflow 改动后重新运行 Main Preview，并用同仓库测试 PR 验证 PR Preview。
+5. 在两个预览环境各提交一次自然语言行动，确认返回真实模型结果而非 Fake 文案。
+
+健康检查只证明容器和 HTTP 服务可用，不会产生计费模型请求，也不能证明模型配置
+正确。真实验证必须覆盖一次 Host Agent 工具调用和最终结构化输出。轮换期间不要在
+Issue、PR、Actions 参数或服务器命令历史中粘贴明文 key。
+
 公共 WebSocket 只发送安全进度：`turn.started`、`turn.phase_changed`、
 `tool.started`、`tool.completed`、`turn.failed` 和 `view.updated`。内部 call id、
 工具参数/结果、Prompt、raw model output、reasoning、异常栈和模组秘密不会进入浏览器。

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -19,12 +19,13 @@
 # 价值，容器销毁即丢，完全不碰生产/开发用的 Postgres——见 issue #200
 # 「决策 5」。
 #
-# HOST_MODEL_PROVIDER / DEEPSEEK_API_KEY 从宿主环境变量透传：同仓库 PR 由
-# workflow 注入真实 key；fork PR 因 GitHub Actions 平台限制拿不到 secrets、
-# 甚至连这个 workflow 的部署 job 都不会跑（见 pr-preview.yml 里的 job
-# 条件），本文件里的 fallback 只覆盖"本地跑、不传任何 key"这一种情况——
-# 远程 provider 模式缺 key 时后端会启动失败，不是优雅降级，所以本地不传
-# key 时必须落到 fake，不能让 HOST_MODEL_PROVIDER 意外等于 deepseek。
+# HOST_MODEL_PROVIDER / DEEPSEEK_* 从宿主环境变量透传：同仓库 PR 由 workflow
+# 注入真实 key、OpenAI-compatible API 根地址和模型名；fork PR 因 GitHub
+# Actions 平台限制拿不到 secrets，甚至连部署 job 都不会跑（见
+# pr-preview.yml）。下面的 DeepSeek 默认值只服务于本地复现和旧配置兼容，
+# CI Preview 配了 key 时必须显式提供三项配置，不能静默使用旧厂商默认值。
+# Base URL 填 API 根地址（如 https://api.example.com/v1），不能填完整的
+# /chat/completions；OpenAI SDK 会自行追加请求路径。
 
 services:
   backend:
@@ -46,6 +47,7 @@ services:
       OPENING_NARRATION_MODE: ${OPENING_NARRATION_MODE:-model}
       OPENING_NARRATION_TIMEOUT_SECONDS: ${OPENING_NARRATION_TIMEOUT_SECONDS:-10}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      # CI Preview 会用 Repository Variables 覆盖这两个本地兼容默认值。
       DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.deepseek.com}
       DEEPSEEK_MODEL: ${DEEPSEEK_MODEL:-deepseek-chat}
       # 没有一整套独立限额凭证时保持 disabled；应用不会回退到浏览器 TTS。


### PR DESCRIPTION
Closes #243

为 PR Preview 与 Main Preview 增加可配置的模型 API 根地址和模型名，使预览环境可以安全切换到新的 OpenAI 兼容服务商。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `.github/workflows/pr-preview.yml` | 注入 Preview Base URL 和模型变量；校验配置完整性；通过 Base64 安全传递模型配置 |
| `.github/workflows/main-preview.yml` | 与 PR Preview 使用相同配置和失败策略，避免两套预览环境行为不一致 |
| `docker-compose.preview.yml` | 补充兼容 Provider、API 根地址和服务器变量透传说明 |
| `README.md` | 记录 Repository Secret、Variables、服务器模板和密钥轮换流程 |

## 关键决策

**为什么不新增新厂商 Provider**：新服务商使用 OpenAI-compatible Chat Completions，现有 DeepSeek adapter 已支持自定义 API 根地址和模型名，无需增加供应商专用代码。

**为什么 Base URL 和模型名使用 Repository Variables**：这两项不是敏感信息；API key 仍使用 Repository Secret，避免明文进入仓库和日志。

**为什么配置不完整时直接失败**：有 key 但缺少 Base URL 或模型名时，静默使用旧默认值会继续请求旧服务商。workflow 现在会明确报错，避免产生误导性的成功部署。

**为什么不能填写完整 `/chat/completions` 地址**：OpenAI SDK 会自行追加该请求路径，workflow 会拒绝包含 `/chat/completions` 的 Base URL。

**为什么使用 Base64 传递配置**：Base64 用于避免 SSH heredoc 二次解析密钥中的 shell 元字符，同时对编码后的 key 注册 Actions 日志掩码；它不被视为加密。

## 验证

- `actionlint` 与 ShellCheck 通过
- GitHub Actions YAML 解析通过
- `docker compose config --quiet` 通过
- Fake、完整配置、缺少模型和误填完整 endpoint 四种 Shell 分支验证通过
- API key 特殊字符 Base64 往返验证通过
- 后端配置与现有 DeepSeek adapter 无网络构造测试通过
- 服务器固定 compose 模板已人工执行 `docker compose config --quiet` 验证
- Repository Secret 和两个 Repository Variables 已由维护者完成配置

## 已知限制

- 本地验证不调用真实模型，避免在测试中使用或泄露计费密钥。
- 当前 PR 来自 fork，按既有安全策略不会部署 PR Preview，也无法读取主仓库 Secrets。
- 合并后 Main Preview 会自动部署，需要在预览环境提交一次自然语言行动，验证新服务商的流式输出、工具调用和最终结构化结果。
- 健康检查只证明容器和 HTTP 服务正常，不代表模型请求成功。

## 不在本 PR 范围

- 不修改 Host Agent、规则引擎或叙事契约。
- 不新增供应商专用 SDK。
- 不向 fork PR 开放真实密钥。
- 不把 API key 写入仓库、README 或服务器 compose 模板。
