### PR TITLE
test: complete Issue #246 ActionPlan acceptance

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -379,14 +379,29 @@ class ActionPlanOrchestrator:
             raise ActionPlanPolicyError("PLAN_OWNER_MISMATCH", "行动计划不属于当前玩家")
         if request.request_id in run.cancel_request_ids or run.status == "cancelled":
             return run
-        if run.is_terminal:
+        if run.is_terminal and run.status != "stopped":
             return run
+        if run.status == "waiting_for_player":
+            current = run.steps[run.current_step_index]
+            status = await self._executor.get_status(
+                GetAdjudicationStatusRequest(
+                    room_id=run.room_id,
+                    player_id=run.player_id,
+                    action_request_id=current.step_request_id,
+                )
+            )
+            if status.execution is not None and status.execution.status == "cancelled":
+                run = await self._apply_execution(run, status.execution)
         if run.current_step_index < len(run.steps):
             current = run.steps[run.current_step_index]
             cancellable_boundary = current.status == "pending" or (
                 run.status == "needs_clarification"
                 and current.status == "stopped"
                 and current.adjudication_execution is None
+            ) or (
+                current.status == "stopped"
+                and current.adjudication_execution is not None
+                and current.adjudication_execution.status == "cancelled"
             )
             if not cancellable_boundary:
                 raise ActionPlanPolicyError(

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -21,6 +21,8 @@ from collaboration_framework.contracts import (
     NarrativeOnlyEffect,
     NoAdjudicationCheck,
     PlayerInput,
+    PostRollDecisionRequest,
+    PushAdjudication,
     RequiredAdjudicationCheck,
     SceneSpec,
     SelectCheckChoice,
@@ -198,6 +200,27 @@ class ClarificationAdjudicator:
         )
 
 
+class FailSecondStepOnceAdjudicator(RecordingAdjudicator):
+    def __init__(self, world_ref: str) -> None:
+        super().__init__(world_ref)
+        self.failed = False
+
+    async def adjudicate(self, context):
+        if context.step_index == 1 and not self.failed:
+            self.contexts.append(context)
+            self.failed = True
+            raise RuntimeError("temporary provider outage")
+        return await super().adjudicate(context)
+
+
+class RejectSecondStepAdjudicator(RecordingAdjudicator):
+    async def adjudicate(self, context):
+        if context.step_index == 1:
+            self.contexts.append(context)
+            raise ContractError("provider output failed schema validation")
+        return await super().adjudicate(context)
+
+
 class OutOfScopeNarrationModel:
     async def generate(self, context):
         return {
@@ -301,6 +324,34 @@ async def test_five_steps_cross_soft_window_without_becoming_product_limit() -> 
         parent_action_id=original.client_action_id,
     )
     assert completed.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_persisted_narration_recovery_finishes_plan_without_replaying_engine_steps() -> None:
+    service, _, _, _, engine_store = orchestrator()
+    original = player_input("narration-recovery-parent")
+
+    settled = await service.start_or_resume(original, plan=plan(2))
+    assert settled.run.status == "awaiting_narration"
+    context = await service.build_narration_context(original)
+    assert context.allowed_evidence_refs
+    assert len(engine_store.inspect_domain_events("room_01")) == 2
+
+    recovered = await service.start_or_resume(original, plan=plan(2))
+    assert recovered.run.status == "awaiting_narration"
+    assert recovered.run.run_version == settled.run.run_version
+    assert len(engine_store.inspect_domain_events("room_01")) == 2
+
+    completed = await service.mark_narration_completed(
+        room_id="room_01",
+        parent_action_id=original.client_action_id,
+    )
+    replay = await service.mark_narration_completed(
+        room_id="room_01",
+        parent_action_id=original.client_action_id,
+    )
+    assert completed.status == "completed"
+    assert replay == completed
 
 
 def test_decision_parser_accepts_variable_lengths_and_rejects_invalid_shape() -> None:
@@ -421,6 +472,63 @@ async def test_pending_check_stops_plan_and_resumes_same_step_after_decision() -
 
 
 @pytest.mark.asyncio
+async def test_post_roll_retry_resolves_plan_once_without_duplicate_effects() -> None:
+    module, engine_store, projector = runtime()
+    adjudicator = RecordingAdjudicator(module.world_ref, check_step=0)
+    engine = AdjudicationEngineService(
+        engine_store,
+        dice=DiceRoller(SequenceDiceSource([80, 1])),
+    )
+    service = ActionPlanOrchestrator(
+        store=InMemoryActionPlanRunStore(),
+        adjudicator=adjudicator,
+        executor=engine,
+        player_view_projector=projector,
+    )
+    original = player_input("post-roll-parent")
+
+    waiting = await service.start_or_resume(original, plan=plan(2))
+    pending = waiting.latest_execution
+    assert pending is not None and pending.pending_decision is not None
+    rolled = await engine.decide(
+        CheckDecisionRequest(
+            request_id="post-roll-parent:select",
+            room_id="room_01",
+            player_id="player_01",
+            source_revision=pending.view_revision,
+            decision_id=pending.pending_decision.decision_id,
+            decision_version=pending.pending_decision.decision_version,
+            choice=SelectCheckChoice(candidate_id="spot"),
+        )
+    )
+    assert rolled.status == "awaiting_post_roll_decision"
+    check_run = rolled.check_run
+    assert check_run is not None
+    accept = PostRollDecisionRequest(
+        request_id="post-roll-parent:accept",
+        room_id="room_01",
+        player_id="player_01",
+        source_revision=rolled.view_revision,
+        check_id=check_run.check_id,
+        check_version=check_run.version,
+        option_id="push-once",
+        push_adjudication=PushAdjudication(method_description="换一种方式继续调查"),
+    )
+    resolved = await engine.decide_post_roll(accept)
+    replay = await engine.decide_post_roll(accept)
+    assert resolved.status == "resolved"
+    assert replay == resolved
+
+    completed = await service.start_or_resume(original, plan=plan(2))
+    assert completed.run.status == "awaiting_narration"
+    assert completed.run.current_step_index == 2
+    assert len(engine_store.inspect_domain_events("room_01")) == 7
+    assert [event.type for event in engine_store.inspect_domain_events("room_01")].count(
+        "action.succeeded"
+    ) == 2
+
+
+@pytest.mark.asyncio
 async def test_engine_commit_before_plan_cursor_update_reconciles_without_replay() -> None:
     module, engine_store, projector = runtime()
     engine = AdjudicationEngineService(engine_store)
@@ -495,6 +603,63 @@ async def test_unsubmitted_stale_step_is_refreshed_on_same_parent_retry() -> Non
         "2",
     ]
     assert len(engine_store.inspect_domain_events("room_01")) == 3
+
+
+@pytest.mark.asyncio
+async def test_second_step_provider_failure_retries_from_same_cursor() -> None:
+    module, engine_store, projector = runtime()
+    adjudicator = FailSecondStepOnceAdjudicator(module.world_ref)
+    service = ActionPlanOrchestrator(
+        store=InMemoryActionPlanRunStore(),
+        adjudicator=adjudicator,
+        executor=AdjudicationEngineService(engine_store),
+        player_view_projector=projector,
+    )
+    original = player_input("provider-retry-parent")
+
+    failed = await service.start_or_resume(original, plan=plan(2))
+
+    assert failed.run.status == "retryable_failure"
+    assert failed.run.current_step_index == 1
+    assert [step.status for step in failed.run.steps] == ["completed", "pending"]
+    assert failed.run.steps[1].safe_failure_code == "STEP_ADJUDICATOR_FAILED"
+    assert len(engine_store.inspect_domain_events("room_01")) == 1
+
+    recovered = await service.start_or_resume(original, plan=plan(2))
+
+    assert recovered.run.status == "awaiting_narration"
+    assert recovered.run.current_step_index == 2
+    assert [context.step_index for context in adjudicator.contexts] == [0, 1, 1]
+    assert [context.player_view.revision for context in adjudicator.contexts] == [
+        "0",
+        "1",
+        "1",
+    ]
+    assert len(engine_store.inspect_domain_events("room_01")) == 2
+
+
+@pytest.mark.asyncio
+async def test_invalid_second_step_fails_closed_before_engine_commit() -> None:
+    module, engine_store, projector = runtime()
+    adjudicator = RejectSecondStepAdjudicator(module.world_ref)
+    service = ActionPlanOrchestrator(
+        store=InMemoryActionPlanRunStore(),
+        adjudicator=adjudicator,
+        executor=AdjudicationEngineService(engine_store),
+        player_view_projector=projector,
+    )
+
+    failed = await service.start_or_resume(
+        player_input("invalid-step-parent"),
+        plan=plan(2),
+    )
+
+    assert failed.run.status == "retryable_failure"
+    assert failed.run.current_step_index == 1
+    assert [step.status for step in failed.run.steps] == ["completed", "pending"]
+    assert failed.run.steps[1].adjudication is None
+    assert failed.run.steps[1].safe_failure_code == "STEP_ADJUDICATOR_FAILED"
+    assert len(engine_store.inspect_domain_events("room_01")) == 1
 
 
 @pytest.mark.asyncio

--- a/e2e/scripts/run-e2e.ts
+++ b/e2e/scripts/run-e2e.ts
@@ -52,6 +52,8 @@ const backendEnv = {
   // ⚠️ 显式锁定 Fake：本地 .env 可能把 Provider 切到远程模型，仅清空 Key 会在
   // Settings 校验阶段失败；若透传 Key 则会让 E2E 依赖外部服务并产生费用。
   HOST_MODEL_PROVIDER: 'fake',
+  APP_ENV: 'test',
+  TEST_FIXED_DICE_ROLL: '1',
   NARRATOR_DELAY_SECONDS: '1',
   DEEPSEEK_API_KEY: '',
 }

--- a/e2e/tests/action-plan-acceptance.e2e.ts
+++ b/e2e/tests/action-plan-acceptance.e2e.ts
@@ -1,0 +1,492 @@
+import assert from 'node:assert/strict'
+import { DatabaseSync } from 'node:sqlite'
+import { test } from 'node:test'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type { AgentPlayerView, ServerToClientEvent } from 'trpg-sdk'
+
+import { createRoomWithModule, legalCharacterPayload, registerPlayer } from './helpers.ts'
+
+const DB_FILE = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../trpg-backend/e2e.db'
+)
+const LEGAL_ATTRIBUTES = {
+  STR: 50, CON: 50, POW: 50, DEX: 50,
+  APP: 50, SIZ: 50, INT: 50, EDU: 50, LUCK: 50,
+}
+
+function waitForEvent(
+  owner: { roomSocket: { onMessage: (handler: (event: ServerToClientEvent) => void) => () => void } },
+  predicate: (event: ServerToClientEvent) => boolean,
+  timeoutMs = 10_000,
+): Promise<ServerToClientEvent> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      off()
+      rejectPromise(new Error(`等待 ActionPlan 事件超时（${timeoutMs}ms）`))
+    }, timeoutMs)
+    const off = owner.roomSocket.onMessage((event) => {
+      if (!predicate(event)) return
+      clearTimeout(timer)
+      off()
+      resolvePromise(event)
+    })
+  })
+}
+
+async function buildCharacter(
+  sdk: Awaited<ReturnType<typeof registerPlayer>>['sdk'],
+  roomId: string,
+  reconnectToken: string,
+): Promise<void> {
+  const draft = await sdk.characters.createDraft(roomId, reconnectToken)
+  await sdk.characters.save(
+    roomId,
+    draft.characterId,
+    {
+      ...legalCharacterPayload(LEGAL_ATTRIBUTES),
+      skills: {
+        'credit-rating': 30,
+        'library-use': 90,
+        'spot-hidden': 90,
+      },
+    },
+    reconnectToken,
+  )
+  await sdk.characters.complete(roomId, draft.characterId, reconnectToken)
+}
+
+interface CanonCase {
+  name: string
+  utterance: string
+  destinationSceneId: string
+  destinationEntityId: string
+  destinationCheckpointId: string
+  assertFinal(view: AgentPlayerView): void
+}
+
+const CANON_CASES: CanonCase[] = [
+  {
+    name: '书房搜索',
+    utterance: '去书房找线索',
+    destinationSceneId: 'kimball_house',
+    destinationEntityId: 'kimball_study',
+    destinationCheckpointId: 'search_kimball_study',
+    assertFinal(view) {
+      assert.ok(
+        view.scene.visible_entities.some((entity) => entity.id === 'douglas_diary'),
+        '成功搜索后应在最终 PlayerView 中看到已找到的日记',
+      )
+    },
+  },
+  {
+    name: '图书馆旧报',
+    utterance: '去图书馆查旧报纸',
+    destinationSceneId: 'library',
+    destinationEntityId: 'newspaper_archive',
+    destinationCheckpointId: 'research_library_archive',
+    assertFinal(view) {
+      assert.ok(
+        view.known_information.some((item) => item.id === 'cemetery_dance_report'),
+        '成功查阅后应公开墓地旧报信息',
+      )
+    },
+  },
+  {
+    name: '墓地询问',
+    utterance: '到墓地问守墓人',
+    destinationSceneId: 'cemetery',
+    destinationEntityId: 'melodias',
+    destinationCheckpointId: 'impress_caretaker',
+    assertFinal(view) {
+      const caretaker = view.scene.visible_entities.find((entity) => entity.id === 'melodias')
+      assert.ok(caretaker, '最终 PlayerView 应保留目的地可见守墓人')
+    },
+  },
+]
+
+function assertPersistedPlan(roomId: string, actionId: string): void {
+  const database = new DatabaseSync(DB_FILE, { readOnly: true })
+  database.exec('PRAGMA busy_timeout = 5000')
+  const persistedRoomId = roomId.replaceAll('-', '')
+  try {
+    const row = database.prepare(
+      `SELECT status, current_step_index, run_json
+       FROM action_plan_runs
+       WHERE room_id = ? AND parent_action_id = ?`
+    ).get(persistedRoomId, actionId) as {
+      status: string
+      current_step_index: number
+      run_json: string
+    } | undefined
+    assert.ok(row, 'SQL ActionPlanRun 必须存在')
+    assert.equal(row.status, 'completed')
+    assert.equal(row.current_step_index, 2)
+    const run = JSON.parse(row.run_json) as { steps?: unknown[] }
+    assert.equal(run.steps?.length, 2)
+
+    const commands = database.prepare(
+      `SELECT COUNT(*) AS count
+       FROM adjudication_command_executions
+       WHERE room_id = ? AND action_request_id IN (
+         SELECT json_extract(value, '$.step_request_id')
+         FROM action_plan_runs, json_each(action_plan_runs.run_json, '$.steps')
+         WHERE room_id = ? AND parent_action_id = ?
+       )`
+    ).get(persistedRoomId, persistedRoomId, actionId) as { count: number }
+    assert.equal(commands.count, 3, '两次 step submit 加一次技能选择应各持久化一次')
+  } finally {
+    database.close()
+  }
+}
+
+function assertPersistedCancellation(roomId: string, actionId: string): void {
+  const database = new DatabaseSync(DB_FILE, { readOnly: true })
+  database.exec('PRAGMA busy_timeout = 5000')
+  try {
+    const row = database.prepare(
+      `SELECT status, current_step_index
+       FROM action_plan_runs
+       WHERE room_id = ? AND parent_action_id = ?`
+    ).get(roomId.replaceAll('-', ''), actionId) as {
+      status: string
+      current_step_index: number
+    } | undefined
+    assert.ok(row)
+    assert.equal(row.status, 'cancelled')
+    assert.equal(row.current_step_index, 1)
+  } finally {
+    database.close()
+  }
+}
+
+for (const canon of CANON_CASES) {
+  test(`Issue #246 Canon：${canon.name}由一次 action.plan.submit 完成`, { timeout: 30_000 }, async () => {
+    const room = await createRoomWithModule(`canon-${canon.destinationSceneId}`)
+    await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
+    await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken)
+
+    const socket = room.host.sdk.roomSocket.connect(room.roomId, room.host.token)
+    const observed: ServerToClientEvent[] = []
+    const off = room.host.sdk.roomSocket.onMessage((event) => observed.push(event))
+    try {
+      await room.host.sdk.roomSocket.waitForOpen(socket)
+      const bound = waitForEvent(room.host.sdk, (event) => event.type === 'session.bound')
+      room.host.sdk.roomSocket.joinRoom(room.hostPlayerId, {
+        reconnectToken: room.reconnectToken,
+      })
+      await bound
+
+      const openingViewPromise = waitForEvent(
+        room.host.sdk,
+        (event) => event.type === 'view.updated',
+      )
+      const openingNarration = waitForEvent(
+        room.host.sdk,
+        (event) => event.type === 'narration.push',
+      )
+      room.host.sdk.roomSocket.startGame(room.hostPlayerId)
+      const [openingViewEvent] = await Promise.all([openingViewPromise, openingNarration])
+      assert.equal(openingViewEvent.type, 'view.updated')
+      const initialView = openingViewEvent.payload.playerView
+      assert.equal(initialView.scene.id, 'client_briefing')
+      assert.equal(
+        initialView.scene.visible_entities.some(
+          (entity) => entity.id === canon.destinationEntityId,
+        ),
+        false,
+        '目的地实体不得提前进入第一步 PlayerView',
+      )
+      assert.equal(
+        initialView.checkpoint_options.some(
+          (checkpoint) => checkpoint.id === canon.destinationCheckpointId,
+        ),
+        false,
+        '目的地 Checkpoint 不得提前进入第一步 PlayerView',
+      )
+
+      const actionId = `canon-${canon.destinationSceneId}-${Date.now()}`
+      const pendingPromise = waitForEvent(
+        room.host.sdk,
+        (event) =>
+          event.type === 'adjudication.pending' &&
+          event.payload.correlationId === actionId,
+      )
+      const turnPromise = room.host.sdk.roomSocket.submitPlannedAction(
+        room.hostPlayerId,
+        { clientActionId: actionId, utterance: canon.utterance },
+      )
+      const pendingEvent = await pendingPromise
+      assert.equal(pendingEvent.type, 'adjudication.pending')
+      const pending = pendingEvent.payload
+      assert.equal(pending.status, 'awaiting_skill_choice')
+      assert.ok(pending.planId, '复合行动 pending 必须归属于持久化 PlanRun')
+      assert.notEqual(
+        pending.sourceRevision,
+        initialView.revision,
+        '目的地裁决必须绑定 travel 提交后的新 revision',
+      )
+      assert.ok(pending.pendingDecision)
+      const decision = pending.pendingDecision
+      assert.equal(decision.summary.includes(canon.utterance), false)
+      assert.equal(decision.options.length, 1)
+
+      const completedProgress = waitForEvent(
+        room.host.sdk,
+        (event) =>
+          event.type === 'plan.completed' &&
+          event.payload.correlationId === actionId,
+      )
+      room.host.sdk.roomSocket.selectAdjudication(room.hostPlayerId, {
+        clientActionId: actionId,
+        requestId: `${actionId}:select`,
+        sourceRevision: pending.sourceRevision,
+        decisionId: decision.decision_id,
+        decisionVersion: decision.decision_version,
+        candidateId: decision.options[0].candidate_id,
+      })
+      const [turn, terminal] = await Promise.all([turnPromise, completedProgress])
+      assert.equal(terminal.type, 'plan.completed')
+      assert.equal(terminal.payload.completedSteps, 2)
+      assert.equal(turn.player_view.scene.id, canon.destinationSceneId)
+      assert.equal(
+        room.host.sdk.roomSocket.getPlayerView()?.revision,
+        turn.player_view.revision,
+      )
+      canon.assertFinal(turn.player_view)
+      assert.match(turn.narration.text, /依次完成/)
+
+      const actionEchoes = observed.filter(
+        (event) =>
+          event.type === 'action.broadcast' &&
+          event.payload.clientActionId === actionId,
+      )
+      assert.equal(actionEchoes.length, 1, '玩家原话必须作为一个父行动持久化和广播')
+      const actionEcho = actionEchoes[0]
+      assert.equal(actionEcho?.type, 'action.broadcast')
+      if (actionEcho?.type !== 'action.broadcast') {
+        assert.fail('缺少 action.broadcast')
+      }
+      assert.equal(actionEcho.payload.utterance, canon.utterance)
+      const started = observed.find(
+        (event) =>
+          event.type === 'plan.started' && event.payload.correlationId === actionId,
+      )
+      assert.equal(started?.type, 'plan.started')
+      assert.equal(started.payload.totalSteps, 2)
+
+      const publicProgress = observed.filter(
+        (event) =>
+          event.type.startsWith('plan.') || event.type === 'adjudication.pending',
+      )
+      const serializedProgress = JSON.stringify(publicProgress)
+      for (const forbidden of [
+        'success_effects',
+        'failure_effects',
+        'raw_adjudication',
+        'tool_arguments',
+        '公墓地下有神秘生物',
+      ]) {
+        assert.equal(serializedProgress.includes(forbidden), false)
+      }
+
+      const conversation = await room.host.sdk.rooms.listConversation(
+        room.roomId,
+        room.reconnectToken,
+      )
+      assert.equal(
+        conversation.filter(
+          (event) =>
+            event.type === 'action.broadcast' &&
+            event.payload.clientActionId === actionId,
+        ).length,
+        1,
+      )
+      assert.equal(
+        conversation.filter(
+          (event) =>
+            event.type === 'narration.push' && event.payload.messageId === actionId,
+        ).length,
+        1,
+      )
+      assertPersistedPlan(room.roomId, actionId)
+    } finally {
+      off()
+      room.host.sdk.roomSocket.disconnect()
+    }
+  })
+}
+
+test('Issue #246 恢复：断线重连后用原 parent 恢复 pending，重复选择不重掷', { timeout: 30_000 }, async () => {
+  const room = await createRoomWithModule('reconnect-pending')
+  await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
+  await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken)
+  let socket = room.host.sdk.roomSocket.connect(room.roomId, room.host.token)
+  const observed: ServerToClientEvent[] = []
+  const off = room.host.sdk.roomSocket.onMessage((event) => observed.push(event))
+  const actionId = `reconnect-pending-${Date.now()}`
+  try {
+    await room.host.sdk.roomSocket.waitForOpen(socket)
+    const bound = waitForEvent(room.host.sdk, (event) => event.type === 'session.bound')
+    room.host.sdk.roomSocket.joinRoom(room.hostPlayerId, {
+      reconnectToken: room.reconnectToken,
+    })
+    await bound
+    const firstView = waitForEvent(room.host.sdk, (event) => event.type === 'view.updated')
+    const firstOpening = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'narration.push' && event.payload.messageId === 'game-opening',
+    )
+    room.host.sdk.roomSocket.startGame(room.hostPlayerId)
+    await Promise.all([firstView, firstOpening])
+
+    const firstPending = waitForEvent(
+      room.host.sdk,
+      (event) =>
+        event.type === 'adjudication.pending' && event.payload.correlationId === actionId,
+    )
+    const lostTurn = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
+      clientActionId: actionId,
+      utterance: '去图书馆查旧报纸',
+    })
+    const pending = await firstPending
+    assert.equal(pending.type, 'adjudication.pending')
+    assert.ok(pending.payload.pendingDecision)
+    const firstDecision = pending.payload.pendingDecision
+    socket.close()
+    room.host.sdk.roomSocket.disconnect()
+    await assert.rejects(lostTurn)
+
+    socket = room.host.sdk.roomSocket.connect(room.roomId, room.host.token)
+    await room.host.sdk.roomSocket.waitForOpen(socket)
+    const rebound = waitForEvent(room.host.sdk, (event) => event.type === 'session.bound')
+    const openingReplay = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'narration.push' && event.payload.messageId === 'game-opening',
+    )
+    room.host.sdk.roomSocket.joinRoom(room.hostPlayerId, {
+      reconnectToken: room.reconnectToken,
+    })
+    await Promise.all([rebound, openingReplay])
+
+    const resumedPending = waitForEvent(
+      room.host.sdk,
+      (event) =>
+        event.type === 'adjudication.pending' && event.payload.correlationId === actionId,
+    )
+    const recoveredTurn = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
+      clientActionId: actionId,
+      utterance: '去图书馆查旧报纸',
+    })
+    const resumed = await resumedPending
+    assert.equal(resumed.type, 'adjudication.pending')
+    assert.equal(resumed.payload.sourceRevision, pending.payload.sourceRevision)
+    assert.deepEqual(resumed.payload.pendingDecision, firstDecision)
+    assert.ok(resumed.payload.planId)
+
+    const planCompleted = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'plan.completed' && event.payload.correlationId === actionId,
+    )
+    const decision = resumed.payload.pendingDecision
+    assert.ok(decision)
+    room.host.sdk.roomSocket.selectAdjudication(room.hostPlayerId, {
+      clientActionId: actionId,
+      requestId: `${actionId}:select`,
+      sourceRevision: resumed.payload.sourceRevision,
+      decisionId: decision.decision_id,
+      decisionVersion: decision.decision_version,
+      candidateId: decision.options[0].candidate_id,
+    })
+    const [turn] = await Promise.all([recoveredTurn, planCompleted])
+    assert.equal(turn.player_view.scene.id, 'library')
+
+    // 模拟“选择请求已被 Engine 提交但客户端没收到响应”的重试：复用同一个
+    // requestId/clientActionId，SQL 幂等记录应直接重放，不产生第二次骰点/效果。
+    room.host.sdk.roomSocket.selectAdjudication(room.hostPlayerId, {
+      clientActionId: actionId,
+      requestId: `${actionId}:select`,
+      sourceRevision: resumed.payload.sourceRevision,
+      decisionId: decision.decision_id,
+      decisionVersion: decision.decision_version,
+      candidateId: decision.options[0].candidate_id,
+    })
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100))
+    const conversation = await room.host.sdk.rooms.listConversation(
+      room.roomId,
+      room.reconnectToken,
+    )
+    assert.equal(
+      conversation.filter(
+        (event) => event.type === 'narration.push' && event.payload.messageId === actionId,
+      ).length,
+      1,
+    )
+    assertPersistedPlan(room.roomId, actionId)
+    assert.equal(
+      observed.some(
+        (event) =>
+          event.type === 'turn.failed' && event.payload.correlationId === actionId,
+      ),
+      false,
+    )
+  } finally {
+    off()
+    room.host.sdk.roomSocket.disconnect()
+  }
+})
+
+test('Issue #246 恢复：取消保留已提交 travel 且停止剩余步骤', { timeout: 30_000 }, async () => {
+  const room = await createRoomWithModule('cancel-plan')
+  await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
+  await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken)
+  const socket = room.host.sdk.roomSocket.connect(room.roomId, room.host.token)
+  const off = room.host.sdk.roomSocket.onMessage(() => undefined)
+  const actionId = `cancel-plan-${Date.now()}`
+  try {
+    await room.host.sdk.roomSocket.waitForOpen(socket)
+    const bound = waitForEvent(room.host.sdk, (event) => event.type === 'session.bound')
+    room.host.sdk.roomSocket.joinRoom(room.hostPlayerId, {
+      reconnectToken: room.reconnectToken,
+    })
+    await bound
+    const firstView = waitForEvent(room.host.sdk, (event) => event.type === 'view.updated')
+    const firstOpening = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'narration.push' && event.payload.messageId === 'game-opening',
+    )
+    room.host.sdk.roomSocket.startGame(room.hostPlayerId)
+    await Promise.all([firstView, firstOpening])
+    const pending = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'adjudication.pending' && event.payload.correlationId === actionId,
+    )
+    const turnPromise = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
+      clientActionId: actionId,
+      utterance: '去书房找线索',
+    })
+    await pending
+    const completedEvent = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'view.updated' && event.payload.playerId === room.hostPlayerId,
+    )
+    room.host.sdk.roomSocket.cancelActionPlan(room.hostPlayerId, {
+      clientActionId: actionId,
+      requestId: `${actionId}:cancel`,
+    })
+    const [turn] = await Promise.all([turnPromise, completedEvent])
+    assert.equal(turn.player_view.scene.id, 'kimball_house')
+    assert.equal(
+      turn.player_view.scene.visible_entities.some((entity) => entity.id === 'douglas_diary'),
+      false,
+      '取消后不得执行剩余搜索步骤',
+    )
+    assert.match(turn.narration.text, /后续行动已停止/)
+    assertPersistedCancellation(room.roomId, actionId)
+  } finally {
+    off()
+    room.host.sdk.roomSocket.disconnect()
+  }
+})

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -15,12 +15,19 @@ from collaboration_framework.contracts import (
     ActionTarget,
     AdjudicationExecution,
     CancelActionPlanRequest,
+    CancelCheckChoice,
+    ChangeEntityStateEffect,
+    CheckDecisionRequest,
+    EnterLocationEffect,
     HostTurnDecision,
     NarrativeOnlyEffect,
     NoAdjudicationCheck,
     PlayerInput,
     PlayerView,
+    RequiredAdjudicationCheck,
+    RevealInformationEffect,
     SingleActionDecision,
+    SkillCheckCandidate,
 )
 from collaboration_framework.engine import AdjudicationEngineService, EngineStore, RuleEngineService
 from collaboration_framework.host.adapters import InMemoryActionPlanRunStore
@@ -88,6 +95,30 @@ class DeterministicHostTurnDecisionModel:
                     for part in pieces
                 ),
             )
+
+        compact = _compact_travel_plan(context.player_view, utterance)
+        if compact is not None:
+            return compact
+
+        destination = _match_visible_exit(context.player_view, utterance)
+        if destination is not None and destination.destination is not None:
+            return SingleActionDecision(
+                adjudication=ActionAdjudication(
+                    request_id="application-owned",
+                    source_revision=context.player_view.revision,
+                    actor_id=context.player_input.actor_id,
+                    summary=utterance,
+                    target=ActionTarget(
+                        kind="location",
+                        id=destination.destination.scene_id,
+                    ),
+                    method=ActionMethod(family="travel", description=utterance),
+                    check=NoAdjudicationCheck(),
+                    success_effects=(
+                        EnterLocationEffect(location_id=destination.destination.scene_id),
+                    ),
+                )
+            )
         return SingleActionDecision(
             adjudication=ActionAdjudication(
                 request_id="application-owned",
@@ -100,6 +131,108 @@ class DeterministicHostTurnDecisionModel:
                 success_effects=(NarrativeOnlyEffect(),),
             )
         )
+
+
+def _compact_travel_plan(view: PlayerView, utterance: str) -> ActionPlan | None:
+    """Split compact fake-provider phrases without consulting hidden ModuleContent."""
+
+    destination = _match_visible_exit(view, utterance)
+    if destination is None or destination.destination is None:
+        return None
+    anchor = _best_label_overlap(
+        utterance,
+        (
+            destination.name,
+            destination.id,
+            *destination.aliases,
+            destination.destination.name,
+            destination.destination.scene_id,
+        ),
+    )
+    if anchor is None:
+        return None
+    anchor_end = utterance.find(anchor) + len(anchor)
+    remainder = utterance[anchor_end:].strip(" ，,。")
+    action_markers = (
+        "搜索",
+        "调查",
+        "查阅",
+        "查找",
+        "研究",
+        "询问",
+        "交谈",
+        "找",
+        "查",
+        "问",
+    )
+    marker = next((item for item in action_markers if item in remainder), None)
+    if marker is None:
+        return None
+    action_start = remainder.find(marker)
+    follow_up = remainder[action_start:].strip(" ，,。")
+    if not follow_up:
+        return None
+    destination_name = destination.destination.name
+    return ActionPlan(
+        goal=utterance,
+        steps=(
+            ActionPlanStep(kind="travel", semantic_goal=f"前往{destination_name}"),
+            ActionPlanStep(
+                kind=(
+                    "dialogue"
+                    if any(word in follow_up for word in ("问", "交谈"))
+                    else "action"
+                ),
+                semantic_goal=f"在{destination_name}{follow_up}",
+            ),
+        ),
+    )
+
+
+def _match_visible_exit(view: PlayerView, text: str):
+    if not any(word in text for word in ("去", "前往", "进入", "到", "抵达")):
+        return None
+    matches = []
+    for exit_view in view.scene.available_exits:
+        destination_labels = (
+            (exit_view.destination.name, exit_view.destination.scene_id)
+            if exit_view.destination
+            else ()
+        )
+        labels = (
+            exit_view.name,
+            exit_view.id,
+            *exit_view.aliases,
+            *destination_labels,
+        )
+        overlap = _best_label_overlap(text, labels)
+        if overlap is not None:
+            matches.append((len(overlap), exit_view.id, exit_view))
+    if not matches:
+        return None
+    matches.sort(key=lambda item: (-item[0], item[1]))
+    if len(matches) > 1 and matches[0][0] == matches[1][0]:
+        return None
+    return matches[0][2]
+
+
+def _best_label_overlap(text: str, labels: tuple[str, ...]) -> str | None:
+    candidates: set[str] = set()
+    for label in labels:
+        normalized = label.strip()
+        if not normalized:
+            continue
+        if normalized in text:
+            candidates.add(normalized)
+        if any("\u4e00" <= character <= "\u9fff" for character in normalized):
+            for width in range(len(normalized), 1, -1):
+                for start in range(len(normalized) - width + 1):
+                    candidate = normalized[start : start + width]
+                    if candidate in text:
+                        candidates.add(candidate)
+                if candidates:
+                    break
+    return max(candidates, key=lambda item: (len(item), item)) if candidates else None
 
 
 class DeterministicActionPlanNarrationModel:
@@ -253,6 +386,32 @@ class ActionPlanTurnApplication:
         request_id: str,
     ) -> ActionPlanTurnResult:
         actor_id = await self._resolve_actor_id(room_id, player_id)
+        existing = await self._orchestrator.get_run(room_id, parent_action_id)
+        if (
+            existing is not None
+            and existing.player_id == player_id
+            and existing.actor_id == actor_id
+            and existing.status == "waiting_for_player"
+            and existing.current_step_index < len(existing.steps)
+        ):
+            execution = existing.steps[existing.current_step_index].adjudication_execution
+            pending = execution.pending_decision if execution is not None else None
+            if (
+                execution is not None
+                and execution.status == "awaiting_skill_choice"
+                and pending is not None
+            ):
+                await self._adjudication_engine.decide(
+                    CheckDecisionRequest(
+                        request_id=request_id,
+                        room_id=room_id,
+                        player_id=player_id,
+                        source_revision=execution.view_revision,
+                        decision_id=pending.decision_id,
+                        decision_version=pending.decision_version,
+                        choice=CancelCheckChoice(),
+                    )
+                )
         run = await self._orchestrator.cancel_remaining(
             CancelActionPlanRequest(
                 request_id=request_id,
@@ -526,12 +685,81 @@ class _DeterministicStepAdjudicator:
                 "当前步骤需要尚未接入的时间/休息领域能力",
                 retryable=False,
             )
+        if context.step.kind == "travel":
+            destination = _match_visible_exit(
+                context.player_view,
+                context.step.semantic_goal,
+            )
+            if destination is None or destination.destination is None:
+                raise TurnExecutionError(
+                    "STEP_DESTINATION_NOT_VISIBLE",
+                    "当前地点没有可安全确认的目标路线",
+                    retryable=False,
+                )
+            destination_id = destination.destination.scene_id
+            return ActionAdjudication(
+                request_id=context.step_request_id,
+                source_revision=context.player_view.revision,
+                actor_id=context.player_input.actor_id,
+                summary=context.step.semantic_goal,
+                target=ActionTarget(kind="location", id=destination_id),
+                method=ActionMethod(
+                    family="travel",
+                    description=context.step.semantic_goal,
+                ),
+                check=NoAdjudicationCheck(),
+                success_effects=(EnterLocationEffect(location_id=destination_id),),
+            )
+
+        action_text = context.step.semantic_goal.replace(
+            context.player_view.scene.name,
+            "",
+        ).strip(" ，,。")
+        target = _match_visible_entity(
+            context.player_view,
+            action_text,
+        )
+        checkpoint = _match_visible_checkpoint(
+            context.player_view,
+            action_text,
+            target.id if target is not None else None,
+        )
+        if checkpoint is not None:
+            skill_id = checkpoint.skills[0]
+            success_effects, failure_effects = _fake_checkpoint_effects(checkpoint.id)
+            return ActionAdjudication(
+                request_id=context.step_request_id,
+                source_revision=context.player_view.revision,
+                actor_id=context.player_input.actor_id,
+                summary=context.step.semantic_goal,
+                target=ActionTarget(kind="entity", id=checkpoint.target_id),
+                method=ActionMethod(
+                    family=checkpoint.action_hint,
+                    description=context.step.semantic_goal,
+                ),
+                check=RequiredAdjudicationCheck(
+                    candidates=(
+                        SkillCheckCandidate(
+                            candidate_id=f"{checkpoint.id}:{skill_id}",
+                            skill_id=skill_id,
+                            difficulty=checkpoint.difficulty or "regular",
+                            method_summary=context.step.semantic_goal,
+                            player_safe_reason="使用当前地点公开的检定方式",
+                        ),
+                    )
+                ),
+                success_effects=success_effects,
+                failure_effects=failure_effects,
+            )
+
+        target_kind = "entity" if target is not None else "location"
+        target_id = target.id if target is not None else context.player_view.scene.id
         return ActionAdjudication(
             request_id=context.step_request_id,
             source_revision=context.player_view.revision,
             actor_id=context.player_input.actor_id,
             summary=context.step.semantic_goal,
-            target=ActionTarget(kind="location", id=context.player_view.scene.id),
+            target=ActionTarget(kind=target_kind, id=target_id),
             method=ActionMethod(
                 family=context.step.kind,
                 description=context.step.semantic_goal,
@@ -539,6 +767,103 @@ class _DeterministicStepAdjudicator:
             check=NoAdjudicationCheck(),
             success_effects=(NarrativeOnlyEffect(),),
         )
+
+
+def _match_visible_entity(view: PlayerView, text: str):
+    matches = []
+    for entity in view.scene.visible_entities:
+        overlap = _best_label_overlap(text, (entity.id, entity.name, *entity.aliases))
+        if overlap is not None:
+            matches.append((len(overlap), entity.id, entity))
+    if not matches:
+        return None
+    matches.sort(key=lambda item: (-item[0], item[1]))
+    if len(matches) > 1 and matches[0][0] == matches[1][0]:
+        return None
+    return matches[0][2]
+
+
+def _match_visible_checkpoint(view: PlayerView, text: str, target_id: str | None):
+    family_markers = {
+        "search": ("搜索", "搜查", "找线索", "找"),
+        "research": ("查阅", "查找", "研究", "旧报", "查"),
+        "social": ("询问", "交谈", "问"),
+        "observe": ("观察", "查看"),
+        "intimidate": ("威胁", "恐吓"),
+        "bribe": ("贿赂", "送酒"),
+    }
+    matches = [
+        checkpoint
+        for checkpoint in view.checkpoint_options
+        if (target_id is None or checkpoint.target_id == target_id)
+        and any(
+            marker in text
+            for marker in family_markers.get(checkpoint.action_hint, (checkpoint.action_hint,))
+        )
+        and checkpoint.skills
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _fake_checkpoint_effects(checkpoint_id: str):
+    """Deterministic effects for the published Paper Chase fake-provider fixture."""
+
+    effects = {
+        "search_kimball_study": (
+            (
+                ChangeEntityStateEffect(
+                    entity_id="kimball_study",
+                    key="searched",
+                    value=True,
+                ),
+                ChangeEntityStateEffect(
+                    entity_id="douglas_diary",
+                    key="found",
+                    value=True,
+                ),
+            ),
+            (
+                ChangeEntityStateEffect(
+                    entity_id="kimball_study",
+                    key="searched",
+                    value=True,
+                ),
+            ),
+        ),
+        "research_library_archive": (
+            (
+                RevealInformationEffect(
+                    information_id="cemetery_dance_report",
+                    scope="party",
+                ),
+                ChangeEntityStateEffect(
+                    entity_id="newspaper_archive",
+                    key="library_report_found",
+                    value=True,
+                ),
+            ),
+            (NarrativeOnlyEffect(),),
+        ),
+        "impress_caretaker": (
+            (
+                ChangeEntityStateEffect(
+                    entity_id="melodias",
+                    key="impressed",
+                    value=True,
+                ),
+                ChangeEntityStateEffect(
+                    entity_id="favorite_grave",
+                    key="identified",
+                    value=True,
+                ),
+            ),
+            (NarrativeOnlyEffect(),),
+        ),
+    }
+    return effects.get(
+        checkpoint_id,
+        ((NarrativeOnlyEffect(),), (NarrativeOnlyEffect(),)),
+    )
 
 
 __all__ = [

--- a/trpg-backend/app/core/config.py
+++ b/trpg-backend/app/core/config.py
@@ -94,6 +94,10 @@ class Settings(BaseSettings):
     recent_history_max_chars: int = Field(default=6000, ge=2)
     action_plan_max_steps: int = Field(default=32, ge=2, le=256)
     action_plan_max_steps_per_advance: int = Field(default=3, ge=1, le=32)
+    # Deterministic cross-process E2E hook. Production and development always
+    # use the Engine's cryptographic dice source; this value is honored only
+    # when APP_ENV=test.
+    test_fixed_dice_roll: int | None = Field(default=None, ge=1, le=100)
 
     # 讨论区/Narrator 主线的兼容配置：未配置时使用确定性占位叙事，测试可通过
     # 延迟钩子稳定覆盖行动锁并发分支。

--- a/trpg-backend/app/core/engine.py
+++ b/trpg-backend/app/core/engine.py
@@ -2,16 +2,37 @@
 
 from collaboration_framework.engine import (
     AdjudicationEngineService,
+    DiceRoller,
     RuleEngineService,
     RuleKernel,
 )
 
 from app.adapters import SqlAlchemyActionPlanRunStore, SqlAlchemyEngineStore
+from app.core.config import get_settings
 from app.core.db import async_session_factory
+
+
+class _FixedDiceSource:
+    def __init__(self, value: int) -> None:
+        self._value = value
+
+    def randint(self, minimum: int, maximum: int) -> int:
+        if not minimum <= self._value <= maximum:
+            raise AssertionError(
+                f"Fixed test roll {self._value} is outside [{minimum}, {maximum}]"
+            )
+        return self._value
+
 
 engine_store = SqlAlchemyEngineStore(async_session_factory)
 action_plan_store = SqlAlchemyActionPlanRunStore(async_session_factory)
-adjudication_engine_service = AdjudicationEngineService(engine_store)
+_settings = get_settings()
+_dice = (
+    DiceRoller(_FixedDiceSource(_settings.test_fixed_dice_roll))
+    if _settings.app_env == "test" and _settings.test_fixed_dice_roll is not None
+    else None
+)
+adjudication_engine_service = AdjudicationEngineService(engine_store, dice=_dice)
 rule_engine_service = RuleEngineService(
     engine_store,
     kernel=RuleKernel(allow_legacy_missing_skill=False),

--- a/trpg-backend/docs/action-plan-real-model-smoke.md
+++ b/trpg-backend/docs/action-plan-real-model-smoke.md
@@ -13,3 +13,28 @@
 
 该 smoke 只证明当前生产模型能够稳定通过严格结构化边界，选择单动作或可变长度
 `ActionPlan`。CI 使用 scripted/fake client，不依赖外部模型和 API key。
+
+## Issue #246 脱敏验收（2026-08-06）
+
+- Provider / model：DeepSeek / `deepseek-chat`
+- 入口：`PromptHostTurnDecisionModel`，使用当前 `.env` provider 配置
+- 执行方式：离线构造玩家安全 `PlayerView`，逐条提交自然语言输入；只记录
+  `HostTurnDecision` 的 kind、步骤数和 Schema/策略错误分类
+- 安全约束：未记录 API key、原始模型响应、隐藏上下文、PlayerView 内容或思维链；
+  本次调用不进入 CI
+
+| 用例类别 | 输入类别（脱敏） | 结构化结果 | 步骤数 | 结论 |
+| --- | --- | --- | ---: | --- |
+| `go_find` | `去 X 找 Y` | `single_action` | 1 | Schema 通过 |
+| `ask_destination` | `到 X 问 Y` | `action_plan` | 2 | Schema 通过 |
+| `enter_search` | `进入 X 搜索` | `single_action` | 1 | Schema 通过 |
+| `synonym` | `前往/调查` 同义表达 | `single_action` | 1 | Schema 通过 |
+| `omitted_subject` | 省略主语的地点行动 | `single_action` | 1 | Schema 通过 |
+| `two_steps` | 两个连续动作 | `action_plan` | 4 | Schema 通过，模型将紧凑短语展开为 4 步 |
+| `three_steps` | 三个连续动作 | `action_plan` | 4 | Schema 通过，模型将短语展开为 4 步 |
+| `four_steps` | 四个连续动作 | `single_action` | 1 | Schema 通过，模型选择单动作解释 |
+| `over_policy` | 超过当前策略上限的长串动作 | `action_plan` | 6 | Provider 输出通过 Schema；策略层随后按配置拒绝超限计划 |
+
+本次真实模型记录验证了自然语言输入能够到达严格的单动作/ActionPlan 契约边界；
+最终是否执行由 `ActionPlanPolicy` 再次校验，Engine 仍只接收单个
+`ActionAdjudication`。步骤数不是产品固定值，当前默认技术上限为 32，可由策略配置调整。

--- a/trpg-backend/tests/test_action_plan_persistence.py
+++ b/trpg-backend/tests/test_action_plan_persistence.py
@@ -10,11 +10,21 @@ from collaboration_framework.contracts import (
     ActionPlan,
     ActionPlanStep,
     ActionTarget,
+    ChangeEntityStateEffect,
+    CheckDecisionRequest,
     NarrativeOnlyEffect,
     NoAdjudicationCheck,
     PlayerInput,
+    RequiredAdjudicationCheck,
+    SelectCheckChoice,
+    SkillCheckCandidate,
 )
-from collaboration_framework.engine import AdjudicationEngineService, RuleEngineService
+from collaboration_framework.engine import (
+    AdjudicationEngineService,
+    DiceRoller,
+    RuleEngineService,
+    SequenceDiceSource,
+)
 from collaboration_framework.host.application import (
     ActionPlanOrchestrator,
     PlayerViewProjector,
@@ -24,7 +34,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters import SqlAlchemyActionPlanRunStore, SqlAlchemyEngineStore
-from app.models.engine import ActionPlanRunRecord, RoomActionReservation
+from app.models.engine import (
+    ActionPlanRunRecord,
+    AdjudicationCommandExecution,
+    GameEvent,
+    RoomActionReservation,
+)
 from tests.test_engine_runtime import _start_room
 
 
@@ -44,6 +59,43 @@ class SqlPlanAdjudicator:
             method=ActionMethod(family=context.step.kind, description=context.step.semantic_goal),
             check=NoAdjudicationCheck(),
             success_effects=(NarrativeOnlyEffect(),),
+        )
+
+
+class SqlPendingPlanAdjudicator(SqlPlanAdjudicator):
+    def __init__(self, world_ref: str, entity_id: str) -> None:
+        super().__init__(world_ref)
+        self.entity_id = entity_id
+
+    async def adjudicate(self, context):
+        self.revisions.append(context.player_view.revision)
+        if context.step_index != 1:
+            return await super().adjudicate(context)
+        return ActionAdjudication(
+            request_id="untrusted",
+            source_revision="untrusted",
+            actor_id="untrusted",
+            summary=context.step.semantic_goal,
+            target=ActionTarget(kind="world", id=self.world_ref),
+            method=ActionMethod(family="research", description=context.step.semantic_goal),
+            check=RequiredAdjudicationCheck(
+                candidates=(
+                    SkillCheckCandidate(
+                        candidate_id="recoverable-choice",
+                        skill_id="spot-hidden",
+                        difficulty="regular",
+                        method_summary="观察当前可见材料",
+                        player_safe_reason="使用当前 Actor 的公开技能",
+                    ),
+                )
+            ),
+            success_effects=(
+                ChangeEntityStateEffect(
+                    entity_id=self.entity_id,
+                    key="recovery_effect_applied",
+                    value=True,
+                ),
+            ),
         )
 
 
@@ -207,3 +259,100 @@ async def test_sql_plan_worker_lease_blocks_then_allows_recovery(
     )
     assert recovered.lease_owner == "worker-b"
     assert recovered.run_version == run.run_version + 2
+
+
+async def test_sql_pending_plan_rebuild_replays_decision_without_duplicate_effect(
+    db_session: AsyncSession,
+    engine_store_factory: Callable[..., SqlAlchemyEngineStore],
+    action_plan_store_factory: Callable[[], SqlAlchemyActionPlanRunStore],
+) -> None:
+    room, players, _ = await _start_room(db_session, prepare_checkpoint=False)
+    engine_store = engine_store_factory()
+    async with engine_store.transaction(room.id) as transaction:
+        runtime = await transaction.load_runtime()
+    actor_id = next(
+        actor_id
+        for actor_id, actor in runtime.game_state.actors.items()
+        if actor.player_id == players[0].id
+    )
+    entity_id = runtime.module_content.entities[0].id
+    original = PlayerInput(
+        room_id=room.id,
+        player_id=players[0].id,
+        actor_id=actor_id,
+        client_action_id="sql-pending-rebuild-246",
+        utterance="先移动，再调查",
+    )
+    plan = ActionPlan(
+        goal=original.utterance,
+        steps=(
+            ActionPlanStep(kind="action", semantic_goal="先完成第一步"),
+            ActionPlanStep(kind="action", semantic_goal="再完成需要玩家选择的第二步"),
+        ),
+    )
+    first_store = action_plan_store_factory()
+    first_service = ActionPlanOrchestrator(
+        store=first_store,
+        adjudicator=SqlPendingPlanAdjudicator(runtime.module_content.world_ref, entity_id),
+        executor=AdjudicationEngineService(
+            engine_store,
+            dice=DiceRoller(SequenceDiceSource([1])),
+        ),
+        player_view_projector=PlayerViewProjector(RuleEngineService(engine_store)),
+    )
+
+    waiting = await first_service.start_or_resume(original, plan=plan)
+    assert waiting.run.status == "waiting_for_player"
+    assert waiting.run.current_step_index == 1
+    pending = waiting.latest_execution
+    assert pending is not None and pending.pending_decision is not None
+
+    decision_request = CheckDecisionRequest(
+        request_id="sql-pending-rebuild-246:select",
+        room_id=room.id,
+        player_id=players[0].id,
+        source_revision=pending.view_revision,
+        decision_id=pending.pending_decision.decision_id,
+        decision_version=pending.pending_decision.decision_version,
+        choice=SelectCheckChoice(candidate_id="recoverable-choice"),
+    )
+    rebuilt_engine = AdjudicationEngineService(
+        engine_store_factory(),
+        dice=DiceRoller(SequenceDiceSource([1])),
+    )
+    resolved = await rebuilt_engine.decide(decision_request)
+    replay = await rebuilt_engine.decide(decision_request)
+    assert resolved.status == "resolved"
+    assert replay == resolved
+
+    rebuilt_plan = ActionPlanOrchestrator(
+        store=action_plan_store_factory(),
+        adjudicator=SqlPendingPlanAdjudicator(runtime.module_content.world_ref, entity_id),
+        executor=AdjudicationEngineService(engine_store_factory()),
+        player_view_projector=PlayerViewProjector(RuleEngineService(engine_store_factory())),
+    )
+    completed = await rebuilt_plan.start_or_resume(original, plan=plan)
+    assert completed.run.status == "awaiting_narration"
+    assert completed.run.current_step_index == 2
+
+    commands = (
+        await db_session.scalars(
+            select(AdjudicationCommandExecution).where(
+                AdjudicationCommandExecution.room_id == room.id
+            )
+        )
+    ).all()
+    events = (
+        await db_session.scalars(
+            select(GameEvent).where(GameEvent.room_id == room.id).order_by(GameEvent.sequence)
+        )
+    ).all()
+    assert len(commands) == 3
+    assert [event.type for event in events].count("entity.state_changed") == 1
+    assert [event.type for event in events].count("action.succeeded") == 2
+
+    terminal = await rebuilt_plan.mark_narration_completed(
+        room_id=room.id,
+        parent_action_id=original.client_action_id,
+    )
+    assert terminal.status == "completed"

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -17,6 +17,7 @@ from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
 from app.controller import ws as ws_controller
+from app.core.action_plan_turn import ActionPlanNarrator
 from app.core.turn import build_turn_application
 from app.main import app
 
@@ -124,6 +125,18 @@ class _WsCountingOpening:
     async def generate(self, context: OpeningNarrationContext) -> JsonObject:
         self.calls += 1
         return await self._fake.generate(context)
+
+
+class _FailOnceActionPlanNarrator:
+    def __init__(self, delegate: ActionPlanNarrator) -> None:
+        self.delegate = delegate
+        self.calls = 0
+
+    async def narrate(self, context):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("temporary narrator outage")
+        return await self.delegate.narrate(context)
 
 
 @pytest.fixture
@@ -1549,6 +1562,66 @@ def test_action_plan_submit_emits_safe_progress_and_one_parent_completion(
     ]
     assert len(persisted_actions) == 1
     assert persisted_actions[0]["payload"]["utterance"] == "先观察房间，然后询问眼前的人"
+
+
+def test_action_plan_narrator_failure_retries_narration_without_replaying_steps(
+    sync_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = register_and_login(sync_client, "action_plan_narrator_retry")
+    room = create_room(sync_client, token)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+    application = ws_controller.action_plan_turn_application
+    narrator = _FailOnceActionPlanNarrator(application._narrator)
+    monkeypatch.setattr(application, "_narrator", narrator)
+    action = {
+        "type": "action.plan.submit",
+        "playerId": room["playerId"],
+        "payload": {
+            "clientActionId": "plan-narrator-retry-246",
+            "utterance": "先观察房间，然后询问眼前的人",
+        },
+    }
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        ws.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        ws.receive_json()
+        ws.receive_json()
+        receive_replayed_opening(ws)
+
+        ws.send_json(action)
+        failed, first_seen = receive_until(
+            ws,
+            lambda message: message.get("type") == "turn.failed",
+            limit=40,
+        )
+        assert failed["payload"]["code"] == "PLAN_NARRATOR_FAILED"
+        assert all(message.get("type") != "plan.completed" for message in first_seen)
+
+        ws.send_json(action)
+        completed, retry_seen = receive_until(
+            ws,
+            lambda message: message.get("message_type") == "turn.completed",
+            limit=40,
+        )
+        terminal, _ = receive_until(
+            ws,
+            lambda message: message.get("type") == "plan.completed",
+            limit=40,
+        )
+
+    assert narrator.calls == 2
+    assert completed["correlation_id"] == "plan-narrator-retry-246"
+    assert terminal["payload"]["correlationId"] == "plan-narrator-retry-246"
+    assert all(message.get("type") != "adjudication.pending" for message in retry_seen)
 
 
 def test_legacy_action_submit_is_blocked_while_plan_is_active(


### PR DESCRIPTION
## Summary

Closes #246.

补齐 Issue #149 的复合意图与 ActionPlan 恢复关闭验收，并修复测试过程中发现的“等待技能选择时取消计划”行为缺口。

## Changes

- 增加三个 Canon 场景的真实 Uvicorn + SQLite + SDK WebSocket 单提交 E2E：书房搜索、图书馆旧报、墓地询问。
- 覆盖 ActionPlan 步骤上下文刷新、PlanRun 持久化、pending 断线重连、重复技能选择幂等、post-roll 重试、第二步 provider failure/invalid output fail-closed。
- 允许等待技能选择的当前步骤通过统一取消请求安全取消 Engine pending decision，保留已完成步骤并停止后续步骤；post-roll 继续保持现有协议语义。
- 增加 Narrator failure retry 和 narration 已持久化但 Plan 未 terminal 的恢复测试。
- 固定骰点仅在 `APP_ENV=test` 下用于跨进程 E2E 稳定性，development/production 仍使用默认随机源。
- 增加脱敏真实 DeepSeek `deepseek-chat` 自然语言验收记录，不记录 API key、原始响应、隐藏上下文或 CoT。

## Verification

- Framework: `261 passed, 3 skipped`
- Backend: `257 passed, 3 skipped`
- SDK: `20 passed`
- E2E: `36 passed`
- E2E typecheck: passed
- Backend Ruff / ty: passed
- Framework Ruff: passed
- Frontend lint/build: passed

前端 Vitest 在当前环境仍有既有 `localStorage` 测试环境失败（未修改前端相关文件），详见本次工作记录。

相关上下文：#149、#225、#247，以及已合并的 PR #249。
