### PR TITLE
[修复][前端] 修复 D100 双骰重合与检定结果错配

### DIFF
--- a/trpg-frontend/src/features/dice3d/Dice3DStage.test.tsx
+++ b/trpg-frontend/src/features/dice3d/Dice3DStage.test.tsx
@@ -1,0 +1,65 @@
+import { createRef } from 'react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Dice3DStage, type Dice3DHandle } from './Dice3DStage'
+
+const { createdStages, mockDispose, mockStageRoll } = vi.hoisted(() => ({
+  createdStages: [] as Array<{ onSettled: (value: number) => void }>,
+  mockDispose: vi.fn(),
+  mockStageRoll: vi.fn(() => true),
+}))
+
+vi.mock('./support', () => ({
+  supports3DDice: () => true,
+}))
+
+vi.mock('./engine', () => ({
+  createDiceStage: ({ onSettled }: { onSettled: (value: number) => void }) => {
+    createdStages.push({ onSettled })
+    return { roll: mockStageRoll, dispose: mockDispose }
+  },
+}))
+
+describe('Dice3DStage', () => {
+  beforeEach(() => {
+    createdStages.length = 0
+    mockDispose.mockReset()
+    mockStageRoll.mockReset()
+    mockStageRoll.mockReturnValue(true)
+  })
+
+  afterEach(cleanup)
+
+  it('returns the accepted roll token when the physical animation settles', async () => {
+    const ref = createRef<Dice3DHandle>()
+    const onSettled = vi.fn()
+    render(<Dice3DStage ref={ref} kind="d100" onSettled={onSettled} />)
+    await waitFor(() => expect(createdStages).toHaveLength(1))
+
+    expect(ref.current?.roll('check-a:1')).toBe(true)
+    expect(mockStageRoll).toHaveBeenCalledTimes(1)
+    expect(ref.current?.roll('check-b:2')).toBe(false)
+
+    act(() => createdStages[0].onSettled(23))
+    expect(onSettled).toHaveBeenCalledWith(23, 'check-a:1')
+
+    expect(ref.current?.roll('check-b:2')).toBe(true)
+    act(() => createdStages[0].onSettled(41))
+    expect(onSettled).toHaveBeenLastCalledWith(41, 'check-b:2')
+  })
+
+  it('drops the active token when the stage is unmounted', async () => {
+    const ref = createRef<Dice3DHandle>()
+    const onSettled = vi.fn()
+    const view = render(<Dice3DStage ref={ref} kind="d100" onSettled={onSettled} />)
+    await waitFor(() => expect(createdStages).toHaveLength(1))
+
+    expect(ref.current?.roll('check-a:1')).toBe(true)
+    view.unmount()
+    expect(mockDispose).toHaveBeenCalledTimes(1)
+
+    act(() => createdStages[0].onSettled(23))
+    expect(onSettled).not.toHaveBeenCalled()
+  })
+})

--- a/trpg-frontend/src/features/dice3d/Dice3DStage.tsx
+++ b/trpg-frontend/src/features/dice3d/Dice3DStage.tsx
@@ -8,19 +8,19 @@ import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 're
 
 import type { DiceStage } from './engine'
 import { supports3DDice } from './support'
-import type { DiceKind } from './types'
+import type { DiceKind, DiceRollToken } from './types'
 
 export interface Dice3DHandle {
-  /** 掷一次。引擎还没加载完时会记下来，加载完立刻补掷。 */
-  roll: () => void
+  /** 返回 false 表示舞台仍在处理上一轮，未接受本次请求。 */
+  roll: (token: DiceRollToken) => boolean
 }
 
 interface Dice3DStageProps {
   kind: DiceKind
   /** 骰子停稳、结果可读时调用一次。 */
-  onSettled: (value: number) => void
+  onSettled: (value: number, token: DiceRollToken) => void
   /** 环境不支持 3D（无 WebGL / 用户要求减少动效）时调用，调用方据此回退 2D。 */
-  onUnsupported?: () => void
+  onUnsupported?: (token: DiceRollToken | null) => void
   className?: string
 }
 
@@ -31,7 +31,8 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
   const containerRef = useRef<HTMLDivElement>(null)
   const stageRef = useRef<DiceStage | null>(null)
   // 引擎异步加载期间收到的掷骰请求先记下来，加载完补上——否则首次点击会丢。
-  const pendingRollRef = useRef(false)
+  const pendingRollRef = useRef<DiceRollToken | null>(null)
+  const activeRollRef = useRef<DiceRollToken | null>(null)
   const [failed, setFailed] = useState(false)
 
   // 回调放进 ref：它们的引用变化不应该触发引擎重建（重建会丢掉画面上的骰子）。
@@ -46,7 +47,7 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
 
     if (!supports3DDice()) {
       setFailed(true)
-      onUnsupportedRef.current?.()
+      onUnsupportedRef.current?.(null)
       return
     }
 
@@ -57,24 +58,34 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
         const stage = createDiceStage({
           container,
           kind,
-          onSettled: (value) => onSettledRef.current(value),
+          onSettled: (value) => {
+            const token = activeRollRef.current
+            activeRollRef.current = null
+            if (token !== null) onSettledRef.current(value, token)
+          },
         })
         stageRef.current = stage
-        if (pendingRollRef.current) {
-          pendingRollRef.current = false
-          stage.roll()
+        const pendingToken = pendingRollRef.current
+        if (pendingToken !== null) {
+          pendingRollRef.current = null
+          activeRollRef.current = pendingToken
+          if (!stage.roll()) activeRollRef.current = null
         }
       })
       .catch(() => {
         if (cancelled) return
         // 加载或初始化失败同样退回 2D，不能把检定卡死在这里。
+        const failedToken = activeRollRef.current ?? pendingRollRef.current
+        activeRollRef.current = null
+        pendingRollRef.current = null
         setFailed(true)
-        onUnsupportedRef.current?.()
+        onUnsupportedRef.current?.(failedToken)
       })
 
     return () => {
       cancelled = true
-      pendingRollRef.current = false
+      pendingRollRef.current = null
+      activeRollRef.current = null
       stageRef.current?.dispose()
       stageRef.current = null
     }
@@ -83,11 +94,19 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
   useImperativeHandle(
     ref,
     () => ({
-      roll() {
-        if (failed) return
+      roll(token) {
+        if (failed || pendingRollRef.current !== null || activeRollRef.current !== null) return false
         const stage = stageRef.current
-        if (stage) stage.roll()
-        else pendingRollRef.current = true
+        if (stage) {
+          activeRollRef.current = token
+          if (!stage.roll()) {
+            activeRollRef.current = null
+            return false
+          }
+          return true
+        }
+        pendingRollRef.current = token
+        return true
       },
     }),
     [failed],

--- a/trpg-frontend/src/features/dice3d/collision.test.ts
+++ b/trpg-frontend/src/features/dice3d/collision.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveSphereCollision, separatePlanarTargets, type CollisionBody } from './collision'
+
+function body(
+  position: [number, number, number],
+  velocity: [number, number, number] = [0, 0, 0],
+): CollisionBody {
+  return {
+    position: { x: position[0], y: position[1], z: position[2] },
+    velocity: { x: velocity[0], y: velocity[1], z: velocity[2] },
+    radius: 1,
+  }
+}
+
+describe('resolveSphereCollision', () => {
+  it('separates overlapping dice and reflects their closing velocity', () => {
+    const first = body([0, 0, 0], [1, 0, 0])
+    const second = body([1.5, 0, 0], [-1, 0, 0])
+
+    expect(resolveSphereCollision(first, second)).toBe(true)
+    expect(
+      Math.hypot(
+        second.position.x - first.position.x,
+        second.position.y - first.position.y,
+        second.position.z - first.position.z,
+      ),
+    ).toBeCloseTo(2)
+    expect(first.velocity.x).toBeLessThan(0)
+    expect(second.velocity.x).toBeGreaterThan(0)
+  })
+
+  it('uses a stable finite direction when both centers coincide', () => {
+    const first = body([0, 0, 0])
+    const second = body([0, 0, 0])
+
+    expect(resolveSphereCollision(first, second)).toBe(true)
+    expect(first.position.x).toBe(-1)
+    expect(second.position.x).toBe(1)
+    expect(Object.values(first.position).every(Number.isFinite)).toBe(true)
+    expect(Object.values(second.position).every(Number.isFinite)).toBe(true)
+  })
+
+  it('leaves separated dice unchanged', () => {
+    const first = body([-2, 0, 0], [1, 0, 0])
+    const second = body([2, 0, 0], [-1, 0, 0])
+
+    expect(resolveSphereCollision(first, second)).toBe(false)
+    expect(first.position).toEqual({ x: -2, y: 0, z: 0 })
+    expect(second.position).toEqual({ x: 2, y: 0, z: 0 })
+  })
+})
+
+describe('separatePlanarTargets', () => {
+  it('lays overlapping percentile dice out left-to-right within the arena', () => {
+    const [first, second] = separatePlanarTargets(
+      { x: 2.7, z: 1.4 },
+      { x: 2.8, z: 1.3 },
+      2.2,
+      { halfX: 2.65, halfZ: 1.1 },
+    )
+
+    expect(Math.hypot(second.x - first.x, second.z - first.z)).toBeCloseTo(2.2)
+    expect(first.x).toBeGreaterThanOrEqual(-2.65)
+    expect(second.x).toBeLessThanOrEqual(2.65)
+    expect(first.z).toBe(1.1)
+    expect(second.z).toBe(1.1)
+  })
+
+  it('preserves already separated natural targets', () => {
+    expect(
+      separatePlanarTargets(
+        { x: -1.5, z: -0.2 },
+        { x: 1.5, z: 0.3 },
+        2.2,
+        { halfX: 2.65, halfZ: 1.1 },
+      ),
+    ).toEqual([
+      { x: -1.5, z: -0.2 },
+      { x: 1.5, z: 0.3 },
+    ])
+  })
+})

--- a/trpg-frontend/src/features/dice3d/collision.ts
+++ b/trpg-frontend/src/features/dice3d/collision.ts
@@ -1,0 +1,125 @@
+export interface CollisionVector {
+  x: number
+  y: number
+  z: number
+}
+
+export interface CollisionBody {
+  position: CollisionVector
+  velocity: CollisionVector
+  radius: number
+}
+
+export interface PlanarPoint {
+  x: number
+  z: number
+}
+
+export interface PlanarBounds {
+  halfX: number
+  halfZ: number
+}
+
+const EPSILON = 1e-6
+
+/** Resolve one equal-mass sphere collision in place. */
+export function resolveSphereCollision(
+  first: CollisionBody,
+  second: CollisionBody,
+  restitution = 0.32,
+): boolean {
+  let dx = second.position.x - first.position.x
+  let dy = second.position.y - first.position.y
+  let dz = second.position.z - first.position.z
+  let distance = Math.hypot(dx, dy, dz)
+  const minimumDistance = first.radius + second.radius
+
+  if (distance >= minimumDistance) return false
+
+  if (distance < EPSILON) {
+    const relativeX = second.velocity.x - first.velocity.x
+    const relativeY = second.velocity.y - first.velocity.y
+    const relativeZ = second.velocity.z - first.velocity.z
+    const relativeLength = Math.hypot(relativeX, relativeY, relativeZ)
+    if (relativeLength >= EPSILON) {
+      dx = -relativeX / relativeLength
+      dy = -relativeY / relativeLength
+      dz = -relativeZ / relativeLength
+    } else {
+      dx = 1
+      dy = 0
+      dz = 0
+    }
+    distance = 0
+  } else {
+    dx /= distance
+    dy /= distance
+    dz /= distance
+  }
+
+  const correction = (minimumDistance - distance) / 2
+  first.position.x -= dx * correction
+  first.position.y -= dy * correction
+  first.position.z -= dz * correction
+  second.position.x += dx * correction
+  second.position.y += dy * correction
+  second.position.z += dz * correction
+
+  const relativeSpeed =
+    (second.velocity.x - first.velocity.x) * dx +
+    (second.velocity.y - first.velocity.y) * dy +
+    (second.velocity.z - first.velocity.z) * dz
+
+  if (relativeSpeed < 0) {
+    const impulse = (-(1 + restitution) * relativeSpeed) / 2
+    first.velocity.x -= impulse * dx
+    first.velocity.y -= impulse * dy
+    first.velocity.z -= impulse * dz
+    second.velocity.x += impulse * dx
+    second.velocity.y += impulse * dy
+    second.velocity.z += impulse * dz
+  }
+
+  return true
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Preserve natural resting positions when possible. Overlapping D100 dice are
+ * arranged left-to-right so both percentile faces remain readable.
+ */
+export function separatePlanarTargets(
+  first: PlanarPoint,
+  second: PlanarPoint,
+  minimumDistance: number,
+  bounds: PlanarBounds,
+): [PlanarPoint, PlanarPoint] {
+  const distance = Math.hypot(second.x - first.x, second.z - first.z)
+  if (distance >= minimumDistance) {
+    return [
+      {
+        x: clamp(first.x, -bounds.halfX, bounds.halfX),
+        z: clamp(first.z, -bounds.halfZ, bounds.halfZ),
+      },
+      {
+        x: clamp(second.x, -bounds.halfX, bounds.halfX),
+        z: clamp(second.z, -bounds.halfZ, bounds.halfZ),
+      },
+    ]
+  }
+
+  const halfGap = minimumDistance / 2
+  const centerX = clamp(
+    (first.x + second.x) / 2,
+    -bounds.halfX + halfGap,
+    bounds.halfX - halfGap,
+  )
+  const centerZ = clamp((first.z + second.z) / 2, -bounds.halfZ, bounds.halfZ)
+  return [
+    { x: centerX - halfGap, z: centerZ },
+    { x: centerX + halfGap, z: centerZ },
+  ]
+}

--- a/trpg-frontend/src/features/dice3d/engine.ts
+++ b/trpg-frontend/src/features/dice3d/engine.ts
@@ -35,6 +35,7 @@ import {
   WebGLRenderer,
 } from 'three'
 
+import { resolveSphereCollision, separatePlanarTargets } from './collision'
 import { faceNormal, polyhedronFaces } from './geometry'
 import { shuffle } from './shuffle'
 import { PALETTES, makeFaceTexture, type Palette } from './textures'
@@ -55,6 +56,8 @@ interface Die {
   group: Group
   /** 静止时质心离地高度：以面着地，取内切半径。 */
   restY: number
+  /** 仅用于轻量骰子间碰撞的保守包围半径。 */
+  collisionRadius: number
   faces: FaceInfo[]
 }
 
@@ -86,9 +89,11 @@ function buildDie(
   const faces: FaceInfo[] = []
   const coreTris: number[] = []
   let minInradius = Infinity
+  let maxVertexRadius = 0
   const usePips = kind === 'd6'
 
   polys.forEach((verts, faceIndex) => {
+    for (const vertex of verts) maxVertexRadius = Math.max(maxVertexRadius, vertex.length())
     // 保证顶点绕序让法线朝外。
     const normal = faceNormal(verts)
     const centroid = new Vector3()
@@ -172,7 +177,12 @@ function buildDie(
   core.scale.setScalar(0.985)
   group.add(core)
 
-  return { group, restY: minInradius, faces }
+  return {
+    group,
+    restY: minInradius,
+    collisionRadius: maxVertexRadius * 0.88,
+    faces,
+  }
 }
 
 function disposeGroup(group: Group): void {
@@ -232,7 +242,7 @@ function diceDefinitions(kind: DiceKind): {
 
 export interface DiceStage {
   /** 掷一次。正在掷的时候重复调用会被忽略。 */
-  roll: () => void
+  roll: () => boolean
   /** 释放 WebGL 资源并停掉动画循环。 */
   dispose: () => void
 }
@@ -349,7 +359,22 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
   const enterAlign = () => {
     phase = 'align'
     alignProgress = 0
-    for (const actor of actors) {
+    const targets = actors.map((actor) => ({
+      x: actor.die.group.position.x,
+      z: actor.die.group.position.z,
+    }))
+    if (actors.length === 2) {
+      const separated = separatePlanarTargets(
+        targets[0],
+        targets[1],
+        actors[0].die.collisionRadius + actors[1].die.collisionRadius,
+        { halfX: ARENA.halfX - 0.25, halfZ: ARENA.halfZ - 0.25 },
+      )
+      targets[0] = separated[0]
+      targets[1] = separated[1]
+    }
+
+    for (const [index, actor] of actors.entries()) {
       actor.qStart = actor.die.group.quaternion.clone()
       actor.pStart = actor.die.group.position.clone()
       const top = findTopFace(actor.die)
@@ -360,7 +385,9 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
         new Vector3(0, 1, 0),
       )
       const target = actor.die.group.position.clone()
+      target.x = targets[index].x
       target.y = actor.die.restY
+      target.z = targets[index].z
       actor.pTarget = target
     }
   }
@@ -427,6 +454,28 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
         }
       }
 
+      if (actors.length === 2) {
+        const collided = resolveSphereCollision(
+          {
+            position: actors[0].die.group.position,
+            velocity: actors[0].vel,
+            radius: actors[0].die.collisionRadius,
+          },
+          {
+            position: actors[1].die.group.position,
+            velocity: actors[1].vel,
+            radius: actors[1].die.collisionRadius,
+          },
+        )
+        if (collided) allResting = false
+        for (const actor of actors) {
+          const position = actor.die.group.position
+          position.x = Math.min(Math.max(position.x, -ARENA.halfX), ARENA.halfX)
+          position.y = Math.max(position.y, actor.die.restY)
+          position.z = Math.min(Math.max(position.z, -ARENA.halfZ), ARENA.halfZ)
+        }
+      }
+
       if ((allResting && elapsed >= minTumble) || elapsed >= MAX_TUMBLE_SECONDS) {
         enterAlign()
       }
@@ -458,7 +507,7 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
 
   return {
     roll() {
-      if (disposed || phase !== 'idle') return
+      if (disposed || phase !== 'idle') return false
       clearActors()
       diceDefinitions(kind).forEach((def, index) => {
         const die = buildDie(def.poly, def.palette, def.values, def.labels)
@@ -478,6 +527,7 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
       elapsed = 0
       minTumble = rand(1.2, 1.5)
       phase = 'tumble'
+      return true
     },
     dispose() {
       if (disposed) return

--- a/trpg-frontend/src/features/dice3d/index.ts
+++ b/trpg-frontend/src/features/dice3d/index.ts
@@ -1,4 +1,4 @@
 export { Dice3DStage, type Dice3DHandle } from './Dice3DStage'
 export { supports3DDice, isWebGLAvailable, prefersReducedMotion } from './support'
 export { shuffle } from './shuffle'
-export type { DiceKind } from './types'
+export type { DiceKind, DiceRollToken } from './types'

--- a/trpg-frontend/src/features/dice3d/types.ts
+++ b/trpg-frontend/src/features/dice3d/types.ts
@@ -5,5 +5,8 @@
 /** 本项目用到的骰型。D100 由两颗 D10 组成，几何上没有 d100。 */
 export type DiceKind = 'd100' | 'd20' | 'd6'
 
+/** Opaque identity carried through one asynchronous 3D roll. */
+export type DiceRollToken = string
+
 /** 实际存在的多面体。 */
 export type PolyhedronKind = 'd10' | 'd20' | 'd6'

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -107,11 +107,15 @@ const {
   mockWaitForWsOpen,
   wsHandlers,
   dice3dSupported,
+  dice3dBehavior,
+  dice3dRolls,
 } = vi.hoisted(() => {
   const handlers = new Set<(event: ServerToClientEvent) => void>()
   return {
     wsHandlers: handlers,
     dice3dSupported: { value: false },
+    dice3dBehavior: { value: 'unsupported' as 'unsupported' | 'manual' },
+    dice3dRolls: [] as Array<{ token: string; settle: (value: number) => void }>,
     emitWsMessage: (event: ServerToClientEvent) => {
       for (const handler of handlers) handler(event)
     },
@@ -170,8 +174,8 @@ vi.mock('@/services/room', () => ({
  * 3D 骰子在 jsdom 里跑不了（没有 WebGL），默认按"不支持"处理，与真实 jsdom
  * 行为一致，不影响其余用例。
  *
- * `dice3dSupported` 置 true 时启用一个只做一件事的假舞台：被调用 roll() 就触发
- * `onUnsupported` —— 模拟"玩家已经点了掷骰、引擎 chunk 这时才加载失败"。
+ * `dice3dSupported` 置 true 时启用可控假舞台：默认模拟引擎加载失败；切到 manual
+ * 后由测试决定每一轮何时定格，用来覆盖跨请求迟到回调。
  */
 vi.mock('@/features/dice3d', async () => {
   const { forwardRef, useImperativeHandle } = await import('react')
@@ -179,10 +183,29 @@ vi.mock('@/features/dice3d', async () => {
     supports3DDice: () => dice3dSupported.value,
     Dice3DStage: forwardRef(
       (
-        { onUnsupported }: { onUnsupported?: () => void },
-        ref: React.Ref<{ roll: () => void }>,
+        {
+          onSettled,
+          onUnsupported,
+        }: {
+          onSettled: (value: number, token: string) => void
+          onUnsupported?: (token: string | null) => void
+        },
+        ref: React.Ref<{ roll: (token: string) => boolean }>,
       ) => {
-        useImperativeHandle(ref, () => ({ roll: () => onUnsupported?.() }), [onUnsupported])
+        useImperativeHandle(
+          ref,
+          () => ({
+            roll: (token: string) => {
+              if (dice3dBehavior.value === 'unsupported') {
+                onUnsupported?.(token)
+                return true
+              }
+              dice3dRolls.push({ token, settle: (value) => onSettled(value, token) })
+              return true
+            },
+          }),
+          [onSettled, onUnsupported],
+        )
         return <div data-testid="dice-3d-stage" />
       },
     ),
@@ -336,6 +359,8 @@ describe('RoomPage conversation history', () => {
     vi.clearAllMocks()
     wsHandlers.clear()
     dice3dSupported.value = false
+    dice3dBehavior.value = 'unsupported'
+    dice3dRolls.length = 0
     Object.defineProperty(window, 'speechSynthesis', { configurable: true, value: undefined })
     Object.defineProperty(window, 'SpeechSynthesisUtterance', { configurable: true, value: undefined })
     Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
@@ -1001,6 +1026,61 @@ describe('RoomPage conversation history', () => {
     expect(screen.getByRole('button', { name: '确认并发送' })).toBeInTheDocument()
     // 已经退回 2D 展示。
     expect(screen.queryByTestId('dice-3d-stage')).not.toBeInTheDocument()
+  })
+
+  it('ignores a stale 3D result and lets the replacement check roll normally', async () => {
+    dice3dSupported.value = true
+    dice3dBehavior.value = 'manual'
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    await act(async () => {
+      emitWsMessage({
+        type: 'check.request',
+        payload: {
+          playerId: 'player-1',
+          clientActionId: 'check-a',
+          summary: '调查书架',
+          difficulty: 'regular',
+          skills: [{ id: 'skill-library', name: '图书馆使用', targetValue: 50 }],
+        },
+      })
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: '掷骰' }))
+    expect(dice3dRolls).toHaveLength(1)
+
+    await act(async () => {
+      emitWsMessage({
+        type: 'check.request',
+        payload: {
+          playerId: 'player-1',
+          clientActionId: 'check-b',
+          summary: '检查门锁',
+          difficulty: 'regular',
+          skills: [{ id: 'skill-locksmith', name: '锁匠', targetValue: 40 }],
+        },
+      })
+    })
+
+    expect(screen.getByText('锁匠')).toBeInTheDocument()
+    act(() => dice3dRolls[0].settle(23))
+
+    expect(screen.queryByText('23')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '确认并发送' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '掷骰' }))
+    expect(dice3dRolls).toHaveLength(2)
+
+    act(() => dice3dRolls[1].settle(41))
+    expect(screen.getByText('41')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '确认并发送' }))
+
+    expect(mockRollCheck).toHaveBeenCalledTimes(1)
+    expect(mockRollCheck).toHaveBeenCalledWith('player-1', {
+      clientActionId: 'check-b',
+      skill: 'skill-locksmith',
+      rollValue: 41,
+    })
   })
 
   it('shows explicit occupation choice skills in the occupation tab', () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -11,7 +11,7 @@ import { useRoomPlayers } from '@/hooks/useRoomPlayers'
 import { useRuleset } from '@/hooks/useRuleset'
 import { useHostSpeech } from '@/hooks/useHostSpeech'
 import { useSpeechInput } from '@/hooks/useSpeechInput'
-import { Dice3DStage, supports3DDice, type Dice3DHandle } from '@/features/dice3d'
+import { Dice3DStage, supports3DDice, type Dice3DHandle, type DiceRollToken } from '@/features/dice3d'
 import { DERIVED_STAT_DEFINITIONS } from '@/data/derived-stats'
 import { OnboardingTrigger } from '@/features/onboarding'
 import { CheckWorkflowPanel } from '@/features/adjudication'
@@ -450,6 +450,7 @@ function DiceModal({
   const [freeOnes, setFreeOnes] = useState(0)
   const submitLockRef = useRef(false)
   const dice3dRef = useRef<Dice3DHandle>(null)
+  const rollGenerationRef = useRef(0)
   // 3D 不可用（无 WebGL / 用户要求减少动效 / 引擎加载失败）时退回原来的 2D 展示。
   // 检定是主流程的一环，不能因为渲染能力缺失就卡住。
   const [use3D, setUse3D] = useState(() => supports3DDice())
@@ -510,11 +511,13 @@ function DiceModal({
    * 那时 `rolling` 的 setState 还没生效，读 state 会拿到旧值、判断成"没有掷骰
    * 在进行"，等于没修。
    */
-  const inFlight3DRollRef = useRef<{ requestId: string | null } | null>(null)
+  const inFlight3DRollRef = useRef<{
+    requestId: string | null
+    token: DiceRollToken
+  } | null>(null)
 
   /** 结果落地：3D 由动画定格回调进来，2D 由本地随机 + 定时器进来，两条路共用。 */
   const settle = (value: number, requestId: string | null) => {
-    inFlight3DRollRef.current = null
     const { tens, ones } = activeDiceType === 'd100' ? splitD100(value) : { tens: 0, ones: 0 }
     if (requestId !== null) {
       setCheckDiceState((current) => {
@@ -531,6 +534,17 @@ function DiceModal({
   }
 
   const currentRequestId = () => (isCheckMode ? checkRequest?.clientActionId ?? null : null)
+
+  const resetRolling = useCallback((requestId: string | null) => {
+    if (requestId === null) {
+      setFreeRolling(false)
+      return
+    }
+    setCheckDiceState((current) => {
+      if (!current || current.clientActionId !== requestId) return current
+      return { ...current, rolling: false }
+    })
+  }, [setCheckDiceState])
 
   /** 2D 回退掷骰：本地随机 + 固定时长的假动画，与改造前一致。 */
   const roll2D = (requestId: string | null) => {
@@ -562,8 +576,12 @@ function DiceModal({
     // 3D：值来自物理定格后朝上的那一面（面上的点数已由 Fisher–Yates 均匀洗过），
     // 所以这里不预先取值，等 onSettled 回调。
     if (use3D) {
-      inFlight3DRollRef.current = { requestId }
-      dice3dRef.current?.roll()
+      const token = `${requestId ?? 'free'}:${++rollGenerationRef.current}`
+      inFlight3DRollRef.current = { requestId, token }
+      if (!dice3dRef.current?.roll(token)) {
+        if (inFlight3DRollRef.current?.token === token) inFlight3DRollRef.current = null
+        resetRolling(requestId)
+      }
       return
     }
     roll2D(requestId)
@@ -577,12 +595,29 @@ function DiceModal({
    * 排任何定时器。只翻 use3D 的话 rolling 永远不清，检定会卡在"骰子还在滚"，
    * 既没有结果也没有重掷入口——恰好是这套降级本该防住的情况（PR #219 review）。
    */
-  const handle3DUnsupported = () => {
+  const handle3DUnsupported = (token: DiceRollToken | null) => {
     const pending = inFlight3DRollRef.current
+    if (token !== null && pending?.token !== token) return
     inFlight3DRollRef.current = null
     setUse3D(false)
     if (pending) roll2D(pending.requestId)
   }
+
+  const handle3DSettled = (value: number, token: DiceRollToken) => {
+    const pending = inFlight3DRollRef.current
+    if (!pending || pending.token !== token) return
+    inFlight3DRollRef.current = null
+    if (pending.requestId !== currentRequestId()) return
+    settle(value, pending.requestId)
+  }
+
+  useEffect(() => {
+    if (open) return
+    const pending = inFlight3DRollRef.current
+    if (!pending) return
+    inFlight3DRollRef.current = null
+    resetRolling(pending.requestId)
+  }, [open, resetRolling])
 
   const canRoll = !activeRolling && !activeShowResult && activeResult === null && !activeCheckDice?.submitted
 
@@ -606,13 +641,14 @@ function DiceModal({
   }
 
   const renderDiceDisplay = () => {
-    if (use3D) {
+    if (use3D && open) {
       return (
         <Dice3DStage
+          key={checkRequest?.clientActionId ?? `free-${activeDiceType}`}
           ref={dice3dRef}
           kind={activeDiceType}
           className="w-full h-48"
-          onSettled={(value) => settle(value, currentRequestId())}
+          onSettled={handle3DSettled}
           onUnsupported={handle3DUnsupported}
         />
       )


### PR DESCRIPTION
## 关联 Issue

Closes #251

## 问题背景

当前 D100 由十位骰和个位骰两颗 D10 组成，但 3D 动画使用独立的简化物理逻辑：

- 两颗骰子没有碰撞分离机制，运动过程中可能穿透或重叠；
- 骰子停止时，如果两颗骰子的目标位置过近，最终仍可能重合；
- 3D 舞台异步加载和检定请求切换时，旧动画可能在新请求之后返回结果；
- 旧结果被页面接收后，可能污染当前检定的显示结果或触发错误的 2D fallback。

## 改动说明

- 为骰子增加轻量球体碰撞检测和分离处理。
- 在 D100 滚动阶段处理十位骰与个位骰之间的相对速度和反弹。
- 在动画定格阶段增加最终位置校正，保证两颗骰子保持最小间距。
- 对定格位置增加骰盘范围限制，避免骰子被分离到可视区域之外。
- 当两颗骰子中心完全重合时，使用稳定方向完成分离，避免出现 NaN 或位置抖动。
- 为每轮 3D 掷骰增加唯一请求 token。
- 3D 动画完成时携带原始 token 返回页面。
- 旧 token 的迟到结果会被直接丢弃，不会覆盖当前检定。
- 3D 舞台在检定请求变化时重建，旧动画会被释放。
- 动画进行期间拒绝重复掷骰请求。
- 3D 初始化失败时继续使用原有 2D fallback，并保留当前请求 ID。
- 补充舞台卸载、重复掷骰和旧结果回调等异常路径处理。

## 代码范围

本次改动仅涉及前端，不涉及后端 API、数据库、SDK、WebSocket 协议或部署配置。

新增：

- `trpg-frontend/src/features/dice3d/collision.ts`
- `trpg-frontend/src/features/dice3d/collision.test.ts`
- `trpg-frontend/src/features/dice3d/Dice3DStage.test.tsx`

修改：

- `trpg-frontend/src/features/dice3d/engine.ts`
- `trpg-frontend/src/features/dice3d/Dice3DStage.tsx`
- `trpg-frontend/src/features/dice3d/index.ts`
- `trpg-frontend/src/features/dice3d/types.ts`
- `trpg-frontend/src/routes/games/trpg/RoomPage.tsx`
- `trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx`

## 关键实现决策

### 采用轻量碰撞代理

本次没有引入额外物理引擎，而是使用骰子的保守包围半径进行球体碰撞计算。

这样可以解决 D100 双骰重合问题，同时保持 Three.js 懒加载结构和现有构建体积，不改变其他骰型的显示与结果逻辑。

### 结果与动画请求绑定

页面不再只依赖“当前是否有检定”判断动画结果，而是为每一轮 3D 掷骰绑定 token。

只有仍属于当前检定的 token 才能提交结果；旧舞台、旧动画或旧 fallback 回调即使迟到，也不会修改新检定状态。

### 保留 2D fallback

WebGL 不可用、3D 动态模块加载失败或舞台初始化失败时，仍然回退到原有 2D 骰子流程，不影响不支持 3D 的设备。

## 测试与验证

- [x] `npm run test`：17 个测试文件、123 项测试通过
- [x] `npm run lint`：通过，0 warning
- [x] `npm run build`：通过
- [x] `git diff --check`：通过
- [x] 碰撞分离数学逻辑测试通过
- [x] 3D 舞台重复掷骰和卸载回调测试通过
- [x] 页面级旧检定结果污染新检定回归测试通过
- [x] 本地 Fake Provider 环境创建房间并进入游戏验证通过
- [x] 桌面视口验证 D100 两颗骰子定格后保持分离
- [x] 移动视口验证 D100 两颗骰子定格后保持分离
- [x] 验证结果数值与画面显示的十位骰、个位骰一致
- [x] 浏览器控制台未发现本次改动引入的错误

构建仍会输出仓库已有的 Three.js `engine` chunk 体积提示，本 PR 未新增物理依赖，也未扩大该问题。

## 风险与回滚

- 碰撞逻辑使用保守包围半径，可能使骰子之间的间距略大于视觉上的实际接触距离，但不会影响骰子结果。
- 定格阶段会对重叠骰子进行位置调整，极端情况下可能改变骰子的最终落点，但不会改变已经读取的朝上面值。
- 3D 舞台请求 token 只作用于前端展示层，不改变后端检定结果和游戏状态。
- 如需回滚，可直接回退本 PR，不涉及数据库迁移或服务器配置清理。

## 不在本 PR 范围

- 不修改后端骰子计算和检定规则。
- 不实现多人客户端同步观看同一段 3D 动画。
- 不修改 D100 的数值规则、十位骰/个位骰取值方式或 00 的结果解释。
- 不引入完整物理引擎。
- 不修改 D20、D6 的现有结果计算逻辑。

## UI 证据

已在本地 Fake Provider 环境完成浏览器验证：

- D100 面板正常打开；
- 两颗 D10 在滚动和定格后均可见；
- 两颗骰子不会重合；
- 定格显示的面值与结果文本保持一致；
- 桌面和移动视口均未出现画布裁切或布局溢出。

本 PR 暂不附截图，避免使用与本 Issue 无关的历史截图。

## AI 使用情况

本 PR 使用 Codex 辅助实现。

AI 主要参与了碰撞分离逻辑、3D 动画请求 token、旧结果竞态处理和回归测试编写。已完成自动化测试、生产构建、浏览器桌面/移动端验证及差异检查。

合并前仍建议由维护者重点 Review：

- D100 定格阶段的分离距离；
- 舞台销毁后的迟到回调；
- 3D fallback 与当前请求 token 的对应关系。

## 自检

- [x] 改动范围符合 Issue #251
- [x] 未修改后端、数据库和 SDK
- [x] 未引入额外物理依赖
- [x] 已补充碰撞和竞态回归测试
- [x] 未包含密钥、个人信息或构建产物
- [x] 已完成本地桌面与移动端验证
- [ ] 尚待维护者 Review 后再合并
