### PR TITLE
[功能][CI] 为 Main Preview 和 PR Preview 接入真实角色生图

### DIFF
--- a/.github/workflows/main-preview.yml
+++ b/.github/workflows/main-preview.yml
@@ -80,11 +80,21 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.PREVIEW_DEEPSEEK_API_KEY }}
           DEEPSEEK_BASE_URL: ${{ vars.PREVIEW_DEEPSEEK_BASE_URL }}
           DEEPSEEK_MODEL: ${{ vars.PREVIEW_DEEPSEEK_MODEL }}
+          # 当前凭证同时支持 DeepSeek v4 Pro 和 Sufy Gemini 生图；仍按用途
+          # 使用两个 Secret 名称，后续可以独立轮换。不要把图片 key 放进前端。
+          SUFY_API_KEY: ${{ secrets.PREVIEW_SUFY_API_KEY }}
+          SUFY_BASE_URL: ${{ vars.PREVIEW_SUFY_BASE_URL }}
+          SUFY_IMAGE_MODEL: ${{ vars.PREVIEW_SUFY_IMAGE_MODEL }}
           DOUBAO_TTS_API_KEY: ${{ secrets.PREVIEW_DOUBAO_TTS_API_KEY }}
           DOUBAO_TTS_VOICES: ${{ secrets.PREVIEW_DOUBAO_TTS_VOICES }}
           DOUBAO_TTS_DEFAULT_VOICE_TYPE: ${{ secrets.PREVIEW_DOUBAO_TTS_DEFAULT_VOICE_TYPE }}
         run: |
-          if [ -n "$DEEPSEEK_API_KEY" ]; then
+          SUFY_BASE_URL="${SUFY_BASE_URL:-https://openai.sufy.com/v1}"
+          SUFY_IMAGE_MODEL="${SUFY_IMAGE_MODEL:-google/gemini-3-pro-image}"
+          # DeepSeek 与 Sufy 是同一条角色生图链路的两个阶段：前者整理提示词，
+          # 后者生成图片。两套 key 必须成对存在；只配置一套会让预览出现
+          # 难以发现的半真实链路，因此在部署前直接失败。
+          if [ -n "$DEEPSEEK_API_KEY" ] && [ -n "$SUFY_API_KEY" ]; then
             if [ -z "$DEEPSEEK_BASE_URL" ] || [ -z "$DEEPSEEK_MODEL" ]; then
               echo "::error::已配置 Preview 模型密钥，但缺少 PREVIEW_DEEPSEEK_BASE_URL 或 PREVIEW_DEEPSEEK_MODEL"
               exit 1
@@ -97,9 +107,29 @@ jobs:
               echo "::error::PREVIEW_DEEPSEEK_BASE_URL 应填写 API 根地址，不能包含 /chat/completions"
               exit 1
             fi
+            if [[ ! "$SUFY_BASE_URL" =~ ^https?://[^/[:space:]]+(/.*)?$ ]]; then
+              echo "::error::PREVIEW_SUFY_BASE_URL 必须是包含主机名的 HTTP(S) 根地址"
+              exit 1
+            fi
+            if [[ "$SUFY_BASE_URL" == */images/generations* ]]; then
+              echo "::error::PREVIEW_SUFY_BASE_URL 应填写 API 根地址，不能包含 /images/generations"
+              exit 1
+            fi
+            if [ -z "$SUFY_IMAGE_MODEL" ]; then
+              echo "::error::已配置 Preview 生图密钥，但 PREVIEW_SUFY_IMAGE_MODEL 为空"
+              exit 1
+            fi
             HOST_MODEL_PROVIDER=deepseek
+            PORTRAIT_PROMPT_PROVIDER=deepseek
+            PORTRAIT_IMAGE_PROVIDER=sufy
           else
+            if [ -n "$DEEPSEEK_API_KEY" ] || [ -n "$SUFY_API_KEY" ]; then
+              echo "::error::Preview 的 DeepSeek 和 Sufy 密钥必须同时配置，不能只启用其中一段"
+              exit 1
+            fi
             HOST_MODEL_PROVIDER=fake
+            PORTRAIT_PROMPT_PROVIDER=deterministic
+            PORTRAIT_IMAGE_PROVIDER=mock
           fi
           if [ -n "$DOUBAO_TTS_API_KEY" ] && [ -n "$DOUBAO_TTS_VOICES" ] && [ -n "$DOUBAO_TTS_DEFAULT_VOICE_TYPE" ]; then
             HOST_SPEECH_PROVIDER=doubao
@@ -111,6 +141,12 @@ jobs:
           DEEPSEEK_MODEL_B64=$(printf '%s' "$DEEPSEEK_MODEL" | base64 | tr -d '\n')
           if [ -n "$DEEPSEEK_API_KEY_B64" ]; then
             echo "::add-mask::$DEEPSEEK_API_KEY_B64"
+          fi
+          SUFY_API_KEY_B64=$(printf '%s' "$SUFY_API_KEY" | base64 | tr -d '\n')
+          SUFY_BASE_URL_B64=$(printf '%s' "$SUFY_BASE_URL" | base64 | tr -d '\n')
+          SUFY_IMAGE_MODEL_B64=$(printf '%s' "$SUFY_IMAGE_MODEL" | base64 | tr -d '\n')
+          if [ -n "$SUFY_API_KEY_B64" ]; then
+            echo "::add-mask::$SUFY_API_KEY_B64"
           fi
           DOUBAO_TTS_API_KEY_B64=$(printf '%s' "$DOUBAO_TTS_API_KEY" | base64 | tr -d '\n')
           DOUBAO_TTS_VOICES_B64=$(printf '%s' "$DOUBAO_TTS_VOICES" | base64 | tr -d '\n')
@@ -131,6 +167,14 @@ jobs:
             export DEEPSEEK_API_KEY="\$(printf '%s' '$DEEPSEEK_API_KEY_B64' | base64 -d)"
             export DEEPSEEK_BASE_URL="\$(printf '%s' '$DEEPSEEK_BASE_URL_B64' | base64 -d)"
             export DEEPSEEK_MODEL="\$(printf '%s' '$DEEPSEEK_MODEL_B64' | base64 -d)"
+            export CHARACTER_PORTRAIT_ENABLED=true
+            export PORTRAIT_PROMPT_PROVIDER="$PORTRAIT_PROMPT_PROVIDER"
+            export PORTRAIT_IMAGE_PROVIDER="$PORTRAIT_IMAGE_PROVIDER"
+            export SUFY_API_KEY="\$(printf '%s' '$SUFY_API_KEY_B64' | base64 -d)"
+            export SUFY_BASE_URL="\$(printf '%s' '$SUFY_BASE_URL_B64' | base64 -d)"
+            export SUFY_IMAGE_MODEL="\$(printf '%s' '$SUFY_IMAGE_MODEL_B64' | base64 -d)"
+            export PORTRAIT_REFERENCE_IMAGE_PATH=app/assets/portrait-style-reference.png
+            export PORTRAIT_GENERATION_TIMEOUT_SECONDS=120
             export HOST_SPEECH_PROVIDER="$HOST_SPEECH_PROVIDER"
             # 编码后穿过未加引号的 SSH heredoc，避免 token/JSON 中的 shell
             # 元字符在部署机上被二次解析；解码结果只作为赋值结果，不会重新执行。

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -157,14 +157,21 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.PREVIEW_DEEPSEEK_API_KEY }}
           DEEPSEEK_BASE_URL: ${{ vars.PREVIEW_DEEPSEEK_BASE_URL }}
           DEEPSEEK_MODEL: ${{ vars.PREVIEW_DEEPSEEK_MODEL }}
+          # 当前凭证同时支持 DeepSeek v4 Pro 和 Sufy Gemini 生图；仍按用途
+          # 使用两个 Secret 名称，后续可以独立轮换。不要把图片 key 放进前端。
+          SUFY_API_KEY: ${{ secrets.PREVIEW_SUFY_API_KEY }}
+          SUFY_BASE_URL: ${{ vars.PREVIEW_SUFY_BASE_URL }}
+          SUFY_IMAGE_MODEL: ${{ vars.PREVIEW_SUFY_IMAGE_MODEL }}
           DOUBAO_TTS_API_KEY: ${{ secrets.PREVIEW_DOUBAO_TTS_API_KEY }}
           DOUBAO_TTS_VOICES: ${{ secrets.PREVIEW_DOUBAO_TTS_VOICES }}
           DOUBAO_TTS_DEFAULT_VOICE_TYPE: ${{ secrets.PREVIEW_DOUBAO_TTS_DEFAULT_VOICE_TYPE }}
         run: |
-          # 远程 provider 模式缺 key 时后端会启动失败（不是优雅降级，
-          # README「主持模型配置」一节已说明）——这个判断必须在部署前做，
-          # 不能让 compose 直接把空字符串当 key 传给 deepseek provider。
-          if [ -n "$DEEPSEEK_API_KEY" ]; then
+          SUFY_BASE_URL="${SUFY_BASE_URL:-https://openai.sufy.com/v1}"
+          SUFY_IMAGE_MODEL="${SUFY_IMAGE_MODEL:-google/gemini-3-pro-image}"
+          # DeepSeek 与 Sufy 是同一条角色生图链路的两个阶段：前者整理提示词，
+          # 后者生成图片。两套 key 必须成对存在；只配置一套会让预览出现
+          # 难以发现的半真实链路，因此在部署前直接失败。
+          if [ -n "$DEEPSEEK_API_KEY" ] && [ -n "$SUFY_API_KEY" ]; then
             if [ -z "$DEEPSEEK_BASE_URL" ] || [ -z "$DEEPSEEK_MODEL" ]; then
               echo "::error::已配置 Preview 模型密钥，但缺少 PREVIEW_DEEPSEEK_BASE_URL 或 PREVIEW_DEEPSEEK_MODEL"
               exit 1
@@ -177,9 +184,29 @@ jobs:
               echo "::error::PREVIEW_DEEPSEEK_BASE_URL 应填写 API 根地址，不能包含 /chat/completions"
               exit 1
             fi
+            if [[ ! "$SUFY_BASE_URL" =~ ^https?://[^/[:space:]]+(/.*)?$ ]]; then
+              echo "::error::PREVIEW_SUFY_BASE_URL 必须是包含主机名的 HTTP(S) 根地址"
+              exit 1
+            fi
+            if [[ "$SUFY_BASE_URL" == */images/generations* ]]; then
+              echo "::error::PREVIEW_SUFY_BASE_URL 应填写 API 根地址，不能包含 /images/generations"
+              exit 1
+            fi
+            if [ -z "$SUFY_IMAGE_MODEL" ]; then
+              echo "::error::已配置 Preview 生图密钥，但 PREVIEW_SUFY_IMAGE_MODEL 为空"
+              exit 1
+            fi
             HOST_MODEL_PROVIDER=deepseek
+            PORTRAIT_PROMPT_PROVIDER=deepseek
+            PORTRAIT_IMAGE_PROVIDER=sufy
           else
+            if [ -n "$DEEPSEEK_API_KEY" ] || [ -n "$SUFY_API_KEY" ]; then
+              echo "::error::Preview 的 DeepSeek 和 Sufy 密钥必须同时配置，不能只启用其中一段"
+              exit 1
+            fi
             HOST_MODEL_PROVIDER=fake
+            PORTRAIT_PROMPT_PROVIDER=deterministic
+            PORTRAIT_IMAGE_PROVIDER=mock
           fi
           if [ -n "$DOUBAO_TTS_API_KEY" ] && [ -n "$DOUBAO_TTS_VOICES" ] && [ -n "$DOUBAO_TTS_DEFAULT_VOICE_TYPE" ]; then
             HOST_SPEECH_PROVIDER=doubao
@@ -191,6 +218,12 @@ jobs:
           DEEPSEEK_MODEL_B64=$(printf '%s' "$DEEPSEEK_MODEL" | base64 | tr -d '\n')
           if [ -n "$DEEPSEEK_API_KEY_B64" ]; then
             echo "::add-mask::$DEEPSEEK_API_KEY_B64"
+          fi
+          SUFY_API_KEY_B64=$(printf '%s' "$SUFY_API_KEY" | base64 | tr -d '\n')
+          SUFY_BASE_URL_B64=$(printf '%s' "$SUFY_BASE_URL" | base64 | tr -d '\n')
+          SUFY_IMAGE_MODEL_B64=$(printf '%s' "$SUFY_IMAGE_MODEL" | base64 | tr -d '\n')
+          if [ -n "$SUFY_API_KEY_B64" ]; then
+            echo "::add-mask::$SUFY_API_KEY_B64"
           fi
           DOUBAO_TTS_API_KEY_B64=$(printf '%s' "$DOUBAO_TTS_API_KEY" | base64 | tr -d '\n')
           DOUBAO_TTS_VOICES_B64=$(printf '%s' "$DOUBAO_TTS_VOICES" | base64 | tr -d '\n')
@@ -236,6 +269,14 @@ jobs:
             export DEEPSEEK_API_KEY="\$(printf '%s' '$DEEPSEEK_API_KEY_B64' | base64 -d)"
             export DEEPSEEK_BASE_URL="\$(printf '%s' '$DEEPSEEK_BASE_URL_B64' | base64 -d)"
             export DEEPSEEK_MODEL="\$(printf '%s' '$DEEPSEEK_MODEL_B64' | base64 -d)"
+            export CHARACTER_PORTRAIT_ENABLED=true
+            export PORTRAIT_PROMPT_PROVIDER="$PORTRAIT_PROMPT_PROVIDER"
+            export PORTRAIT_IMAGE_PROVIDER="$PORTRAIT_IMAGE_PROVIDER"
+            export SUFY_API_KEY="\$(printf '%s' '$SUFY_API_KEY_B64' | base64 -d)"
+            export SUFY_BASE_URL="\$(printf '%s' '$SUFY_BASE_URL_B64' | base64 -d)"
+            export SUFY_IMAGE_MODEL="\$(printf '%s' '$SUFY_IMAGE_MODEL_B64' | base64 -d)"
+            export PORTRAIT_REFERENCE_IMAGE_PATH=app/assets/portrait-style-reference.png
+            export PORTRAIT_GENERATION_TIMEOUT_SECONDS=120
             export HOST_SPEECH_PROVIDER="$HOST_SPEECH_PROVIDER"
             # base64 只负责安全穿过 SSH heredoc，不是加密；GitHub 日志仍由
             # secrets 掩码保护，应用日志则永远不记录这些字段。

--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ Repository Secret，非敏感的 API 根地址和模型名使用 Repository Vari
 | `PREVIEW_DEEPSEEK_API_KEY` | Repository Secret | 新服务商签发的 Preview 专用 key（不要写入仓库或日志） |
 | `PREVIEW_DEEPSEEK_BASE_URL` | Repository Variable | `https://api.qnaigc.com/v1` |
 | `PREVIEW_DEEPSEEK_MODEL` | Repository Variable | `deepseek/deepseek-v4-pro-202606` |
+| `PREVIEW_SUFY_API_KEY` | Repository Secret | 与 `PREVIEW_DEEPSEEK_API_KEY` 使用同一把支持两个模型的 key |
+| `PREVIEW_SUFY_BASE_URL` | Repository Variable | `https://openai.sufy.com/v1`，可留空使用默认值 |
+| `PREVIEW_SUFY_IMAGE_MODEL` | Repository Variable | `google/gemini-3-pro-image`，可留空使用默认值 |
 
 `PREVIEW_DEEPSEEK_BASE_URL` 必须是 OpenAI-compatible API 根地址，不能填完整的
 `https://api.qnaigc.com/v1/chat/completions`；客户端会自行追加 `/chat/completions`。
@@ -329,7 +332,10 @@ Repository Secret，非敏感的 API 根地址和模型名使用 Repository Vari
 两份 Preview workflow 遵循同一配置规则：
 
 - key 为空时使用 `HOST_MODEL_PROVIDER=fake`，其余预览功能仍可验证；
-- key 非空时 Base URL 和模型名必须同时存在，否则部署立即失败；
+- DeepSeek 和 Sufy key 必须成对存在；只有一套 key 时部署立即失败，避免出现半真实链路；
+- 两套 key 都存在时，`DEEPSEEK_MODEL` 先整理角色图片提示词，`SUFY_IMAGE_MODEL` 再生成图片；
+- 当前推荐的两套模型分别为 `deepseek/deepseek-v4-pro-202606` 和 `google/gemini-3-pro-image`；
+- DeepSeek key 非空时，其 Base URL 和模型名必须同时存在，否则部署立即失败；Sufy 的 Base URL 和模型名可留空使用上述默认值；
 - 配置真实 provider 时不会静默使用代码中的旧厂商默认值；
 - fork PR 不执行部署 job，也不能读取 Repository Secret。
 
@@ -341,17 +347,25 @@ service 必须透传相同配置：
 environment:
   HOST_MODEL_PROVIDER: ${HOST_MODEL_PROVIDER:-fake}
   DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
-  DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.deepseek.com}
-  DEEPSEEK_MODEL: ${DEEPSEEK_MODEL:-deepseek-chat}
+  DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.qnaigc.com/v1}
+  DEEPSEEK_MODEL: ${DEEPSEEK_MODEL:-deepseek/deepseek-v4-pro-202606}
+  CHARACTER_PORTRAIT_ENABLED: ${CHARACTER_PORTRAIT_ENABLED:-true}
+  PORTRAIT_PROMPT_PROVIDER: ${PORTRAIT_PROMPT_PROVIDER:-deterministic}
+  PORTRAIT_IMAGE_PROVIDER: ${PORTRAIT_IMAGE_PROVIDER:-mock}
+  SUFY_API_KEY: ${SUFY_API_KEY:-}
+  SUFY_BASE_URL: ${SUFY_BASE_URL:-https://openai.sufy.com/v1}
+  SUFY_IMAGE_MODEL: ${SUFY_IMAGE_MODEL:-google/gemini-3-pro-image}
+  PORTRAIT_REFERENCE_IMAGE_PATH: ${PORTRAIT_REFERENCE_IMAGE_PATH:-app/assets/portrait-style-reference.png}
+  PORTRAIT_GENERATION_TIMEOUT_SECONDS: ${PORTRAIT_GENERATION_TIMEOUT_SECONDS:-120}
 ```
 
 切换或轮换服务商时按以下顺序操作，避免 workflow 已更新但外部配置尚未就绪：
 
-1. 先更新服务器固定 compose 模板，确认三项 `DEEPSEEK_*` 环境变量都会进入 backend。
-2. 在主仓库创建或更新 `PREVIEW_DEEPSEEK_BASE_URL`、`PREVIEW_DEEPSEEK_MODEL`。
-3. 将 `PREVIEW_DEEPSEEK_API_KEY` 替换为新服务商的 Preview 专用 key。
+1. 先更新服务器固定 compose 模板，确认 `DEEPSEEK_*`、`SUFY_*` 和 `PORTRAIT_*` 环境变量都会进入 backend。
+2. 在主仓库创建或更新 `PREVIEW_DEEPSEEK_BASE_URL`、`PREVIEW_DEEPSEEK_MODEL`、`PREVIEW_SUFY_BASE_URL` 和 `PREVIEW_SUFY_IMAGE_MODEL`。
+3. 新建 `PREVIEW_SUFY_API_KEY`，其值暂时复用 `PREVIEW_DEEPSEEK_API_KEY`；两套 Secret 按用途分别映射。
 4. 合并 workflow 改动后重新运行 Main Preview，并用同仓库测试 PR 验证 PR Preview。
-5. 在两个预览环境各提交一次自然语言行动，确认返回真实模型结果而非 Fake 文案。
+5. 在两个预览环境各完成一次自然语言行动和一次角色生图，确认 DeepSeek v4 Pro 与 Sufy Gemini 都返回真实结果。
 
 健康检查只证明容器和 HTTP 服务可用，不会产生计费模型请求，也不能证明模型配置
 正确。真实验证必须覆盖一次 Host Agent 工具调用和最终结构化输出。轮换期间不要在

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -19,13 +19,13 @@
 # 价值，容器销毁即丢，完全不碰生产/开发用的 Postgres——见 issue #200
 # 「决策 5」。
 #
-# HOST_MODEL_PROVIDER / DEEPSEEK_* 从宿主环境变量透传：同仓库 PR 由 workflow
-# 注入真实 key、OpenAI-compatible API 根地址和模型名；fork PR 因 GitHub
-# Actions 平台限制拿不到 secrets，甚至连部署 job 都不会跑（见
-# pr-preview.yml）。下面的 DeepSeek 默认值只服务于本地复现和旧配置兼容，
-# CI Preview 配了 key 时必须显式提供三项配置，不能静默使用旧厂商默认值。
+# HOST_MODEL_PROVIDER / DEEPSEEK_* 以及角色生图的 PORTRAIT_* / SUFY_* 都从
+# 宿主环境变量透传：同仓库 PR 由 workflow 注入真实 key、API 根地址、模型名
+# 和 provider；fork PR 因 GitHub Actions 平台限制拿不到 secrets，甚至连部署
+# job 都不会跑（见 pr-preview.yml）。下面的默认值只服务于本地复现和旧配置
+# 兼容，CI Preview 启用真实链路时必须显式选择对应 provider。
 # Base URL 填 API 根地址（如 https://api.example.com/v1），不能填完整的
-# /chat/completions；OpenAI SDK 会自行追加请求路径。
+# /chat/completions 或 /images/generations；客户端会自行追加请求路径。
 
 services:
   backend:
@@ -47,9 +47,21 @@ services:
       OPENING_NARRATION_MODE: ${OPENING_NARRATION_MODE:-model}
       OPENING_NARRATION_TIMEOUT_SECONDS: ${OPENING_NARRATION_TIMEOUT_SECONDS:-10}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
-      # CI Preview 会用 Repository Variables 覆盖这两个本地兼容默认值。
-      DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.deepseek.com}
-      DEEPSEEK_MODEL: ${DEEPSEEK_MODEL:-deepseek-chat}
+      # Preview 默认使用当前新厂商的 v4 Pro；CI 仍可通过 Repository
+      # Variables 显式覆盖，通用后端配置不受这里的 Preview 默认值影响。
+      DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.qnaigc.com/v1}
+      DEEPSEEK_MODEL: ${DEEPSEEK_MODEL:-deepseek/deepseek-v4-pro-202606}
+      # 角色生图的提示词与图片生成是两段独立链路：DeepSeek 负责提示词，
+      # Sufy Gemini 负责图片。CI 在两套 key 都存在时启用真实链路，否则
+      # 通过显式 provider 选择回退到本地可验证的 deterministic/mock。
+      CHARACTER_PORTRAIT_ENABLED: ${CHARACTER_PORTRAIT_ENABLED:-true}
+      PORTRAIT_PROMPT_PROVIDER: ${PORTRAIT_PROMPT_PROVIDER:-deterministic}
+      PORTRAIT_IMAGE_PROVIDER: ${PORTRAIT_IMAGE_PROVIDER:-mock}
+      SUFY_API_KEY: ${SUFY_API_KEY:-}
+      SUFY_BASE_URL: ${SUFY_BASE_URL:-https://openai.sufy.com/v1}
+      SUFY_IMAGE_MODEL: ${SUFY_IMAGE_MODEL:-google/gemini-3-pro-image}
+      PORTRAIT_REFERENCE_IMAGE_PATH: ${PORTRAIT_REFERENCE_IMAGE_PATH:-app/assets/portrait-style-reference.png}
+      PORTRAIT_GENERATION_TIMEOUT_SECONDS: ${PORTRAIT_GENERATION_TIMEOUT_SECONDS:-120}
       # 没有一整套独立限额凭证时保持 disabled；应用不会回退到浏览器 TTS。
       HOST_SPEECH_PROVIDER: ${HOST_SPEECH_PROVIDER:-disabled}
       DOUBAO_TTS_API_KEY: ${DOUBAO_TTS_API_KEY:-}

--- a/trpg-backend/.env.example
+++ b/trpg-backend/.env.example
@@ -24,7 +24,7 @@ QWEN_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 QWEN_MODEL=qwen3.7-plus
 QWEN_TIMEOUT_SECONDS=30
 
-# OpenAI-compatible provider 示例：DeepSeek 是首个内置实现。
+# OpenAI-compatible provider 示例：默认值对应 DeepSeek 官方服务。
 DEEPSEEK_API_KEY=
 DEEPSEEK_BASE_URL=https://api.deepseek.com
 DEEPSEEK_MODEL=deepseek-chat
@@ -59,6 +59,12 @@ DASHSCOPE_IMAGE_MODEL=wan2.2-t2i-flash
 SUFY_API_KEY=
 SUFY_BASE_URL=https://openai.sufy.com/v1
 SUFY_IMAGE_MODEL=google/gemini-3-pro-image
+# 使用新厂商的完整双模型链路时，改用下面这一组配置；同一把兼容 key
+# 可以同时填入 DEEPSEEK_API_KEY 和 SUFY_API_KEY，但变量仍按用途分开。
+# DEEPSEEK_BASE_URL=https://api.qnaigc.com/v1
+# DEEPSEEK_MODEL=deepseek/deepseek-v4-pro-202606
+# PORTRAIT_PROMPT_PROVIDER=deepseek
+# PORTRAIT_IMAGE_PROVIDER=sufy
 # 项目内置漫画风格参考图由后端读取并随镜像打包，不需要公网 URL。
 # 参考图只用于锁定线稿、上色和光影风格；留空或文件不可读时降级为纯提示词。
 PORTRAIT_REFERENCE_IMAGE_PATH=app/assets/portrait-style-reference.png


### PR DESCRIPTION
## 关联 Issue

Closes #254

## 背景

角色生图已经合入主分支，但 Main Preview 和同仓库 PR Preview 原先只透传主持模型使用的 `DEEPSEEK_*` 配置，未启用真实的提示词整理与 Sufy 图片生成链路，因此从 README 进入的预览环境无法生成真实角色图片。

## 修改内容

### 1. 接入双模型角色生图链路

- 使用 `deepseek/deepseek-v4-pro-202606` 根据人物卡整理生图提示词。
- 使用 `google/gemini-3-pro-image` 生成最终角色图片。
- 真实模式显式设置 `PORTRAIT_PROMPT_PROVIDER=deepseek` 和 `PORTRAIT_IMAGE_PROVIDER=sufy`。
- 无模型密钥时保留 `fake + deterministic + mock`，预览仍可离线验证。

### 2. 完善 Preview 部署配置

- Main Preview 与 PR Preview 同步读取 `PREVIEW_SUFY_API_KEY`、`PREVIEW_SUFY_BASE_URL` 和 `PREVIEW_SUFY_IMAGE_MODEL`。
- DeepSeek 与 Sufy Secret 必须成对存在，只有一套时在部署前明确失败，避免半真实链路。
- 校验两套 API 根地址，拒绝误填完整的 `/chat/completions` 或 `/images/generations` 请求路径。
- Sufy 密钥、Base URL 和模型名通过 Base64 安全穿过 SSH heredoc；密钥及编码结果均加入日志掩码。
- 向服务器固定 Compose 模板透传角色生图开关、provider、模型、参考图路径和超时配置。

### 3. 更新配置说明

- `docker-compose.preview.yml` 增加角色生图环境变量，Preview 默认使用 DeepSeek v4 Pro。
- README 补充 Repository Secrets、Variables 和服务器固定模板配置步骤。
- `.env.example` 补充新厂商双模型链路示例，同一把兼容 key 可按用途分别配置。

## 代码范围

- `.github/workflows/pr-preview.yml`
- `.github/workflows/main-preview.yml`
- `docker-compose.preview.yml`
- `trpg-backend/.env.example`
- `README.md`

本次不修改角色生图核心逻辑、Sufy provider、前端交互、数据库或人物卡结构。

## 验证

- [x] `git diff --check`
- [x] `actionlint -color=false .github/workflows/pr-preview.yml .github/workflows/main-preview.yml`
- [x] 使用占位密钥执行 `docker compose -f docker-compose.preview.yml config --quiet`
- [x] 检查 Compose 展开后的两套 provider、Base URL 和模型名
- [x] `uv run pytest tests/test_portrait_generation.py -q`（36 passed）

## 合并前配置

1. 在服务器固定模板 `~/trpg-previews/compose-template/docker-compose.yml` 的 backend 环境变量中补齐 README 列出的 `PORTRAIT_*` 和 `SUFY_*`。
2. 新建 Repository Secret `PREVIEW_SUFY_API_KEY`，当前可与 `PREVIEW_DEEPSEEK_API_KEY` 使用同一值。
3. 确认 `PREVIEW_DEEPSEEK_BASE_URL=https://api.qnaigc.com/v1`。
4. 确认 `PREVIEW_DEEPSEEK_MODEL=deepseek/deepseek-v4-pro-202606`。
5. `PREVIEW_SUFY_BASE_URL` 和 `PREVIEW_SUFY_IMAGE_MODEL` 可留空使用默认值，也可显式设置为 `https://openai.sufy.com/v1` 和 `google/gemini-3-pro-image`。
