### PR TITLE
[Frontend][Bug] 修复建卡完成页规则指引无法重播

### DIFF
--- a/trpg-frontend/src/styles.css
+++ b/trpg-frontend/src/styles.css
@@ -2670,6 +2670,8 @@
   font-family: 'STKaiti', 'KaiTi', 'PingFang SC', sans-serif;
   font-size: 0.72rem;
   font-weight: 800;
+  cursor: pointer;
+  pointer-events: auto;
 }
 
 .character-ready-scene__dossier {


### PR DESCRIPTION
## 问题

建卡完成页的自动指引可以正常显示，但点击“下一步”后，右上角“规则指引”按钮无法手动重新播放当前页面指引。

父容器 `.lobby-scene__header` 设置了 `pointer-events: none`，返回按钮恢复了点击能力，但该页面的规则指引按钮没有恢复，因此无法触发 `requestReplay`。

## 修复

- 为 `.character-ready-scene__guide` 增加 `pointer-events: auto`。
- 增加 `cursor: pointer`，明确按钮可交互状态。
- 不修改自动指引、步骤状态及路由逻辑。

## 验证

- 新手指引及建卡完成页针对性测试：21 项通过
- `npm run lint`：通过
- `npm run build`：通过

Closes #278