### PR TITLE
[Bug][A/B] 修复 ActionPlan post-roll 阶段取消剩余计划

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -375,6 +375,21 @@ class ActionPlanOrchestrator:
                     player_view=view,
                     latest_execution=latest,
                 )
+            if run.status == "cancelled":
+                await self._emit(
+                    on_progress,
+                    self._progress(
+                        run,
+                        "plan.stopped",
+                        "stopped",
+                        reason="PLAN_CANCELLED",
+                    ),
+                )
+                return ActionPlanAdvanceResult(
+                    run=run,
+                    player_view=view,
+                    latest_execution=latest,
+                )
             if run.status == "stopped":
                 run = await self._release_lease(run)
                 await self._emit(
@@ -490,6 +505,78 @@ class ActionPlanOrchestrator:
             ),
         )
         return cancelled
+
+    async def request_cancel_after_current(
+        self,
+        request: CancelActionPlanRequest,
+    ) -> ActionPlanRun:
+        """Persist a post-roll cancel intent without cancelling the check.
+
+        The caller must settle the current check afterwards.  Persisting the
+        intent first makes that settlement recoverable if the process exits
+        between the two authoritative writes.
+        """
+
+        run = await self._store.load(request.room_id, request.parent_action_id)
+        if run is None:
+            raise ActionPlanPolicyError("PLAN_NOT_FOUND", "没有可取消的行动计划")
+        if run.player_id != request.player_id or run.actor_id != request.actor_id:
+            raise ActionPlanPolicyError("PLAN_OWNER_MISMATCH", "行动计划不属于当前玩家")
+        if request.request_id in run.cancel_request_ids:
+            return run
+        if run.pending_cancel_request_id == request.request_id:
+            return run
+        if run.pending_cancel_request_id is not None:
+            raise ActionPlanPolicyError(
+                "PLAN_CANCEL_IN_PROGRESS",
+                "当前行动计划已有一个取消请求正在处理",
+            )
+        if run.status != "waiting_for_player" or run.current_step_index >= len(run.steps):
+            raise ActionPlanPolicyError(
+                "PLAN_CANCEL_NOT_AT_BOUNDARY",
+                "当前步骤已经开始；请先完成或取消当前检定，再取消剩余计划",
+            )
+        current = run.steps[run.current_step_index]
+        status = await self._executor.get_status(
+            GetAdjudicationStatusRequest(
+                room_id=run.room_id,
+                player_id=run.player_id,
+                action_request_id=current.step_request_id,
+            )
+        )
+        execution = status.execution
+        if (
+            current.status != "waiting_for_player"
+            or execution is None
+            or status.status != "awaiting_post_roll_decision"
+            or execution.check_run is None
+        ):
+            raise ActionPlanPolicyError(
+                "PLAN_CANCEL_NOT_AT_BOUNDARY",
+                "当前步骤不在可接受检定结果的取消节点",
+            )
+        now = datetime.now(UTC)
+        steps = list(run.steps)
+        steps[run.current_step_index] = current.model_copy(
+            update={
+                "adjudication_execution": execution,
+                "event_refs": execution.event_refs,
+            },
+            deep=True,
+        )
+        updated = run.model_copy(
+            update={
+                "steps": tuple(steps),
+                "pending_cancel_request_id": request.request_id,
+                "run_version": run.run_version + 1,
+                "updated_at": now,
+            },
+            deep=True,
+        )
+        return await self._store.compare_and_swap(
+            expected_run_version=run.run_version,
+            updated_run=self._validated(updated),
+        )
 
     async def mark_narration_completed(
         self,
@@ -805,13 +892,41 @@ class ActionPlanOrchestrator:
                 update={**common, "status": "stopped", "safe_failure_code": code},
                 deep=True,
             )
-            return await self._replace_steps(run, tuple(steps), status="stopped")
+            return await self._replace_steps(
+                run,
+                tuple(steps),
+                status="stopped",
+                consume_cancel_request=run.pending_cancel_request_id is not None,
+            )
 
         steps[index] = current.model_copy(
             update={**common, "status": "completed"},
             deep=True,
         )
         next_index = index + 1
+        if run.pending_cancel_request_id is not None:
+            if next_index < len(steps):
+                steps[next_index] = steps[next_index].model_copy(
+                    update={
+                        "status": "stopped",
+                        "safe_failure_code": "PLAN_CANCELLED",
+                    },
+                    deep=True,
+                )
+                return await self._replace_steps(
+                    run,
+                    tuple(steps),
+                    current_step_index=next_index,
+                    status="cancelled",
+                    consume_cancel_request=True,
+                )
+            return await self._replace_steps(
+                run,
+                tuple(steps),
+                current_step_index=next_index,
+                status="awaiting_narration",
+                consume_cancel_request=True,
+            )
         return await self._replace_steps(
             run,
             tuple(steps),
@@ -855,6 +970,7 @@ class ActionPlanOrchestrator:
         *,
         status: str | None = None,
         current_step_index: int | None = None,
+        consume_cancel_request: bool = False,
     ) -> ActionPlanRun:
         now = datetime.now(UTC)
         next_status = status or run.status
@@ -865,18 +981,24 @@ class ActionPlanOrchestrator:
         # could no longer load the row it had just written, so the follow-up
         # release would fail too and leave the run permanently unreadable.
         release_lease = next_status in TERMINAL_PLAN_STATUSES
+        update: dict[str, object] = {
+            "steps": steps,
+            "status": next_status,
+            "current_step_index": (
+                run.current_step_index if current_step_index is None else current_step_index
+            ),
+            "run_version": run.run_version + 1,
+            "lease_owner": None if release_lease else run.lease_owner,
+            "lease_expires_at": None if release_lease else run.lease_expires_at,
+            "updated_at": now,
+        }
+        if consume_cancel_request:
+            request_id = run.pending_cancel_request_id
+            if request_id is not None and request_id not in run.cancel_request_ids:
+                update["cancel_request_ids"] = (*run.cancel_request_ids, request_id)
+            update["pending_cancel_request_id"] = None
         updated = run.model_copy(
-            update={
-                "steps": steps,
-                "status": next_status,
-                "current_step_index": (
-                    run.current_step_index if current_step_index is None else current_step_index
-                ),
-                "run_version": run.run_version + 1,
-                "lease_owner": None if release_lease else run.lease_owner,
-                "lease_expires_at": None if release_lease else run.lease_expires_at,
-                "updated_at": now,
-            },
+            update=update,
             deep=True,
         )
         return await self._store.compare_and_swap(

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
@@ -150,6 +150,10 @@ class ActionPlanRun(ContractModel):
     lease_owner: str | None = Field(default=None, min_length=1, max_length=200)
     lease_expires_at: datetime | None = None
     cancel_request_ids: tuple[str, ...] = ()
+    # A post-roll cancel is a two-phase operation: persist this intent first,
+    # then accept the already-authoritative roll and stop the remaining plan.
+    # Keeping it on the run makes the operation recoverable across a crash.
+    pending_cancel_request_id: str | None = Field(default=None, min_length=1, max_length=200)
     created_at: datetime
     updated_at: datetime
 
@@ -194,6 +198,18 @@ class ActionPlanRun(ContractModel):
             raise ValueError("终态 PlanRun 不得持有 worker lease")
         if len(self.cancel_request_ids) != len(set(self.cancel_request_ids)):
             raise ValueError("cancel request id 必须唯一")
+        if self.pending_cancel_request_id is not None:
+            if self.pending_cancel_request_id in self.cancel_request_ids:
+                raise ValueError("pending cancel request 不得已经完成")
+            if self.status != "waiting_for_player" or self.current_step_index >= len(self.steps):
+                raise ValueError("pending cancel request 只能存在于等待玩家处理的当前步骤")
+            current = self.steps[self.current_step_index]
+            if (
+                current.status != "waiting_for_player"
+                or current.adjudication_execution is None
+                or current.adjudication_execution.status != "awaiting_post_roll_decision"
+            ):
+                raise ValueError("pending cancel request 必须对应等待 post-roll 的当前步骤")
         return self
 
     @property

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -517,6 +517,117 @@ async def test_pending_check_stops_plan_and_resumes_same_step_after_decision() -
     assert status.status == "resolved"
 
 
+@pytest.mark.parametrize(
+    ("roll_value", "expected_outcome", "expected_status"),
+    ((10, "success", "cancelled"), (80, "failure", "stopped")),
+)
+@pytest.mark.asyncio
+async def test_post_roll_cancel_accepts_current_roll_and_stops_remaining_steps(
+    roll_value: int,
+    expected_outcome: str,
+    expected_status: str,
+) -> None:
+    module, engine_store, projector = runtime()
+    adjudicator = RecordingAdjudicator(module.world_ref, check_step=0)
+    engine = AdjudicationEngineService(
+        engine_store,
+        dice=DiceRoller(SequenceDiceSource([roll_value])),
+    )
+    plan_store = InMemoryActionPlanRunStore()
+    service = ActionPlanOrchestrator(
+        store=plan_store,
+        adjudicator=adjudicator,
+        executor=engine,
+        player_view_projector=projector,
+    )
+    original = player_input("post-roll-cancel-parent")
+
+    waiting = await service.start_or_resume(original, plan=plan(3))
+    pending = waiting.latest_execution
+    assert pending is not None and pending.pending_decision is not None
+    rolled = await engine.decide(
+        CheckDecisionRequest(
+            request_id="post-roll-cancel-parent:select",
+            room_id="room_01",
+            player_id="player_01",
+            source_revision=pending.view_revision,
+            decision_id=pending.pending_decision.decision_id,
+            decision_version=pending.pending_decision.decision_version,
+            choice=SelectCheckChoice(candidate_id="spot"),
+        )
+    )
+    assert rolled.status == "awaiting_post_roll_decision"
+    assert rolled.check_run is not None
+
+    cancel = CancelActionPlanRequest(
+        request_id="post-roll-cancel-parent:cancel",
+        room_id="room_01",
+        player_id="player_01",
+        actor_id="pc_1",
+        parent_action_id=original.client_action_id,
+    )
+    intent = await service.request_cancel_after_current(cancel)
+    assert intent.pending_cancel_request_id == cancel.request_id
+    assert intent.status == "waiting_for_player"
+    assert await service.request_cancel_after_current(cancel) == intent
+
+    accepted = await engine.decide_post_roll(
+        PostRollDecisionRequest(
+            request_id=f"{cancel.request_id}:accept-current",
+            room_id="room_01",
+            player_id="player_01",
+            source_revision=rolled.view_revision,
+            check_id=rolled.check_run.check_id,
+            check_version=rolled.check_run.version,
+            option_id="accept-current",
+        )
+    )
+    replay = await engine.decide_post_roll(
+        PostRollDecisionRequest(
+            request_id=f"{cancel.request_id}:accept-current",
+            room_id="room_01",
+            player_id="player_01",
+            source_revision=rolled.view_revision,
+            check_id=rolled.check_run.check_id,
+            check_version=rolled.check_run.version,
+            option_id="accept-current",
+        )
+    )
+    assert accepted == replay
+    assert accepted.outcome == expected_outcome
+
+    stopped = await service.resume_owned(
+        room_id="room_01",
+        player_id="player_01",
+        actor_id="pc_1",
+        parent_action_id=original.client_action_id,
+    )
+    assert stopped.run.status == expected_status
+    if expected_status == "cancelled":
+        assert [step.status for step in stopped.run.steps] == [
+            "completed",
+            "stopped",
+            "pending",
+        ]
+        assert stopped.run.steps[1].safe_failure_code == "PLAN_CANCELLED"
+    else:
+        assert stopped.run.steps[0].safe_failure_code == "STEP_FAILED"
+    assert stopped.run.pending_cancel_request_id is None
+    assert cancel.request_id in stopped.run.cancel_request_ids
+    assert len(adjudicator.contexts) == 1
+
+    # A retry after the reconciliation is a pure replay: no later step starts
+    # and no effect/event is duplicated.
+    replayed = await service.resume_owned(
+        room_id="room_01",
+        player_id="player_01",
+        actor_id="pc_1",
+        parent_action_id=original.client_action_id,
+    )
+    assert replayed.run == stopped.run
+    assert len(adjudicator.contexts) == 1
+
+
 @pytest.mark.asyncio
 async def test_post_roll_retry_resolves_plan_once_without_duplicate_effects() -> None:
     module, engine_store, projector = runtime()

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -970,55 +970,76 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 room_id
                             )
                             if active_plan is not None and active_plan.player_id == bound_player_id:
-                                await _send_plan_progress(
-                                    websocket,
-                                    type(
-                                        "RecoveredPlanProgress",
-                                        (),
-                                        {
-                                            "type": "plan.step_changed",
-                                            "correlation_id": active_plan.parent_action_id,
-                                            "current_step": min(
-                                                active_plan.current_step_index + 1,
-                                                len(active_plan.steps),
-                                            ),
-                                            "completed_steps": active_plan.completed_steps,
-                                            "total_steps": len(active_plan.steps),
-                                            "phase": (
-                                                "waiting_for_player"
-                                                if active_plan.status == "waiting_for_player"
-                                                else "understanding"
-                                            ),
-                                            "public_progress_label": None,
-                                            "safe_reason": None,
-                                        },
-                                    )(),
-                                )
-                                if active_plan.status == "waiting_for_player":
-                                    execution = active_plan.steps[
-                                        active_plan.current_step_index
-                                    ].adjudication_execution
-                                    if execution is not None:
-                                        pending = AdjudicationPendingPayload(
-                                            correlation_id=active_plan.parent_action_id,
-                                            plan_id=active_plan.plan_id,
-                                            source_revision=execution.view_revision,
-                                            status=_require_pending_adjudication_status(
-                                                execution.status
-                                            ),
-                                            pending_decision=execution.pending_decision,
-                                            check_run=execution.check_run,
-                                        )
-                                        await _send_to_player(
+                                if active_plan.pending_cancel_request_id is not None:
+                                    # A reconnect is also a recovery worker. The
+                                    # durable intent owns the Engine command;
+                                    # never replay the stale post-roll menu.
+                                    recovered = await action_plan_turn_application.resume_owned(
+                                        room_id=room_id,
+                                        player_id=bound_player_id,
+                                        parent_action_id=active_plan.parent_action_id,
+                                        on_progress=lambda event: _send_plan_progress(
                                             websocket,
-                                            ServerEnvelope(
-                                                type="adjudication.pending",
-                                                payload=pending.model_dump(
-                                                    by_alias=True,
-                                                    mode="json",
+                                            event,
+                                        ),
+                                    )
+                                    await _send_action_plan_result(
+                                        db,
+                                        websocket,
+                                        room_id,
+                                        bound_player_id,
+                                        recovered,
+                                    )
+                                else:
+                                    await _send_plan_progress(
+                                        websocket,
+                                        type(
+                                            "RecoveredPlanProgress",
+                                            (),
+                                            {
+                                                "type": "plan.step_changed",
+                                                "correlation_id": active_plan.parent_action_id,
+                                                "current_step": min(
+                                                    active_plan.current_step_index + 1,
+                                                    len(active_plan.steps),
                                                 ),
-                                            ).model_dump(by_alias=True),
-                                        )
+                                                "completed_steps": active_plan.completed_steps,
+                                                "total_steps": len(active_plan.steps),
+                                                "phase": (
+                                                    "waiting_for_player"
+                                                    if active_plan.status == "waiting_for_player"
+                                                    else "understanding"
+                                                ),
+                                                "public_progress_label": None,
+                                                "safe_reason": None,
+                                            },
+                                        )(),
+                                    )
+                                    if active_plan.status == "waiting_for_player":
+                                        execution = active_plan.steps[
+                                            active_plan.current_step_index
+                                        ].adjudication_execution
+                                        if execution is not None:
+                                            pending = AdjudicationPendingPayload(
+                                                correlation_id=active_plan.parent_action_id,
+                                                plan_id=active_plan.plan_id,
+                                                source_revision=execution.view_revision,
+                                                status=_require_pending_adjudication_status(
+                                                    execution.status
+                                                ),
+                                                pending_decision=execution.pending_decision,
+                                                check_run=execution.check_run,
+                                            )
+                                            await _send_to_player(
+                                                websocket,
+                                                ServerEnvelope(
+                                                    type="adjudication.pending",
+                                                    payload=pending.model_dump(
+                                                        by_alias=True,
+                                                        mode="json",
+                                                    ),
+                                                ).model_dump(by_alias=True),
+                                            )
                             else:
                                 # No ActionPlan-driven pending decision — but a
                                 # standalone single-action check (not part of a

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -51,6 +51,7 @@ from collaboration_framework.host.schemas import (
     ActionPlanAdvanceResult,
     ActionPlanNarrationContext,
     ActionPlanNarrationOutput,
+    ActionPlanRun,
     ActionPlanStepContext,
     CompletedPlanStepSummary,
     HostAgentContext,
@@ -634,6 +635,15 @@ class ActionPlanTurnApplication:
         on_phase: TurnPhaseObserver | None = None,
     ) -> ActionPlanTurnResult:
         actor_id = await self._resolve_actor_id(room_id, player_id)
+        run = await self._orchestrator.get_run(room_id, parent_action_id)
+        if (
+            run is not None
+            and run.player_id == player_id
+            and run.actor_id == actor_id
+            and run.parent_action_id == parent_action_id
+            and run.pending_cancel_request_id is not None
+        ):
+            await self._recover_pending_post_roll_cancel(run)
         advanced = await self._orchestrator.resume_owned(
             room_id=room_id,
             player_id=player_id,
@@ -747,6 +757,22 @@ class ActionPlanTurnApplication:
     ) -> ActionPlanTurnResult:
         actor_id = await self._resolve_actor_id(room_id, player_id)
         existing = await self._orchestrator.get_run(room_id, parent_action_id)
+        if (
+            existing is not None
+            and existing.player_id == player_id
+            and existing.actor_id == actor_id
+            and existing.parent_action_id == parent_action_id
+            and existing.pending_cancel_request_id is not None
+        ):
+            # The durable intent, rather than the current client request ID,
+            # owns recovery. This also handles a retry with a fresh request ID
+            # after either authoritative write has already committed.
+            await self._recover_pending_post_roll_cancel(existing)
+            return await self.resume_owned(
+                room_id=room_id,
+                player_id=player_id,
+                parent_action_id=parent_action_id,
+            )
         execution: AdjudicationExecution | None = None
         if (
             existing is not None
@@ -797,39 +823,9 @@ class ActionPlanTurnApplication:
             # A post-roll cancel accepts the already-authoritative roll.  The
             # intent is durable before the Engine command so recovery can
             # finish the same check and stop later steps after a crash.
-            check_run = execution.check_run
-            accept_option = next(
-                (
-                    option
-                    for option in check_run.post_roll_options
-                    if option.kind == "accept_result"
-                ),
-                None,
-            )
-            if accept_option is None:
-                raise TurnExecutionError(
-                    "POST_ROLL_ACCEPT_UNAVAILABLE",
-                    "当前检定没有可接受的已掷结果",
-                    retryable=False,
-                )
-            await self._orchestrator.request_cancel_after_current(cancel_request)
-            derived_request_id = f"{request_id}:accept-current"
-            if len(derived_request_id) > 200:
-                derived_request_id = (
-                    "post-roll-accept-" + hashlib.sha256(request_id.encode("utf-8")).hexdigest()
-                )
-            await self._adjudication_engine.decide_post_roll(
-                PostRollDecisionRequest(
-                    request_id=derived_request_id,
-                    room_id=room_id,
-                    player_id=player_id,
-                    source_revision=execution.view_revision,
-                    check_id=check_run.check_id,
-                    check_version=check_run.version,
-                    option_id=accept_option.option_id,
-                )
-            )
-            result = await self.resume_pending(
+            intent = await self._orchestrator.request_cancel_after_current(cancel_request)
+            await self._recover_pending_post_roll_cancel(intent)
+            result = await self.resume_owned(
                 room_id=room_id,
                 player_id=player_id,
                 parent_action_id=parent_action_id,
@@ -853,6 +849,81 @@ class ActionPlanTurnApplication:
             result,
             verify_fingerprint=False,
         )
+
+    async def _recover_pending_post_roll_cancel(
+        self,
+        run: ActionPlanRun,
+    ) -> None:
+        """Finish a durable post-roll cancel intent after any process restart.
+
+        The persisted cancel ID is the idempotency key. A resolved Engine
+        execution needs no second write; an awaiting execution receives the
+        same derived accept-current command regardless of which client request
+        triggered recovery.
+        """
+
+        cancel_id = run.pending_cancel_request_id
+        if cancel_id is None:
+            return
+        if run.current_step_index >= len(run.steps):
+            raise TurnExecutionError(
+                "PLAN_CANCEL_RECOVERY_UNAVAILABLE",
+                "取消请求无法从当前行动计划状态恢复，请刷新后重试",
+                retryable=True,
+            )
+        current = run.steps[run.current_step_index]
+        status = await self._adjudication_engine.get_status(
+            GetAdjudicationStatusRequest(
+                room_id=run.room_id,
+                player_id=run.player_id,
+                action_request_id=current.step_request_id,
+            )
+        )
+        if status.status in {"resolved", "cancelled"}:
+            return
+        if status.status != "awaiting_post_roll_decision" or status.execution is None:
+            raise TurnExecutionError(
+                "PLAN_CANCEL_RECOVERY_UNAVAILABLE",
+                "取消请求无法从当前检定状态恢复，请刷新后重试",
+                retryable=True,
+            )
+        execution = status.execution
+        check_run = execution.check_run
+        if check_run is None:
+            raise TurnExecutionError(
+                "PLAN_CANCEL_RECOVERY_UNAVAILABLE",
+                "取消请求无法从当前检定状态恢复，请刷新后重试",
+                retryable=True,
+            )
+        accept_option = next(
+            (option for option in check_run.post_roll_options if option.kind == "accept_result"),
+            None,
+        )
+        if accept_option is None:
+            raise TurnExecutionError(
+                "POST_ROLL_ACCEPT_UNAVAILABLE",
+                "当前检定没有可接受的已掷结果",
+                retryable=False,
+            )
+        derived_request_id = self._post_roll_accept_request_id(cancel_id)
+        await self._adjudication_engine.decide_post_roll(
+            PostRollDecisionRequest(
+                request_id=derived_request_id,
+                room_id=run.room_id,
+                player_id=run.player_id,
+                source_revision=execution.view_revision,
+                check_id=check_run.check_id,
+                check_version=check_run.version,
+                option_id=accept_option.option_id,
+            )
+        )
+
+    @staticmethod
+    def _post_roll_accept_request_id(cancel_id: str) -> str:
+        derived_request_id = f"{cancel_id}:accept-current"
+        if len(derived_request_id) <= 200:
+            return derived_request_id
+        return "post-roll-accept-" + hashlib.sha256(cancel_id.encode("utf-8")).hexdigest()
 
     async def mark_narration_persisted(
         self,

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -815,9 +815,9 @@ class ActionPlanTurnApplication:
             await self._orchestrator.request_cancel_after_current(cancel_request)
             derived_request_id = f"{request_id}:accept-current"
             if len(derived_request_id) > 200:
-                derived_request_id = "post-roll-accept-" + hashlib.sha256(
-                    request_id.encode("utf-8")
-                ).hexdigest()
+                derived_request_id = (
+                    "post-roll-accept-" + hashlib.sha256(request_id.encode("utf-8")).hexdigest()
+                )
             await self._adjudication_engine.decide_post_roll(
                 PostRollDecisionRequest(
                     request_id=derived_request_id,

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Protocol
@@ -28,6 +29,7 @@ from collaboration_framework.contracts import (
     NoAdjudicationCheck,
     PlayerInput,
     PlayerView,
+    PostRollDecisionRequest,
     RequiredAdjudicationCheck,
     RuleDecisionRef,
     SingleActionDecision,
@@ -745,6 +747,7 @@ class ActionPlanTurnApplication:
     ) -> ActionPlanTurnResult:
         actor_id = await self._resolve_actor_id(room_id, player_id)
         existing = await self._orchestrator.get_run(room_id, parent_action_id)
+        execution: AdjudicationExecution | None = None
         if (
             existing is not None
             and existing.player_id == player_id
@@ -753,6 +756,15 @@ class ActionPlanTurnApplication:
             and existing.current_step_index < len(existing.steps)
         ):
             execution = existing.steps[existing.current_step_index].adjudication_execution
+            status = await self._adjudication_engine.get_status(
+                GetAdjudicationStatusRequest(
+                    room_id=room_id,
+                    player_id=player_id,
+                    action_request_id=existing.steps[existing.current_step_index].step_request_id,
+                )
+            )
+            if status.execution is not None:
+                execution = status.execution
             pending = execution.pending_decision if execution is not None else None
             if (
                 execution is not None
@@ -770,15 +782,61 @@ class ActionPlanTurnApplication:
                         choice=CancelCheckChoice(),
                     )
                 )
-        run = await self._orchestrator.cancel_remaining(
-            CancelActionPlanRequest(
-                request_id=request_id,
+        cancel_request = CancelActionPlanRequest(
+            request_id=request_id,
+            room_id=room_id,
+            player_id=player_id,
+            actor_id=actor_id,
+            parent_action_id=parent_action_id,
+        )
+        if (
+            execution is not None
+            and execution.status == "awaiting_post_roll_decision"
+            and execution.check_run is not None
+        ):
+            # A post-roll cancel accepts the already-authoritative roll.  The
+            # intent is durable before the Engine command so recovery can
+            # finish the same check and stop later steps after a crash.
+            check_run = execution.check_run
+            accept_option = next(
+                (
+                    option
+                    for option in check_run.post_roll_options
+                    if option.kind == "accept_result"
+                ),
+                None,
+            )
+            if accept_option is None:
+                raise TurnExecutionError(
+                    "POST_ROLL_ACCEPT_UNAVAILABLE",
+                    "当前检定没有可接受的已掷结果",
+                    retryable=False,
+                )
+            await self._orchestrator.request_cancel_after_current(cancel_request)
+            derived_request_id = f"{request_id}:accept-current"
+            if len(derived_request_id) > 200:
+                derived_request_id = "post-roll-accept-" + hashlib.sha256(
+                    request_id.encode("utf-8")
+                ).hexdigest()
+            await self._adjudication_engine.decide_post_roll(
+                PostRollDecisionRequest(
+                    request_id=derived_request_id,
+                    room_id=room_id,
+                    player_id=player_id,
+                    source_revision=execution.view_revision,
+                    check_id=check_run.check_id,
+                    check_version=check_run.version,
+                    option_id=accept_option.option_id,
+                )
+            )
+            result = await self.resume_pending(
                 room_id=room_id,
                 player_id=player_id,
-                actor_id=actor_id,
                 parent_action_id=parent_action_id,
             )
-        )
+            return result
+
+        run = await self._orchestrator.cancel_remaining(cancel_request)
         player_input = PlayerInput(
             room_id=room_id,
             player_id=player_id,

--- a/trpg-backend/tests/test_action_plan_turn_recovery.py
+++ b/trpg-backend/tests/test_action_plan_turn_recovery.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from collaboration_framework.contracts import PostRollDecisionRequest
+
+from app.core.action_plan_turn import ActionPlanTurnApplication
+
+
+def _run(*, cancel_id: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        room_id="room-281",
+        player_id="player-281",
+        actor_id="actor-281",
+        parent_action_id="plan-281",
+        parent_utterance="完成连续行动",
+        plan=SimpleNamespace(goal="完成连续行动"),
+        plan_id="plan-281",
+        status="waiting_for_player",
+        current_step_index=0,
+        pending_cancel_request_id=cancel_id,
+        steps=(
+            SimpleNamespace(
+                step_request_id="step-281",
+                status="waiting_for_player",
+                adjudication_execution=None,
+            ),
+        ),
+    )
+
+
+def _status(status: str) -> SimpleNamespace:
+    check_run = SimpleNamespace(
+        check_id="check-281",
+        version=1,
+        post_roll_options=(SimpleNamespace(kind="accept_result", option_id="accept-current"),),
+    )
+    execution = SimpleNamespace(
+        status=status,
+        view_revision="revision-7",
+        check_run=check_run if status == "awaiting_post_roll_decision" else None,
+    )
+    return SimpleNamespace(status=status, execution=execution)
+
+
+class _Engine:
+    def __init__(self, status: SimpleNamespace) -> None:
+        self.status = status
+        self.status_requests = []
+        self.post_roll_requests: list[PostRollDecisionRequest] = []
+
+    async def get_status(self, request):
+        self.status_requests.append(request)
+        return self.status
+
+    async def decide_post_roll(self, request: PostRollDecisionRequest):
+        self.post_roll_requests.append(request)
+        self.status = _status("resolved")
+        return self.status.execution
+
+
+class _Orchestrator:
+    def __init__(self, run: SimpleNamespace) -> None:
+        self.run = run
+        self.resume_calls = []
+
+    async def get_run(self, room_id: str, parent_action_id: str):
+        assert room_id == self.run.room_id
+        assert parent_action_id == self.run.parent_action_id
+        return self.run
+
+    async def resume_owned(self, **kwargs):
+        self.resume_calls.append(kwargs)
+        return SimpleNamespace(run=self.run)
+
+
+def _application(run: SimpleNamespace, engine: _Engine, orchestrator: _Orchestrator):
+    application = object.__new__(ActionPlanTurnApplication)
+    application._adjudication_engine = engine
+    application._orchestrator = orchestrator
+    application._resolve_actor_id = AsyncMock(return_value=run.actor_id)
+    application._finish_plan_with_phases = AsyncMock(return_value="recovered")
+    return application
+
+
+@pytest.mark.asyncio
+async def test_resume_owned_recovers_intent_after_crash_before_engine_write() -> None:
+    run = _run(cancel_id="cancel-original")
+    engine = _Engine(_status("awaiting_post_roll_decision"))
+    orchestrator = _Orchestrator(run)
+    application = _application(run, engine, orchestrator)
+
+    result = await application.resume_owned(
+        room_id=run.room_id,
+        player_id=run.player_id,
+        parent_action_id=run.parent_action_id,
+    )
+
+    assert result == "recovered"
+    assert len(engine.post_roll_requests) == 1
+    request = engine.post_roll_requests[0]
+    assert request.request_id == "cancel-original:accept-current"
+    assert request.source_revision == "revision-7"
+    assert request.check_id == "check-281"
+    assert len(orchestrator.resume_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_retry_reconciles_resolved_engine_after_crash_before_plan_write() -> None:
+    run = _run(cancel_id="cancel-original")
+    engine = _Engine(_status("resolved"))
+    orchestrator = _Orchestrator(run)
+    application = _application(run, engine, orchestrator)
+
+    result = await application.cancel_remaining(
+        room_id=run.room_id,
+        player_id=run.player_id,
+        parent_action_id=run.parent_action_id,
+        request_id="cancel-retry-with-new-id",
+    )
+
+    assert result == "recovered"
+    assert engine.post_roll_requests == []
+    assert len(orchestrator.resume_calls) == 1
+    assert orchestrator.resume_calls[0]["parent_action_id"] == run.parent_action_id


### PR DESCRIPTION
## 背景

这是 issue #281 的补充 PR，承接 PR #276 中 fennoai 指出的 post-roll 取消问题。

PR #276 已经合并时，分支 head 停在 `cf8414a`；本 PR 将之后完成但未进入主分支的 post-roll 取消修复，从最新 `main` 单独补入。

## 问题

ActionPlan 当前步骤已经完成权威掷骰并进入 `awaiting_post_roll_decision` 后，玩家发送 `action.plan.cancel` 会因为取消入口只处理 `awaiting_skill_choice` 而落到 `PLAN_CANCEL_NOT_AT_BOUNDARY`。

由于 post-roll 选项没有取消项，玩家无法表达“接受当前结果，但取消剩余计划”，计划和检定会一直挂起。

## 修复

- ActionPlanRun 持久化 post-roll 取消意图，旧 JSON 缺少字段时默认兼容。
- 取消入口读取 Engine 最新状态，避免使用落后的 PlanRun 快照。
- 先持久化取消意图，再用稳定的派生 request ID 提交 `accept-current`。
- 当前骰点和成功/失败结果保留，不回滚已提交事件或效果。
- 当前步骤结算后停止剩余步骤；失败结果不会被取消规避。
- 重复取消、重复 `accept-current` 和恢复流程保持幂等。
- 技能选择阶段原有的直接取消语义不变。
- 不新增数据库表、列或迁移。

## 验收

- 成功骰点后取消：当前步骤完成，后续步骤停止。
- 失败骰点后取消：失败结果保留，PlanRun 停止，不执行后续步骤。
- 同一个取消请求重复提交只产生一次状态变化。
- 同一个 `accept-current` 请求重放不重新掷骰、不重复应用效果或事件。
- 取消意图持久化后恢复，能够继续结算同一结果并停止后续计划。
- 最后一步取消不回滚当前结果，并正常进入叙事收尾。

## 验证

- framework：`331 passed, 3 skipped`
- backend：`355 passed, 8 skipped`
- backend `ruff check)：通过
- backend `ty check)：通过

关联 issue：#281
关联 PR：#276