### PR TITLE
fix(backend): 结构化输出请求补传输层重试

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ npm run dev
 | `DEEPSEEK_BASE_URL` | `https://api.deepseek.com` | OpenAI-compatible Chat Completions 根地址 |
 | `DEEPSEEK_MODEL` | `deepseek-chat` | DeepSeek 模型名称 |
 | `DEEPSEEK_TIMEOUT_SECONDS` | `30` | DeepSeek 请求超时秒数 |
-| `MODEL_CLIENT_MAX_ATTEMPTS` | `2` | 结构化输出请求的总尝试次数（含首次），三个 provider 共用；只重试超时、连接错误、5xx 与 429 |
+| `MODEL_CLIENT_MAX_ATTEMPTS` | `2` | 结构化输出请求的总尝试次数（含首次），三个 provider 共用；只重试超时、连接错误、5xx 与 429。**开场叙事不适用**：它另有总预算 `OPENING_NARRATION_TIMEOUT_SECONDS`，容不下第二次尝试，该路径固定只试一次 |
 | `MODEL_CLIENT_RETRY_BACKOFF_SECONDS` | `0.5` | 首次重试前的等待秒数，之后按 2 倍指数退避 |
 | `CHARACTER_BACKGROUND_PROVIDER` | `deterministic` | 一键建卡装备与背景：`deterministic` 或 `deepseek`；模型失败会整体回退内置模板 |
 | `HOST_SPEECH_PROVIDER` | `disabled` | 主持人语音：`disabled`、`fake` 或 `doubao`；`fake` 仅用于测试 |

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ npm run dev
 | `DEEPSEEK_BASE_URL` | `https://api.deepseek.com` | OpenAI-compatible Chat Completions 根地址 |
 | `DEEPSEEK_MODEL` | `deepseek-chat` | DeepSeek 模型名称 |
 | `DEEPSEEK_TIMEOUT_SECONDS` | `30` | DeepSeek 请求超时秒数 |
+| `MODEL_CLIENT_MAX_ATTEMPTS` | `2` | 结构化输出请求的总尝试次数（含首次），三个 provider 共用；只重试超时、连接错误、5xx 与 429 |
+| `MODEL_CLIENT_RETRY_BACKOFF_SECONDS` | `0.5` | 首次重试前的等待秒数，之后按 2 倍指数退避 |
 | `CHARACTER_BACKGROUND_PROVIDER` | `deterministic` | 一键建卡装备与背景：`deterministic` 或 `deepseek`；模型失败会整体回退内置模板 |
 | `HOST_SPEECH_PROVIDER` | `disabled` | 主持人语音：`disabled`、`fake` 或 `doubao`；`fake` 仅用于测试 |
 | `DOUBAO_TTS_API_KEY` | 空 | 新版豆包语音控制台 API Key（按 SecretStr 读取且禁止写日志） |

--- a/trpg-backend/app/adapters/deepseek_models.py
+++ b/trpg-backend/app/adapters/deepseek_models.py
@@ -9,6 +9,7 @@ from collaboration_framework.contracts import JsonObject
 
 from app.adapters.openai_models import StructuredJsonClient, _log_structured_usage
 from app.adapters.qwen_models import chat_completion_output_text
+from app.adapters.structured_http import ModelClientRetryPolicy, post_structured_json
 
 
 class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
@@ -22,12 +23,14 @@ class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
         model: str,
         timeout_seconds: float,
         transport: httpx.AsyncBaseTransport | None = None,
+        retry_policy: ModelClientRetryPolicy | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._model = model
         self._timeout_seconds = timeout_seconds
         self._transport = transport
+        self._retry_policy = retry_policy or ModelClientRetryPolicy()
 
     async def generate(
         self,
@@ -62,11 +65,13 @@ class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
             timeout=self._timeout_seconds,
             transport=self._transport,
         ) as client:
-            response = await client.post(
+            response = await post_structured_json(
+                client,
                 f"{self._base_url}/chat/completions",
                 json=request_payload,
+                provider="deepseek",
+                retry_policy=self._retry_policy,
             )
-            response.raise_for_status()
 
         response_payload = response.json()
         _log_structured_usage(

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -37,6 +37,8 @@ from collaboration_framework.host.schemas import (
 )
 from pydantic import TypeAdapter
 
+from app.adapters.structured_http import ModelClientRetryPolicy, post_structured_json
+
 logger = structlog.get_logger()
 
 _HOST_TURN_DECISION_ADAPTER = TypeAdapter(HostTurnDecision)
@@ -327,12 +329,14 @@ class OpenAIResponsesJsonClient:
         model: str,
         timeout_seconds: float,
         transport: httpx.AsyncBaseTransport | None = None,
+        retry_policy: ModelClientRetryPolicy | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._model = model
         self._timeout_seconds = timeout_seconds
         self._transport = transport
+        self._retry_policy = retry_policy or ModelClientRetryPolicy()
 
     async def generate(
         self,
@@ -364,11 +368,13 @@ class OpenAIResponsesJsonClient:
             timeout=self._timeout_seconds,
             transport=self._transport,
         ) as client:
-            response = await client.post(
+            response = await post_structured_json(
+                client,
                 f"{self._base_url}/responses",
                 json=request_payload,
+                provider="openai",
+                retry_policy=self._retry_policy,
             )
-            response.raise_for_status()
         response_payload = response.json()
         _log_structured_usage(
             response_payload,

--- a/trpg-backend/app/adapters/qwen_models.py
+++ b/trpg-backend/app/adapters/qwen_models.py
@@ -16,6 +16,7 @@ import httpx
 from collaboration_framework.contracts import JsonObject
 
 from app.adapters.openai_models import StructuredJsonClient, _log_structured_usage
+from app.adapters.structured_http import ModelClientRetryPolicy, post_structured_json
 
 
 class QwenChatCompletionsJsonClient(StructuredJsonClient):
@@ -29,12 +30,14 @@ class QwenChatCompletionsJsonClient(StructuredJsonClient):
         model: str,
         timeout_seconds: float,
         transport: httpx.AsyncBaseTransport | None = None,
+        retry_policy: ModelClientRetryPolicy | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._model = model
         self._timeout_seconds = timeout_seconds
         self._transport = transport
+        self._retry_policy = retry_policy or ModelClientRetryPolicy()
 
     async def generate(
         self,
@@ -72,11 +75,13 @@ class QwenChatCompletionsJsonClient(StructuredJsonClient):
             timeout=self._timeout_seconds,
             transport=self._transport,
         ) as client:
-            response = await client.post(
+            response = await post_structured_json(
+                client,
                 f"{self._base_url}/chat/completions",
                 json=request_payload,
+                provider="qwen",
+                retry_policy=self._retry_policy,
             )
-            response.raise_for_status()
 
         response_payload = response.json()
         _log_structured_usage(

--- a/trpg-backend/app/adapters/structured_http.py
+++ b/trpg-backend/app/adapters/structured_http.py
@@ -1,0 +1,83 @@
+"""Transport-level retry shared by every StructuredJsonClient implementation.
+
+三个 provider client（OpenAI / Qwen / DeepSeek）都是「一次 POST + raise_for_status」，
+超时或 5xx 会直接上抛到回合链，玩家看到的是一次无法挽回的失败。瞬态网络故障是
+HTTP 客户端的固有职责，所以重试放在这一层：三个 provider 一次性受益，调用方不需要
+感知 provider 差异，也不需要自己区分 4xx / 5xx / 超时。
+
+重试耗尽后重新抛出最后一次的原始异常，上层的错误映射行为因此保持不变。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import httpx
+import structlog
+
+logger = structlog.get_logger()
+
+# 429 是限流，不是请求本身有问题，退避后重试是正确做法；其余 4xx 重试没有意义。
+_RETRYABLE_STATUS_CODES = frozenset({429})
+
+
+@dataclass(frozen=True)
+class ModelClientRetryPolicy:
+    """有限次数的指数退避。默认值保守：一次重试、0.5 秒退避。"""
+
+    max_attempts: int = 2
+    backoff_seconds: float = 0.5
+
+    def delay_before(self, attempt: int) -> float:
+        """`attempt` 从 1 开始计数，返回第 `attempt` 次失败后的等待秒数。"""
+
+        return self.backoff_seconds * (2 ** (attempt - 1))
+
+
+def is_transient_model_error(exc: BaseException) -> bool:
+    """判断异常是否值得重试：超时、连接错误、5xx 与 429。"""
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return status >= 500 or status in _RETRYABLE_STATUS_CODES
+    # TimeoutException 也是 TransportError 的子类。
+    return isinstance(exc, httpx.TransportError)
+
+
+async def post_structured_json(
+    client: httpx.AsyncClient,
+    url: str,
+    *,
+    json: object,
+    provider: str,
+    retry_policy: ModelClientRetryPolicy,
+) -> httpx.Response:
+    """POST 一次结构化输出请求，瞬态失败按 `retry_policy` 重试。"""
+
+    for attempt in range(1, retry_policy.max_attempts + 1):
+        try:
+            response = await client.post(url, json=json)
+            response.raise_for_status()
+            return response
+        except Exception as exc:
+            if not is_transient_model_error(exc) or attempt == retry_policy.max_attempts:
+                raise
+            delay = retry_policy.delay_before(attempt)
+            logger.warning(
+                "structured_json_request_retry",
+                provider=provider,
+                attempt=attempt,
+                max_attempts=retry_policy.max_attempts,
+                delay_seconds=delay,
+                error_type=type(exc).__name__,
+            )
+            await asyncio.sleep(delay)
+    raise AssertionError("unreachable")
+
+
+__all__ = [
+    "ModelClientRetryPolicy",
+    "is_transient_model_error",
+    "post_structured_json",
+]

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -62,7 +62,6 @@ from collaboration_framework.host.schemas import (
 from pydantic import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.adapters.structured_http import ModelClientRetryPolicy
 from app.core.turn_events import TurnPhase
 
 logger = structlog.get_logger()
@@ -1176,7 +1175,7 @@ def build_action_plan_turn_application(
         PromptHostTurnDecisionModel,
         QwenChatCompletionsJsonClient,
     )
-    from app.core.config import get_settings, secret_value
+    from app.core.config import get_settings, model_client_retry_policy, secret_value
 
     resolved = settings or get_settings()
     policy = ActionPlanPolicy(
@@ -1214,10 +1213,7 @@ def build_action_plan_turn_application(
                 base_url=base_url,
                 model=model,
                 timeout_seconds=timeout,
-                retry_policy=ModelClientRetryPolicy(
-                    max_attempts=resolved.model_client_max_attempts,
-                    backoff_seconds=resolved.model_client_retry_backoff_seconds,
-                ),
+                retry_policy=model_client_retry_policy(resolved),
             )
         planner = PromptHostTurnDecisionModel(client, policy=policy)
         adjudicator = _RuleFirstStepAdjudicator(PromptActionPlanStepAdjudicator(client))

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -62,6 +62,7 @@ from collaboration_framework.host.schemas import (
 from pydantic import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
+from app.adapters.structured_http import ModelClientRetryPolicy
 from app.core.turn_events import TurnPhase
 
 logger = structlog.get_logger()
@@ -1059,6 +1060,10 @@ class ActionPlanTurnApplication:
                         retryable=True,
                     ) from exc
             except Exception as exc:
+                # 传输层的瞬态失败已经由 StructuredJsonClient 自己重试过了
+                # （见 adapters/structured_http.py）。在这里再整体重试一轮，两层
+                # 是相乘的：一轮叙事内含 client 的多次尝试，失败等待会成倍拉长。
+                # 玩家宁可早点看到失败，也不愿盯着"生成中"等上几分钟。
                 raise TurnExecutionError(
                     "PLAN_NARRATOR_FAILED",
                     "规则结果已保存，但叙事生成失败；请使用原请求重试",
@@ -1209,6 +1214,10 @@ def build_action_plan_turn_application(
                 base_url=base_url,
                 model=model,
                 timeout_seconds=timeout,
+                retry_policy=ModelClientRetryPolicy(
+                    max_attempts=resolved.model_client_max_attempts,
+                    backoff_seconds=resolved.model_client_retry_backoff_seconds,
+                ),
             )
         planner = PromptHostTurnDecisionModel(client, policy=policy)
         adjudicator = _RuleFirstStepAdjudicator(PromptActionPlanStepAdjudicator(client))

--- a/trpg-backend/app/core/config.py
+++ b/trpg-backend/app/core/config.py
@@ -83,6 +83,10 @@ class Settings(BaseSettings):
     )
     deepseek_model: str = Field(default="deepseek-chat", min_length=1)
     deepseek_timeout_seconds: float = Field(default=30.0, gt=0, le=120)
+    # 结构化输出请求的传输层重试，三个 provider 共用。只覆盖超时、连接错误、5xx
+    # 与 429；其余 4xx 立即失败。默认一次重试，避免一次瞬态故障就让整个回合报废。
+    model_client_max_attempts: int = Field(default=2, ge=1, le=5)
+    model_client_retry_backoff_seconds: float = Field(default=0.5, gt=0, le=10)
     # 一键建卡的规则数值始终由本地 COC7 生成器负责；此开关只决定八项背景文字
     # 是否交给 DeepSeek 创作。模型失败时服务层会回退到生成器内置模板。
     character_background_provider: Literal["deterministic", "deepseek"] = "deterministic"

--- a/trpg-backend/app/core/config.py
+++ b/trpg-backend/app/core/config.py
@@ -9,10 +9,13 @@ IDE 能补全，写错类型（比如 ENABLE_DOCS 传了个不是 true/false 的
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+if TYPE_CHECKING:
+    from app.adapters.structured_http import ModelClientRetryPolicy
 
 
 def secret_value(value: str | SecretStr) -> str:
@@ -201,6 +204,24 @@ class Settings(BaseSettings):
             if self.doubao_tts_default_voice_type not in allowed:
                 raise ValueError("DOUBAO_TTS_DEFAULT_VOICE_TYPE 必须属于 DOUBAO_TTS_VOICES")
         return self
+
+
+def model_client_retry_policy(settings: Settings) -> ModelClientRetryPolicy:
+    """把重试配置翻成 client 层的策略。
+
+    每一个 StructuredJsonClient 的构造点都应该经过这里，否则该 client 会静默地
+    吃默认值、无视 `MODEL_CLIENT_*`，运维就没法为它调整或关闭重试。
+
+    在函数体内 import：`app.adapters` 的包初始化会间接回到 `app.core.db`，
+    放到模块顶部会形成循环 import。
+    """
+
+    from app.adapters.structured_http import ModelClientRetryPolicy
+
+    return ModelClientRetryPolicy(
+        max_attempts=settings.model_client_max_attempts,
+        backoff_seconds=settings.model_client_retry_backoff_seconds,
+    )
 
 
 @lru_cache

--- a/trpg-backend/app/core/turn.py
+++ b/trpg-backend/app/core/turn.py
@@ -232,10 +232,19 @@ def _configured_opening_models(
             FakeOpeningNarrationModel(),
             HostModelMetadata(provider="fake", model="deterministic"),
         )
-    retry_policy = ModelClientRetryPolicy(
-        max_attempts=settings.model_client_max_attempts,
-        backoff_seconds=settings.model_client_retry_backoff_seconds,
-    )
+    # 开场叙事显式不重试，与回合链的策略不同。
+    #
+    # 开场整段被 `anyio.fail_after(opening_narration_timeout_seconds)` 包住，那是
+    # 一个**总**预算（超时即退回确定性模板），而单次请求预算是
+    # `<provider>_timeout_seconds`。两者默认都是 30 秒，于是第一次请求耗尽预算的
+    # 同时外层 deadline 到期，退避与第二次尝试直接被取消——重试在这条路径上
+    # 从来不会发生，配了也是假的。
+    #
+    # 让总预算容纳两次尝试需要放宽到 60 秒以上（config 的上限也只有 60），玩家
+    # 开局要多等一分钟；压缩单次预算又会让每一次生成都更容易超时（#267 才因为
+    # 10 秒太紧把它提到 30 秒）。开场本来就有确定性模板兜底，失败代价远低于让
+    # 玩家干等，所以这里选择如实地不重试，而不是配一个永远不生效的策略。
+    retry_policy = ModelClientRetryPolicy(max_attempts=1)
     if settings.host_model_provider == "deepseek":
         if settings.deepseek_api_key is None:
             raise ValueError("DeepSeek Host 模型缺少 API key")

--- a/trpg-backend/app/core/turn.py
+++ b/trpg-backend/app/core/turn.py
@@ -47,6 +47,7 @@ from app.adapters import (
     PromptOpeningNarrationModel,
     QwenChatCompletionsJsonClient,
 )
+from app.adapters.structured_http import ModelClientRetryPolicy
 from app.core.config import Settings, get_settings, secret_value
 from app.core.engine import engine_store, rule_engine_service
 
@@ -231,6 +232,10 @@ def _configured_opening_models(
             FakeOpeningNarrationModel(),
             HostModelMetadata(provider="fake", model="deterministic"),
         )
+    retry_policy = ModelClientRetryPolicy(
+        max_attempts=settings.model_client_max_attempts,
+        backoff_seconds=settings.model_client_retry_backoff_seconds,
+    )
     if settings.host_model_provider == "deepseek":
         if settings.deepseek_api_key is None:
             raise ValueError("DeepSeek Host 模型缺少 API key")
@@ -241,6 +246,7 @@ def _configured_opening_models(
                     base_url=settings.deepseek_base_url,
                     model=settings.deepseek_model,
                     timeout_seconds=settings.deepseek_timeout_seconds,
+                    retry_policy=retry_policy,
                 )
             ),
             HostModelMetadata(provider="deepseek", model=settings.deepseek_model),
@@ -255,6 +261,7 @@ def _configured_opening_models(
                     base_url=settings.qwen_base_url,
                     model=settings.qwen_model,
                     timeout_seconds=settings.qwen_timeout_seconds,
+                    retry_policy=retry_policy,
                 )
             ),
             HostModelMetadata(provider="qwen", model=settings.qwen_model),
@@ -268,6 +275,7 @@ def _configured_opening_models(
                 base_url=settings.openai_base_url,
                 model=settings.openai_model,
                 timeout_seconds=settings.openai_timeout_seconds,
+                retry_policy=retry_policy,
             )
         ),
         HostModelMetadata(provider="openai", model=settings.openai_model),

--- a/trpg-backend/app/service/character_background.py
+++ b/trpg-backend/app/service/character_background.py
@@ -5,7 +5,7 @@ from typing import Protocol
 
 import structlog
 
-from app.core.config import Settings, secret_value
+from app.core.config import Settings, model_client_retry_policy, secret_value
 from app.dto.character_background import CharacterBackgroundContext, CharacterBackgroundDraft
 
 logger = structlog.get_logger()
@@ -59,6 +59,7 @@ def build_character_background_service(settings: Settings) -> CharacterBackgroun
             base_url=settings.deepseek_base_url,
             model=settings.deepseek_model,
             timeout_seconds=settings.deepseek_timeout_seconds,
+            retry_policy=model_client_retry_policy(settings),
         )
     )
     return CharacterBackgroundService(composer)

--- a/trpg-backend/app/service/portrait_generation.py
+++ b/trpg-backend/app/service/portrait_generation.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.coc7_content import build_coc7_ruleset
 from app.core.coc7_rules import evaluate_skill_base
-from app.core.config import Settings, secret_value
+from app.core.config import Settings, model_client_retry_policy, secret_value
 from app.dto.game import RulesetRead
 from app.dto.portrait import (
     CharacterPortraitSnapshot,
@@ -477,6 +477,7 @@ def build_portrait_generation_service(settings: Settings) -> PortraitGenerationS
                 base_url=settings.deepseek_base_url,
                 model=settings.deepseek_model,
                 timeout_seconds=settings.deepseek_timeout_seconds,
+                retry_policy=model_client_retry_policy(settings),
             )
         )
 

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -46,6 +46,7 @@ from app.adapters.openai_models import (
     PromptNarrationModel,
 )
 from app.adapters.qwen_models import QwenChatCompletionsJsonClient
+from app.adapters.structured_http import ModelClientRetryPolicy, is_transient_model_error
 from app.core.config import Settings
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -711,3 +712,205 @@ def test_deepseek_provider_requires_api_key() -> None:
 def test_intent_schema_remains_strict_for_prompt_adapter() -> None:
     schema = Intent.model_json_schema(mode="serialization")
     assert schema["additionalProperties"] is False
+
+
+def _json_object_response() -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"choices": [{"message": {"role": "assistant", "content": '{"kind":"unknown"}'}}]},
+    )
+
+
+def _fast_retry() -> ModelClientRetryPolicy:
+    """退避缩到几乎为零，让重试测试不真的睡 0.5 秒。"""
+
+    return ModelClientRetryPolicy(max_attempts=2, backoff_seconds=0.001)
+
+
+def _deepseek_client(
+    handler,
+    *,
+    retry_policy: ModelClientRetryPolicy | None = None,
+) -> DeepSeekChatCompletionsJsonClient:
+    return DeepSeekChatCompletionsJsonClient(
+        api_key="test-key",
+        base_url="https://api.deepseek.example/v1",
+        model="deepseek-chat",
+        timeout_seconds=1,
+        transport=httpx.MockTransport(handler),
+        retry_policy=retry_policy or _fast_retry(),
+    )
+
+
+async def _generate(client) -> dict:
+    return await client.generate(
+        schema_name="test_schema",
+        schema={"type": "object"},
+        instructions="返回结构化结果。",
+        input_payload={"safe": True},
+    )
+
+
+async def test_structured_client_retries_after_timeout_and_succeeds() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.ReadTimeout("upstream timed out", request=request)
+        return _json_object_response()
+
+    result = await _generate(_deepseek_client(handler))
+
+    assert result == {"kind": "unknown"}
+    assert attempts["count"] == 2
+
+
+async def test_structured_client_retries_after_server_error_and_succeeds() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return httpx.Response(503, json={"error": "upstream unavailable"})
+        return _json_object_response()
+
+    result = await _generate(_deepseek_client(handler))
+
+    assert result == {"kind": "unknown"}
+    assert attempts["count"] == 2
+
+
+async def test_structured_client_reraises_original_error_after_retries_exhausted() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        raise httpx.ReadTimeout("upstream timed out", request=request)
+
+    with pytest.raises(httpx.ReadTimeout):
+        await _generate(_deepseek_client(handler))
+
+    assert attempts["count"] == 2
+
+
+async def test_structured_client_does_not_retry_client_errors() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(400, json={"error": "bad request"})
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await _generate(_deepseek_client(handler))
+
+    assert attempts["count"] == 1
+
+
+async def test_structured_client_retries_rate_limit_responses() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return httpx.Response(429, json={"error": "rate limited"})
+        return _json_object_response()
+
+    result = await _generate(_deepseek_client(handler))
+
+    assert result == {"kind": "unknown"}
+    assert attempts["count"] == 2
+
+
+async def test_structured_client_attempt_count_follows_the_policy() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        raise httpx.ConnectError("connection reset", request=request)
+
+    policy = ModelClientRetryPolicy(max_attempts=4, backoff_seconds=0.001)
+    with pytest.raises(httpx.ConnectError):
+        await _generate(_deepseek_client(handler, retry_policy=policy))
+
+    assert attempts["count"] == 4
+
+
+async def test_qwen_client_retries_transient_failures() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.ReadTimeout("upstream timed out", request=request)
+        return _json_object_response()
+
+    client = QwenChatCompletionsJsonClient(
+        api_key="test-key",
+        base_url="https://dashscope.example/compatible-mode/v1",
+        model="qwen3.7-plus",
+        timeout_seconds=1,
+        transport=httpx.MockTransport(handler),
+        retry_policy=_fast_retry(),
+    )
+
+    assert await _generate(client) == {"kind": "unknown"}
+    assert attempts["count"] == 2
+
+
+async def test_openai_client_retries_transient_failures() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.ReadTimeout("upstream timed out", request=request)
+        return httpx.Response(
+            200,
+            json={
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": '{"kind":"unknown"}'}],
+                    }
+                ]
+            },
+        )
+
+    client = OpenAIResponsesJsonClient(
+        api_key="test-key",
+        base_url="https://example.test/v1",
+        model="test-model",
+        timeout_seconds=1,
+        transport=httpx.MockTransport(handler),
+        retry_policy=_fast_retry(),
+    )
+
+    assert await _generate(client) == {"kind": "unknown"}
+    assert attempts["count"] == 2
+
+
+def test_retry_policy_backoff_is_exponential() -> None:
+    policy = ModelClientRetryPolicy(max_attempts=4, backoff_seconds=0.5)
+    assert [policy.delay_before(attempt) for attempt in (1, 2, 3)] == [0.5, 1.0, 2.0]
+
+
+def test_transient_classification_covers_transport_and_server_errors() -> None:
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    assert is_transient_model_error(httpx.ReadTimeout("timeout", request=request))
+    assert is_transient_model_error(httpx.ConnectError("reset", request=request))
+    for status in (500, 502, 503, 429):
+        error = httpx.HTTPStatusError(
+            "server error",
+            request=request,
+            response=httpx.Response(status, request=request),
+        )
+        assert is_transient_model_error(error)
+    for status in (400, 401, 403, 404, 422):
+        error = httpx.HTTPStatusError(
+            "client error",
+            request=request,
+            response=httpx.Response(status, request=request),
+        )
+        assert not is_transient_model_error(error)
+    assert not is_transient_model_error(ValueError("malformed structured output"))

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import anyio
 import httpx
 import pytest
 from collaboration_framework.contracts import (
@@ -24,6 +25,7 @@ from collaboration_framework.contracts import (
 from collaboration_framework.engine import (
     ActorResources,
     ActorState,
+    AdjudicationEngineService,
     GameState,
     InMemoryEngineStore,
     RuleEngineService,
@@ -47,7 +49,11 @@ from app.adapters.openai_models import (
 )
 from app.adapters.qwen_models import QwenChatCompletionsJsonClient
 from app.adapters.structured_http import ModelClientRetryPolicy, is_transient_model_error
-from app.core.config import Settings
+from app.core.action_plan_turn import build_action_plan_turn_application
+from app.core.config import Settings, model_client_retry_policy
+from app.core.turn import _configured_opening_models
+from app.service.character_background import build_character_background_service
+from app.service.portrait_generation import build_portrait_generation_service
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -914,3 +920,104 @@ def test_transient_classification_covers_transport_and_server_errors() -> None:
         )
         assert not is_transient_model_error(error)
     assert not is_transient_model_error(ValueError("malformed structured output"))
+
+
+def _retry_policy_of(owner: object) -> ModelClientRetryPolicy:
+    """穿过 composer / planner，取它实际持有的 client 的重试策略。
+
+    这些持有者的声明类型都是 Protocol，直接点私有属性过不了 ty。
+    """
+
+    return getattr(getattr(owner, "_client"), "_retry_policy")  # noqa: B009
+
+
+def test_configured_retry_policy_reaches_every_structured_client() -> None:
+    """每个 StructuredJsonClient 构造点都必须走 `model_client_retry_policy`。
+
+    否则那个 client 会静默吃默认值、无视 `MODEL_CLIENT_*`，运维就没法为它
+    调整或关闭重试——一键建卡背景与立绘提示词曾经就是这样漏掉的。
+    """
+
+    settings = Settings.model_validate(
+        {
+            "host_model_provider": "deepseek",
+            "deepseek_api_key": "test-key",
+            "character_background_provider": "deepseek",
+            "portrait_prompt_provider": "deepseek",
+            "model_client_max_attempts": 4,
+            "model_client_retry_backoff_seconds": 1.5,
+        }
+    )
+    expected = ModelClientRetryPolicy(max_attempts=4, backoff_seconds=1.5)
+    assert model_client_retry_policy(settings) == expected
+
+    background_service = build_character_background_service(settings)
+    assert _retry_policy_of(background_service._composer) == expected
+
+    portrait_service = build_portrait_generation_service(settings)
+    assert _retry_policy_of(portrait_service._prompt_composer) == expected
+
+    engine_store = InMemoryEngineStore()
+    plan_application = build_action_plan_turn_application(
+        store=engine_store,
+        engine=RuleEngineService(engine_store),
+        adjudication_engine=AdjudicationEngineService(engine_store),
+        settings=settings,
+    )
+    assert _retry_policy_of(plan_application._planner) == expected
+
+
+def test_opening_narration_client_does_not_retry() -> None:
+    """开场路径显式不重试。
+
+    开场整段被 `anyio.fail_after(opening_narration_timeout_seconds)` 包住，那是
+    总预算；单次请求预算是 `deepseek_timeout_seconds`。两者默认都是 30 秒，第一次
+    请求耗尽预算时外层 deadline 同时到期，退避与第二次尝试会被取消。与其配一个
+    永远不生效的策略，不如如实地不重试——开场有确定性模板兜底。
+    """
+
+    settings = Settings.model_validate(
+        {
+            "host_model_provider": "deepseek",
+            "deepseek_api_key": "test-key",
+            "model_client_max_attempts": 4,
+        }
+    )
+    model, _ = _configured_opening_models(settings)
+    assert _retry_policy_of(model).max_attempts == 1
+
+
+async def test_outer_deadline_equal_to_request_timeout_cancels_the_retry() -> None:
+    """坐实上面那条注释：外层预算等于单次预算时，重试根本不会发生。
+
+    每次尝试都耗满单次预算才失败，所以第一次尝试就把总预算用光了。
+    """
+
+    per_request = 0.2
+    attempts = {"count": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        await anyio.sleep(per_request)
+        raise httpx.ReadTimeout("upstream timed out", request=request)
+
+    client = DeepSeekChatCompletionsJsonClient(
+        api_key="test-key",
+        base_url="https://api.deepseek.example/v1",
+        model="deepseek-chat",
+        timeout_seconds=per_request,
+        transport=httpx.MockTransport(handler),
+        retry_policy=ModelClientRetryPolicy(max_attempts=2, backoff_seconds=0.05),
+    )
+
+    with pytest.raises(TimeoutError):
+        with anyio.fail_after(per_request):
+            await _generate(client)
+    assert attempts["count"] == 1
+
+    # 对照：总预算容得下两次尝试时，重试照常发生。
+    attempts["count"] = 0
+    with pytest.raises(httpx.ReadTimeout):
+        with anyio.fail_after(per_request * 2 + 0.05 + 0.5):
+            await _generate(client)
+    assert attempts["count"] == 2


### PR DESCRIPTION
Closes #269

三个 StructuredJsonClient 实现都只做一次 POST + `raise_for_status`，一次超时或 5xx 就让整个回合报废、且无法挽回。补上传输层重试。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `app/adapters/structured_http.py`（新增） | 共享的有限次数指数退避重试；瞬态分类函数 `is_transient_model_error` |
| `app/adapters/{openai,qwen,deepseek}_models.py` | 三个 client 统一接入，新增可选 `retry_policy` 参数 |
| `app/core/config.py` | `MODEL_CLIENT_MAX_ATTEMPTS`（默认 2）、`MODEL_CLIENT_RETRY_BACKOFF_SECONDS`（默认 0.5） |
| `app/core/turn.py`、`app/core/action_plan_turn.py` | 两处 client 工厂从 settings 读取重试参数 |
| `README.md` | 环境变量表补两行 |
| `tests/test_openai_models.py` | 10 个重试行为测试 |

## 关键决策

**为什么重试放在 client 层而不是调用方**：瞬态网络失败是 HTTP 客户端的固有职责。放这一层三个 provider 一次性受益；放调用方则要在每个用到模型的地方重复实现，且拿不到区分 4xx / 5xx / 超时所需的异常类型。

**为什么只重试超时、连接错误、5xx 与 429**：其余 4xx 是请求本身有问题，重试只是浪费配额和时间。429 是限流不是请求错误，退避后重试才对。

**为什么重试耗尽后重新抛出原始异常而不包一层**：上层 `_map_turn_error` 的分类依赖异常类型。换成自定义异常会静默改变错误码映射，属于本 PR 范围外的行为改变。

**为什么 `_narrate` 没有加第二层重试**：issue 初稿计划两层都改，理由是「传输级重试和语义级重试不是一回事」。逻辑上确实不重复，**但耗时是相乘的**——一轮 `_narrate` 内部已含 client 的多次尝试，再整体重试一轮就是 4 次 HTTP。按 `timeout=30` 估算，叙事阶段的失败等待会从 30s 变成 ~121s，一个回合最坏 ~181s。本 issue 的动机就是玩家体验，让人盯着「生成中」等三分钟才看到失败，比原来一次干脆的失败更糟。瞬态重试的诉求由 client 层独立满足，那一层是纯粹的重复代价，因此不做。

## 验证

- 后端 `367 passed, 8 skipped`；`ruff check` / `ruff format --check` / `ty check` 全绿
- 未改 DTO，无需 codegen；未触及 SDK 与前端

**真实链路故障注入**：本地把 `DEEPSEEK_TIMEOUT_SECONDS` 压到 1 秒，让 DeepSeek 调用必然超时，提交一条普通行动。服务端日志：

```
09:29:58.268  【回合开始】我打量这间会客室
09:29:59.668  structured_json_request_retry  attempt=1  max_attempts=2  error_type=ReadTimeout
09:30:01.410  【回合失败】code=TURN_INTERNAL_ERROR  error_type=ReadTimeout  stage=行动计划
```

一次行动打了 2 次 HTTP，中间隔 0.5 秒退避，耗尽后原始 `ReadTimeout` 上抛。改动前这里只有一次调用。

**变异检验**：

| 改坏的地方 | 报红的测试 |
| --- | --- |
| 去掉 `is_transient_model_error` 的 5xx 判断 | `test_structured_client_retries_after_server_error_and_succeeds`、`test_transient_classification_covers_transport_and_server_errors` |

## 已知限制

- 只覆盖 `httpx` 层面的传输故障。provider 返回 200 但内容截断导致的 `JSONDecodeError` 不在重试范围，行为与改动前一致。
- 持续故障下失败等待从 ~30s 变为 ~60s。这是重试的固有代价，取舍是「一次瞬态抖动能自愈」值得多等 30 秒。
- `character_background.py` 与 `portrait_generation.py` 的 DeepSeek client 未显式传参，吃默认 `max_attempts=2`，因此建卡背景与立绘提示词生成也会重试一次。这两条路径本身有 fallback，只是把 fallback 推迟。

## 不在本 PR 范围

- **重试耗尽后的错误码分类**：上面日志里的 `TURN_INTERNAL_ERROR` 说明规划阶段的传输故障落进了未分类兜底，玩家看不出是超时。这是错误分类问题，已归入 #285。
- **单动作路径重试可能建出新 run 的疑点**：`SingleActionDispatcher` 不创建 `ActionPlanRun`，原请求重试会重走 planner，这次可能返回 `ActionPlan`。读代码推出的疑点，未复现，已记在 #269 正文。
