### PR TITLE
fix: 体格 Build 与伤害加值分列，补全 205 以上档位

### DIFF
--- a/trpg-backend/app/core/coc7_rules.py
+++ b/trpg-backend/app/core/coc7_rules.py
@@ -23,6 +23,7 @@ issue #112：此前本模块直接 import `app/core/coc7_content.py` 的模块�
 "complete 时校验"两条腿走路、结果不一致的情况。
 """
 
+import math
 import re
 from dataclasses import dataclass, field
 
@@ -88,20 +89,33 @@ class ComputeResult:
     validation: list[ValidationIssue] = field(default_factory=list)
 
 
-def _damage_bonus_and_build(str_: int, siz: int) -> str:
-    """伤害加值 DB 和体格 Build 是同一张表查出来的同一个值（COC7 规则）。"""
+# COC7「伤害加值与体格」表：DB 与 Build 是同一张表的**两列**，不是同一个值。
+# 前三档两者恰好相同，从 125 起分叉——DB 是骰子表达式，Build 是整数。
+# 每项为 (STR+SIZ 上界, DB, Build)。
+_DAMAGE_BONUS_BUILD_TABLE: tuple[tuple[int, str, int], ...] = (
+    (64, "-2", -2),
+    (84, "-1", -1),
+    (124, "0", 0),
+    (164, "+1D4", 1),
+    (204, "+1D6", 2),
+    (284, "+2D6", 3),
+    (364, "+3D6", 4),
+    (444, "+4D6", 5),
+    (524, "+5D6", 6),
+)
+
+
+def _damage_bonus_and_build(str_: int, siz: int) -> tuple[str, int]:
+    """按 STR+SIZ 查 COC7 表，返回 (伤害加值, 体格)。"""
     total = str_ + siz
-    if total <= 64:
-        return "-2"
-    if total <= 84:
-        return "-1"
-    if total <= 124:
-        return "0"
-    if total <= 164:
-        return "+1D4"
-    if total <= 204:
-        return "+1D6"
-    return "+1D8"
+    for upper_bound, damage_bonus, build in _DAMAGE_BONUS_BUILD_TABLE:
+        if total <= upper_bound:
+            return damage_bonus, build
+    # 表格印到 524 为止，之后按规则书递推：「每额外 80 点或其零头，再加 1D6
+    # 与 1 点 Build」。「或其零头」意味着不满 80 也算一档，所以向上取整。
+    # 这一段只有怪物级数值够得着，调查员两项属性都拉满也到不了。
+    steps = math.ceil((total - 524) / 80)
+    return f"+{5 + steps}D6", 6 + steps
 
 
 def compute_derived_stats(attributes: dict[str, int]) -> dict[str, int | str]:
@@ -113,7 +127,7 @@ def compute_derived_stats(attributes: dict[str, int]) -> dict[str, int | str]:
     dex = attributes.get("DEX", 0)
     siz = attributes.get("SIZ", 0)
 
-    db_build = _damage_bonus_and_build(str_, siz)
+    damage_bonus, build = _damage_bonus_and_build(str_, siz)
 
     if str_ < siz and dex < siz:
         move = 7
@@ -126,8 +140,8 @@ def compute_derived_stats(attributes: dict[str, int]) -> dict[str, int | str]:
         "HP": (siz + con) // 10,
         "MP": pow_ // 5,
         "SAN": pow_,
-        "DB": db_build,
-        "Build": db_build,
+        "DB": damage_bonus,
+        "Build": build,
         "MOV": move,
     }
 

--- a/trpg-backend/tests/test_coc7_rules.py
+++ b/trpg-backend/tests/test_coc7_rules.py
@@ -17,6 +17,8 @@ issue #112：这个模块的公开入口现在都要求调用方传入 `RulesetR
 COC7 毫无关系的最小 ruleset 证明这一点。
 """
 
+import pytest
+
 from app.core.coc7_content import build_coc7_ruleset
 from app.core.coc7_rules import (
     SkillPointsBudget,
@@ -53,7 +55,7 @@ ACCOUNTANT_NAME = "会计师"
 
 def test_derived_stats_formulas() -> None:
     stats = compute_derived_stats(ATTRS)
-    assert stats == {"HP": 10, "MP": 10, "SAN": 50, "DB": "0", "Build": "0", "MOV": 8}
+    assert stats == {"HP": 10, "MP": 10, "SAN": 50, "DB": "0", "Build": 0, "MOV": 8}
 
 
 def test_derived_stats_move_small_and_large() -> None:
@@ -65,10 +67,51 @@ def test_derived_stats_move_small_and_large() -> None:
     assert large["MOV"] == 9
 
 
-def test_damage_bonus_build_table() -> None:
-    assert compute_derived_stats({**ATTRS, "STR": 10, "SIZ": 10})["DB"] == "-2"
-    assert compute_derived_stats({**ATTRS, "STR": 90, "SIZ": 90})["DB"] == "+1D6"
-    assert compute_derived_stats({**ATTRS, "STR": 150, "SIZ": 150})["DB"] == "+1D8"
+@pytest.mark.parametrize(
+    ("total", "expected_db", "expected_build"),
+    [
+        # 每一档的下界与上界都取到。DB 与 Build 前三档相同、从 125 起分叉，
+        # 这个 bug 当初能在全绿套件下存活，正是因为唯一的断言落在相同的那一档。
+        (2, "-2", -2),
+        (64, "-2", -2),
+        (65, "-1", -1),
+        (84, "-1", -1),
+        (85, "0", 0),
+        (124, "0", 0),
+        (125, "+1D4", 1),
+        (164, "+1D4", 1),
+        (165, "+1D6", 2),
+        (204, "+1D6", 2),
+        (205, "+2D6", 3),
+        (284, "+2D6", 3),
+        (285, "+3D6", 4),
+        (364, "+3D6", 4),
+        (365, "+4D6", 5),
+        (444, "+4D6", 5),
+        (445, "+5D6", 6),
+        (524, "+5D6", 6),
+        # 印表止于 524，之后每额外 80 点或其零头再加 1D6 与 1 点 Build。
+        (525, "+6D6", 7),
+        (604, "+6D6", 7),
+        (605, "+7D6", 8),
+    ],
+)
+def test_damage_bonus_and_build_table(total: int, expected_db: str, expected_build: int) -> None:
+    """DB 与 Build 是 COC7 同一张表的两列，不是同一个值。"""
+
+    stats = compute_derived_stats({**ATTRS, "STR": total - total // 2, "SIZ": total // 2})
+    assert stats["DB"] == expected_db
+    assert stats["Build"] == expected_build
+
+
+def test_damage_bonus_never_returns_a_die_absent_from_the_table() -> None:
+    """`+1D8` 在 COC7 的表里不存在，曾被当作 205 以上的封顶值。"""
+
+    produced = {
+        compute_derived_stats({**ATTRS, "STR": total - total // 2, "SIZ": total // 2})["DB"]
+        for total in range(2, 1000)
+    }
+    assert "+1D8" not in produced
 
 
 def test_evaluate_skill_base_handles_fixed_formula_and_divisor() -> None:

--- a/trpg-frontend/src/data/derived-stats.test.ts
+++ b/trpg-frontend/src/data/derived-stats.test.ts
@@ -8,16 +8,30 @@ describe('derived stats display', () => {
       SAN: 55,
       MP: 11,
       DB: '+1D4',
-      Build: '+1D4',
+      Build: 1,
       MOV: 8,
     })).toEqual({
       hp: 12,
       san: 55,
       mp: 11,
       db: '+1D4',
-      build: '+1D4',
+      build: 1,
       move: 8,
     })
+  })
+
+  it('reads integer build values stored as strings', () => {
+    // 修复前后端把体格也存成字符串；前三档的值本身是对的，照常读出来。
+    expect(normalizeDerivedStats({ Build: '0' }).build).toBe(0)
+    expect(normalizeDerivedStats({ Build: '-2' }).build).toBe(-2)
+  })
+
+  it('leaves build empty when the stored value is a damage-bonus expression', () => {
+    // 修复前体格与伤害加值共用一个值，已建的角色卡里存着骰子表达式。
+    // 兜底成 0 会让玩家看到一个看似正常的错误体格，所以显式留空。
+    expect(normalizeDerivedStats({ Build: '+1D4' }).build).toBeNull()
+    expect(normalizeDerivedStats({ Build: '+1D8' }).build).toBeNull()
+    expect(normalizeDerivedStats(undefined).build).toBeNull()
   })
 
   it('defines six Chinese-first labels in display order', () => {

--- a/trpg-frontend/src/data/derived-stats.ts
+++ b/trpg-frontend/src/data/derived-stats.ts
@@ -24,27 +24,30 @@ export const DERIVED_STAT_DEFINITIONS: ReadonlyArray<{
   { key: 'move', label: '移动力', abbreviation: 'MOV', color: '#c08050' },
 ]
 
+/**
+ * 体格在修复前与伤害加值共用同一个值，所以已经建好的角色卡（以及
+ * localStorage 里的缓存）可能存着 `+1D4` 这样的骰子表达式。解析不出整数就
+ * 留空——0 是合法体格值，兜底成它只会让玩家看到一个看似正常的错误数字。
+ */
+export function coerceBuild(value: unknown): number | null {
+  if (typeof value === 'number') return value
+  if (typeof value === 'string' && /^[+-]?\d+$/.test(value.trim())) {
+    return Number(value)
+  }
+  return null
+}
+
 export function normalizeDerivedStats(
   derived: Record<string, number | string> | undefined,
 ): DerivedStatsView {
   const numberValue = (value: unknown) => (typeof value === 'number' ? value : 0)
   const stringValue = (value: unknown) => (value == null ? '0' : String(value))
-  // 体格在修复前与伤害加值共用同一个值，所以已经建好的角色卡里可能存着
-  // `+1D4` 这样的骰子表达式。解析不出整数就留空——0 是合法体格值，兜底成
-  // 它只会让玩家看到一个看似正常的错误数字。
-  const buildValue = (value: unknown) => {
-    if (typeof value === 'number') return value
-    if (typeof value === 'string' && /^[+-]?\d+$/.test(value.trim())) {
-      return Number(value)
-    }
-    return null
-  }
   return {
     hp: numberValue(derived?.HP),
     san: numberValue(derived?.SAN),
     mp: numberValue(derived?.MP),
     db: stringValue(derived?.DB),
-    build: buildValue(derived?.Build),
+    build: coerceBuild(derived?.Build),
     move: numberValue(derived?.MOV),
   }
 }

--- a/trpg-frontend/src/data/derived-stats.ts
+++ b/trpg-frontend/src/data/derived-stats.ts
@@ -3,7 +3,8 @@ export interface DerivedStatsView {
   san: number
   mp: number
   db: string
-  build?: string
+  /** 体格是整数；`null` 表示这份角色卡存的值无法解读，由渲染层显示占位符。 */
+  build: number | null
   move: number
 }
 
@@ -28,12 +29,22 @@ export function normalizeDerivedStats(
 ): DerivedStatsView {
   const numberValue = (value: unknown) => (typeof value === 'number' ? value : 0)
   const stringValue = (value: unknown) => (value == null ? '0' : String(value))
+  // 体格在修复前与伤害加值共用同一个值，所以已经建好的角色卡里可能存着
+  // `+1D4` 这样的骰子表达式。解析不出整数就留空——0 是合法体格值，兜底成
+  // 它只会让玩家看到一个看似正常的错误数字。
+  const buildValue = (value: unknown) => {
+    if (typeof value === 'number') return value
+    if (typeof value === 'string' && /^[+-]?\d+$/.test(value.trim())) {
+      return Number(value)
+    }
+    return null
+  }
   return {
     hp: numberValue(derived?.HP),
     san: numberValue(derived?.SAN),
     mp: numberValue(derived?.MP),
     db: stringValue(derived?.DB),
-    build: stringValue(derived?.Build),
+    build: buildValue(derived?.Build),
     move: numberValue(derived?.MOV),
   }
 }

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -656,7 +656,7 @@ describe('CharacterPage', () => {
         equipment: '',
         background: '没有分类前缀的旧背景',
         notes: '',
-        derived: { hp: 0, san: 0, mp: 0, db: '0', move: 0 },
+        derived: { hp: 0, san: 0, mp: 0, db: '0', build: 0, move: 0 },
       },
       'room-1'
     )

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -1010,7 +1010,7 @@ describe('RoomPage conversation history', () => {
         equipment: '',
         background,
         notes: '',
-        derived: { hp: 10, san: 60, mp: 10, db: '0', build: '0', move: 8 },
+        derived: { hp: 10, san: 60, mp: 10, db: '0', build: 0, move: 8 },
       },
       'room-1',
     )
@@ -1308,7 +1308,7 @@ describe('RoomPage conversation history', () => {
         equipment: '',
         background: '',
         notes: '',
-        derived: { hp: 10, san: 60, mp: 10, db: '0', build: '0', move: 8 },
+        derived: { hp: 10, san: 60, mp: 10, db: '0', build: 0, move: 8 },
       },
       'room-1',
     )

--- a/trpg-frontend/src/stores/character-store.test.ts
+++ b/trpg-frontend/src/stores/character-store.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { CHARACTER_STORE_VERSION, migrateCharacterState } from './character-store'
+
+const legacyState = (build: unknown) => ({
+  roomId: 'room-1',
+  character: {
+    info: {},
+    attr: {},
+    skillAlloc: {},
+    skillFinalValues: {},
+    equipment: '',
+    background: '',
+    notes: '',
+    derived: { hp: 12, san: 55, mp: 11, db: '+1D4', build, move: 8 },
+  },
+})
+
+describe('character store migration', () => {
+  it('clears a build that was stored as a damage-bonus expression', () => {
+    // #284 之前体格与伤害加值共用一个值，localStorage 里存着骰子表达式。
+    const migrated = migrateCharacterState(legacyState('+1D4'), 0) as ReturnType<
+      typeof legacyState
+    >
+    expect(migrated.character.derived.build).toBeNull()
+  })
+
+  it('keeps integer builds that were stored as strings', () => {
+    const migrated = migrateCharacterState(legacyState('-2'), 0) as ReturnType<typeof legacyState>
+    expect(migrated.character.derived.build).toBe(-2)
+  })
+
+  it('leaves already-migrated state untouched', () => {
+    const current = legacyState(3)
+    expect(migrateCharacterState(current, CHARACTER_STORE_VERSION)).toBe(current)
+  })
+
+  it('tolerates an empty store', () => {
+    expect(migrateCharacterState({ roomId: null, character: null }, 0)).toEqual({
+      roomId: null,
+      character: null,
+    })
+  })
+})

--- a/trpg-frontend/src/stores/character-store.ts
+++ b/trpg-frontend/src/stores/character-store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import type { Attributes, InvestigatorInfo } from '@/data/character-model'
-import type { DerivedStatsView } from '@/data/derived-stats'
+import { coerceBuild, type DerivedStatsView } from '@/data/derived-stats'
 
 export interface CompletedCharacter {
   info: InvestigatorInfo
@@ -42,6 +42,28 @@ interface CharacterState {
 // 房间时，会展示上一个房间的角色卡；换账号登录也会继承上一个用户的数据
 // （见 PR #67 review）。现在额外存一个 roomId，读取时用 getForRoom 核对，
 // 房间对不上就当作没建过卡，而不是直接把 character 暴露出去。
+export const CHARACTER_STORE_VERSION = 1
+
+/**
+ * v1（issue #284）：体格从「与伤害加值共用的字符串」收敛为整数。已经写进
+ * localStorage 的角色卡里存着 `+1D4` 这类骰子表达式，不迁移的话类型声明与
+ * 运行时不符，玩家也会继续看到那个错误的体格。
+ */
+export function migrateCharacterState(persisted: unknown, version: number): unknown {
+  const state = persisted as CharacterState | null
+  if (version >= 1 || !state?.character) return state
+  return {
+    ...state,
+    character: {
+      ...state.character,
+      derived: {
+        ...state.character.derived,
+        build: coerceBuild(state.character.derived?.build),
+      },
+    },
+  }
+}
+
 export const useCharacterStore = create<CharacterState>()(
   persist(
     (set, get) => ({
@@ -51,6 +73,14 @@ export const useCharacterStore = create<CharacterState>()(
       getForRoom: (roomId) => (get().roomId === roomId ? get().character : null),
       clear: () => set({ character: null, roomId: null }),
     }),
-    { name: 'aidm-character', storage: createJSONStorage(() => localStorage) }
+    {
+      name: 'aidm-character',
+      storage: createJSONStorage(() => localStorage),
+      // v1（issue #284）：体格从「与伤害加值共用的字符串」收敛为整数。已经
+      // 写进 localStorage 的角色卡里存着 `+1D4` 这类骰子表达式，不迁移的话
+      // 类型声明与运行时不符，玩家也会继续看到那个错误的体格。
+      version: CHARACTER_STORE_VERSION,
+      migrate: migrateCharacterState,
+    }
   )
 )


### PR DESCRIPTION
Closes #284

COC7 的「伤害加值与体格」是同一张表的**两列**，不是同一个值。原实现用一个函数返回一个值同时充当两者，于是 STR+SIZ ≥ 125 的 Build 全部错成 `+1D4` 这类骰子表达式。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `app/core/coc7_rules.py` | `_damage_bonus_and_build` 改为查表返回 `(DB, Build)` 二元组；表数据提为常量，补全 205 以上四档与 524 以上的递推 |
| `src/data/derived-stats.ts` | `DerivedStatsView.build` 由 `string` 收敛为 `number \| null`；解析逻辑提为导出的 `coerceBuild` |
| `src/stores/character-store.ts` | persist 加 `version: 1` 与迁移，规整 localStorage 里的旧值 |
| `tests/test_coc7_rules.py` | 21 个档位边界用例 + 一条「不得产出表外骰型」的断言 |
| `src/data/derived-stats.test.ts`、`src/stores/character-store.test.ts` | 覆盖三种输入与迁移的四种情形 |

## 关键决策

**为什么顺带改了 DB 而不只是 Build**：原实现 205 以上封顶返回 `+1D8`，而这个值在 COC7 的表里根本不存在。它和 Build 是同一个函数的同一个返回值，修 Build 必然要动这张表——留着一个已知错误的 DB 反而更奇怪。正确档位为 205–284 `+2D6`、285–364 `+3D6`、365–444 `+4D6`、445–524 `+5D6`，524 以上每 80 点递推。

**规则数值怎么确认的**：没凭记忆写。两个独立来源交叉验证（[Roll20 Compendium](https://roll20.net/compendium/coc/Step%20Two%20(Generate%20Characteristics))、[Cthulhu House Rules](https://jdmold.github.io/cthulhu/character-generation/)），各有一处转录笔误，比对可定。其中一个来源举例说 STR+SIZ 605 得 `+6D6`，但按它自己引的规则文字（605−524=81，已越过一个 80 点区间）应为 `+7D6`——实现按规则文字，取舍写在代码注释里。这段只有怪物级数值够得着，调查员两项拉满也到不了。

**为什么 `build` 是 `number | null` 而不是 `number`**：已建的角色卡里存着 `+1D4`。强转数字会得到 `0`，而 **0 是合法体格值**——玩家会看到一个看似正常的错误数字。解析不出就留空，渲染层现成的 `?? '—'` 显示占位符。旧数据里前三档（`'0'`/`'-1'`/`'-2'`）本来就对，照常解析保留。

**为什么要加 localStorage 迁移**：`character-store` 持久化的就是 `DerivedStatsView`。只改类型不迁移的话，TypeScript 不做运行时校验，老用户本地那份仍是字符串——类型声明撒谎，而且修复对已建过卡的人完全不生效。

**为什么现在修，尽管 Build 目前只用于展示**：它是战斗对抗（擒抱、推挤）的输入，一旦实现战斗就会直接进判定。在还没有消费方的时候修比之后便宜。

## 验证

- 后端 `391 passed, 8 skipped`；`ruff check` / `ruff format --check` / `ty check` 全绿
- 前端 `170 passed`；`lint` / `build` 全绿
- 未动 DTO，无需 codegen

issue 里的复现案例：`STR=65, SIZ=70`（总和 135）→ `{'DB': '+1D4', 'Build': 1}`，修复前 `Build` 是 `'+1D4'`。

**变异检验**：

| 改坏的地方 | 报红的测试 |
| --- | --- |
| 205–284 档改回 `+1D8` | 3 个用例，含 `test_damage_bonus_never_returns_a_die_absent_from_the_table` |
| `Build` 改回等于 `DB` | 22 个用例 |
| 前端解析失败兜底成 `0` | `leaves build empty when the stored value is a damage-bonus expression` |
| migrate 直接返回原状态 | `character-store.test.ts` 4 个用例里 2 个 |

旧的 `test_damage_bonus_build_table` 断言 `STR=150, SIZ=150 → +1D8`（总和 300，正确值 `+3D6`）——它锁着错误行为，已替换。这个 bug 能在 355 个测试全绿的情况下存活，正是因为唯一断言 Build 的用例落在 DB 与 Build 恰好相同的那一档。

## 已知限制

- **数据库里已建角色的 `derived_stats` 不会被回填**。角色卡展示走前端 `normalizeDerivedStats`，旧值会显示为 `—` 而不是错误数字；重新建卡即为正确值。写一次性回填脚本的收益不足以抵消风险——Build 目前没有任何规则消费方。
- 不含使用 Build 的战斗规则（擒抱、推挤对抗），那属于战斗系统。

## 不在本 PR 范围

- 不改 HP / MP / SAN / MOV 的计算。
- 年龄修正、信用评级等其他建卡期规则缺口不在此处理。
