### PR TITLE
fix(backend): 规划阶段模型故障单独分类，未分类兜底留下堆栈

### DIFF
--- a/trpg-backend/app/adapters/deepseek_models.py
+++ b/trpg-backend/app/adapters/deepseek_models.py
@@ -9,7 +9,11 @@ from collaboration_framework.contracts import JsonObject
 
 from app.adapters.openai_models import StructuredJsonClient, _log_structured_usage
 from app.adapters.qwen_models import chat_completion_output_text
-from app.adapters.structured_http import ModelClientRetryPolicy, post_structured_json
+from app.adapters.structured_http import (
+    ModelClientRetryPolicy,
+    decode_structured_json,
+    post_structured_json,
+)
 
 
 class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
@@ -84,10 +88,7 @@ class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
             response_payload,
             provider_name="DeepSeek",
         )
-        parsed = json.loads(output_text)
-        if not isinstance(parsed, dict):
-            raise ValueError("DeepSeek structured output must be a JSON object")
-        return parsed
+        return decode_structured_json(output_text, provider_name="DeepSeek")
 
 
 __all__ = ["DeepSeekChatCompletionsJsonClient"]

--- a/trpg-backend/app/adapters/deepseek_models.py
+++ b/trpg-backend/app/adapters/deepseek_models.py
@@ -13,6 +13,7 @@ from app.adapters.structured_http import (
     ModelClientRetryPolicy,
     decode_structured_json,
     post_structured_json,
+    read_structured_payload,
 )
 
 
@@ -77,7 +78,7 @@ class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
                 retry_policy=self._retry_policy,
             )
 
-        response_payload = response.json()
+        response_payload = read_structured_payload(response, provider_name="DeepSeek")
         _log_structured_usage(
             response_payload,
             provider="deepseek",

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -42,6 +42,7 @@ from app.adapters.structured_http import (
     StructuredOutputError,
     decode_structured_json,
     post_structured_json,
+    read_structured_payload,
 )
 
 logger = structlog.get_logger()
@@ -380,7 +381,7 @@ class OpenAIResponsesJsonClient:
                 provider="openai",
                 retry_policy=self._retry_policy,
             )
-        response_payload = response.json()
+        response_payload = read_structured_payload(response, provider_name="OpenAI")
         _log_structured_usage(
             response_payload,
             provider="openai",

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -37,7 +37,12 @@ from collaboration_framework.host.schemas import (
 )
 from pydantic import TypeAdapter
 
-from app.adapters.structured_http import ModelClientRetryPolicy, post_structured_json
+from app.adapters.structured_http import (
+    ModelClientRetryPolicy,
+    StructuredOutputError,
+    decode_structured_json,
+    post_structured_json,
+)
 
 logger = structlog.get_logger()
 
@@ -383,10 +388,7 @@ class OpenAIResponsesJsonClient:
             schema_name=schema_name,
         )
         output_text = _response_output_text(response_payload)
-        parsed = json.loads(output_text)
-        if not isinstance(parsed, dict):
-            raise ValueError("Structured model output must be a JSON object")
-        return parsed
+        return decode_structured_json(output_text, provider_name="OpenAI")
 
 
 class PromptIntentModel:
@@ -519,13 +521,13 @@ def _log_structured_usage(
 
 def _response_output_text(payload: object) -> str:
     if not isinstance(payload, dict):
-        raise ValueError("Responses API payload must be an object")
+        raise StructuredOutputError("Responses API payload must be an object")
     direct = payload.get("output_text")
     if isinstance(direct, str) and direct:
         return direct
     output = payload.get("output")
     if not isinstance(output, list):
-        raise ValueError("Responses API payload has no output list")
+        raise StructuredOutputError("Responses API payload has no output list")
     for item in output:
         if not isinstance(item, dict) or item.get("type") != "message":
             continue
@@ -540,4 +542,4 @@ def _response_output_text(payload: object) -> str:
                 and isinstance(text, str)
             ):
                 return text
-    raise ValueError("Responses API payload has no structured output text")
+    raise StructuredOutputError("Responses API payload has no structured output text")

--- a/trpg-backend/app/adapters/qwen_models.py
+++ b/trpg-backend/app/adapters/qwen_models.py
@@ -21,6 +21,7 @@ from app.adapters.structured_http import (
     StructuredOutputError,
     decode_structured_json,
     post_structured_json,
+    read_structured_payload,
 )
 
 
@@ -88,7 +89,7 @@ class QwenChatCompletionsJsonClient(StructuredJsonClient):
                 retry_policy=self._retry_policy,
             )
 
-        response_payload = response.json()
+        response_payload = read_structured_payload(response, provider_name="Qwen")
         _log_structured_usage(
             response_payload,
             provider="qwen",

--- a/trpg-backend/app/adapters/qwen_models.py
+++ b/trpg-backend/app/adapters/qwen_models.py
@@ -16,7 +16,12 @@ import httpx
 from collaboration_framework.contracts import JsonObject
 
 from app.adapters.openai_models import StructuredJsonClient, _log_structured_usage
-from app.adapters.structured_http import ModelClientRetryPolicy, post_structured_json
+from app.adapters.structured_http import (
+    ModelClientRetryPolicy,
+    StructuredOutputError,
+    decode_structured_json,
+    post_structured_json,
+)
 
 
 class QwenChatCompletionsJsonClient(StructuredJsonClient):
@@ -94,27 +99,24 @@ class QwenChatCompletionsJsonClient(StructuredJsonClient):
             response_payload,
             provider_name="Qwen",
         )
-        parsed = json.loads(output_text)
-        if not isinstance(parsed, dict):
-            raise ValueError("Qwen structured output must be a JSON object")
-        return parsed
+        return decode_structured_json(output_text, provider_name="Qwen")
 
 
 def chat_completion_output_text(payload: object, *, provider_name: str) -> str:
     if not isinstance(payload, dict):
-        raise ValueError(f"{provider_name} Chat Completions payload must be an object")
+        raise StructuredOutputError(f"{provider_name} Chat Completions payload must be an object")
     choices = payload.get("choices")
     if not isinstance(choices, list) or not choices:
-        raise ValueError(f"{provider_name} Chat Completions payload has no choices")
+        raise StructuredOutputError(f"{provider_name} Chat Completions payload has no choices")
     first = choices[0]
     if not isinstance(first, dict):
-        raise ValueError(f"{provider_name} Chat Completions choice must be an object")
+        raise StructuredOutputError(f"{provider_name} Chat Completions choice must be an object")
     message = first.get("message")
     if not isinstance(message, dict):
-        raise ValueError(f"{provider_name} Chat Completions choice has no message")
+        raise StructuredOutputError(f"{provider_name} Chat Completions choice has no message")
     content = message.get("content")
     if not isinstance(content, str) or not content.strip():
-        raise ValueError(f"{provider_name} Chat Completions message has no text content")
+        raise StructuredOutputError(f"{provider_name} Chat Completions message has no text content")
     return content
 
 

--- a/trpg-backend/app/adapters/structured_http.py
+++ b/trpg-backend/app/adapters/structured_http.py
@@ -89,6 +89,20 @@ async def post_structured_json(
     raise AssertionError("unreachable")
 
 
+def read_structured_payload(response: httpx.Response, *, provider_name: str) -> object:
+    """把 HTTP 响应体读成 JSON，失败一律抛 `StructuredOutputError`。
+
+    解码是两层的：先 HTTP 响应体 → JSON，再模型正文 → JSON 对象。只包住第二层
+    是不够的——代理或网关返回 200 加一张 HTML 错误页时，坏在第一层，同样属于
+    「拿到了回复但读不懂」，不该掉进未分类兜底。
+    """
+
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise StructuredOutputError(f"{provider_name} response body is not valid JSON") from exc
+
+
 def decode_structured_json(output_text: str, *, provider_name: str) -> JsonObject:
     """把模型正文解成一个 JSON 对象，失败一律抛 `StructuredOutputError`。"""
 
@@ -107,4 +121,5 @@ __all__ = [
     "decode_structured_json",
     "is_transient_model_error",
     "post_structured_json",
+    "read_structured_payload",
 ]

--- a/trpg-backend/app/adapters/structured_http.py
+++ b/trpg-backend/app/adapters/structured_http.py
@@ -11,15 +11,28 @@ HTTP 客户端的固有职责，所以重试放在这一层：三个 provider �
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
 
 import httpx
 import structlog
+from collaboration_framework.contracts import JsonObject
 
 logger = structlog.get_logger()
 
 # 429 是限流，不是请求本身有问题，退避后重试是正确做法；其余 4xx 重试没有意义。
 _RETRYABLE_STATUS_CODES = frozenset({429})
+
+
+class StructuredOutputError(ValueError):
+    """上游回了 200，但响应体不是一个能用的结构化结果。
+
+    与传输故障（超时 / 连接 / 5xx）分开：那类是「没拿到回复」，这类是「拿到了
+    但读不懂」——响应结构不符、正文不是合法 JSON、或者 JSON 顶层不是对象。
+    两者对玩家的含义不同，错误码也不该混在一起。
+
+    继承 `ValueError` 是为了不改变既有调用方的兜底行为。
+    """
 
 
 @dataclass(frozen=True)
@@ -76,8 +89,22 @@ async def post_structured_json(
     raise AssertionError("unreachable")
 
 
+def decode_structured_json(output_text: str, *, provider_name: str) -> JsonObject:
+    """把模型正文解成一个 JSON 对象，失败一律抛 `StructuredOutputError`。"""
+
+    try:
+        parsed = json.loads(output_text)
+    except json.JSONDecodeError as exc:
+        raise StructuredOutputError(f"{provider_name} structured output is not valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise StructuredOutputError(f"{provider_name} structured output must be a JSON object")
+    return parsed
+
+
 __all__ = [
     "ModelClientRetryPolicy",
+    "StructuredOutputError",
+    "decode_structured_json",
     "is_transient_model_error",
     "post_structured_json",
 ]

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -67,6 +67,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.websockets import WebSocketState
 
+from app.adapters.structured_http import StructuredOutputError, is_transient_model_error
 from app.core.action_plan_turn import (
     ActionPlanTurnResult,
     action_plan_turn_application,
@@ -748,6 +749,24 @@ def _map_turn_error(exc: Exception) -> tuple[str, str, bool]:
         return "REVISION_CONFLICT", "房间状态已被其他动作更新，请重试", True
     if isinstance(exc, SQLAlchemyError):
         return "DATABASE_CONFLICT", "动作提交发生数据库并发冲突，请重试", True
+    # 模型调用的普通故障。叙事阶段的同类失败已经在 `_narrate` 里被包装成
+    # TurnExecutionError，所以这两条实际认领的是规划阶段——那里此前什么分类都没有，
+    # 一个 30 秒超时和「引擎内部炸了」共用同一个兜底码（#285）。
+    #
+    # 两句文案都明确「本次动作未生效」：这类失败发生在裁决提交规则引擎之前，
+    # 没有任何权威效果落库，不能让玩家以为动作已经算数、只是缺一段叙事。
+    if is_transient_model_error(exc):
+        return (
+            "MODEL_UPSTREAM_UNAVAILABLE",
+            "主持模型暂时不可用，本次动作未生效，请重试",
+            True,
+        )
+    if isinstance(exc, StructuredOutputError):
+        return (
+            "MODEL_OUTPUT_UNREADABLE",
+            "主持模型返回了无法解读的结果，本次动作未生效，请重试",
+            True,
+        )
 
     message = str(exc)
     if "运行时不存在" in message:
@@ -1212,6 +1231,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 correlation_id=submit_payload.client_action_id,
                                 error_type=type(exc).__name__,
                                 error_reason=_turn_error_reason(exc),
+                                exc=exc,
                             )
                             await _send_turn_failed(
                                 websocket,
@@ -1284,6 +1304,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 correlation_id=choice.client_action_id,
                                 error_type=type(exc).__name__,
                                 error_reason=_turn_error_reason(exc),
+                                exc=exc,
                             )
                             await _send_turn_failed(websocket, choice.client_action_id, exc)
                     elif event_type == "adjudication.post_roll":
@@ -1343,6 +1364,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 correlation_id=choice.client_action_id,
                                 error_type=type(exc).__name__,
                                 error_reason=_turn_error_reason(exc),
+                                exc=exc,
                             )
                             await _send_turn_failed(websocket, choice.client_action_id, exc)
                     elif event_type == "action.plan.cancel":
@@ -1370,6 +1392,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 correlation_id=cancel.client_action_id,
                                 error_type=type(exc).__name__,
                                 error_reason=_turn_error_reason(exc),
+                                exc=exc,
                             )
                             await _send_turn_failed(websocket, cancel.client_action_id, exc)
                     elif event_type == "san.check.roll":

--- a/trpg-backend/app/core/turn_observability.py
+++ b/trpg-backend/app/core/turn_observability.py
@@ -8,12 +8,16 @@
 from __future__ import annotations
 
 import json
+import traceback
 from typing import Any
 
 import structlog
 from collaboration_framework.engine import StateModifiedEvent
 
 logger = structlog.get_logger()
+
+# `_map_turn_error` 的最后兜底：没有任何分类分支命中时用的错误码。
+UNCLASSIFIED_TURN_ERROR_CODE = "TURN_INTERNAL_ERROR"
 
 _DIFFICULTY_LABELS = {
     "regular": "常规",
@@ -159,6 +163,7 @@ def log_turn_failed(
     code: str,
     error_type: str,
     error_reason: str = "",
+    exc: BaseException | None = None,
 ) -> None:
     logger.warning(
         "【回合失败】",
@@ -169,6 +174,22 @@ def log_turn_failed(
         error_type=error_type,
         error_reason=error_reason,
     )
+    if code != UNCLASSIFIED_TURN_ERROR_CODE or exc is None:
+        return
+    # 兜底错误码的含义就是「这个失败我们没预料到」。只记一个异常名根本没法定位：
+    # #285 在预览环境上撞到它时，正因为服务端只留下 `TURN_INTERNAL_ERROR`，
+    # 根因只能靠读代码猜，猜出来的还是错的。
+    #
+    # 堆栈只写服务端日志，绝不进 WebSocket 事件——玩家侧仍然只看到错误码和
+    # 那句安全文案。
+    logger.error(
+        "turn_unclassified_exception",
+        room=_short_ref(room_id),
+        action=correlation_id,
+        stage=stage,
+        error_type=error_type,
+        stack="".join(traceback.format_exception(exc)),
+    )
 
 
 __all__ = [
@@ -178,4 +199,5 @@ __all__ = [
     "log_state_changes",
     "log_turn_completed",
     "log_turn_failed",
+    "UNCLASSIFIED_TURN_ERROR_CODE",
 ]

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -1178,3 +1178,49 @@ def test_classified_failure_does_not_log_a_stack_trace(
     recorder = _log_failure_with("MODEL_UPSTREAM_UNAVAILABLE", monkeypatch)
     assert [call for call in recorder.calls if call[0] == "error"] == []
     assert [call for call in recorder.calls if call[0] == "warning"]
+
+
+async def test_non_json_http_body_is_classified_as_unreadable_output() -> None:
+    """上游 200 但响应体根本不是 JSON（代理的 HTML 错误页是典型）。
+
+    解码分两层：HTTP 响应体 → JSON，再 JSON 里的 content → JSON 对象。
+    只包住第二层的话，第一层失败仍然会掉进 `TURN_INTERNAL_ERROR` 兜底。
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="<html><body>502 Bad Gateway</body></html>")
+
+    with pytest.raises(StructuredOutputError):
+        await _generate(_deepseek_client(handler))
+
+
+async def test_qwen_non_json_http_body_is_classified() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="upstream proxy error")
+
+    client = QwenChatCompletionsJsonClient(
+        api_key="test-key",
+        base_url="https://dashscope.example/compatible-mode/v1",
+        model="qwen3.7-plus",
+        timeout_seconds=1,
+        transport=httpx.MockTransport(handler),
+        retry_policy=_fast_retry(),
+    )
+    with pytest.raises(StructuredOutputError):
+        await _generate(client)
+
+
+async def test_openai_non_json_http_body_is_classified() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="upstream proxy error")
+
+    client = OpenAIResponsesJsonClient(
+        api_key="test-key",
+        base_url="https://example.test/v1",
+        model="test-model",
+        timeout_seconds=1,
+        transport=httpx.MockTransport(handler),
+        retry_policy=_fast_retry(),
+    )
+    with pytest.raises(StructuredOutputError):
+        await _generate(client)

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -48,7 +48,11 @@ from app.adapters.openai_models import (
     PromptNarrationModel,
 )
 from app.adapters.qwen_models import QwenChatCompletionsJsonClient
-from app.adapters.structured_http import ModelClientRetryPolicy, is_transient_model_error
+from app.adapters.structured_http import (
+    ModelClientRetryPolicy,
+    StructuredOutputError,
+    is_transient_model_error,
+)
 from app.core.action_plan_turn import build_action_plan_turn_application
 from app.core.config import Settings, model_client_retry_policy
 from app.core.turn import _configured_opening_models
@@ -1021,3 +1025,156 @@ async def test_outer_deadline_equal_to_request_timeout_cancels_the_retry() -> No
         with anyio.fail_after(per_request * 2 + 0.05 + 0.5):
             await _generate(client)
     assert attempts["count"] == 2
+
+
+def _map(exc: Exception) -> tuple[str, str, bool]:
+    from app.controller.ws import _map_turn_error
+
+    return _map_turn_error(exc)
+
+
+def test_planner_transport_failures_get_their_own_error_code() -> None:
+    """规划阶段的模型故障不能再落进 `TURN_INTERNAL_ERROR` 兜底（#285）。
+
+    兜底的语义是「我们没预料到这个失败」。一个 30 秒超时是完全预料得到的，
+    把它和引擎内部错误混在一起，玩家既不知道能否重试，也让兜底本身失去意义。
+    """
+
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    transport_failures: list[Exception] = [
+        httpx.ReadTimeout("timeout", request=request),
+        httpx.ConnectError("reset", request=request),
+        httpx.HTTPStatusError(
+            "server error",
+            request=request,
+            response=httpx.Response(503, request=request),
+        ),
+        httpx.HTTPStatusError(
+            "rate limited",
+            request=request,
+            response=httpx.Response(429, request=request),
+        ),
+    ]
+    for exc in transport_failures:
+        code, message, retryable = _map(exc)
+        assert code == "MODEL_UPSTREAM_UNAVAILABLE", exc
+        assert retryable is True
+        # 这类失败发生在裁决提交规则引擎之前，没有任何权威效果落库。
+        assert "未生效" in message
+        assert "已保存" not in message
+
+
+def test_unreadable_model_output_gets_its_own_error_code() -> None:
+    """上游回了 200 但正文读不懂，与「没拿到回复」是两回事。"""
+
+    code, message, retryable = _map(StructuredOutputError("not valid JSON"))
+    assert code == "MODEL_OUTPUT_UNREADABLE"
+    assert retryable is True
+    assert "未生效" in message
+    assert "已保存" not in message
+
+
+def test_client_errors_still_fall_through_to_contract_or_fallback() -> None:
+    """4xx 不属于上游不可用，分类不能把它一起认领走。"""
+
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    code, _, _ = _map(
+        httpx.HTTPStatusError(
+            "bad request",
+            request=request,
+            response=httpx.Response(400, request=request),
+        )
+    )
+    assert code == "TURN_INTERNAL_ERROR"
+
+
+async def test_client_raises_structured_output_error_on_unparsable_body() -> None:
+    """上游 200 + 非 JSON 正文：客户端抛可分类的异常，而不是裸 ValueError。"""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"role": "assistant", "content": "抱歉，我不能这样做。"}}]
+            },
+        )
+
+    with pytest.raises(StructuredOutputError):
+        await _generate(_deepseek_client(handler))
+
+
+async def test_client_raises_structured_output_error_when_json_is_not_an_object() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"role": "assistant", "content": "[1, 2, 3]"}}]},
+        )
+
+    with pytest.raises(StructuredOutputError):
+        await _generate(_deepseek_client(handler))
+
+
+class _RecordingLogger:
+    """记下 structlog 调用的事件名与结构化字段。
+
+    堆栈是作为 `stack=` 字段传出去的，不在 caplog 的渲染文本里，直接捕获调用
+    参数才能断言它的内容。
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.calls.append(("warning", event, dict(kwargs)))
+
+    def error(self, event: str, **kwargs: object) -> None:
+        self.calls.append(("error", event, dict(kwargs)))
+
+
+def _log_failure_with(code: str, monkeypatch: pytest.MonkeyPatch) -> _RecordingLogger:
+    from app.core import turn_observability
+
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(turn_observability, "logger", recorder)
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exc:
+        turn_observability.log_turn_failed(
+            room_id="room-1",
+            correlation_id="action-1",
+            stage="行动计划",
+            code=code,
+            error_type=type(exc).__name__,
+            exc=exc,
+        )
+    return recorder
+
+
+def test_unclassified_failure_logs_a_stack_trace_to_the_server_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """兜底必须留下可定位的证据，否则事后只有一个错误码可查（#285）。
+
+    #285 的原始正文正是在拿不到堆栈的情况下靠读代码猜出来的，猜错了机制。
+    """
+
+    recorder = _log_failure_with("TURN_INTERNAL_ERROR", monkeypatch)
+    errors = [call for call in recorder.calls if call[0] == "error"]
+    assert len(errors) == 1
+    _, event, fields = errors[0]
+    assert event == "turn_unclassified_exception"
+    assert "Traceback" in fields["stack"]
+    assert "RuntimeError: boom" in fields["stack"]
+    # 定位号与阶段必须一并记下，否则玩家报来的定位号仍然查不到东西。
+    assert fields["action"] == "action-1"
+    assert fields["stage"] == "行动计划"
+
+
+def test_classified_failure_does_not_log_a_stack_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """已分类的失败是预期内的，不该往日志里灌堆栈。"""
+
+    recorder = _log_failure_with("MODEL_UPSTREAM_UNAVAILABLE", monkeypatch)
+    assert [call for call in recorder.calls if call[0] == "error"] == []
+    assert [call for call in recorder.calls if call[0] == "warning"]


### PR DESCRIPTION
Closes #285

`_map_turn_error` 此前没有认领任何模型调用故障，超时、连接重置、上游 5xx，以及「回了 200 但正文读不懂」，全都落进 `TURN_INTERNAL_ERROR` 兜底，和「引擎内部炸了」共用同一句「本次动作处理失败」。玩家既不知道是网络问题，也不知道该不该重试。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `app/controller/ws.py` | `_map_turn_error` 新增两条分类分支；四处 `log_turn_failed` 传入原始异常 |
| `app/adapters/structured_http.py` | 新增 `StructuredOutputError` 与 `decode_structured_json` |
| `app/adapters/{openai,qwen,deepseek}_models.py` | 解码路径统一走 `decode_structured_json`，响应结构错误改抛 `StructuredOutputError` |
| `app/core/turn_observability.py` | 落入兜底时记录完整堆栈 |
| `tests/test_openai_models.py` | 8 个用例覆盖两个新错误码、4xx 不被误认领、客户端解码异常、堆栈日志的正反面 |

新增错误码：

- **`MODEL_UPSTREAM_UNAVAILABLE`** — 超时 / 连接错误 / 5xx / 429
- **`MODEL_OUTPUT_UNREADABLE`** — 上游 200 但正文非法 JSON 或顶层不是对象

## 关键决策

**为什么这个缺口只暴露在规划阶段**：叙事阶段的同类失败早已被 `_narrate` 包装成 `TurnExecutionError`（`PLAN_NARRATOR_FAILED`），走不到 httpx 分支。规划阶段则完全没有包装，两份独立证据也都落在 Host Planner 上——本地故障注入（`DEEPSEEK_TIMEOUT_SECONDS=1`）与 @LMH168 的真机复现，后者还查了 SQLite 五张表，确认 `action_plan_runs` / `action_executions` / `game_events` 全空、`state_version` 仍为 0。

**为什么文案必须写「本次动作未生效」**：上面那份持久化检查证明这类失败发生在裁决提交规则引擎之前，什么都没落库。沿用「规则结果已保存」会让玩家以为动作已经算数、只差一段叙事——那正是 #285 原本记录的问题之一。

**为什么把「没拿到回复」和「拿到了但读不懂」分成两个错误码**：前者是上游不可用，重试大概率能过；后者是模型输出坏了，重试也许有用但性质不同。混成一个码会让玩家和排障都失去区分能力。`StructuredOutputError` 继承 `ValueError`，所以不改变任何既有调用方的兜底行为。

**为什么堆栈只进服务端日志**：WebSocket 只发玩家安全事件，异常栈是硬性禁止项。玩家侧仍然只看到错误码与安全文案，服务端这一侧才拿到 room / 定位号 / 阶段 / 完整调用链。这条改动本身就是 #285 的一半——原 issue 的成因是在拿不到堆栈的情况下靠读代码猜的，方向对（确实是未分类异常），机制却是错的，白白误导了一轮。

**为什么不顺手清理 `secondaryProgressLabel` 死代码**：它在 `RoomPage.tsx`，而 #283 要重构整个游戏页面。为一段永不执行的代码去撞车不划算，已在 issue 里注明。

## 验证

- 后端 `398 passed, 8 skipped`；`ruff check` / `ruff format --check` / `ty check` 全绿
- 未改 DTO，无需 codegen；未触及 `agent-collaboration-framework`

**变异检验**：

| 改坏的地方 | 报红的测试 |
| --- | --- |
| 移除 `is_transient_model_error` 分类分支 | `test_planner_transport_failures_get_their_own_error_code` |
| 让 `log_turn_failed` 提前 return，不记堆栈 | `test_unclassified_failure_logs_a_stack_trace_to_the_server_log` |

**过程中修正的一个测试错误**：最初用 `caplog.text` 断言堆栈内容，测试红了——structlog 把 `stack` 作为结构化字段传递，不进渲染文本。改成直接捕获 logger 调用参数才断言得到。

## 已知限制

- 分类基于异常类型，不基于阶段。如果将来别处也直接上抛 httpx 异常，会一并被认领为 `MODEL_UPSTREAM_UNAVAILABLE`——就当前代码而言只有规划阶段如此。
- 堆栈只写日志，没有落库。定位号仍然依赖运维能拿到服务端日志；预览环境那种拿不到日志的场景不会因此变好。
- 未验证的一条：`chat_completion_output_text` 抛出的响应结构错误现在归入 `MODEL_OUTPUT_UNREADABLE`，但真实 provider 在什么情况下会返回这种结构，没有实测样本。

## 不在本 PR 范围

- **传输层重试本身**（#287 已完成）。本 PR 只管重试耗尽之后如何表达与排障。
- **`TARGET_UNAVAILABLE` 这类已正确分类的失败**：引擎标了 `repairability="auto_repairable"` 却没有任何组件去修复，属于 #272，另行开 issue。
- **前端自由掷骰用硬编码 65 伪造判定结果**：与错误分类无关，另行开 issue。
- **错误码的全面重构**：只补规划阶段这一个缺口，其余映射不动。
