### PR TITLE
fix(engine): target kind 填错但 id 唯一可辨时确定性归一

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -7,6 +7,7 @@ commits them without interpreting player language.
 
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from typing import Literal, NoReturn
 from uuid import uuid4
@@ -17,6 +18,7 @@ from collaboration_framework.contracts import (
     AcceptResultOption,
     ActionAdjudication,
     ActionEffect,
+    ActionTarget,
     AdvanceWorldTimeEffect,
     AdjudicationRecovery,
     AdjudicationExecution,
@@ -87,6 +89,69 @@ from .rules_v3 import (
     resolve_rule_option,
     walk_rule,
 )
+
+
+logger = logging.getLogger(__name__)
+
+
+def _target_kinds_matching(
+    runtime: EngineRuntimeSnapshot,
+    target_id: str,
+) -> frozenset[str]:
+    """`target_id` 在哪些 kind 的集合里存在。
+
+    `ActionTarget.kind` 决定去哪个集合查 id，这里把五个集合全查一遍，供存在性
+    校验和 kind 归一共用同一份定义。
+    """
+
+    state = runtime.game_state
+    matches = {
+        "information": target_id in runtime.canon_information_ids,
+        "entity": target_id in runtime.canon_entity_ids
+        or target_id in state.runtime_entities
+        or target_id in state.item_instances,
+        "location": target_id in runtime.canon_location_ids
+        or target_id in state.runtime_locations,
+        "actor": target_id in state.actors,
+        "world": target_id == runtime.module_content.world_ref,
+    }
+    return frozenset(kind for kind, hit in matches.items() if hit)
+
+
+def _normalize_target_kind(
+    runtime: EngineRuntimeSnapshot,
+    adjudication: ActionAdjudication,
+) -> ActionAdjudication:
+    """`kind` 填错但 `id` 唯一可辨时改写 `kind`，其余情况原样返回。
+
+    模型经常把 NPC 写成 `kind="actor"`——`state.actors` 只有玩家角色，NPC 一律在
+    entity 侧，于是整个回合以 `TARGET_NOT_FOUND` 失败，玩家原样重发又能过。引擎
+    自己把这条拒绝标成 `auto_repairable` / `fault="agent"`，但答案本来就在引擎
+    手里：`id` 已经唯一确定了对象，错的只是那个分类标签，不必再问模型一次。
+
+    只在**恰好一个**其它 kind 命中时归一。零命中仍然拒绝；多个 kind 同时命中而
+    `kind` 不在其中时也拒绝——跨集合撞名的归一是猜，不能猜。
+
+    归一不放宽可见性边界：能碰到的对象集合与直接写对 `kind` 完全一致。
+    """
+
+    target = adjudication.target
+    matched = _target_kinds_matching(runtime, target.id)
+    if target.kind in matched or len(matched) != 1:
+        return adjudication
+    (resolved,) = matched
+    logger.warning(
+        "adjudication_target_kind_normalized",
+        extra={
+            "target_id": target.id,
+            "declared_kind": target.kind,
+            "resolved_kind": resolved,
+            "request_id": adjudication.request_id,
+        },
+    )
+    return adjudication.model_copy(
+        update={"target": ActionTarget(kind=resolved, id=target.id)}
+    )
 
 
 def _visibility_knowledge(
@@ -487,6 +552,16 @@ class AdjudicationEngineService:
             self._require_revision(
                 request.adjudication.source_revision,
                 runtime.revision,
+            )
+            # 归一必须发生在校验之前，且改写后的 target 要贯穿这次提交的余下
+            # 部分——规则范围匹配、效果校验和持久化用的都是 `request.adjudication`。
+            request = request.model_copy(
+                update={
+                    "adjudication": _normalize_target_kind(
+                        runtime,
+                        request.adjudication,
+                    )
+                }
             )
             self._validate_adjudication(runtime, request.adjudication)
             proposal_validation, proposal_committed_level = (
@@ -1089,20 +1164,9 @@ class AdjudicationEngineService:
         runtime: EngineRuntimeSnapshot,
         adjudication: ActionAdjudication,
     ) -> None:
-        module = runtime.module_content
         state = runtime.game_state
         target = adjudication.target
-        exists = {
-            "information": target.id in runtime.canon_information_ids,
-            "entity": target.id in runtime.canon_entity_ids
-            or target.id in state.runtime_entities
-            or target.id in state.item_instances,
-            "location": target.id in runtime.canon_location_ids
-            or target.id in state.runtime_locations,
-            "actor": target.id in state.actors,
-            "world": target.id == module.world_ref,
-        }[target.kind]
-        if not exists:
+        if target.kind not in _target_kinds_matching(runtime, target.id):
             self._reject_validation(
                 "TARGET_NOT_FOUND",
                 repairability="auto_repairable",

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -143,6 +143,7 @@ def _normalize_target_kind(
     logger.warning(
         "adjudication_target_kind_normalized",
         extra={
+            "room_id": runtime.game_state.room_id,
             "target_id": target.id,
             "declared_kind": target.kind,
             "resolved_kind": resolved,

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -545,6 +545,21 @@ class AdjudicationEngineService:
                 player_id=request.player_id,
                 actor_id=request.adjudication.actor_id,
             )
+            # 归一要贯穿这次提交的余下部分——重放比对、规则范围匹配、效果校验和
+            # 持久化用的都是 `request.adjudication`。
+            #
+            # 尤其**必须**排在重放比对之前：`_replay` 比的是整个 request，而落库的
+            # 是归一后的那份；客户端重试原样重发未归一的报文（响应丢失时正是如此），
+            # 放在比对之后会让每一条被本特性修好的请求反而丢掉幂等，报
+            # REQUEST_ID_REUSED。
+            request = request.model_copy(
+                update={
+                    "adjudication": _normalize_target_kind(
+                        runtime,
+                        request.adjudication,
+                    )
+                }
+            )
             replay = await transaction.find_adjudication_command(
                 request.adjudication.request_id
             )
@@ -553,16 +568,6 @@ class AdjudicationEngineService:
             self._require_revision(
                 request.adjudication.source_revision,
                 runtime.revision,
-            )
-            # 归一必须发生在校验之前，且改写后的 target 要贯穿这次提交的余下
-            # 部分——规则范围匹配、效果校验和持久化用的都是 `request.adjudication`。
-            request = request.model_copy(
-                update={
-                    "adjudication": _normalize_target_kind(
-                        runtime,
-                        request.adjudication,
-                    )
-                }
             )
             self._validate_adjudication(runtime, request.adjudication)
             proposal_validation, proposal_committed_level = (

--- a/agent-collaboration-framework/tests/test_adjudication_engine.py
+++ b/agent-collaboration-framework/tests/test_adjudication_engine.py
@@ -608,6 +608,62 @@ class AdjudicationEngineTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.store.inspect_state("room_01").event_sequence, 0)
         self.assertEqual(self.store.inspect_domain_events("room_01"), ())
 
+    async def test_wrong_target_kind_is_normalized_when_id_is_unambiguous(
+        self,
+    ) -> None:
+        # 模型常把 NPC 写成 kind="actor"：`state.actors` 只有玩家角色，NPC 在
+        # entity 侧。id 唯一可辨，归一后回合应照常完成。
+        mislabeled = adjudication(
+            "mislabeled-target", "0", check=NoAdjudicationCheck()
+        ).model_copy(
+            update={"target": ActionTarget(kind="actor", id="butler")},
+            deep=True,
+        )
+
+        await self.submit(self.service(), mislabeled)
+
+        async with self.store.transaction("room_01") as transaction:
+            completed = await transaction.find_adjudication_command(
+                "mislabeled-target"
+            )
+        assert completed is not None
+        # 归一后的 target 贯穿整次提交：范围匹配、效果校验和持久化拿到的是同一份。
+        persisted = completed.request.adjudication.target
+        self.assertEqual(persisted.kind, "entity")
+        self.assertEqual(persisted.id, "butler")
+
+    async def test_ambiguous_target_id_is_rejected_instead_of_guessed(self) -> None:
+        # butler 同时是 canon entity 和一个 actor id，declared kind 两边都不是：
+        # 跨集合撞名时归一等于猜，必须维持拒绝。
+        state = self.store.inspect_state("room_01")
+        actors = dict(state.actors)
+        actors["butler"] = actors["pc_1"].model_copy(deep=True)
+        self.store.register_room(
+            module_content=self.module,
+            initial_state=state.model_copy(
+                update={"actors": actors, "room_id": "room_ambiguous"},
+                deep=True,
+            ),
+        )
+        ambiguous = adjudication(
+            "ambiguous-target", "0", check=NoAdjudicationCheck()
+        ).model_copy(
+            update={"target": ActionTarget(kind="location", id="butler")},
+            deep=True,
+        )
+
+        with self.assertRaises(AdjudicationValidationError) as error:
+            await self.service().submit(
+                SubmitAdjudicationRequest(
+                    room_id="room_ambiguous",
+                    player_id="player_01",
+                    adjudication=ambiguous,
+                )
+            )
+
+        self.assertEqual(error.exception.result.code, "TARGET_NOT_FOUND")
+        self.assertEqual(self.store.inspect_state("room_ambiguous").event_sequence, 0)
+
     async def test_l4_can_commit_while_l5_direct_ending_is_rejected(self) -> None:
         core_action = ActionAdjudication(
             request_id="core-resolution",

--- a/agent-collaboration-framework/tests/test_adjudication_engine.py
+++ b/agent-collaboration-framework/tests/test_adjudication_engine.py
@@ -620,7 +620,7 @@ class AdjudicationEngineTests(unittest.IsolatedAsyncioTestCase):
             deep=True,
         )
 
-        await self.submit(self.service(), mislabeled)
+        execution = await self.submit(self.service(), mislabeled)
 
         async with self.store.transaction("room_01") as transaction:
             completed = await transaction.find_adjudication_command(
@@ -631,6 +631,19 @@ class AdjudicationEngineTests(unittest.IsolatedAsyncioTestCase):
         persisted = completed.request.adjudication.target
         self.assertEqual(persisted.kind, "entity")
         self.assertEqual(persisted.id, "butler")
+
+        # 客户端重试会原样重发**未归一**的报文（响应丢失时尤其如此）。归一必须
+        # 发生在重放比对之前，否则存下来的是归一后的 request，重试永远比对不上，
+        # 恰好在被本特性修复的每一条请求上打破幂等。
+        replayed = await self.submit(self.service(), mislabeled)
+
+        self.assertEqual(replayed.request_id, execution.request_id)
+        self.assertEqual(replayed.outcome, execution.outcome)
+        self.assertEqual(replayed.event_refs, execution.event_refs)
+        self.assertEqual(
+            self.store.inspect_state("room_01").event_sequence,
+            int(execution.view_revision),
+        )
 
     async def test_ambiguous_target_id_is_rejected_instead_of_guessed(self) -> None:
         # butler 同时是 canon entity 和一个 actor id，declared kind 两边都不是：


### PR DESCRIPTION
Closes #295

模型偶发把 NPC 的 `target.kind` 填成 `actor`，导致整个回合以 `TARGET_NOT_FOUND` 失败；改为在提交前做一次确定性的 kind 归一——`id` 唯一可辨时改写 `kind`，有歧义或查无此物一律维持拒绝。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `engine/adjudication.py` | 抽出 `_target_kinds_matching()`：`target.id` 在五个集合里的命中情况，存在性校验和归一共用同一份定义 |
| `engine/adjudication.py` | 新增 `_normalize_target_kind()`：`kind` 未命中但**恰好一个**其它 kind 命中时改写 `kind`，写一条 `adjudication_target_kind_normalized` 服务端日志 |
| `engine/adjudication.py` | `submit()` 在 `_validate_adjudication` 之前把归一后的 adjudication 写回 `request` |
| `engine/adjudication.py` | `_validate_adjudication()` 的存在性判断改为 `target.kind not in _target_kinds_matching(...)`，拒绝行为与元数据不变 |
| `tests/test_adjudication_engine.py` | 两条新测试：`kind='actor'` + NPC id 归一后回合完成（并断言原样重发未归一报文仍走重放）；跨集合撞名维持拒绝 |

## 关键决策

**为什么不实现 #272 的自动修复循环**：#272 是完整体——修复预算、语义保持校验、四类 repairability 分派、单动作与 ActionPlan 双入口统一策略。而这一类错误根本不需要问模型第二次：`id` 已经唯一确定了对象，错的只是那个分类标签，答案就在引擎手里。做半个 #272 只会和它撞车。本 PR 不碰 #272 的范围。

**为什么这不是「静默回退」**：仓库禁止失败时偷偷降级。归一不是降级——它不引入任何模型重试、预算或超时，纯确定性、零额外 token；有歧义就拒绝，不猜。真正的失败路径（零命中）行为一字未改。

**为什么归一不放宽可见性边界**：存在性检查本来就不看 visibility——`canon_entity_ids` 包含 keeper 可见性的实体，模型直接写对 `kind='entity'` 原本就能通过。归一后能碰到的对象集合与写对 kind 完全一致。可见性把关在效果层（`CANON_SHADOW`、keeper entity 检查），本 PR 没有触碰。

**为什么归一必须发生在重放比对之前并写回 `request`**：`target.kind` 的下游权威用途是 `agent_match_scope_admits()` 的规则范围匹配。若只在校验里放行而不改写，范围匹配拿到的仍是错的 kind。而位置还必须再往前提到 `find_adjudication_command()` 之前——`_replay` 比的是整个 request，落库的却是归一后的那份，客户端重试原样重发未归一的报文（响应丢失后的正常重试正是如此），比对必然不等，会在**每一条被本特性修好的请求**上打破幂等、报 `REQUEST_ID_REUSED`。感谢 review 指出，已复现并修正，新测试断言了这条重试路径。

**为什么多个 kind 同时命中时仍然拒绝**：跨集合撞名时归一等于猜。宁可让玩家重试，也不能让引擎替模型选一个对象。

**为什么不改 prompt**：`_SAFE_ADJUDICATION_INSTRUCTIONS` 和 `action_plan_prompt.py` 已经写明 kind/id 的对应关系。DeepSeek 走 `response_format: json_object`，JSON Schema 只拼进 system prompt 靠模型自觉，没有 API 侧强制，所以这是改 prompt 根治不了的输出噪声。

## 验证

- `agent-collaboration-framework`：268 passed，3 skipped
- `trpg-backend`：`ruff check` / `ruff format --check` / `ty check` 全过；`test_adjudication_persistence` `test_rule_match_adjudication` `test_validation_feedback` `test_engine_runtime` `test_ws` 共 50 passed

变异检验（两条新测试都能抓到改坏的实现）：

- 把归一改成「多个命中时取排序第一个」→ 歧义测试报红 `AdjudicationValidationError not raised`
- 把 `_normalize_target_kind` 改成原样返回 → 归一测试抛 `TARGET_NOT_FOUND`

### 触发这个 PR 的真实故障

2026-08-12 本地真机测试，追书人开局连续抓到两次，都指向同一个 NPC、都是 `kind='actor'`，中间夹着一次成功的同类动作：

- `dc434d0a`「我要接下这个委托」——**开局第一个动作直接失败**
- `b3d888cc`「向托马斯询问线索」，临时调试日志抓到裁决内容：

```
TARGET_NOT_FOUND kind='actor' id='thomas'
summary='你向托马斯·金博尔询问他是否掌握关于失窃藏书或叔叔下落的线索。'
actors=['actor_1']
```

`state.actors` 只有玩家角色 `actor_1`，托马斯在 PlayerView 里是 `visible_entities` 的 `npc`。玩家原样重发同一句话就通过了。

## 已知限制

- CI 没有跑 `agent-collaboration-framework` unittest 的 job（`trpg-backend-ci.yml` 只跑 backend 自己的 ruff / ty / pytest），所以这两条新测试只有本地跑过，CI 拦不住这块的回归。这是既有的覆盖缺口，不在本 PR 范围。
- **归一结果依赖运行时状态，重试路径上有一条理论残留**：若首次提交与重试之间状态发生变化、使同一个 id 从「唯一命中」变成「歧义」或反之，两次归一结论不同，重试仍会落到 `REQUEST_ID_REUSED`。实际碰不到——`state.actors` 在会话中途不增长，canon 集合更是不变；要彻底消掉得让归一完全不依赖状态，那是另一个量级的改动，本 PR 不做。
- 归一只覆盖 kind/id 不配套这一种模型输出噪声。其余四处标着 `auto_repairable` 的拒绝（`SKILL_NOT_AVAILABLE`、`CANON_SHADOW`、`RUNTIME_ITEM_TOO_LARGE`）仍然直接失败，等 #272。

## 不在本 PR 范围

- #272 的 Agent 自动修复循环
- `ActionTarget` 契约（不新增字段，不改 `kind` 字面量集合）
- prompt 与 JSON Schema 下发方式
