### PR TITLE
fix(frontend): 角色卡面板改读 PlayerView 的当前资源

### DIFF
--- a/trpg-frontend/src/features/character/CharacterBasicInfo.test.tsx
+++ b/trpg-frontend/src/features/character/CharacterBasicInfo.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CharacterBasicInfo } from './CharacterBasicInfo'
+import type { CompletedCharacter } from '@/stores/character-store'
+
+const ATTRIBUTES = [
+  { key: 'STR', label: '力量' },
+  { key: 'CON', label: '体质' },
+  { key: 'POW', label: '意志' },
+  { key: 'LUCK', label: '幸运' },
+] as const
+
+function character(): CompletedCharacter {
+  return {
+    info: {
+      name: '杜调查员',
+      playerName: '陈探员',
+      age: '32',
+      gender: '男',
+      residence: '阿卡姆',
+      birthplace: '波士顿',
+      occupationId: 1,
+    },
+    attr: { STR: 60, CON: 55, POW: 65, LUCK: 50 },
+    skillAlloc: {},
+    skillFinalValues: {},
+    equipment: '',
+    background: '',
+    notes: '',
+    derived: { hp: 10, san: 65, mp: 13, db: '0', build: 0, move: 8 },
+  } as CompletedCharacter
+}
+
+describe('CharacterBasicInfo', () => {
+  afterEach(() => cleanup())
+
+  // 幸运在 COC7 里是属性而不是衍生值，但它有状态、能被 `luck.spend` 消耗，
+  // 所以雷达图上那个点必须跟着引擎走。
+  it('renders the live LUCK from the engine and keeps the initial value visible', () => {
+    render(
+      <CharacterBasicInfo
+        character={character()}
+        attributes={ATTRIBUTES}
+        liveResources={{ luck: 37, san: 45 }}
+      />,
+    )
+
+    expect(screen.getByTestId('derived-stat-san')).toHaveTextContent('45')
+    expect(screen.getByTestId('initial-values-note')).toHaveTextContent(
+      '初始：SAN 65 · 幸运 50',
+    )
+  })
+
+  // 建卡完成页在开局前渲染同一个组件，那时没有 PlayerView 可读。
+  it('falls back to the creation snapshot when no live resources are supplied', () => {
+    render(<CharacterBasicInfo character={character()} attributes={ATTRIBUTES} />)
+
+    expect(screen.getByTestId('derived-stat-hp')).toHaveTextContent('10')
+    expect(screen.getByTestId('derived-stat-san')).toHaveTextContent('65')
+    expect(screen.queryByTestId('initial-values-note')).not.toBeInTheDocument()
+  })
+
+  it('omits unchanged values from the initial note', () => {
+    render(
+      <CharacterBasicInfo
+        character={character()}
+        attributes={ATTRIBUTES}
+        liveResources={{ hp: 10, san: 45, mp: 13, luck: 50 }}
+      />,
+    )
+
+    const note = screen.getByTestId('initial-values-note')
+    expect(note).toHaveTextContent('初始：SAN 65')
+    expect(note).not.toHaveTextContent('HP')
+    expect(note).not.toHaveTextContent('幸运')
+  })
+})

--- a/trpg-frontend/src/features/character/CharacterBasicInfo.test.tsx
+++ b/trpg-frontend/src/features/character/CharacterBasicInfo.test.tsx
@@ -74,4 +74,24 @@ describe('CharacterBasicInfo', () => {
     expect(note).not.toHaveTextContent('HP')
     expect(note).not.toHaveTextContent('幸运')
   })
+
+  // 老角色卡整个缺 `mp` 这类键（`character-store` 里确实存在这种快照）。
+  // 没有初始值可言时不能凑一条 `MP undefined` 出来。
+  it('skips derived keys the creation snapshot never recorded', () => {
+    const legacy = character()
+    delete (legacy.derived as unknown as Record<string, unknown>).mp
+
+    render(
+      <CharacterBasicInfo
+        character={legacy}
+        attributes={ATTRIBUTES}
+        liveResources={{ mp: 8, san: 45 }}
+      />,
+    )
+
+    expect(screen.getByTestId('derived-stat-mp')).toHaveTextContent('8')
+    const note = screen.getByTestId('initial-values-note')
+    expect(note).toHaveTextContent('初始：SAN 65')
+    expect(note).not.toHaveTextContent('MP')
+  })
 })

--- a/trpg-frontend/src/features/character/CharacterBasicInfo.tsx
+++ b/trpg-frontend/src/features/character/CharacterBasicInfo.tsx
@@ -25,6 +25,25 @@ interface RadarAttribute {
   label: string
 }
 
+/**
+ * PlayerView 投影出来的当前资源，按 id 索引（`hp` / `san` / `mp` / `luck`）。
+ *
+ * 角色卡按可变性分两类数据源：姓名、职业、出生地这些建卡时定死的仍来自
+ * `character-store` 的快照；HP/SAN/MP/幸运在游戏中会被引擎改写，权威值只在
+ * PlayerView 里。把运行时资源写回 store 会制造第二份权威状态，所以这里只接
+ * 一份只读入参，组件自己不持有运行时状态。
+ *
+ * 建卡完成页在开局前渲染同一个组件，那时根本没有 PlayerView——它不传这个
+ * 入参，全部落回快照值。
+ */
+export type LiveResources = Readonly<Record<string, number>>
+
+/** 资源 id 与属性/衍生值的键大小写并不一致（`LUCK` vs `luck`）。 */
+function liveValueOf(live: LiveResources | undefined, key: string): number | null {
+  const value = live?.[key.toLocaleLowerCase()]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
 function AttributeRadarChart({
   attributes,
   values,
@@ -120,12 +139,40 @@ export function CharacterBasicInfo({
   portraitUrl,
   occupationName,
   attributes,
+  liveResources,
 }: {
   character: CompletedCharacter
   portraitUrl?: string
   occupationName?: string | null
   attributes: readonly RadarAttribute[]
+  liveResources?: LiveResources
 }) {
+  // 当前值优先，没有运行时投影时才落回建卡快照。
+  const derivedValues = DERIVED_STAT_DEFINITIONS.map(definition => ({
+    definition,
+    initial: character.derived[definition.key],
+    current: liveValueOf(liveResources, definition.key) ?? character.derived[definition.key],
+  }))
+  const attributeValues: Record<string, number | undefined> = { ...character.attr }
+  for (const attribute of attributes) {
+    const live = liveValueOf(liveResources, attribute.key)
+    if (live !== null) attributeValues[attribute.key] = live
+  }
+
+  // 初始值不能就这么消失：SAN 的初始值决定不定性疯狂的阈值（1/5），幸运的初始
+  // 值是成长上限的参考。只列出真正变过的项，没变时这一行不渲染。
+  const changed = [
+    ...derivedValues
+      .filter(item => item.initial !== null && item.current !== item.initial)
+      .map(item => `${item.definition.abbreviation} ${item.initial}`),
+    ...attributes
+      .filter(attribute => {
+        const initial = character.attr[attribute.key]
+        return typeof initial === 'number' && attributeValues[attribute.key] !== initial
+      })
+      .map(attribute => `${attribute.label} ${character.attr[attribute.key]}`),
+  ]
+
   return (
     <>
       <div className="character-ready-sheet__profile">
@@ -158,7 +205,7 @@ export function CharacterBasicInfo({
       </div>
 
       <div className="character-ready-sheet__derived" data-testid="derived-stats-grid">
-        {DERIVED_STAT_DEFINITIONS.map(definition => {
+        {derivedValues.map(({ definition, current }) => {
           const StatIcon = DERIVED_STAT_ICONS[definition.key]
           return (
             <div key={definition.key} className="character-ready-sheet__derived-item">
@@ -167,8 +214,9 @@ export function CharacterBasicInfo({
               <span
                 className="character-ready-sheet__derived-value character-ready-sheet__numbered"
                 style={{ color: definition.color }}
+                data-testid={`derived-stat-${definition.key}`}
               >
-                {character.derived[definition.key] ?? '—'}
+                {current ?? '—'}
               </span>
             </div>
           )
@@ -177,7 +225,15 @@ export function CharacterBasicInfo({
 
       <div className="character-ready-sheet__attributes">
         <h4 className="character-ready-sheet__section-title">基础属性</h4>
-        <AttributeRadarChart attributes={attributes} values={character.attr} />
+        <AttributeRadarChart attributes={attributes} values={attributeValues} />
+        {changed.length > 0 && (
+          <p
+            className="character-ready-sheet__initial-values text-xs text-text-muted mt-1"
+            data-testid="initial-values-note"
+          >
+            初始：{changed.join(' · ')}
+          </p>
+        )}
       </div>
     </>
   )

--- a/trpg-frontend/src/features/character/CharacterBasicInfo.tsx
+++ b/trpg-frontend/src/features/character/CharacterBasicInfo.tsx
@@ -162,8 +162,10 @@ export function CharacterBasicInfo({
   // 初始值不能就这么消失：SAN 的初始值决定不定性疯狂的阈值（1/5），幸运的初始
   // 值是成长上限的参考。只列出真正变过的项，没变时这一行不渲染。
   const changed = [
+    // 只认数字：`db` 是字符串且从不作为资源投影；老角色卡还可能整个缺 `mp`
+    // 这类键，那时没有「初始值」可言，列出来只会是 `MP undefined`。
     ...derivedValues
-      .filter(item => item.initial !== null && item.current !== item.initial)
+      .filter(item => typeof item.initial === 'number' && item.current !== item.initial)
       .map(item => `${item.definition.abbreviation} ${item.initial}`),
     ...attributes
       .filter(attribute => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -1037,6 +1037,91 @@ describe('RoomPage conversation history', () => {
     expect(renderedBackground).toHaveClass('whitespace-pre-wrap')
   })
 
+  // 回归 #286：角色卡面板读的是建卡快照，顶部状态栏读的是 PlayerView，同一页
+  // 的同名数值于是对不上——掉了理智、花了幸运，角色卡上一点看不出来。
+  it('shows live resources in the character sheet instead of the creation snapshot', async () => {
+    useCharacterStore.getState().setCharacter(
+      {
+        info: {
+          name: '杜调查员',
+          playerName: '陈探员',
+          age: '32',
+          gender: '男',
+          residence: '阿卡姆',
+          birthplace: '波士顿',
+          occupationId: 1,
+        },
+        attr: {},
+        skillAlloc: {},
+        skillFinalValues: {},
+        equipment: '',
+        background: '',
+        notes: '',
+        derived: { hp: 10, san: 60, mp: 10, db: '0', build: 0, move: 8 },
+      },
+      'room-1',
+    )
+    mockListConversation.mockResolvedValue([])
+
+    renderRoomPage()
+
+    const playerView = playerViewFixture()
+    playerView.self_actor.resources = [
+      { id: 'hp', name: '生命值', value: 7 },
+      { id: 'san', name: '理智值', value: 45 },
+      { id: 'mp', name: '魔法值', value: 8 },
+    ]
+    act(() =>
+      emitWsMessage({
+        type: 'view.updated',
+        payload: { playerId: 'player-1', playerView },
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '角色卡' }))
+
+    expect(screen.getByTestId('derived-stat-hp')).toHaveTextContent('7')
+    expect(screen.getByTestId('derived-stat-san')).toHaveTextContent('45')
+    expect(screen.getByTestId('derived-stat-mp')).toHaveTextContent('8')
+    // 初始值不能就这么消失：SAN 的初始值决定不定性疯狂的阈值。
+    expect(screen.getByTestId('initial-values-note')).toHaveTextContent(
+      '初始：HP 10 · SAN 60 · MP 10',
+    )
+    // 未被引擎投影的衍生值仍来自快照。
+    expect(screen.getByTestId('derived-stat-move')).toHaveTextContent('8')
+  })
+
+  it('keeps the snapshot in the character sheet until the first PlayerView arrives', async () => {
+    useCharacterStore.getState().setCharacter(
+      {
+        info: {
+          name: '杜调查员',
+          playerName: '陈探员',
+          age: '32',
+          gender: '男',
+          residence: '阿卡姆',
+          birthplace: '波士顿',
+          occupationId: 1,
+        },
+        attr: {},
+        skillAlloc: {},
+        skillFinalValues: {},
+        equipment: '',
+        background: '',
+        notes: '',
+        derived: { hp: 10, san: 60, mp: 10, db: '0', build: 0, move: 8 },
+      },
+      'room-1',
+    )
+    mockListConversation.mockResolvedValue([])
+
+    renderRoomPage()
+    fireEvent.click(screen.getByRole('button', { name: '角色卡' }))
+
+    expect(screen.getByTestId('derived-stat-hp')).toHaveTextContent('10')
+    expect(screen.queryByTestId('initial-values-note')).not.toBeInTheDocument()
+  })
+
   // jsdom 没有 WebGL，supports3DDice() 为 false —— 正好覆盖降级路径：
   // 渲染能力缺失时不能把检定卡住（issue #217）。
   it('falls back to the 2D dice display when WebGL is unavailable', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -259,6 +259,24 @@ function formatWorldTime(dayIndex: number, hourOfDay: number): string {
   return `第 ${dayIndex + 1} 天 ${String(hourOfDay).padStart(2, '0')}:00`
 }
 
+/**
+ * PlayerView 的当前资源，按小写 id 索引，供角色卡面板显示活的 HP/SAN/MP/幸运。
+ *
+ * 顶部状态栏一直读 PlayerView，角色卡面板读的却是建卡快照，同一页的同名数值
+ * 于是对不上（issue #286）。两处现在共用这同一份投影。
+ */
+function liveResourcesOf(playerView: AgentPlayerView | null): Record<string, number> {
+  const resources: Record<string, number> = {}
+  for (const item of playerView?.self_actor.resources ?? []) {
+    if (typeof item.value !== 'number' || !Number.isFinite(item.value)) continue
+    // id 与 name 都建索引，和 `resourceValue` 的匹配口径保持一致：否则顶部
+    // 状态栏能按 name 命中的资源，面板会按 id 找不到，又变回两个数。
+    resources[item.id.toLocaleLowerCase()] = item.value
+    resources[item.name.toLocaleLowerCase()] = item.value
+  }
+  return resources
+}
+
 function resourceValue(playerView: AgentPlayerView | null, id: string): number | null {
   const normalized = id.toLocaleLowerCase()
   const resource = playerView?.self_actor.resources.find((item) =>
@@ -1326,6 +1344,7 @@ export default function RoomPage() {
   const suspended = (roomPhase || roomInfo?.phase) === 'Suspended'
   const mapLocations = mapLocationsFromPlayerView(playerView)
   const currentLocationImage = playerView ? LOCATION_IMAGE_BY_ID[playerView.scene.id] : undefined
+  const liveResources = liveResourcesOf(playerView)
   const currentHp = resourceValue(playerView, 'hp') ?? character?.derived.hp ?? null
   const currentSan = resourceValue(playerView, 'san') ?? character?.derived.san ?? null
   // 权限请求、识别和整理结果期间都占用语音会话。UI 用同一个布尔值切换
@@ -2333,6 +2352,7 @@ export default function RoomPage() {
                     ? ruleset?.occupations.find(o => o.id === character.info.occupationId)?.name
                     : null}
                   attributes={ruleset?.attributes ?? []}
+                  liveResources={liveResources}
                 />
               </div>
             )}


### PR DESCRIPTION
Closes #286

角色卡面板读的是 `character-store` 里的建卡快照，顶部状态栏读的是 PlayerView，同一页的同名数值于是对不上——花掉幸运、掉了理智，角色卡上一点看不出来。面板改为按可变性取数据源：会变的读 PlayerView，不变的仍读快照。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `features/character/CharacterBasicInfo.tsx` | 新增可选入参 `liveResources`：衍生值格的 HP/SAN/MP 与雷达图的 LUCK 优先取当前值，缺省落回快照 |
| `features/character/CharacterBasicInfo.tsx` | 属性区下方新增一行「初始：SAN 65 · 幸运 50」，只列真正变过的项，没变则整行不渲染 |
| `routes/games/trpg/RoomPage.tsx` | 新增 `liveResourcesOf(playerView)`，把 PlayerView 的资源投影成按 id / name 索引的只读表并传给面板 |
| `features/character/CharacterBasicInfo.test.tsx` | 新建，4 条：live LUCK、无入参时回落快照、未变项不进初始值行、快照缺键时不渲染 `undefined` |
| `routes/games/trpg/RoomPage.test.tsx` | 2 条：`view.updated` 后面板显示当前 HP/SAN/MP 且列出初始值；首个 PlayerView 到达前维持快照 |

## 关键决策

**为什么不是「刷新 character-store」而是改数据源**：把运行时资源写回 store 会制造第二份权威状态，还要处理谁先到、谁覆盖谁。角色卡本来就分两类数据——建卡时定死的（姓名、职业、出生地、初始属性）与游戏中会变的（HP/SAN/MP/幸运）。按可变性划分数据源，比让两份状态互相同步更稳。这一条沿用 issue 里的判断。

**为什么入参是可选的**：`CharacterBasicInfo` 是共享组件，`CharacterReadyPage` 也在用它，而那个页面在开局前渲染、根本没有 PlayerView。所以不能把 PlayerView 读进组件内部，只能由调用方注入；不传即全部落回快照，有专门一条测试盯这个回落路径。

**为什么雷达图直接显示当前 LUCK 而不是标注区分**：issue 给了两个选项，取了「直接展示当前值」。幸运在 COC7 里归在属性而非衍生值（它不由任何属性推导，但有状态、能被 `luck.spend` 消耗），雷达图上那个点若停在建卡值，就和顶部幸运按钮上的「当前 X 点」正面矛盾。初始值改由下方那行承载，不动 SVG 结构。

**为什么初始值要单独留一行**：SAN 的初始值决定不定性疯狂的阈值（起始值的 1/5），幸运的初始值是成长上限的参考，直接覆盖会把这些信息丢掉。只列变过的项，未变时整行不渲染，静态角色卡的观感不受影响。

**为什么 `liveResourcesOf` 按 id 和 name 双索引**：顶部状态栏用的 `resourceValue()` 本来就是 id 或 name 任一命中即可。面板若只按 id 查，会出现「顶部按 name 命中、面板按 id 找不到」的新分裂——正是本 issue 要消灭的那种分裂。

## 验证

`npm run lint` / `npm run build` / `npm run test` 全绿：24 个测试文件，**177 passed**。

变异检验：

- 衍生值格改回只读 `character.derived` → 3 条测试报红
- 雷达图的属性覆盖条件取反 → 2 条测试报红

真机验证（本地 9890 + 8030，真实 DeepSeek）：走 issue 给的复现路径——检定失败 → 消耗幸运 → 打开角色卡，确认幸运确实跟着减少。

### review 阶段抓到的真问题

老角色卡的 `derived` 可能整个缺 `mp` 键（`character-store` 里确实有这种快照，`RoomPage.test.tsx` 的 legacy fixture 就是），初始值那行会渲染成 **「初始：MP undefined」**：

```
Expected element not to have text content: undefined
Received: 初始：MP undefined
```

原因是过滤条件只挡了 `null`，缺键时是 `undefined`，与当前值不等就被算成「变过了」。改为只认数字——`db` 是字符串且从不作为资源投影，缺键时也本就没有初始值可言。探针已转成正式回归测试。

## 已知限制

- 只覆盖 PlayerView 已投影的资源（HP/SAN/MP/幸运）。`db` / `build` / `move` 不是引擎资源，仍取自快照——它们由属性推导，游戏中不变。
- 「初始：…」这一行的排版是直接沿用面板既有的 `text-xs text-text-muted`，没有新增样式规则。

## 不在本 PR 范围

- 后端资源扣减逻辑（已正确）
- PlayerView 的投影内容（已包含 resources）
- 新增 DTO 或协议字段
