### PR TITLE
fix(frontend): 讨论区隔离行动区的叙事、进度、报错与骰子

### DIFF
--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -703,6 +703,46 @@ describe('RoomPage conversation history', () => {
 
     // 引擎在等玩家掷骰。单纯藏起来会让这次检定静默卡住——玩家看不到任何提示，
     // 回合悬着。所以把频道切回行动区，而不是压住面板。
+    // 输入框在两个频道复用过，草稿会跟着频道一起漂移：在讨论区打了一半、
+    // 检定到达把频道切回行动区，那段本来要说给队友听的话再一按发送就提交给
+    // 引擎了（#306 review 指出）。草稿必须按频道各存各的。
+    it('keeps each channel draft to itself when a check pulls the player back', async () => {
+      renderRoomPage()
+      await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+      const field = () => screen.getByPlaceholderText('输入行动…')
+      fireEvent.change(field(), { target: { value: '这是行动区的草稿' } })
+
+      switchToDiscussion()
+      fireEvent.change(field(), { target: { value: '我们先商量一下路线' } })
+
+      await act(async () => {
+        emitWsMessage({
+          type: 'check.request',
+          payload: {
+            playerId: 'player-1',
+            clientActionId: 'check-with-draft',
+            summary: '检查旧报纸',
+            difficulty: 'regular',
+            skills: [{ id: 'library', name: '图书馆使用', targetValue: 60 }],
+          },
+        })
+      })
+
+      // 被拉回行动区，输入框里必须是行动区自己的草稿，不能是讨论区那句。
+      expect(field()).toHaveValue('这是行动区的草稿')
+
+      fireEvent.submit(field().closest('form')!)
+      await waitFor(() => expect(mockSubmitPlannedAction).toHaveBeenCalledTimes(1))
+      expect(mockSubmitPlannedAction.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ utterance: '这是行动区的草稿' }),
+      )
+
+      // 讨论区那句原样还在，没被顺手清掉也没被提交。
+      switchToDiscussion()
+      expect(field()).toHaveValue('我们先商量一下路线')
+    })
+
     it('switches back to the action channel when a check arrives during discussion', async () => {
       renderRoomPage()
       await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -648,6 +648,88 @@ describe('RoomPage conversation history', () => {
     expect(realtime).toHaveClass('whitespace-pre-wrap')
   })
 
+  // 频道隔离此前只做在历史消息那一层（按 msg.channel 过滤），运行时的行动区
+  // UI 一个都没隔离：叙事气泡、进度指示器、行动报错和骰子入口全都漏进讨论区。
+  // 讨论区只承载玩家之间的讨论，不承载任何行动区的叙事、判定与状态（#304）。
+  describe('channel isolation', () => {
+    const switchToDiscussion = () =>
+      fireEvent.click(screen.getByRole('button', { name: '讨论区' }))
+
+    it('keeps the streaming narration and progress indicator out of the discussion channel', async () => {
+      renderRoomPage()
+      await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+      act(() => {
+        emitWsMessage({
+          type: 'narration.chunk',
+          payload: { messageId: 'leak-1', sequence: 0, text: '午后的阳光透过百叶窗。' },
+        })
+      })
+      // 先确认行动区确实在生成，否则这条用例可能因为压根没渲染而假绿。
+      expect(await screen.findByText('生成中…')).toBeInTheDocument()
+
+      switchToDiscussion()
+
+      expect(screen.queryByText('生成中…')).not.toBeInTheDocument()
+      expect(screen.queryByText(/午后的阳光/)).not.toBeInTheDocument()
+    })
+
+    it('keeps the action error and its retry entry out of the discussion channel', async () => {
+      mockSubmitPlannedAction.mockRejectedValueOnce(new Error('boom'))
+      renderRoomPage()
+      await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+      const field = screen.getByPlaceholderText('输入行动…')
+      fireEvent.change(field, { target: { value: '我查看书架' } })
+      fireEvent.submit(field.closest('form')!)
+
+      expect(await screen.findByText('行动提交失败，请重试')).toBeInTheDocument()
+
+      switchToDiscussion()
+
+      expect(screen.queryByText('行动提交失败，请重试')).not.toBeInTheDocument()
+    })
+
+    it('removes the dice entry from the discussion channel', async () => {
+      renderRoomPage()
+      await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+      expect(screen.getByRole('button', { name: '骰子' })).toBeInTheDocument()
+
+      switchToDiscussion()
+
+      expect(screen.queryByRole('button', { name: '骰子' })).not.toBeInTheDocument()
+    })
+
+    // 引擎在等玩家掷骰。单纯藏起来会让这次检定静默卡住——玩家看不到任何提示，
+    // 回合悬着。所以把频道切回行动区，而不是压住面板。
+    it('switches back to the action channel when a check arrives during discussion', async () => {
+      renderRoomPage()
+      await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+      switchToDiscussion()
+      expect(screen.queryByRole('button', { name: '骰子' })).not.toBeInTheDocument()
+
+      await act(async () => {
+        emitWsMessage({
+          type: 'check.request',
+          payload: {
+            playerId: 'player-1',
+            clientActionId: 'check-during-discussion',
+            summary: '检查旧报纸',
+            difficulty: 'regular',
+            skills: [{ id: 'library', name: '图书馆使用', targetValue: 60 }],
+          },
+        })
+      })
+
+      expect(
+        screen.getByRole('button', { name: '行动' }),
+      ).toHaveAttribute('aria-pressed', 'true')
+      expect(await screen.findByText('图书馆使用')).toBeInTheDocument()
+    })
+  })
+
   it('reveals narration chunks gradually instead of dumping the whole text', async () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1262,6 +1262,7 @@ export default function RoomPage() {
   const [confirmExit, setConfirmExit] = useState(false)
   const [messages, setMessages] = useState<Message[]>([])
   const [channel, setChannel] = useState<'action' | 'discussion'>('action')
+  const isActionChannel = channel === 'action'
   const [input, setInput] = useState('')
   const handleSpeechTranscript = useCallback((transcript: string) => {
     // 使用函数式更新读取回调到达那一刻的输入，避免覆盖识别期间玩家新键入的文字。
@@ -1328,6 +1329,17 @@ export default function RoomPage() {
   const [sheetPage, setSheetPage] = useState<'info' | 'background'>('info')
   const [skillsTab, setSkillsTab] = useState<'occupation' | 'interest'>('occupation')
   const [showDice, setShowDice] = useState(false)
+  /**
+   * 引擎在等玩家掷骰时唯一的开面板入口（issue #304）。
+   *
+   * 讨论区只承载玩家之间的讨论，不出现骰子。但玩家停在讨论区时不能只是把面板
+   * 藏起来——那会让这次检定静默卡住，回合一直悬着。所以先把频道切回行动区再
+   * 呈现：「在讨论区掷骰」这件事因此从不发生，检定也不会挂起。
+   */
+  const openDiceForCheck = useCallback(() => {
+    setChannel('action')
+    setShowDice(true)
+  }, [])
   const notesKey = roomId ? `aidm-notes-${roomId}` : null
   // ★ 之前"📋 案件笔记"标题是直接塞进 textarea 初始内容里的普通文本，用户
   // 一编辑/全选删除就会把标题本身也删掉。改成占位符（placeholder），真正
@@ -1610,7 +1622,7 @@ export default function RoomPage() {
             ? current
             : createPendingCheckDiceState(envelope.payload)
         )
-        setShowDice(true)
+        openDiceForCheck()
       } else if (envelope.type === 'check.result') {
         setTyping(true)
         showBackendPhase('executing_action')
@@ -1692,7 +1704,7 @@ export default function RoomPage() {
             }
             setPendingCheck(checkRequest)
             setPendingCheckDice(createPendingCheckDiceState(checkRequest))
-            setShowDice(true)
+            openDiceForCheck()
           }
         }
       } else if (
@@ -1772,7 +1784,7 @@ export default function RoomPage() {
       setProgressLabel('守秘人正在生成开场叙事')
     }
     return off
-  }, [clearBackendProgress, clearSettledAction, enqueueHostSpeech, handleHostSpeechSettingsUpdated, playerId, senderName, showBackendPhase])
+  }, [clearBackendProgress, clearSettledAction, enqueueHostSpeech, handleHostSpeechSettingsUpdated, openDiceForCheck, playerId, senderName, showBackendPhase])
 
   const submitPlayerAction = (action: { clientActionId: string; utterance: string }) => {
     if (!playerId || suspended) return
@@ -2085,8 +2097,11 @@ export default function RoomPage() {
         })}
 
         {/* 渐进到达的主持叙事（issue #203）。没有"重播"按钮：它还不是权威
-            消息，语音朗读只认最终 narration.push。*/}
-        {streamingNarration && streamingNarration.revealed > 0 && (
+            消息，语音朗读只认最终 narration.push。
+
+            频道判断不能只做在上面那条历史消息的 filter 上：这个气泡和下面的
+            进度指示器都不经过 messages，漏进讨论区过（issue #304）。*/}
+        {isActionChannel && streamingNarration && streamingNarration.revealed > 0 && (
           <div className="room-play__message room-play__message--narration animate-[msgIn_0.3s_ease]">
             <div className="room-play__avatar room-play__avatar--keeper">
               <img src="/assets/rooms/play/keeper-cat.webp" alt="" aria-hidden="true" />
@@ -2105,7 +2120,7 @@ export default function RoomPage() {
 
         {/* Typing indicator。第一个片段到达后还没揭示出字的那一瞬间也留着它，
             避免出现一个空气泡。*/}
-        {(progressLabel !== null || typing || (streamingNarration !== null && streamingNarration.revealed === 0)) && (
+        {isActionChannel && (progressLabel !== null || typing || (streamingNarration !== null && streamingNarration.revealed === 0)) && (
           <div className="room-play__message room-play__message--narration animate-[msgIn_0.3s_ease]">
             <div className="room-play__avatar room-play__avatar--keeper">
               <img src="/assets/rooms/play/keeper-cat.webp" alt="" aria-hidden="true" />
@@ -2186,7 +2201,7 @@ export default function RoomPage() {
             游戏已挂起，恢复后才能继续提交行动
           </p>
         )}
-        {actionError && !suspended && (
+        {isActionChannel && actionError && !suspended && (
           <div className="pb-1.5 px-1">
             <div className="flex items-center justify-between gap-2">
               <p className={`text-[11px] ${actionErrorIsGuidance ? 'text-[#8a642d]' : 'text-[#c04040]'}`}>
@@ -2238,16 +2253,19 @@ export default function RoomPage() {
           </p>
         )}
         <form data-onboarding-target="action-input" onSubmit={sendMessage} className="room-play__composer-form">
-          <button
-            type="button"
-            aria-label="骰子"
-            data-onboarding-target="dice-button"
-            onClick={() => setShowDice(true)}
-            disabled={suspended}
-            className="room-play__composer-button room-play__dice-button"
-          >
-            <IsometricDiceIcon />
-          </button>
+          {/* 讨论区只承载玩家之间的讨论，不提供掷骰入口（issue #304）。 */}
+          {isActionChannel && (
+            <button
+              type="button"
+              aria-label="骰子"
+              data-onboarding-target="dice-button"
+              onClick={() => setShowDice(true)}
+              disabled={suspended}
+              className="room-play__composer-button room-play__dice-button"
+            >
+              <IsometricDiceIcon />
+            </button>
+          )}
           <textarea
             ref={composerInputRef}
             rows={1}

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1263,11 +1263,32 @@ export default function RoomPage() {
   const [messages, setMessages] = useState<Message[]>([])
   const [channel, setChannel] = useState<'action' | 'discussion'>('action')
   const isActionChannel = channel === 'action'
-  const [input, setInput] = useState('')
+  /**
+   * 草稿按频道各存各的（issue #304）。
+   *
+   * 输入框在两个频道复用，但一份共享草稿会跟着频道漂移：在讨论区打了一半、
+   * 检定到达把频道切回行动区，那段本来要说给队友听的话再一按发送就提交给了
+   * 引擎——`sendMessage` 只看当前 `channel` 决定走 sendChat 还是提交行动。
+   * 手动切频道同样漏，只是自动切换让它在玩家毫无预期时发生。
+   */
+  const [drafts, setDrafts] = useState<Record<'action' | 'discussion', string>>({
+    action: '',
+    discussion: '',
+  })
+  const input = drafts[channel]
+  const setInput = useCallback(
+    (next: string | ((current: string) => string)) => {
+      setDrafts((current) => ({
+        ...current,
+        [channel]: typeof next === 'function' ? next(current[channel]) : next,
+      }))
+    },
+    [channel],
+  )
   const handleSpeechTranscript = useCallback((transcript: string) => {
     // 使用函数式更新读取回调到达那一刻的输入，避免覆盖识别期间玩家新键入的文字。
     setInput((current) => appendSpeechTranscript(current, transcript))
-  }, [])
+  }, [setInput])
   const speechInput = useSpeechInput(handleSpeechTranscript)
   // 单独取稳定方法，避免 effect 依赖每次渲染都会新建的 Hook 返回对象。
   const cancelSpeechInput = speechInput.cancel


### PR DESCRIPTION
Closes #304

频道隔离此前只做在历史消息那一层，不经过 `messages` 的运行时行动区 UI 全都漏进了讨论区——包括可以在讨论区直接掷骰。四处补上频道判断，骰子另加一层「检定到达时切回行动区」，避免藏面板把检定卡死。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `RoomPage.tsx` | 新增 `isActionChannel`，为流式叙事气泡、「生成中…」进度指示器、行动失败报错与重试入口、输入栏骰子按钮补上频道判断 |
| `RoomPage.tsx` | 新增 `openDiceForCheck()`：`check.request` 与裁决待决统一经它开面板，先 `setChannel('action')` 再 `setShowDice(true)` |
| `RoomPage.test.tsx` | 新增 `channel isolation` 测试组，4 条：叙事+进度、行动报错、骰子入口、检定到达时切回行动区 |

## 关键决策

**为什么不是在 `messages.filter` 上再加东西**：那条 filter 本身是对的，问题在于它只管历史消息。`streamingNarration`、`typing` / `progressLabel`、`actionError`、`showDice` 这四组状态都不经过 `messages`——它们由 WebSocket 事件和提交回调直接写。改动前 `channel` 在整个文件里**只有 filter 那一处**参与渲染判断，所以补的是这四个渲染点，不是过滤逻辑。

**为什么检定到达时是「切回行动区」而不是「藏起来」**：`check.request` 到达意味着引擎正在等玩家掷骰。玩家停在讨论区时如果只把面板藏掉，这次检定会静默卡住——玩家看不到任何提示，回合一直悬着。切回行动区再呈现，「在讨论区掷骰」这件事从不发生，检定也不会挂起。代价是打断玩家正在进行的讨论输入，相比检定停摆可以接受。

**被否掉的方案**：留在讨论区、只在「行动」标签上打提示角标。不打断讨论，但依赖玩家注意到角标，没注意到就等于检定停摆——把一个确定的中断换成了一个不确定的卡死。

**为什么 `DiceModal` 本身没有加频道判断**：它是全屏浮层，且两个开启入口都已经保证先切回行动区。如果给浮层也加上判断，玩家在检定进行中手动切到讨论区会让骰子面板当场消失，检定就卡死了——正是本 issue 要避免的那件事。详见「已知限制」。

## 验证

`npm run lint` / `npm run build` / `npm run test` 全绿：24 个测试文件，**181 passed**（修复前 177）。

四条测试都是**先写、先跑红**，失败原因逐条核对过。例如行动报错那条在修复前：

```
expected document not to contain element, found <p class="text-[11px] text-[#c04040]">
  行动提交失败，请重试
```

叙事那条特意先断言行动区确实在生成（`findByText('生成中…')`）再切频道，避免因为压根没渲染而假绿。

## 已知限制

- **玩家在检定进行中手动切到讨论区时，骰子浮层继续留着。** 这是有意保留的行为：浮层是全屏的，且关掉它就等于让检定停摆。「讨论区不能掷骰」由两件事保证——讨论区没有掷骰入口，检定到达时把玩家切回行动区。
- 只覆盖 `RoomPage` 内的频道泄漏。角色卡、技能、地图、笔记这些快捷面板不属于任一频道，本 PR 不动。

## 不在本 PR 范围

- 后端与 WebSocket 协议：事件该发还是发，只改前端呈现归属
- 讨论区自身的消息收发（`chat.message` 已正确带 `channel: 'discussion'`）
- 行动区在自己频道内的任何行为
