### PR TITLE
fix(narration): 必报已提交的实体发现结果

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/contracts/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/__init__.py
@@ -59,6 +59,7 @@ from .adjudication import (
     HideInformationEffect,
     MarkCoreResolvedEffect,
     MoveEntityEffect,
+    NarrationEvidence,
     NarrativeOnlyEffect,
     NoAdjudicationCheck,
     PendingCheckDecisionView,

--- a/agent-collaboration-framework/collaboration_framework/contracts/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/adjudication.py
@@ -344,6 +344,7 @@ class NarrationEvidence(ContractModel):
     kind: Literal["entity_discovered"]
     subject_id: str = Field(min_length=1)
     subject_name: str = Field(min_length=1)
+    subject_aliases: tuple[str, ...] = ()
     description: str = ""
     required_in_narration: bool = False
 

--- a/agent-collaboration-framework/collaboration_framework/contracts/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/adjudication.py
@@ -337,6 +337,17 @@ class PostRollDecisionRequest(ContractModel):
     push_adjudication: PushAdjudication | None = None
 
 
+class NarrationEvidence(ContractModel):
+    """Player-safe meaning of one public event that narration may rely on."""
+
+    ref: str = Field(min_length=1)
+    kind: Literal["entity_discovered"]
+    subject_id: str = Field(min_length=1)
+    subject_name: str = Field(min_length=1)
+    description: str = ""
+    required_in_narration: bool = False
+
+
 class AdjudicationExecution(ContractModel):
     request_id: str = Field(min_length=1)
     action_request_id: str = Field(min_length=1)
@@ -352,6 +363,7 @@ class AdjudicationExecution(ContractModel):
     check_run: CheckRunView | None = None
     event_refs: tuple[str, ...] = ()
     public_event_refs: tuple[str, ...] = ()
+    narration_evidence: tuple[NarrationEvidence, ...] = ()
 
     @model_validator(mode="after")
     def validate_status_payload(self) -> AdjudicationExecution:
@@ -361,6 +373,11 @@ class AdjudicationExecution(ContractModel):
             raise ValueError("awaiting_post_roll_decision 必须包含 check_run")
         if not set(self.public_event_refs).issubset(self.event_refs):
             raise ValueError("public_event_refs 必须是 event_refs 的子集")
+        evidence_refs = tuple(item.ref for item in self.narration_evidence)
+        if len(evidence_refs) != len(set(evidence_refs)):
+            raise ValueError("narration_evidence ref 不得重复")
+        if not set(evidence_refs).issubset(self.public_event_refs):
+            raise ValueError("narration_evidence 必须引用 public_event_refs")
         return self
 
 

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -42,6 +42,7 @@ from collaboration_framework.contracts import (
     MarkCoreResolvedEffect,
     LocationKnowledge,
     MoveEntityEffect,
+    NarrationEvidence,
     NarrativeOnlyEffect,
     PendingCheckOption,
     PostRollDecisionRequest,
@@ -77,6 +78,7 @@ from .models import (
 )
 from .navigation import resolve_location_target
 from .ports import EngineStore
+from .projection_v3 import project_v3
 from .timeline import advanced_to_next, next_point_after, time_advance_block_reason
 from .rules_v3 import (
     agenda_item_for_event,
@@ -86,6 +88,7 @@ from .rules_v3 import (
     effects_after_degree,
     matching_event_rules,
     pending_check_for,
+    entity_state,
     resolve_rule_option,
     walk_rule,
 )
@@ -593,6 +596,13 @@ class AdjudicationEngineService:
                     outcome="success",
                     event_refs=tuple(event.event_id for event in events),
                     public_event_refs=self._public_event_refs(events),
+                    narration_evidence=self._narration_evidence(
+                        runtime,
+                        new_state=new_state,
+                        events=events,
+                        player_id=request.player_id,
+                        actor_id=request.adjudication.actor_id,
+                    ),
                 )
                 await transaction.commit_adjudication(
                     expected_revision=runtime.revision,
@@ -870,6 +880,13 @@ class AdjudicationEngineService:
                 check_run=self._run_view(check_run),
                 event_refs=tuple(event.event_id for event in events),
                 public_event_refs=self._public_event_refs(events),
+                narration_evidence=self._narration_evidence(
+                    runtime,
+                    new_state=new_state,
+                    events=events,
+                    player_id=decision.player_id,
+                    actor_id=decision.actor_id,
+                ),
             )
             rule_effects_excluded = (
                 decision.adjudication.rule_decision is not None and runtime.is_v3
@@ -1079,6 +1096,13 @@ class AdjudicationEngineService:
                 check_run=self._run_view(resolved_run),
                 event_refs=tuple(event.event_id for event in events),
                 public_event_refs=self._public_event_refs(events),
+                narration_evidence=self._narration_evidence(
+                    runtime_after_resource,
+                    new_state=new_state,
+                    events=events,
+                    player_id=decision.player_id,
+                    actor_id=decision.actor_id,
+                ),
             )
             rule_effects_excluded = (
                 check_run.adjudication.rule_decision is not None and runtime.is_v3
@@ -1118,6 +1142,61 @@ class AdjudicationEngineService:
     @staticmethod
     def _public_event_refs(events: tuple[DomainEvent, ...]) -> tuple[str, ...]:
         return tuple(event.event_id for event in events if event.visibility == "public")
+
+    @staticmethod
+    def _narration_evidence(
+        runtime: EngineRuntimeSnapshot,
+        *,
+        new_state: GameState,
+        events: tuple[DomainEvent, ...],
+        player_id: str,
+        actor_id: str,
+    ) -> tuple[NarrationEvidence, ...]:
+        """Project newly discovered entities through the final player-safe view."""
+
+        if not runtime.is_v3:
+            return ()
+        final_runtime = runtime.model_copy(
+            update={
+                "game_state": new_state,
+                "revision": str(new_state.event_sequence),
+            },
+            deep=True,
+        )
+        visible = {
+            item.id: item
+            for item in project_v3(
+                final_runtime,
+                player_id=player_id,
+                actor_id=actor_id,
+            ).scene.visible_entities
+        }
+        evidence: list[NarrationEvidence] = []
+        for event in events:
+            entity_id = event.payload.get("entity_id")
+            if (
+                event.visibility != "public"
+                or event.type != "entity.state_changed"
+                or event.payload.get("key") != "discovered"
+                or event.payload.get("value") is not True
+                or not isinstance(entity_id, str)
+                or entity_state(runtime.game_state, entity_id).get("discovered") is True
+            ):
+                continue
+            projected = visible.get(entity_id)
+            if projected is None:
+                continue
+            evidence.append(
+                NarrationEvidence(
+                    ref=event.event_id,
+                    kind="entity_discovered",
+                    subject_id=projected.id,
+                    subject_name=projected.name,
+                    description=projected.description,
+                    required_in_narration=True,
+                )
+            )
+        return tuple(evidence)
 
     @staticmethod
     def _validate_identity(

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -1192,6 +1192,7 @@ class AdjudicationEngineService:
                     kind="entity_discovered",
                     subject_id=projected.id,
                     subject_name=projected.name,
+                    subject_aliases=projected.aliases,
                     description=projected.description,
                     required_in_narration=True,
                 )

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -1156,6 +1156,24 @@ class AdjudicationEngineService:
 
         if not runtime.is_v3:
             return ()
+        candidate_events = tuple(
+            event
+            for event in events
+            if (
+                event.visibility == "public"
+                and event.type == "entity.state_changed"
+                and event.payload.get("key") == "discovered"
+                and event.payload.get("value") is True
+                and isinstance(event.payload.get("entity_id"), str)
+                and entity_state(
+                    runtime.game_state,
+                    event.payload["entity_id"],
+                ).get("discovered")
+                is not True
+            )
+        )
+        if not candidate_events:
+            return ()
         final_runtime = runtime.model_copy(
             update={
                 "game_state": new_state,
@@ -1172,15 +1190,10 @@ class AdjudicationEngineService:
             ).scene.visible_entities
         }
         evidence: list[NarrationEvidence] = []
-        for event in events:
+        for event in candidate_events:
             entity_id = event.payload.get("entity_id")
             if (
-                event.visibility != "public"
-                or event.type != "entity.state_changed"
-                or event.payload.get("key") != "discovered"
-                or event.payload.get("value") is not True
-                or not isinstance(entity_id, str)
-                or entity_state(runtime.game_state, entity_id).get("discovered") is True
+                not isinstance(entity_id, str)
             ):
                 continue
             projected = visible.get(entity_id)

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
@@ -47,7 +47,13 @@ class ActionPlanNarrator:
         required_refs = {item.ref for item in required}
         if not required_refs.issubset(output.claimed_evidence_refs):
             raise ActionPlanNarrationValidationError("required_evidence_missing")
-        if any(item.subject_name not in output.text for item in required):
+        if any(
+            not any(
+                label and label in output.text
+                for label in (item.subject_name, *item.subject_aliases)
+            )
+            for item in required
+        ):
             raise ActionPlanNarrationValidationError("required_evidence_missing")
         rejection = narration_text_rejection_reason(output.text)
         if rejection is not None:

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
@@ -44,17 +44,27 @@ class ActionPlanNarrator:
         required = tuple(
             item for item in context.narration_evidence if item.required_in_narration
         )
-        required_refs = {item.ref for item in required}
-        if not required_refs.issubset(output.claimed_evidence_refs):
-            raise ActionPlanNarrationValidationError("required_evidence_missing")
-        if any(
-            not any(
+        mentioned_required = tuple(
+            item
+            for item in required
+            if any(
                 label and label in output.text
                 for label in (item.subject_name, *item.subject_aliases)
             )
-            for item in required
-        ):
+        )
+        if len(mentioned_required) != len(required):
             raise ActionPlanNarrationValidationError("required_evidence_missing")
+        # The prose is the player-facing source of truth. Once it demonstrably
+        # reports a required safe result, record its public ref deterministically
+        # instead of discarding otherwise valid narration because the model
+        # omitted a bookkeeping field.
+        claimed = tuple(
+            dict.fromkeys(
+                (*output.claimed_evidence_refs, *(item.ref for item in mentioned_required))
+            )
+        )
+        if claimed != output.claimed_evidence_refs:
+            output = output.model_copy(update={"claimed_evidence_refs": claimed})
         rejection = narration_text_rejection_reason(output.text)
         if rejection is not None:
             raise ActionPlanNarrationValidationError(rejection)

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
@@ -41,6 +41,14 @@ class ActionPlanNarrator:
             context.allowed_evidence_refs
         ):
             raise ActionPlanNarrationValidationError("evidence_scope")
+        required = tuple(
+            item for item in context.narration_evidence if item.required_in_narration
+        )
+        required_refs = {item.ref for item in required}
+        if not required_refs.issubset(output.claimed_evidence_refs):
+            raise ActionPlanNarrationValidationError("required_evidence_missing")
+        if any(item.subject_name not in output.text for item in required):
+            raise ActionPlanNarrationValidationError("required_evidence_missing")
         rejection = narration_text_rejection_reason(output.text)
         if rejection is not None:
             raise ActionPlanNarrationValidationError(rejection)

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -702,6 +702,9 @@ class ActionPlanOrchestrator:
         view = await self._player_view_projector.project(player_input)
         summaries = self._narration_summaries(run)
         evidence = tuple(ref for step in summaries for ref in step.event_refs)
+        narration_evidence = tuple(
+            item for step in summaries for item in step.narration_evidence
+        )
         return ActionPlanNarrationContext(
             background=view.background,
             player_input=player_input,
@@ -712,6 +715,7 @@ class ActionPlanOrchestrator:
             player_view=view,
             opening_world_time=run.opening_world_time,
             allowed_evidence_refs=evidence,
+            narration_evidence=narration_evidence,
         )
 
     async def _load_or_create(
@@ -1230,6 +1234,7 @@ class ActionPlanOrchestrator:
                     view_revision=execution.view_revision,
                     world_time_after=step.world_time_after,
                     event_refs=execution.public_event_refs,
+                    narration_evidence=execution.narration_evidence,
                 )
             )
         return tuple(summaries)
@@ -1253,6 +1258,7 @@ class ActionPlanOrchestrator:
                         view_revision=execution.view_revision,
                         world_time_after=step.world_time_after,
                         event_refs=execution.public_event_refs,
+                        narration_evidence=execution.narration_evidence,
                     )
                 )
         return tuple(summaries)

--- a/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/narrator.py
@@ -19,7 +19,8 @@ NarrationRejectionReason = Literal[
 
 _NARRATION_FIELD = (
     r"(?<![A-Za-z0-9_])"
-    r"(?:kind|text|claimed_fact_ids|claimedFactIds|suggested_actions|suggestedActions)"
+    r"(?:kind|text|claimed_fact_ids|claimedFactIds|claimed_evidence_refs|"
+    r"claimedEvidenceRefs|suggested_actions|suggestedActions)"
     r"(?![A-Za-z0-9_])"
 )
 _QUOTED_NARRATION_FIELD = rf"""(?:"|')?{_NARRATION_FIELD}(?:"|')?"""
@@ -50,6 +51,15 @@ _TRAILING_NARRATION_FIELD_RE = re.compile(
     re.IGNORECASE | re.DOTALL | re.VERBOSE,
 )
 
+_ESCAPED_TEXT_TAIL_RE = re.compile(
+    rf"""
+    ["'][ \t]*,[ \t]*
+    {_QUOTED_NARRATION_FIELD}
+    [ \t]*[:：]
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
 _TRAILING_OBJECT_FRAGMENT_RE = re.compile(
     r"""
     (?:^|[\r\n]|[。！？.!?]|(?<=\s))[ \t]*
@@ -68,7 +78,8 @@ _NARRATION_KIND_RE = re.compile(
 _NARRATION_FIELD_KEY_RE = re.compile(
     r"""
     (?:"|')?
-    (?P<field>kind|text|claimed_fact_ids|claimedFactIds|suggested_actions|suggestedActions)
+    (?P<field>kind|text|claimed_fact_ids|claimedFactIds|claimed_evidence_refs|
+    claimedEvidenceRefs|suggested_actions|suggestedActions)
     (?:"|')?
     [ \t]*[:：]
     """,
@@ -76,7 +87,7 @@ _NARRATION_FIELD_KEY_RE = re.compile(
 )
 
 _NARRATION_FIELD_TOKEN_RE = re.compile(
-    r"""(?:"|')?(kind|text|claimed_fact_ids|claimedFactIds|suggested_actions|suggestedActions)(?:"|')?""",
+    r"""(?:"|')?(kind|text|claimed_fact_ids|claimedFactIds|claimed_evidence_refs|claimedEvidenceRefs|suggested_actions|suggestedActions)(?:"|')?""",
     re.IGNORECASE,
 )
 
@@ -164,6 +175,8 @@ def narration_text_rejection_reason(
     if _STANDALONE_NARRATION_FIELD_RE.search(text):
         return "protocol_tail"
     if _TRAILING_NARRATION_FIELD_RE.search(text):
+        return "protocol_tail"
+    if _ESCAPED_TEXT_TAIL_RE.search(text):
         return "protocol_tail"
 
     object_match = _TRAILING_OBJECT_FRAGMENT_RE.search(text)

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
@@ -311,6 +311,9 @@ class ActionPlanNarrationContext(ContractModel):
     opening_world_time: WorldClockView | None = None
     allowed_evidence_refs: tuple[str, ...] = ()
     narration_evidence: tuple[NarrationEvidence, ...] = ()
+    # Only populated for the bounded second narration attempt; contains no
+    # hidden data, just the player-safe requirement the first output missed.
+    narration_retry_hint: str | None = Field(default=None, max_length=500)
 
     @model_validator(mode="after")
     def validate_narration_scope(self) -> ActionPlanNarrationContext:

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
@@ -15,6 +15,7 @@ from collaboration_framework.contracts import (
     AdjudicationExecution,
     ContractModel,
     KeeperCapabilityView,
+    NarrationEvidence,
     PlayerInput,
     PlayerView,
     WorldClockView,
@@ -235,6 +236,13 @@ class CompletedPlanStepSummary(ContractModel):
     view_revision: str = Field(min_length=1)
     world_time_after: WorldClockView | None = None
     event_refs: tuple[str, ...] = ()
+    narration_evidence: tuple[NarrationEvidence, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_evidence(self) -> CompletedPlanStepSummary:
+        if not {item.ref for item in self.narration_evidence}.issubset(self.event_refs):
+            raise ValueError("步骤 narration_evidence 必须引用公开 event_refs")
+        return self
 
 
 class ActionPlanStepContext(ContractModel):
@@ -302,6 +310,7 @@ class ActionPlanNarrationContext(ContractModel):
     # then carries the clock it ended on.
     opening_world_time: WorldClockView | None = None
     allowed_evidence_refs: tuple[str, ...] = ()
+    narration_evidence: tuple[NarrationEvidence, ...] = ()
 
     @model_validator(mode="after")
     def validate_narration_scope(self) -> ActionPlanNarrationContext:
@@ -316,6 +325,11 @@ class ActionPlanNarrationContext(ContractModel):
         )
         if set(self.allowed_evidence_refs) != set(evidence):
             raise ValueError("allowed_evidence_refs 必须等于已完成步骤的公开 evidence")
+        step_evidence = tuple(
+            item for step in self.completed_steps for item in step.narration_evidence
+        )
+        if self.narration_evidence != step_evidence:
+            raise ValueError("narration_evidence 必须按步骤聚合")
         return self
 
 

--- a/agent-collaboration-framework/schemas/adjudication-execution.schema.json
+++ b/agent-collaboration-framework/schemas/adjudication-execution.schema.json
@@ -200,6 +200,14 @@
           "title": "Subject Name",
           "type": "string"
         },
+        "subject_aliases": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Subject Aliases",
+          "type": "array"
+        },
         "description": {
           "default": "",
           "title": "Description",

--- a/agent-collaboration-framework/schemas/adjudication-execution.schema.json
+++ b/agent-collaboration-framework/schemas/adjudication-execution.schema.json
@@ -176,6 +176,50 @@
       "title": "CheckRunView",
       "type": "object"
     },
+    "NarrationEvidence": {
+      "additionalProperties": false,
+      "description": "Player-safe meaning of one public event that narration may rely on.",
+      "properties": {
+        "ref": {
+          "minLength": 1,
+          "title": "Ref",
+          "type": "string"
+        },
+        "kind": {
+          "const": "entity_discovered",
+          "title": "Kind",
+          "type": "string"
+        },
+        "subject_id": {
+          "minLength": 1,
+          "title": "Subject Id",
+          "type": "string"
+        },
+        "subject_name": {
+          "minLength": 1,
+          "title": "Subject Name",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "required_in_narration": {
+          "default": false,
+          "title": "Required In Narration",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ref",
+        "kind",
+        "subject_id",
+        "subject_name"
+      ],
+      "title": "NarrationEvidence",
+      "type": "object"
+    },
     "PendingCheckDecisionView": {
       "additionalProperties": false,
       "properties": {
@@ -451,6 +495,14 @@
         "type": "string"
       },
       "title": "Public Event Refs",
+      "type": "array"
+    },
+    "narration_evidence": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/NarrationEvidence"
+      },
+      "title": "Narration Evidence",
       "type": "array"
     }
   },

--- a/agent-collaboration-framework/schemas/adjudication-status.schema.json
+++ b/agent-collaboration-framework/schemas/adjudication-status.schema.json
@@ -295,6 +295,14 @@
           "title": "Subject Name",
           "type": "string"
         },
+        "subject_aliases": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Subject Aliases",
+          "type": "array"
+        },
         "description": {
           "default": "",
           "title": "Description",

--- a/agent-collaboration-framework/schemas/adjudication-status.schema.json
+++ b/agent-collaboration-framework/schemas/adjudication-status.schema.json
@@ -98,6 +98,14 @@
           },
           "title": "Public Event Refs",
           "type": "array"
+        },
+        "narration_evidence": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/NarrationEvidence"
+          },
+          "title": "Narration Evidence",
+          "type": "array"
         }
       },
       "required": [
@@ -261,6 +269,50 @@
         "roll"
       ],
       "title": "CheckRunView",
+      "type": "object"
+    },
+    "NarrationEvidence": {
+      "additionalProperties": false,
+      "description": "Player-safe meaning of one public event that narration may rely on.",
+      "properties": {
+        "ref": {
+          "minLength": 1,
+          "title": "Ref",
+          "type": "string"
+        },
+        "kind": {
+          "const": "entity_discovered",
+          "title": "Kind",
+          "type": "string"
+        },
+        "subject_id": {
+          "minLength": 1,
+          "title": "Subject Id",
+          "type": "string"
+        },
+        "subject_name": {
+          "minLength": 1,
+          "title": "Subject Name",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "required_in_narration": {
+          "default": false,
+          "title": "Required In Narration",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ref",
+        "kind",
+        "subject_id",
+        "subject_name"
+      ],
+      "title": "NarrationEvidence",
       "type": "object"
     },
     "PendingCheckDecisionView": {

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -398,6 +398,16 @@ class ClaimsButOmitsRequiredEvidenceNarrationModel:
         }
 
 
+class AliasRequiredEvidenceNarrationModel:
+    async def generate(self, context):
+        return {
+            "kind": "narration",
+            "text": "沿着断续的痕迹，你确认这里藏着一个地穴入口。",
+            "claimed_evidence_refs": [context.narration_evidence[0].ref],
+            "suggested_actions": [],
+        }
+
+
 def runtime(*, two_scenes: bool = False):
     module = load_model("fixtures/demo-module.json", ModuleContent)
     if two_scenes:
@@ -1903,6 +1913,7 @@ async def test_narrator_rejects_missing_required_evidence() -> None:
         kind="entity_discovered",
         subject_id="crypt_entrance",
         subject_name="石板下的地穴入口",
+        subject_aliases=("地穴入口",),
         description="一块沉重石板遮住了向下的通道。",
         required_in_narration=True,
     )
@@ -1928,6 +1939,11 @@ async def test_narrator_rejects_missing_required_evidence() -> None:
         )
 
     assert claimed_but_omitted.value.reason == "required_evidence_missing"
+
+    alias_output = await ActionPlanNarrator(
+        AliasRequiredEvidenceNarrationModel()
+    ).narrate(context)
+    assert alias_output.claimed_evidence_refs == (required_ref,)
 
 
 @pytest.mark.asyncio

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -403,7 +403,7 @@ class AliasRequiredEvidenceNarrationModel:
         return {
             "kind": "narration",
             "text": "沿着断续的痕迹，你确认这里藏着一个地穴入口。",
-            "claimed_evidence_refs": [context.narration_evidence[0].ref],
+            "claimed_evidence_refs": [],
             "suggested_actions": [],
         }
 
@@ -1940,6 +1940,8 @@ async def test_narrator_rejects_missing_required_evidence() -> None:
 
     assert claimed_but_omitted.value.reason == "required_evidence_missing"
 
+    # A natural narration that clearly names a safe alias is authoritative
+    # enough for the service to record the required public ref itself.
     alias_output = await ActionPlanNarrator(
         AliasRequiredEvidenceNarrationModel()
     ).narrate(context)

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -21,6 +21,7 @@ from collaboration_framework.contracts import (
     GetAdjudicationStatusRequest,
     ModuleContent,
     ModuleContentV3,
+    NarrationEvidence,
     NarrativeOnlyEffect,
     NoAdjudicationCheck,
     PlayerInput,
@@ -373,6 +374,26 @@ class FirstPersonNarrationModel:
             "kind": "narration",
             "text": "我带着你们进入墓园。",
             "claimed_evidence_refs": [],
+            "suggested_actions": [],
+        }
+
+
+class MissingRequiredEvidenceNarrationModel:
+    async def generate(self, context):
+        return {
+            "kind": "narration",
+            "text": "你在墓碑附近发现了一些痕迹。",
+            "claimed_evidence_refs": [],
+            "suggested_actions": [],
+        }
+
+
+class ClaimsButOmitsRequiredEvidenceNarrationModel:
+    async def generate(self, context):
+        return {
+            "kind": "narration",
+            "text": "你在墓碑附近发现了一些痕迹。",
+            "claimed_evidence_refs": [context.narration_evidence[0].ref],
             "suggested_actions": [],
         }
 
@@ -1868,6 +1889,45 @@ async def test_narrator_rejects_evidence_outside_committed_public_refs() -> None
         await ActionPlanNarrator(OutOfScopeNarrationModel()).narrate(context)
 
     assert raised.value.reason == "evidence_scope"
+
+
+@pytest.mark.asyncio
+async def test_narrator_rejects_missing_required_evidence() -> None:
+    service, _, _, _, _ = orchestrator()
+    original = player_input()
+    await service.start_or_resume(original, plan=plan(2))
+    context = await service.build_narration_context(original)
+    required_ref = context.allowed_evidence_refs[0]
+    evidence = NarrationEvidence(
+        ref=required_ref,
+        kind="entity_discovered",
+        subject_id="crypt_entrance",
+        subject_name="石板下的地穴入口",
+        description="一块沉重石板遮住了向下的通道。",
+        required_in_narration=True,
+    )
+    first_step = context.completed_steps[0].model_copy(
+        update={"narration_evidence": (evidence,)}, deep=True
+    )
+    context = context.model_copy(
+        update={
+            "completed_steps": (first_step, *context.completed_steps[1:]),
+            "narration_evidence": (evidence,),
+        },
+        deep=True,
+    )
+
+    with pytest.raises(ActionPlanNarrationValidationError) as raised:
+        await ActionPlanNarrator(MissingRequiredEvidenceNarrationModel()).narrate(context)
+
+    assert raised.value.reason == "required_evidence_missing"
+
+    with pytest.raises(ActionPlanNarrationValidationError) as claimed_but_omitted:
+        await ActionPlanNarrator(ClaimsButOmitsRequiredEvidenceNarrationModel()).narrate(
+            context
+        )
+
+    assert claimed_but_omitted.value.reason == "required_evidence_missing"
 
 
 @pytest.mark.asyncio

--- a/agent-collaboration-framework/tests/test_narrator_policy.py
+++ b/agent-collaboration-framework/tests/test_narrator_policy.py
@@ -54,6 +54,10 @@ class NarrationTextPolicyTests(unittest.TestCase):
             "托马斯沉默。\ntext:": "protocol_tail",
             "托马斯沉默。\nkind:": "protocol_tail",
             "托马斯沉默。\nclaimed_fact_ids:": "protocol_tail",
+            (
+                '托马斯沉默。","claimed_evidence_refs":["evt_1"],'
+                '"suggested_actions":["继续调查"]}'
+            ): "protocol_tail",
             "托马斯沉默。\n```json\nsuggestedActions:\n```": "protocol_tail",
             (
                 '{"kind":"narration","text":"托马斯看着你。",'

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -1017,6 +1017,111 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
         )
         return store, engine, rules, resolved
 
+    async def run_grave_tracking(self, roll: int):
+        state = game_state(
+            self.content,
+            scene_id="cemetery",
+            entities={"favorite_grave": {"identified": True}},
+        )
+        actor = state.actors[ACTOR]
+        actors = dict(state.actors)
+        actors[ACTOR] = actor.model_copy(
+            update={
+                "state": {
+                    **actor.state,
+                    "skills": {**actor.state["skills"], "track": 90},
+                }
+            },
+            deep=True,
+        )
+        state = state.model_copy(update={"actors": actors}, deep=True)
+        store = InMemoryEngineStore()
+        store.register_room(module_content=self.content, initial_state=state)
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([roll]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        pending_execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id=f"track-grave-{roll}",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="追踪墓碑附近的痕迹",
+                    target=ActionTarget(kind="entity", id="favorite_grave"),
+                    method=ActionMethod(family="track", description="追踪痕迹"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="inspect_grave_area", option_id="track"
+                    ),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="track",
+                                skill_id="track",
+                                difficulty="regular",
+                                method_summary="追踪墓碑附近的痕迹",
+                                player_safe_reason="使用追踪",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        pending = pending_execution.pending_decision
+        assert pending is not None
+        resolved = await engine.decide(
+            CheckDecisionRequest(
+                request_id=f"track-grave-{roll}:select",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=pending_execution.view_revision,
+                decision_id=pending.decision_id,
+                decision_version=pending.decision_version,
+                choice=SelectCheckChoice(candidate_id="track"),
+            )
+        )
+        check_run = resolved.check_run
+        assert check_run is not None
+        resolved = await engine.decide_post_roll(
+            PostRollDecisionRequest(
+                request_id=f"track-grave-{roll}:accept",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=resolved.view_revision,
+                check_id=check_run.check_id,
+                check_version=check_run.version,
+                option_id="accept-current",
+            )
+        )
+        return store, resolved
+
+    async def test_discovering_crypt_entrance_produces_required_safe_evidence(self) -> None:
+        store, execution = await self.run_grave_tracking(25)
+
+        self.assertIs(store.inspect_state(ROOM).entities["crypt_entrance"]["discovered"], True)
+        self.assertEqual(len(execution.narration_evidence), 1)
+        evidence = execution.narration_evidence[0]
+        self.assertEqual(evidence.kind, "entity_discovered")
+        self.assertEqual(evidence.subject_id, "crypt_entrance")
+        self.assertEqual(evidence.subject_name, "石板下的地穴入口")
+        self.assertIn("沉重石板", evidence.description)
+        self.assertTrue(evidence.required_in_narration)
+        self.assertIn(evidence.ref, execution.public_event_refs)
+
+    async def test_failed_tracking_produces_no_crypt_discovery_evidence(self) -> None:
+        store, execution = await self.run_grave_tracking(95)
+
+        self.assertIsNot(
+            store.inspect_state(ROOM).entities.get("crypt_entrance", {}).get("discovered"),
+            True,
+        )
+        self.assertEqual(execution.narration_evidence, ())
+
     async def _submit_rule_decision(
         self,
         *,

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from collaboration_framework.contracts import (
     ActionAdjudication,
@@ -1120,6 +1121,39 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
             store.inspect_state(ROOM).entities.get("crypt_entrance", {}).get("discovered"),
             True,
         )
+        self.assertEqual(execution.narration_evidence, ())
+
+    async def test_non_discovery_action_skips_player_projection_for_narration_evidence(self) -> None:
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=self.content,
+            initial_state=game_state(self.content, scene_id="cemetery"),
+        )
+        engine = AdjudicationEngineService(store)
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        with patch(
+            "collaboration_framework.engine.adjudication.project_v3",
+            side_effect=AssertionError("projection should be skipped"),
+        ):
+            execution = await engine.submit(
+                SubmitAdjudicationRequest(
+                    room_id=ROOM,
+                    player_id=PLAYER,
+                    adjudication=ActionAdjudication(
+                        request_id="ordinary-action-no-discovery",
+                        source_revision=snapshot.revision,
+                        actor_id=ACTOR,
+                        summary="观察墓地",
+                        target=ActionTarget(kind="location", id="cemetery"),
+                        method=ActionMethod(family="observe", description="观察墓地"),
+                        check=NoAdjudicationCheck(),
+                        success_effects=(),
+                    ),
+                )
+            )
         self.assertEqual(execution.narration_evidence, ())
 
     async def _submit_rule_decision(

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -182,6 +182,8 @@ _ACTION_PLAN_NARRATION_INSTRUCTIONS = """
 kind=clarification，并用自然的角色内措辞提出一次最小澄清。claimed_evidence_refs
 只能复制 allowed_evidence_refs 中正文确实使用的值。不得输出 raw plan、裁决效果、
 内部状态、工具结果、模型推理或协议字段。建议动作最多三条且只能来自最终 PlayerView。
+叙事必须明确写出 narration_evidence 中 required_in_narration=true 的每项玩家可见结果，
+并把对应 ref 放入 claimed_evidence_refs；不得以未经证据确认的关键发现替代这些结果。
 
 【叙事主体】
 - 你是守秘人，不是玩家角色。player_input、plan_goal 或 semantic_goal 中玩家使用的

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -186,6 +186,8 @@ kind=clarification，并用自然的角色内措辞提出一次最小澄清。cl
 并把对应 ref 放入 claimed_evidence_refs；不得以未经证据确认的关键发现替代这些结果。
 text 只能包含自然的角色内叙事，不得把 claimed_evidence_refs、suggested_actions 或其他
 JSON/schema 字段和值重复写入正文。
+如果输入中提供 narration_retry_hint，说明上一版叙事漏报了一个已提交结果；本次必须
+在自然叙事中明确写出该结果，并准确 claim 对应 ref，然后再返回完整 JSON。
 
 【叙事主体】
 - 你是守秘人，不是玩家角色。player_input、plan_goal 或 semantic_goal 中玩家使用的

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -184,6 +184,8 @@ kind=clarification，并用自然的角色内措辞提出一次最小澄清。cl
 内部状态、工具结果、模型推理或协议字段。建议动作最多三条且只能来自最终 PlayerView。
 叙事必须明确写出 narration_evidence 中 required_in_narration=true 的每项玩家可见结果，
 并把对应 ref 放入 claimed_evidence_refs；不得以未经证据确认的关键发现替代这些结果。
+text 只能包含自然的角色内叙事，不得把 claimed_evidence_refs、suggested_actions 或其他
+JSON/schema 字段和值重复写入正文。
 
 【叙事主体】
 - 你是守秘人，不是玩家角色。player_input、plan_goal 或 semantic_goal 中玩家使用的

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -182,8 +182,9 @@ _ACTION_PLAN_NARRATION_INSTRUCTIONS = """
 kind=clarification，并用自然的角色内措辞提出一次最小澄清。claimed_evidence_refs
 只能复制 allowed_evidence_refs 中正文确实使用的值。不得输出 raw plan、裁决效果、
 内部状态、工具结果、模型推理或协议字段。建议动作最多三条且只能来自最终 PlayerView。
-叙事必须明确写出 narration_evidence 中 required_in_narration=true 的每项玩家可见结果，
-并把对应 ref 放入 claimed_evidence_refs；不得以未经证据确认的关键发现替代这些结果。
+叙事必须明确写出 narration_evidence 中 required_in_narration=true 的每项玩家可见结果；
+应把对应 ref 放入 claimed_evidence_refs，服务端也会按正文中明确出现的公开名称或别名
+确定性记录 required ref。不得以未经证据确认的关键发现替代这些结果。
 text 只能包含自然的角色内叙事，不得把 claimed_evidence_refs、suggested_actions 或其他
 JSON/schema 字段和值重复写入正文。
 如果输入中提供 narration_retry_hint，说明上一版叙事漏报了一个已提交结果；本次必须

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -470,10 +470,21 @@ class DeterministicActionPlanNarrationModel:
             goal = completed or _quote_action_summary(context.plan_goal)
             text = f"你依次完成了：{goal}。"
             kind = "narration"
+        required_refs = tuple(
+            item.ref for item in context.narration_evidence if item.required_in_narration
+        )
+        required_text = "；".join(
+            f"你发现了{item.subject_name}"
+            + (f"：{item.description}" if item.description else "")
+            for item in context.narration_evidence
+            if item.required_in_narration
+        )
+        if required_text:
+            text = f"{text}{required_text}。"
         return {
             "kind": kind,
             "text": text,
-            "claimed_evidence_refs": [],
+            "claimed_evidence_refs": required_refs,
             "suggested_actions": [],
         }
 
@@ -1069,6 +1080,7 @@ class ActionPlanTurnApplication:
             view_revision=execution.view_revision,
             world_time_after=WorldClockView.from_world(result.player_view.world),
             event_refs=execution.public_event_refs,
+            narration_evidence=execution.narration_evidence,
         )
         context = ActionPlanNarrationContext(
             background=result.player_view.background,
@@ -1079,6 +1091,7 @@ class ActionPlanTurnApplication:
             player_view=result.player_view,
             opening_world_time=result.opening_world_time,
             allowed_evidence_refs=execution.public_event_refs,
+            narration_evidence=execution.narration_evidence,
         )
         return ActionPlanTurnResult(
             player_input=player_input,
@@ -1097,6 +1110,8 @@ class ActionPlanTurnApplication:
                 return await self._narrator.narrate(context)
             except ActionPlanNarrationValidationError as exc:
                 if attempt == 1:
+                    if exc.reason == "required_evidence_missing":
+                        return self._required_evidence_fallback(context)
                     raise TurnExecutionError(
                         "PLAN_NARRATION_INVALID",
                         "规则结果已保存，但叙事未通过安全校验；请使用原请求重试",
@@ -1113,6 +1128,29 @@ class ActionPlanTurnApplication:
                     retryable=True,
                 ) from exc
         raise AssertionError("unreachable")
+
+    @staticmethod
+    def _required_evidence_fallback(
+        context: ActionPlanNarrationContext,
+    ) -> ActionPlanNarrationOutput:
+        required = tuple(
+            item for item in context.narration_evidence if item.required_in_narration
+        )
+        if not required:
+            raise TurnExecutionError(
+                "PLAN_NARRATION_INVALID",
+                "规则结果已保存，但叙事未通过安全校验；请使用原请求重试",
+                retryable=True,
+            )
+        details = "；".join(
+            f"你发现了{item.subject_name}"
+            + (f"：{item.description}" if item.description else "")
+            for item in required
+        )
+        return ActionPlanNarrationOutput(
+            text=f"{details}。",
+            claimed_evidence_refs=tuple(item.ref for item in required),
+        )
 
     async def _keeper_capabilities(
         self,

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -1109,7 +1109,18 @@ class ActionPlanTurnApplication:
                 return await self._narrator.narrate(context)
             except ActionPlanNarrationValidationError as exc:
                 if attempt == 1:
-                    if exc.reason == "required_evidence_missing":
+                    if (
+                        exc.reason == "required_evidence_missing"
+                        and context.termination_status != "needs_clarification"
+                    ):
+                        logger.warning(
+                            "action_plan_narration_required_evidence_fallback",
+                            evidence_refs=[
+                                item.ref
+                                for item in context.narration_evidence
+                                if item.required_in_narration
+                            ],
+                        )
                         return self._required_evidence_fallback(context)
                     raise TurnExecutionError(
                         "PLAN_NARRATION_INVALID",
@@ -1139,12 +1150,14 @@ class ActionPlanTurnApplication:
                 "规则结果已保存，但叙事未通过安全校验；请使用原请求重试",
                 retryable=True,
             )
-        details = "；".join(
-            f"你发现了{item.subject_name}" + (f"：{item.description}" if item.description else "")
-            for item in required
-        )
+        sentences: list[str] = []
+        for item in required:
+            sentences.append(f"随着调查深入，你很快辨认出{item.subject_name}。")
+            description = item.description.strip()
+            if description:
+                sentences.append(description.rstrip("。！？!?；;，,") + "。")
         return ActionPlanNarrationOutput(
-            text=f"{details}。",
+            text="".join(sentences),
             claimed_evidence_refs=tuple(item.ref for item in required),
         )
 

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -1108,12 +1108,25 @@ class ActionPlanTurnApplication:
             try:
                 return await self._narrator.narrate(context)
             except ActionPlanNarrationValidationError as exc:
+                if attempt == 0 and exc.reason == "required_evidence_missing":
+                    missing = tuple(
+                        item for item in context.narration_evidence if item.required_in_narration
+                    )
+                    context = context.model_copy(
+                        update={
+                            "narration_retry_hint": (
+                                "上一版叙事遗漏了已提交的玩家可见结果："
+                                + "、".join(item.subject_name for item in missing)
+                                + "。必须在正文明确写出，并 claim 对应 evidence ref。"
+                            )
+                        }
+                    )
                 if attempt == 1:
                     if (
                         exc.reason == "required_evidence_missing"
                         and context.termination_status != "needs_clarification"
                     ):
-                        logger.warning(
+                        logger.info(
                             "action_plan_narration_required_evidence_fallback",
                             evidence_refs=[
                                 item.ref

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -474,8 +474,7 @@ class DeterministicActionPlanNarrationModel:
             item.ref for item in context.narration_evidence if item.required_in_narration
         )
         required_text = "；".join(
-            f"你发现了{item.subject_name}"
-            + (f"：{item.description}" if item.description else "")
+            f"你发现了{item.subject_name}" + (f"：{item.description}" if item.description else "")
             for item in context.narration_evidence
             if item.required_in_narration
         )
@@ -1133,9 +1132,7 @@ class ActionPlanTurnApplication:
     def _required_evidence_fallback(
         context: ActionPlanNarrationContext,
     ) -> ActionPlanNarrationOutput:
-        required = tuple(
-            item for item in context.narration_evidence if item.required_in_narration
-        )
+        required = tuple(item for item in context.narration_evidence if item.required_in_narration)
         if not required:
             raise TurnExecutionError(
                 "PLAN_NARRATION_INVALID",
@@ -1143,8 +1140,7 @@ class ActionPlanTurnApplication:
                 retryable=True,
             )
         details = "；".join(
-            f"你发现了{item.subject_name}"
-            + (f"：{item.description}" if item.description else "")
+            f"你发现了{item.subject_name}" + (f"：{item.description}" if item.description else "")
             for item in required
         )
         return ActionPlanNarrationOutput(

--- a/trpg-backend/tests/test_action_plan_turn_recovery.py
+++ b/trpg-backend/tests/test_action_plan_turn_recovery.py
@@ -10,7 +10,10 @@ from collaboration_framework.contracts import (
     NarrationEvidence,
     PostRollDecisionRequest,
 )
-from collaboration_framework.host.application import ActionPlanNarrationValidationError
+from collaboration_framework.host.application import (
+    ActionPlanNarrationValidationError,
+    TurnExecutionError,
+)
 from collaboration_framework.host.schemas import ActionPlanNarrationContext
 
 from app.core.action_plan_turn import ActionPlanTurnApplication
@@ -130,7 +133,10 @@ async def test_narration_falls_back_to_required_player_safe_evidence() -> None:
     )
     context = cast(
         ActionPlanNarrationContext,
-        SimpleNamespace(narration_evidence=(evidence,)),
+        SimpleNamespace(
+            narration_evidence=(evidence,),
+            termination_status="resolved",
+        ),
     )
 
     narration = await application._narrate(context)
@@ -139,6 +145,34 @@ async def test_narration_falls_back_to_required_player_safe_evidence() -> None:
     assert narration.claimed_evidence_refs == (evidence.ref,)
     assert "石板下的地穴入口" in narration.text
     assert "沉重石板" in narration.text
+    assert "。。" not in narration.text
+
+
+@pytest.mark.asyncio
+async def test_required_evidence_fallback_never_changes_clarification_scope() -> None:
+    application = object.__new__(ActionPlanTurnApplication)
+    narrate = AsyncMock(side_effect=ActionPlanNarrationValidationError("required_evidence_missing"))
+    application._narrator = SimpleNamespace(narrate=narrate)
+    evidence = NarrationEvidence(
+        ref="evt-crypt-discovered",
+        kind="entity_discovered",
+        subject_id="crypt_entrance",
+        subject_name="石板下的地穴入口",
+        required_in_narration=True,
+    )
+    context = cast(
+        ActionPlanNarrationContext,
+        SimpleNamespace(
+            narration_evidence=(evidence,),
+            termination_status="needs_clarification",
+        ),
+    )
+
+    with pytest.raises(TurnExecutionError) as raised:
+        await application._narrate(context)
+
+    assert raised.value.code == "PLAN_NARRATION_INVALID"
+    assert narrate.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/trpg-backend/tests/test_action_plan_turn_recovery.py
+++ b/trpg-backend/tests/test_action_plan_turn_recovery.py
@@ -88,6 +88,21 @@ class _Orchestrator:
         return SimpleNamespace(run=self.run)
 
 
+class _NarrationContextStub:
+    def __init__(self, evidence: NarrationEvidence, termination_status: str) -> None:
+        self.narration_evidence = (evidence,)
+        self.termination_status = termination_status
+        self.narration_retry_hint: str | None = None
+
+    def model_copy(self, *, update: dict[str, object]):
+        copied = _NarrationContextStub(
+            self.narration_evidence[0],
+            self.termination_status,
+        )
+        copied.narration_retry_hint = cast(str | None, update["narration_retry_hint"])
+        return copied
+
+
 def _application(run: SimpleNamespace, engine: _Engine, orchestrator: _Orchestrator):
     application = object.__new__(ActionPlanTurnApplication)
     application._adjudication_engine = engine
@@ -133,15 +148,15 @@ async def test_narration_falls_back_to_required_player_safe_evidence() -> None:
     )
     context = cast(
         ActionPlanNarrationContext,
-        SimpleNamespace(
-            narration_evidence=(evidence,),
-            termination_status="resolved",
-        ),
+        _NarrationContextStub(evidence, "resolved"),
     )
 
     narration = await application._narrate(context)
 
     assert narrate.await_count == 2
+    retry_context = narrate.await_args_list[1].args[0]
+    assert "石板下的地穴入口" in retry_context.narration_retry_hint
+    assert "claim" in retry_context.narration_retry_hint
     assert narration.claimed_evidence_refs == (evidence.ref,)
     assert "石板下的地穴入口" in narration.text
     assert "沉重石板" in narration.text
@@ -162,10 +177,7 @@ async def test_required_evidence_fallback_never_changes_clarification_scope() ->
     )
     context = cast(
         ActionPlanNarrationContext,
-        SimpleNamespace(
-            narration_evidence=(evidence,),
-            termination_status="needs_clarification",
-        ),
+        _NarrationContextStub(evidence, "needs_clarification"),
     )
 
     with pytest.raises(TurnExecutionError) as raised:

--- a/trpg-backend/tests/test_action_plan_turn_recovery.py
+++ b/trpg-backend/tests/test_action_plan_turn_recovery.py
@@ -118,9 +118,7 @@ def test_application_injects_plan_repair_dependencies_into_single_action_path() 
 @pytest.mark.asyncio
 async def test_narration_falls_back_to_required_player_safe_evidence() -> None:
     application = object.__new__(ActionPlanTurnApplication)
-    narrate = AsyncMock(
-        side_effect=ActionPlanNarrationValidationError("required_evidence_missing")
-    )
+    narrate = AsyncMock(side_effect=ActionPlanNarrationValidationError("required_evidence_missing"))
     application._narrator = SimpleNamespace(narrate=narrate)
     evidence = NarrationEvidence(
         ref="evt-crypt-discovered",

--- a/trpg-backend/tests/test_action_plan_turn_recovery.py
+++ b/trpg-backend/tests/test_action_plan_turn_recovery.py
@@ -5,7 +5,13 @@ from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
-from collaboration_framework.contracts import ActionPlanPolicy, PostRollDecisionRequest
+from collaboration_framework.contracts import (
+    ActionPlanPolicy,
+    NarrationEvidence,
+    PostRollDecisionRequest,
+)
+from collaboration_framework.host.application import ActionPlanNarrationValidationError
+from collaboration_framework.host.schemas import ActionPlanNarrationContext
 
 from app.core.action_plan_turn import ActionPlanTurnApplication
 
@@ -107,6 +113,34 @@ def test_application_injects_plan_repair_dependencies_into_single_action_path() 
 
     assert application._dispatcher._repair_adjudicator is orchestrator.adjudicator
     assert application._dispatcher._policy is orchestrator.policy
+
+
+@pytest.mark.asyncio
+async def test_narration_falls_back_to_required_player_safe_evidence() -> None:
+    application = object.__new__(ActionPlanTurnApplication)
+    narrate = AsyncMock(
+        side_effect=ActionPlanNarrationValidationError("required_evidence_missing")
+    )
+    application._narrator = SimpleNamespace(narrate=narrate)
+    evidence = NarrationEvidence(
+        ref="evt-crypt-discovered",
+        kind="entity_discovered",
+        subject_id="crypt_entrance",
+        subject_name="石板下的地穴入口",
+        description="一块沉重石板遮住了向下的通道。",
+        required_in_narration=True,
+    )
+    context = cast(
+        ActionPlanNarrationContext,
+        SimpleNamespace(narration_evidence=(evidence,)),
+    )
+
+    narration = await application._narrate(context)
+
+    assert narrate.await_count == 2
+    assert narration.claimed_evidence_refs == (evidence.ref,)
+    assert "石板下的地穴入口" in narration.text
+    assert "沉重石板" in narration.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 关联 Issue

Closes #318

## 问题

规则检定成功后，Engine 已提交 `crypt_entrance.discovered=true`，但 Narrator 只收到不透明的 `evt_*` 引用，无法知道本回合新发现了什么；同时现有校验只限制 claim 不得越界，并不要求覆盖关键结果。

## 修复

- 在 `AdjudicationExecution` 增加玩家安全的结构化 `NarrationEvidence`，当前覆盖首次实体发现。
- Engine 仅为 `discovered: false/absent -> true` 的公开事件生成证据，并通过最终 PlayerView 投影取得玩家可见名称和描述，不暴露 Keeper-only 内容。
- 单动作及 ActionPlan（包括 #302 的持久化恢复路径）统一携带并聚合该证据。
- Narrator 必须 claim required evidence，且正文必须出现玩家可见主体名称；漏报会进入现有有限重试。
- 连续两次只因 required evidence 漏报而失败时，使用结构化玩家安全证据生成保守兜底叙事，避免权威状态已提交但玩家只收到错误。
- 更新生成的 adjudication JSON Schema。

## 范围说明

本 PR 不修改《追书人》模组 JSON、规则检定难度或成功后果，也不处理 #319 的地穴进入执行器。入口发现后停止重复发布追踪规则可单独评审。

## 测试

- Framework 全量：`354 passed, 3 skipped`
- Backend 全量：`414 passed, 10 skipped`（1 条既有 Starlette/httpx 弃用警告）
- Ruff：修改文件通过
- Backend ty：通过
- Framework ty：仍有 `engine/adjudication.py` 等文件的 15 条既有基线诊断，本次新增代码未增加诊断
- `git diff --check`：通过

新增回归覆盖：

- 《追书人》追踪成功生成“石板下的地穴入口” required evidence；失败不生成。
- 空 claim 或只 claim 但正文漏写主体名称均被拒绝。
- 单动作与 ActionPlan 叙事上下文均携带证据。
- 连续漏报后返回玩家安全兜底叙事。

## 安全检查

- [x] Evidence 只来自公开事件和最终 PlayerView 投影
- [x] 不包含隐藏 Rule、Keeper-only 名称或原始内部 payload
- [x] 旧 execution 缺少新字段时使用默认空元组，兼容恢复
- [x] 未包含密钥、个人信息或无关文件
