### PR TITLE
fix(frontend): 3D 骰子归还 WebGL context 并处理丢失

### DIFF
--- a/trpg-frontend/src/features/dice3d/Dice3DStage.test.tsx
+++ b/trpg-frontend/src/features/dice3d/Dice3DStage.test.tsx
@@ -4,10 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Dice3DStage, type Dice3DHandle } from './Dice3DStage'
 
-const { createdStages, mockDispose, mockStageRoll } = vi.hoisted(() => ({
-  createdStages: [] as Array<{ onSettled: (value: number) => void }>,
+const { createdStages, mockDispose, mockStageRoll, mockSetKind } = vi.hoisted(() => ({
+  createdStages: [] as Array<{
+    onSettled: (value: number) => void
+    onContextLost?: () => void
+  }>,
   mockDispose: vi.fn(),
   mockStageRoll: vi.fn(() => true),
+  mockSetKind: vi.fn(),
 }))
 
 vi.mock('./support', () => ({
@@ -15,9 +19,15 @@ vi.mock('./support', () => ({
 }))
 
 vi.mock('./engine', () => ({
-  createDiceStage: ({ onSettled }: { onSettled: (value: number) => void }) => {
-    createdStages.push({ onSettled })
-    return { roll: mockStageRoll, dispose: mockDispose }
+  createDiceStage: ({
+    onSettled,
+    onContextLost,
+  }: {
+    onSettled: (value: number) => void
+    onContextLost?: () => void
+  }) => {
+    createdStages.push({ onSettled, onContextLost })
+    return { roll: mockStageRoll, dispose: mockDispose, setKind: mockSetKind }
   },
 }))
 
@@ -25,6 +35,7 @@ describe('Dice3DStage', () => {
   beforeEach(() => {
     createdStages.length = 0
     mockDispose.mockReset()
+    mockSetKind.mockReset()
     mockStageRoll.mockReset()
     mockStageRoll.mockReturnValue(true)
   })
@@ -61,5 +72,67 @@ describe('Dice3DStage', () => {
 
     act(() => createdStages[0].onSettled(23))
     expect(onSettled).not.toHaveBeenCalled()
+  })
+
+  // 浏览器回收 context、GPU 进程重启都是可恢复的偶发事件。走 onRollAbandoned
+  // 是为了只丢掉这一次掷骰——用 onUnsupported 会把 use3D 永久翻成 false，之后
+  // 每次检定都只剩数字版（issue #320）。
+  it('abandons only the current roll when the WebGL context is lost', async () => {
+    const ref = createRef<Dice3DHandle>()
+    const onSettled = vi.fn()
+    const onUnsupported = vi.fn()
+    const onRollAbandoned = vi.fn()
+    render(
+      <Dice3DStage
+        ref={ref}
+        kind="d100"
+        onSettled={onSettled}
+        onUnsupported={onUnsupported}
+        onRollAbandoned={onRollAbandoned}
+      />,
+    )
+    await waitFor(() => expect(createdStages).toHaveLength(1))
+
+    expect(ref.current?.roll('check-a:1')).toBe(true)
+    act(() => createdStages[0].onContextLost?.())
+
+    expect(onRollAbandoned).toHaveBeenCalledWith('check-a:1')
+    expect(onUnsupported).not.toHaveBeenCalled()
+
+    // 这一次被放弃后，槽位要腾出来，下一次检定还能继续用 3D。
+    expect(ref.current?.roll('check-b:2')).toBe(true)
+  })
+
+  // 每重建一次舞台就多一个 WebGLRenderer，顶穿浏览器的 context 上限。切骰型
+  // 只该换骰子，renderer / 相机 / 光照 / 地面都不用动（issue #320）。
+  it('reuses the stage across dice kinds instead of rebuilding the renderer', async () => {
+    const ref = createRef<Dice3DHandle>()
+    const onRollAbandoned = vi.fn()
+    const view = render(
+      <Dice3DStage
+        ref={ref}
+        kind="d100"
+        onSettled={vi.fn()}
+        onRollAbandoned={onRollAbandoned}
+      />,
+    )
+    await waitFor(() => expect(createdStages).toHaveLength(1))
+
+    expect(ref.current?.roll('check-a:1')).toBe(true)
+    view.rerender(
+      <Dice3DStage
+        ref={ref}
+        kind="d20"
+        onSettled={vi.fn()}
+        onRollAbandoned={onRollAbandoned}
+      />,
+    )
+
+    expect(mockSetKind).toHaveBeenCalledWith('d20')
+    expect(createdStages).toHaveLength(1)
+    expect(mockDispose).not.toHaveBeenCalled()
+    // 换型丢掉了上一副骰子，那次掷骰要按「这一次没了」交还，否则 rolling 不清。
+    expect(onRollAbandoned).toHaveBeenCalledWith('check-a:1')
+    expect(ref.current?.roll('check-b:2')).toBe(true)
   })
 })

--- a/trpg-frontend/src/features/dice3d/Dice3DStage.test.tsx
+++ b/trpg-frontend/src/features/dice3d/Dice3DStage.test.tsx
@@ -10,7 +10,7 @@ const { createdStages, mockDispose, mockStageRoll, mockSetKind } = vi.hoisted(()
     onContextLost?: () => void
   }>,
   mockDispose: vi.fn(),
-  mockStageRoll: vi.fn(() => true),
+  mockStageRoll: vi.fn((): boolean => true),
   mockSetKind: vi.fn(),
 }))
 
@@ -26,8 +26,23 @@ vi.mock('./engine', () => ({
     onSettled: (value: number) => void
     onContextLost?: () => void
   }) => {
-    createdStages.push({ onSettled, onContextLost })
-    return { roll: mockStageRoll, dispose: mockDispose, setKind: mockSetKind }
+    // 贴着真实引擎的行为建模：context 一丢，这个舞台就永久拒绝后续掷骰
+    // （engine.ts 的 `roll()` 里 `if (disposed || contextLost) return false`）。
+    // 之前 mock 的 roll 恒为 true，于是「丢失后还能继续掷」这条断言是假绿的。
+    let contextLost = false
+    const entry = {
+      onSettled,
+      onContextLost: () => {
+        contextLost = true
+        onContextLost?.()
+      },
+    }
+    createdStages.push(entry)
+    return {
+      roll: () => (contextLost ? false : mockStageRoll()),
+      dispose: mockDispose,
+      setKind: mockSetKind,
+    }
   },
 }))
 
@@ -99,8 +114,42 @@ describe('Dice3DStage', () => {
     expect(onRollAbandoned).toHaveBeenCalledWith('check-a:1')
     expect(onUnsupported).not.toHaveBeenCalled()
 
-    // 这一次被放弃后，槽位要腾出来，下一次检定还能继续用 3D。
+    // 丢失的 context 救不回来，必须换一个新舞台，否则之后每次掷骰都被静默拒绝
+    // ——玩家点「掷骰」按钮，rolling 清掉了，什么都没发生（#324 review 指出）。
+    await waitFor(() => expect(createdStages).toHaveLength(2))
+    expect(mockDispose).toHaveBeenCalled()
+
     expect(ref.current?.roll('check-b:2')).toBe(true)
+    act(() => createdStages[1].onSettled(41))
+    expect(onSettled).toHaveBeenCalledWith(41, 'check-b:2')
+    expect(onUnsupported).not.toHaveBeenCalled()
+  })
+
+  // 换新舞台也救不回来时（GPU 反复崩），不能无限重建：有限次之后老实退回 2D。
+  it('gives up on 3D after repeated context losses instead of rebuilding forever', async () => {
+    const ref = createRef<Dice3DHandle>()
+    const onUnsupported = vi.fn()
+    render(
+      <Dice3DStage
+        ref={ref}
+        kind="d100"
+        onSettled={vi.fn()}
+        onUnsupported={onUnsupported}
+        onRollAbandoned={vi.fn()}
+      />,
+    )
+    await waitFor(() => expect(createdStages).toHaveLength(1))
+
+    for (let i = 0; i < 5; i += 1) {
+      const stage = createdStages.at(-1)
+      act(() => stage?.onContextLost?.())
+      await waitFor(() => expect(onUnsupported.mock.calls.length + createdStages.length).toBeGreaterThan(i + 1))
+      if (onUnsupported.mock.calls.length > 0) break
+    }
+
+    expect(onUnsupported).toHaveBeenCalled()
+    expect(createdStages.length).toBeLessThanOrEqual(4)
+    expect(ref.current?.roll('check-after-giveup:1')).toBe(false)
   })
 
   // 每重建一次舞台就多一个 WebGLRenderer，顶穿浏览器的 context 上限。切骰型

--- a/trpg-frontend/src/features/dice3d/Dice3DStage.tsx
+++ b/trpg-frontend/src/features/dice3d/Dice3DStage.tsx
@@ -52,6 +52,10 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
   onUnsupportedRef.current = onUnsupported
   const onRollAbandonedRef = useRef(onRollAbandoned)
   onRollAbandonedRef.current = onRollAbandoned
+  // 舞台只建一次；骰型变化由下面那个 effect 通过 setKind 同步。放 ref 里是为了
+  // 让创建时能读到当前值，又不把它变成重建的理由。
+  const kindRef = useRef(kind)
+  kindRef.current = kind
 
   useEffect(() => {
     const container = containerRef.current
@@ -69,11 +73,21 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
         if (cancelled) return
         const stage = createDiceStage({
           container,
-          kind,
+          kind: kindRef.current,
           onSettled: (value) => {
             const token = activeRollRef.current
             activeRollRef.current = null
             if (token !== null) onSettledRef.current(value, token)
+          },
+          // context 丢失走 onRollAbandoned 而不是 onUnsupported：浏览器回收
+          // context、GPU 进程重启都是可恢复的偶发事件，不等于这台设备用不了
+          // 3D。用后者会把 use3D 永久翻成 false，之后每次检定都只剩数字版
+          // ——和「舞台被卸载不代表 3D 不可用」是同一条原则（issue #320）。
+          onContextLost: () => {
+            const token = activeRollRef.current ?? pendingRollRef.current?.token ?? null
+            activeRollRef.current = null
+            pendingRollRef.current = null
+            if (token !== null) onRollAbandonedRef.current?.(token)
           },
         })
         stageRef.current = stage
@@ -84,8 +98,11 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
           if (!stage.roll(pending.targetValue)) activeRollRef.current = null
         }
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (cancelled) return
+        // 回退本身是对的，但之前连一行日志都不留：3D 静默消失，控制台一条错误
+        // 都没有，只能看到「只剩数字版」这个结果（issue #320 排查时踩到）。
+        console.warn('[dice3d] 引擎加载或初始化失败，退回 2D', error)
         // 加载或初始化失败同样退回 2D，不能把检定卡死在这里。
         const failedToken = activeRollRef.current ?? pendingRollRef.current?.token ?? null
         activeRollRef.current = null
@@ -109,6 +126,20 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
       stageRef.current = null
       if (abandoned !== null) onRollAbandonedRef.current?.(abandoned)
     }
+    // 依赖为空：舞台只随组件挂载/卸载建一次。骰型变化不重建——重建一次就多
+    // 一个 WebGLRenderer，顶穿浏览器的 context 上限（issue #320）。
+  }, [])
+
+  // 骰型变化：复用舞台，只换骰子。换型会丢掉上一副骰子，所以已受理但还没定格
+  // 的那次掷骰要按「这一次没了」通知出去，否则父组件的 rolling 永远不清。
+  useEffect(() => {
+    const stage = stageRef.current
+    if (!stage) return
+    const abandoned = activeRollRef.current ?? pendingRollRef.current?.token ?? null
+    activeRollRef.current = null
+    pendingRollRef.current = null
+    stage.setKind(kind)
+    if (abandoned !== null) onRollAbandonedRef.current?.(abandoned)
   }, [kind])
 
   useImperativeHandle(

--- a/trpg-frontend/src/features/dice3d/Dice3DStage.tsx
+++ b/trpg-frontend/src/features/dice3d/Dice3DStage.tsx
@@ -10,6 +10,14 @@ import type { DiceStage } from './engine'
 import { supports3DDice } from './support'
 import type { DiceKind, DiceRollToken } from './types'
 
+/**
+ * context 连续丢失多少次之后放弃 3D。
+ *
+ * 允许重建是因为浏览器回收 context、GPU 进程重启都是可恢复的偶发事件；封顶是
+ * 因为如果每次新建的 context 转头就丢，重建只会一直制造新 context。
+ */
+const MAX_CONTEXT_LOSS_REBUILDS = 2
+
 export interface Dice3DHandle {
   /** 返回 false 表示舞台仍在处理上一轮，未接受本次请求。 */
   roll: (token: DiceRollToken, targetValue?: number) => boolean
@@ -44,6 +52,16 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
   } | null>(null)
   const activeRollRef = useRef<DiceRollToken | null>(null)
   const [failed, setFailed] = useState(false)
+  /**
+   * context 丢失后换一个新舞台（issue #320 review 指出）。
+   *
+   * 丢掉的 context 救不回来：引擎的 `roll()` 从此永久返回 false，而 `RoomPage`
+   * 收到 false 只清 rolling、不回退 2D——同一次面板打开期间，之后每次点「掷骰」
+   * 都静默失效，玩家看到按钮恢复可用却什么都没发生。所以必须换新舞台，拿一个
+   * 新的 context。
+   */
+  const [stageGeneration, setStageGeneration] = useState(0)
+  const contextLossCountRef = useRef(0)
 
   // 回调放进 ref：它们的引用变化不应该触发引擎重建（重建会丢掉画面上的骰子）。
   const onSettledRef = useRef(onSettled)
@@ -88,6 +106,16 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
             activeRollRef.current = null
             pendingRollRef.current = null
             if (token !== null) onRollAbandonedRef.current?.(token)
+            contextLossCountRef.current += 1
+            if (contextLossCountRef.current > MAX_CONTEXT_LOSS_REBUILDS) {
+              // 换了几次还在丢，说明不是偶发回收（GPU 反复崩、驱动有问题）。
+              // 继续重建只会一直制造新 context，老实退回 2D。
+              console.warn('[dice3d] WebGL context 反复丢失，退回 2D')
+              setFailed(true)
+              onUnsupportedRef.current?.(null)
+              return
+            }
+            setStageGeneration((generation) => generation + 1)
           },
         })
         stageRef.current = stage
@@ -126,9 +154,9 @@ export const Dice3DStage = forwardRef<Dice3DHandle, Dice3DStageProps>(function D
       stageRef.current = null
       if (abandoned !== null) onRollAbandonedRef.current?.(abandoned)
     }
-    // 依赖为空：舞台只随组件挂载/卸载建一次。骰型变化不重建——重建一次就多
-    // 一个 WebGLRenderer，顶穿浏览器的 context 上限（issue #320）。
-  }, [])
+    // 只随组件挂载/卸载和 context 丢失重建。骰型变化不重建——重建一次就多一个
+    // WebGLRenderer，顶穿浏览器的 context 上限（issue #320）。
+  }, [stageGeneration])
 
   // 骰型变化：复用舞台，只换骰子。换型会丢掉上一副骰子，所以已受理但还没定格
   // 的那次掷骰要按「这一次没了」通知出去，否则父组件的 rolling 永远不清。

--- a/trpg-frontend/src/features/dice3d/engine.ts
+++ b/trpg-frontend/src/features/dice3d/engine.ts
@@ -243,6 +243,14 @@ function diceDefinitions(kind: DiceKind): {
 export interface DiceStage {
   /** 掷一次。正在掷的时候重复调用会被忽略。 */
   roll: (targetValue?: number) => boolean
+  /**
+   * 换骰型，复用同一个 renderer 与场景。
+   *
+   * 之前换骰型靠整个重建舞台，也就重建一个 `WebGLRenderer`。浏览器对同时存活
+   * 的 context 有上限，这种 churn 会把上限顶穿（issue #320）。骰型只决定生成
+   * 哪几颗骰子，renderer、相机、光照、地面都不需要动。
+   */
+  setKind: (kind: DiceKind) => void
   /** 释放 WebGL 资源并停掉动画循环。 */
   dispose: () => void
 }
@@ -252,9 +260,24 @@ export interface DiceStageOptions {
   kind: DiceKind
   /** 骰子完全停稳、结果可读时调用一次。 */
   onSettled: (value: number) => void
+  /**
+   * WebGL context 丢了，这个舞台再也画不出东西。
+   *
+   * 浏览器对同时存活的 context 有上限，超了会强制掐掉最老的那些；GPU 进程崩溃
+   * 也会触发。之前没有人监听，画布就停在死状态——骰子看着是黑的，渲染循环还在
+   * 往里画（issue #320）。
+   */
+  onContextLost?: () => void
 }
 
-export function createDiceStage({ container, kind, onSettled }: DiceStageOptions): DiceStage {
+export function createDiceStage({
+  container,
+  kind: initialKind,
+  onSettled,
+  onContextLost,
+}: DiceStageOptions): DiceStage {
+  // 可变：`setKind` 换的就是它，下面所有闭包都读这一个变量。
+  let kind = initialKind
   const renderer = new WebGLRenderer({ antialias: true, alpha: true })
   renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
   renderer.shadowMap.enabled = true
@@ -310,6 +333,16 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
   // 这里没有那段 CSS，不写 style 的话 canvas 会按绘制缓冲尺寸当 CSS 像素显示
   // ——在 dpr=2 的屏上就是 2 倍大小，父容器 overflow-hidden 只露出左上四分之一。
   renderer.domElement.style.display = 'block'
+
+  let contextLost = false
+  const handleContextLost = (event: Event) => {
+    // preventDefault 是让浏览器保留恢复这个 context 的可能；不调的话它永久作废。
+    event.preventDefault()
+    contextLost = true
+    cancelAnimationFrame(frame)
+    onContextLost?.()
+  }
+  renderer.domElement.addEventListener('webglcontextlost', handleContextLost)
 
   const resize = () => {
     const w = container.clientWidth
@@ -510,7 +543,8 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
   }
 
   const loop = (now: number) => {
-    if (disposed) return
+    // context 丢了就别再排下一帧，也别往死掉的 context 里画。
+    if (disposed || contextLost) return
     frame = requestAnimationFrame(loop)
     const dt = Math.min((now - lastFrame) / 1000, 0.05)
     lastFrame = now
@@ -520,8 +554,17 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
   frame = requestAnimationFrame(loop)
 
   return {
+    setKind(next: DiceKind) {
+      if (disposed || next === kind) return
+      kind = next
+      // 上一副骰子属于旧骰型，留着会和新骰型混在一起。清掉并回到 idle，
+      // 下一次 roll() 会按新骰型重新生成。
+      clearActors()
+      phase = 'idle'
+      requestedValue = null
+    },
     roll(targetValue?: number) {
-      if (disposed || phase !== 'idle') return false
+      if (disposed || contextLost || phase !== 'idle') return false
       requestedValue = targetValue ?? null
       clearActors()
       diceDefinitions(kind).forEach((def, index) => {
@@ -549,10 +592,18 @@ export function createDiceStage({ container, kind, onSettled }: DiceStageOptions
       disposed = true
       cancelAnimationFrame(frame)
       observer?.disconnect()
+      renderer.domElement.removeEventListener('webglcontextlost', handleContextLost)
       clearActors()
       groundGeom.dispose()
       groundMat.dispose()
       renderer.dispose()
+      // `dispose()` 只释放 GPU 资源，WebGL context 本身要等 GC 才归还。浏览器
+      // 对同时存活的 context 有上限（Chrome 约 16），舞台每次挂载都新建一个
+      // renderer——开关面板、切骰型都会重建——不主动归还就会顶到上限，浏览器
+      // 转而强制掐掉最老的那些 context（issue #320 实测：连开 20 个被掐掉 4 个）。
+      //
+      // context 已经丢了就不要再调：那会在控制台留下一条无意义的告警。
+      if (!contextLost) renderer.forceContextLoss()
       renderer.domElement.remove()
     },
   }


### PR DESCRIPTION
Closes #320

3D 骰子每次挂载都新建一个 `WebGLRenderer` 却不归还 context，浏览器顶到上限后强制掐掉最老的那些；而代码里没有任何 context 丢失处理，渲染循环还在往死掉的 context 里画。骰子变黑、白框崩溃图、永久退化成 2D，都是这一个根因。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `features/dice3d/engine.ts` | `dispose()` 在 `renderer.dispose()` 之后补 `forceContextLoss()`，主动归还 context |
| `features/dice3d/engine.ts` | 监听 `webglcontextlost`：`preventDefault()`、停掉渲染循环、通过新增的 `onContextLost` 通知调用方 |
| `features/dice3d/engine.ts` | 渲染循环判 `contextLost` 时跳过 `render()`；`roll()` 也一并拒掉 |
| `features/dice3d/engine.ts` | `DiceStage` 新增 `setKind()`：切骰型复用同一个 renderer / 相机 / 光照 / 地面，只换骰子 |
| `features/dice3d/Dice3DStage.tsx` | context 丢失走 `onRollAbandoned` 放弃当次掷骰，并递增 `stageGeneration` 换一个新舞台；连续丢失超过 `MAX_CONTEXT_LOSS_REBUILDS`（2）次才 `setFailed` 退回 2D |
| `features/dice3d/Dice3DStage.tsx` | 舞台创建 effect 依赖由 `[kind]` 改为 `[stageGeneration]`，骰型变化由新 effect 调 `setKind()` |
| `features/dice3d/Dice3DStage.tsx` | 引擎加载/初始化失败补一条 `console.warn` |
| `features/dice3d/Dice3DStage.test.tsx` | 三条新测试：context 丢失后换新舞台且新舞台能正常定格、连续丢失到封顶后退回 2D、切骰型不重建舞台；mock 补上「`contextLost` 后永久拒绝」的真实行为 |

## 关键决策

**为什么 context 丢失走 `onRollAbandoned` 而不是 `onUnsupported`**：`RoomPage.tsx` 里 `use3D` 只在挂载时求值一次、只降不升，`onUnsupported` 会把它永久翻成 `false`——之后每次检定都只剩数字版。而浏览器回收 context、GPU 进程重启都是可恢复的偶发事件，不等于这台设备用不了 3D。这和 PR #219 review 定下的「舞台被卸载不代表 3D 不可用」是同一条原则。

**为什么要 `preventDefault()`**：不调的话浏览器会把这个 context 永久作废，连恢复的可能都没有。

**为什么 context 丢失后要换新舞台，而不是让后续掷骰走 2D**（review 指出）：丢掉的 context 救不回来，引擎的 `roll()` 从此永久返回 `false`；而 `RoomPage` 收到 `false` 只清 rolling、不回退 2D——同一次面板打开期间之后每次点「掷骰」都静默失效。另一条路是让 `RoomPage.roll()` 区分「舞台忙，稍后再试」和「舞台废了，别再问了」两种 `false`，但这个区分应该由组件自己吸收，否则每个用到 `Dice3DHandle` 的地方都要重新记得处理一遍。

**为什么给重建次数封顶**：允许重建是因为浏览器回收 context、GPU 进程重启都是可恢复的偶发；但如果每次新建的 context 转头就丢（GPU 反复崩、驱动有问题），无限重建只会一直制造新 context。超过 2 次就 `setFailed` 退回 2D。

**为什么还要动 `setKind()`，只补 `forceContextLoss()` 不够吗**：能缓解，但每次切 D100 / D20 / D6 仍然要重建整个场景、重新生成全部面贴图（每面一张 256×256 Canvas）。既浪费，又持续给 context 上限施压。骰型只决定生成哪几颗骰子，renderer 与场景本来就不需要动。

**为什么 `dispose()` 里 `contextLost` 时不调 `forceContextLoss()`**：context 已经没了，再调只会在控制台留一条无意义的告警。

**为什么给那个 `.catch()` 补日志**：回退到 2D 本身是对的，但它此前连一行日志都不留。排查这个 issue 时，浏览器控制台一条错误都看不到，只能看到「3D 静默消失」这个结果——这正是它难查的原因。日志只进浏览器控制台，不涉及 WebSocket。

## 验证

`npm run lint` / `npm run build` / `npm run test` 全绿：24 个测试文件，**186 passed**（修复前 183）。

变异检验两条：

- 把 context 丢失改回走 `onUnsupported` → 「只放弃当次掷骰」那条报红。
- 去掉 context 丢失后的舞台重建 → 「换新舞台」与「封顶退回 2D」两条都报红。

### 一条测试此前是假绿的

本 PR 初版里 `abandons only the current roll when the WebGL context is lost` 能通过，但它没验到真实路径：测试 mock 的 `stage.roll` 恒返回 `true`，没有建模引擎「`contextLost` 之后永久拒绝」的行为。把 mock 改成贴合引擎后，缺陷立刻暴露：

```
AssertionError: expected [ { …(2) } ] to have a length of 2 but got 1
```

舞台没有被重建。现在 mock 会在 `onContextLost` 之后让 `roll` 返回 `false`，与 `engine.ts` 里 `if (disposed || contextLost) return false` 一致。

### 根因是怎么定下来的

在 preview 环境（`http://218.11.5.114:10005`）里按组件真实生命周期连续创建 20 个 stage，每次 `dispose()` 后再建下一个，并给每张 canvas 挂 `webglcontextlost` 监听：

```
stagesCreated: 20, contextsForciblyLost: 4, lostAtIterations: [1, 2, 3, 4]
```

浏览器强制回收了 4 个 context，全是最早创建的那批。改动前代码里没有任何一处会收到这个事件。

在此之前逐一证伪了六个假设，都是实测而非读代码推断：

| 假设 | 实测结果 |
| --- | --- |
| 贴图画成了黑的 | `makeFaceTexture` 输出 `[144,46,38,255]` 红底、`colorSpace: srgb` |
| 材质 / 光照有问题 | 孤立创建 stage 手动泵 239 帧：`litPixels 61142 / 72013`，`maxLuma 163` |
| 引擎 chunk 加载失败 | `engine-CpQDc_wu.js` 200，140KB，180ms |
| `createDiceStage` 抛异常 | preview 上手动调用正常；连续 24 轮创建/销毁不抛 |
| `supports3DDice()` 判定为假 | preview 上 `hasWebGL: true`、`reducedMotion: false` |
| 探测函数把 context 用光 | 连开 40 个 context 后探测仍为 true |

## 已知限制

- **没有走 `webglcontextrestored` 的原地恢复**。当前是丢失后**换一个新舞台**拿新 context，而不是复用同一个 renderer 等浏览器还回来。原地恢复要重新生成全部面贴图并还原骰子姿态，是独立的一块工作；换舞台已经能让后续掷骰正常工作。
- **连续丢失超过 2 次就放弃 3D**，本次会话内不再重试。阈值是拍的：允许重建是因为浏览器回收 context、GPU 进程重启都是可恢复的偶发；封顶是因为如果新 context 转头就丢，重建只会一直制造新 context。
- 本 PR 没有在真机上复验「长时间游玩不再退化」——那需要连续玩到旧代码会崩的程度。测到的是机制层面：连续创建 20 个 stage 不再触发强制回收。

## 不在本 PR 范围

- 2D 回退路径本身的行为（它是对的，检定不能因为渲染能力缺失而卡住）
- 骰子的物理、动画曲线与配色
- 后端与协议

