### PR TITLE
perf(backend): DeepSeek 结构化输出显式关闭思考模式

### DIFF
--- a/trpg-backend/app/adapters/deepseek_models.py
+++ b/trpg-backend/app/adapters/deepseek_models.py
@@ -61,6 +61,18 @@ class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
                 },
             ],
             "response_format": {"type": "json_object"},
+            # DeepSeek 的 `thinking` 默认是 enabled（`reasoning_effort` 默认
+            # high），不显式关掉，每次结构化输出前都会先产出一段推理内容——而
+            # 这个 client 只要一个符合 schema 的 JSON 对象，推理过程既不读也不
+            # 存，纯属白烧 token 和延迟。
+            #
+            # 实测（issue #330）同一个 trivial 请求，preview 用的 qnaigc 端点上
+            # `deepseek/deepseek-v4-flash`：不发这个参数 151 个 completion
+            # tokens（其中 145 是推理），发了之后 5 个。官方端点同样生效。
+            #
+            # 同目录的 Qwen client 早就用 `enable_thinking: False` 做了同一件事，
+            # 只是字段名不同。
+            "thinking": {"type": "disabled"},
         }
         async with httpx.AsyncClient(
             headers={

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -688,6 +688,11 @@ async def test_deepseek_client_posts_compatible_json_mode_without_qwen_fields() 
     assert captured["authorization"] == "Bearer test-key"
     assert body["model"] == "deepseek-chat"
     assert body["response_format"] == {"type": "json_object"}
+    # DeepSeek 的 `thinking` 默认是 enabled（reasoning_effort 默认 high），不显式
+    # 关掉就会在每次结构化输出前白烧一段推理——实测 qnaigc 端点上同一个 trivial
+    # 请求 151 vs 5 个 completion tokens（issue #330）。我们只要那个 JSON 对象。
+    assert body["thinking"] == {"type": "disabled"}
+    # `enable_thinking` 是 Qwen 的字段名，别混进 DeepSeek 的请求体。
     assert "enable_thinking" not in body
     assert "test_schema" in body["messages"][0]["content"]
     assert "只返回一个 JSON 对象" in body["messages"][0]["content"]


### PR DESCRIPTION
Closes #330

DeepSeek 的 `thinking` 默认是 `enabled`，而这个 client 从来不发这个参数——每次意图解析、每次叙事生成都先产出一段推理内容，可我们只要那个符合 schema 的 JSON 对象。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `app/adapters/deepseek_models.py` | 请求体固定带上 `"thinking": {"type": "disabled"}` |
| `tests/test_openai_models.py` | 断言该字段；顺带给既有的 `assert "enable_thinking" not in body` 补一行注释说明它是 Qwen 的字段名 |

两处改动，没有新增配置项、没有动默认模型、没有碰其它 provider。

## 关键决策

**为什么写死而不是做成可配置项**：官方端点和 preview 用的 qnaigc 端点都实测过接受并生效，不存在「某个端点不认这个参数」需要兜底的情况。而这个 client 的用途是单一的——拿一个符合 schema 的 JSON 对象，任何场景都不需要推理过程。多一个配置项就是多一个能被配错的地方。

**为什么不改 Qwen / OpenAI**：Qwen 早就用 `enable_thinking: False` 做了同一件事（字段名不同）；OpenAI 走的是另一套 Responses API，不适用这个参数。

**关掉思考会不会掉叙事质量**：本地开发一直用 `DEEPSEEK_MODEL=deepseek-chat`，实测这个历史别名返回的就是 `deepseek-v4-flash` 且**自带不思考**——目前所有真机测试都是在「flash + 不思考」这个配置下做的。本 PR 只是让 preview 与本地一致，不是引入一个没验证过的新状态。

## 验证

`ruff check` / `ruff format --check` / `ty check` 全过；`pytest` **415 passed**、10 skipped。

测试先写先跑红：加上 `assert body["thinking"] == {"type": "disabled"}` 后 `KeyError`，实现补上后转绿。

### 真机验证

用改完的**真实 client** 分别打两个端点，确认多这个参数不会被任一端拒掉：

| 端点 | model | 结果 |
| --- | --- | --- |
| `https://api.deepseek.com` | `deepseek-chat` | 正常返回 `{'ok': True}` |
| `https://api.qnaigc.com/v1` | `deepseek/deepseek-v4-flash` | 正常返回 `{'ok': True}` |

### 效果实测

同一个 trivial 请求，只改 `thinking` 参数，qnaigc 端点 + `deepseek/deepseek-v4-flash`：

| 请求 | 有推理内容 | reasoning_tokens | completion_tokens |
| --- | --- | --- | --- |
| 不发 `thinking`（改动前） | 是 | 145 | **151** |
| `thinking: {"type":"disabled"}`（改动后） | 否 | — | **5** |

官方端点上三个模型的默认行为：

| model | 不发 `thinking` |
| --- | --- |
| `deepseek-v4-pro` | 有推理，41 reasoning_tokens |
| `deepseek-v4-flash` | 有推理，24 reasoning_tokens |
| `deepseek-chat` | **无推理**（实际返回 `model: deepseek-v4-flash`） |

对照实验确认探针有效：`deepseek-chat` 显式加 `thinking: {"type":"enabled"}` 能检出 20 个 reasoning_tokens，所以「不发时检不到推理」是真没开，不是探针失灵。

## 为什么现在才暴露

本地一直用 `deepseek-chat`，这个别名自带不思考，所以本地从来没被影响。preview 用的是显式的新 id（`deepseek/deepseek-v4-pro-202606`），走的是「默认开思考」那条路——preview 明显比本地慢，根因是两个叠加：pro 本身更重，加上默认开着思考。

## 配套的部署改动（已完成，不在本 PR）

Repository Variable `PREVIEW_DEEPSEEK_MODEL` 已从 `deepseek/deepseek-v4-pro-202606` 改成 `deepseek/deepseek-v4-flash`。那是 GitHub 配置，不随代码走；两件事一起生效后 preview 才能达到与本地一致的响应速度。

需要注意：`main-preview.yml` 只在 push 到 main 时触发，本 PR 合并即会重新部署并读取新的 Variable。

## 不在本 PR 范围

- `DEEPSEEK_MODEL` 的默认值（仍是 `deepseek-chat`）
- `OPENING_NARRATION_TIMEOUT_SECONDS` 在 preview 上的 10 秒默认值——换成 flash + 不思考之后大概率不会再撞到，先观察，真撞到再单独处理
- Qwen / OpenAI 两个 client
