### PR TITLE
fix(adjudication): 让 Agent 自己的裁决错误可修复，别判玩家死刑

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/contracts/keeper_view.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/keeper_view.py
@@ -131,6 +131,12 @@ class KeeperCapabilityView(ContractModel):
     # Bound to the same revision as the PlayerView it accompanies, so a step
     # adjudicated against a stale capability list is rejected on submit.
     revision: str = Field(min_length=1)
+    # The only id `ActionTarget(kind="world", ...)` accepts. It is the module's
+    # `world_ref`, which is a rule-system id (`coc-7e` for 追书人) — nothing in
+    # PlayerView or anywhere else hints at it, so before #313 an Agent that
+    # wanted the world as a target had to guess and was rejected every time
+    # (TARGET_UNAVAILABLE on "今天几点了" and other non-object utterances).
+    world_id: str | None = Field(default=None, min_length=1)
     information: tuple[KeeperInformationCapability, ...] = ()
     locations: tuple[KeeperLocationCapability, ...] = ()
     entities: tuple[KeeperEntityCapability, ...] = ()

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -1316,9 +1316,16 @@ class AdjudicationEngineService:
                 target_kind=adjudication.target.kind,
                 target_id=adjudication.target.id,
             ):
+                # 可自动修复，不是死路。菜单是按「玩家站在哪」发布的，这里才
+                # 第一次用上 method.family 和 target —— 也就是说模型看得到的
+                # 候选，提交时完全可能不适用（#313：在 neighborhood 说「跟邻居
+                # 打个招呼」，菜单里有 question_neighbors，但它只认
+                # family=interview + target=lyla）。这是 fault="agent" 的错，
+                # 而放弃 rule_decision 就能变回一次普通叙事裁决，没有任何理由
+                # 让玩家的回合直接死在这里。
                 self._reject_validation(
                     "RULE_OUT_OF_SCOPE",
-                    repairability="hard_reject",
+                    repairability="auto_repairable",
                     fault="agent",
                     player_safe_reason="当前行动不能使用该规则选项",
                     internal_reason=(

--- a/agent-collaboration-framework/collaboration_framework/engine/projection_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/projection_v3.py
@@ -738,6 +738,7 @@ def keeper_capabilities_v3(
         room_id=state.room_id,
         actor_id=actor_id,
         revision=runtime.revision,
+        world_id=module.world_ref,
         information=tuple(
             KeeperInformationCapability(
                 id=item.id,

--- a/agent-collaboration-framework/collaboration_framework/engine/service.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/service.py
@@ -364,6 +364,7 @@ class RuleEngineService:
             room_id=state.room_id,
             actor_id=actor_id,
             revision=runtime.revision,
+            world_id=module.world_ref,
             information=information,
             locations=locations,
             entities=entities,

--- a/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/action_plan_prompt.py
+++ b/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/action_plan_prompt.py
@@ -33,14 +33,20 @@ def current_step_adjudication_instructions() -> str:
 这些身份字段。当前步骤需要检定或玩家选择时，按单意图 ActionAdjudication 契约返回，
 不得自行继续后续步骤。
 
-target.id 只能逐字取自 keeper_capabilities 的 entities / locations / information、
-keeper_capabilities.world_id，或 player_view.scene.id。玩家问时间、问天气、只是应答或
-闲聊，没有具体对象可指时，用 kind=world + keeper_capabilities.world_id，或 kind=location
-+ player_view.scene.id；world 只认 world_id 这一个值，不要自己拼一个像 "world" 的 id。
+target.id 只能逐字取自这几处，不要自造：keeper_capabilities 的 entities / locations /
+information；keeper_capabilities.world_id；player_view.scene.id；以及局内角色——
+player_view.self_actor.id（玩家自己）和 player_view.scene.visible_actors[].id（同场其他
+玩家角色），这两类用 kind=actor。玩家帮助、攻击或以别的方式作用于同伴时，目标就是那个
+actor id，不要退而求其次改用 location 或 world。
+
+玩家问时间、问天气、只是应答或闲聊，没有具体对象可指时，才用 kind=world +
+keeper_capabilities.world_id，或 kind=location + player_view.scene.id；world 只认
+world_id 这一个值，不要自己拼一个像 "world" 的 id。
 
 rule_decision 是可选的。keeper_capabilities.rule_candidates 是按玩家当前所在地发布的，
-一条候选还额外声明了 action_families、target_kinds、target_ids——三者都容纳本次裁决时才
-能选它。玩家的话对不上任何一条候选（例如只是打个招呼）时，不要硬套一条规则，直接不带
+一条候选还可能声明 action_families、target_kinds、target_ids 作为额外约束：**这三个字段
+为空表示该维度不设限，非空才要求本次裁决落在其中**。逐个字段判断，非空的都命中才能选它。
+玩家的话对不上任何一条候选（例如只是打个招呼）时，不要硬套一条规则，直接不带
 rule_decision 按普通裁决给出这一步。
 
 这一步提到的对象在当前 PlayerView 里根本不存在时（计划是在更早的 revision 上写的，

--- a/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/action_plan_prompt.py
+++ b/agent-collaboration-framework/collaboration_framework/host/adapters/openai_agents/action_plan_prompt.py
@@ -33,6 +33,16 @@ def current_step_adjudication_instructions() -> str:
 这些身份字段。当前步骤需要检定或玩家选择时，按单意图 ActionAdjudication 契约返回，
 不得自行继续后续步骤。
 
+target.id 只能逐字取自 keeper_capabilities 的 entities / locations / information、
+keeper_capabilities.world_id，或 player_view.scene.id。玩家问时间、问天气、只是应答或
+闲聊，没有具体对象可指时，用 kind=world + keeper_capabilities.world_id，或 kind=location
++ player_view.scene.id；world 只认 world_id 这一个值，不要自己拼一个像 "world" 的 id。
+
+rule_decision 是可选的。keeper_capabilities.rule_candidates 是按玩家当前所在地发布的，
+一条候选还额外声明了 action_families、target_kinds、target_ids——三者都容纳本次裁决时才
+能选它。玩家的话对不上任何一条候选（例如只是打个招呼）时，不要硬套一条规则，直接不带
+rule_decision 按普通裁决给出这一步。
+
 这一步提到的对象在当前 PlayerView 里根本不存在时（计划是在更早的 revision 上写的，
 它提到的物品或人物可能这里没有），通常不要凭空造一个 id，也不要把别的 id 硬套成
 需要的 kind：以 kind=location + player_view.scene.id 为目标，返回 narrative_only，并

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -68,15 +68,18 @@ logger = logging.getLogger(__name__)
 _REPAIR_HINTS: dict[str, str] = {
     "TARGET_UNAVAILABLE": (
         "target.id 必须逐字取自 keeper_capabilities 的 entities / locations / "
-        "information、keeper_capabilities.world_id，或 player_view.scene.id；"
-        "不要自造 id。找不到玩家所指的对象时，以 kind=location + "
-        "player_view.scene.id 为目标返回 narrative_only。"
+        "information、keeper_capabilities.world_id、player_view.scene.id，或局内"
+        "角色 player_view.self_actor.id 与 player_view.scene.visible_actors[].id"
+        "（后两者用 kind=actor）；不要自造 id。作用于同伴的行动目标就是那个 actor "
+        "id，不要改用 location 或 world 绕开。确实找不到玩家所指的对象时，才以 "
+        "kind=location + player_view.scene.id 为目标返回 narrative_only。"
     ),
     "RULE_OUT_OF_SCOPE": (
-        "所选 rule_decision 与本次 method.family 或 target 不匹配。只有在 "
-        "keeper_capabilities.rule_candidates 里找得到一条 action_families、"
-        "target_kinds、target_ids 同时容纳本次裁决的规则时才保留 rule_decision；"
-        "否则去掉 rule_decision，按普通裁决重新给出这一步。"
+        "所选 rule_decision 与本次 method.family 或 target 不匹配。"
+        "keeper_capabilities.rule_candidates 里一条候选的 action_families、"
+        "target_kinds、target_ids 为空即表示该维度不设限，非空才要求本次裁决落在"
+        "其中——逐个字段判断，非空的都命中才能保留 rule_decision；一条都对不上就"
+        "去掉 rule_decision，按普通裁决重新给出这一步。"
     ),
 }
 

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -58,6 +58,33 @@ from .semantic_preservation import compare_repair_semantics
 
 logger = logging.getLogger(__name__)
 
+# 修复预算只有一次，所以这一次必须让模型知道该动哪里。此前 previous_rejection
+# 只有「TARGET_UNAVAILABLE: 当前目标不可用于这次行动」——既没说哪个 id 不存在，
+# 也没说合法的从哪来，等于让模型闭着眼睛再掷一次，重试能不能过全看运气（#313）。
+#
+# 这里刻意只放**与具体 id 无关的静态指引**：拒绝理由里的 id 是模型自己编的，
+# 但它同批次的其它字段未必是，逐字回显等于给自己开一条把引擎内部命名回灌进
+# 提示词的口子。要定位对象，模型手上本来就有 KeeperCapabilityView。
+_REPAIR_HINTS: dict[str, str] = {
+    "TARGET_UNAVAILABLE": (
+        "target.id 必须逐字取自 keeper_capabilities 的 entities / locations / "
+        "information、keeper_capabilities.world_id，或 player_view.scene.id；"
+        "不要自造 id。找不到玩家所指的对象时，以 kind=location + "
+        "player_view.scene.id 为目标返回 narrative_only。"
+    ),
+    "RULE_OUT_OF_SCOPE": (
+        "所选 rule_decision 与本次 method.family 或 target 不匹配。只有在 "
+        "keeper_capabilities.rule_candidates 里找得到一条 action_families、"
+        "target_kinds、target_ids 同时容纳本次裁决的规则时才保留 rule_decision；"
+        "否则去掉 rule_decision，按普通裁决重新给出这一步。"
+    ),
+}
+
+
+def _with_repair_hint(code: str, message: str) -> str:
+    hint = _REPAIR_HINTS.get(code)
+    return f"{code}: {message}" if hint is None else f"{code}: {message}\n{hint}"
+
 
 class ActionPlanOrchestrator:
     """A-owned Saga coordinator; the Engine never receives an ActionPlan."""
@@ -1013,7 +1040,10 @@ class ActionPlanOrchestrator:
     def _validation_feedback_text(step: ActionPlanStepRun) -> str | None:
         if step.last_validation_code is None or step.last_validation_message is None:
             return None
-        return f"{step.last_validation_code}: {step.last_validation_message}"
+        return _with_repair_hint(
+            step.last_validation_code,
+            step.last_validation_message,
+        )
 
     async def _observe_step_failure(
         self,
@@ -1541,8 +1571,9 @@ class HostTurnDecisionExecutor:
                         semantic_goal=decision.adjudication.summary,
                     ),
                     player_view=view,
-                    previous_rejection=(
-                        f"{feedback.code}: {feedback.player_safe_reason}"
+                    previous_rejection=_with_repair_hint(
+                        feedback.code,
+                        feedback.player_safe_reason,
                     ),
                     keeper_capabilities=await self._single_keeper_capabilities(
                         player_input,

--- a/agent-collaboration-framework/collaboration_framework/host/application/semantic_preservation.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/semantic_preservation.py
@@ -50,7 +50,8 @@ def compare_repair_semantics(
         return _clarification("METHOD_CHANGED")
     if not _same_semantic_text(original.method.description, repaired.method.description):
         return _clarification("METHOD_CHANGED")
-    if original.rule_decision != repaired.rule_decision:
+    rule_dropped = _rule_decision_dropped(original, repaired, validation_feedback)
+    if not rule_dropped and original.rule_decision != repaired.rule_decision:
         return _clarification("RULE_DECISION_CHANGED")
     if not _check_is_mechanical(original, repaired):
         return _clarification("CHECK_CHANGED")
@@ -98,6 +99,12 @@ def compare_repair_semantics(
     if failure.status == "requires_clarification":
         return failure
 
+    if rule_dropped:
+        return SemanticPreservationResult(
+            status="narrowed",
+            reason_code="RULE_DECISION_DROPPED",
+            safe_reason="已放弃不适用于本次行动的模组规则选项",
+        )
     if "narrowed" in {success.status, failure.status}:
         return SemanticPreservationResult(
             status="narrowed",
@@ -110,6 +117,25 @@ def compare_repair_semantics(
         status="preserved",
         reason_code="MECHANICAL_REPAIR",
         safe_reason="修复仅调整了行动的机械参数",
+    )
+
+
+def _rule_decision_dropped(
+    original: ActionAdjudication,
+    repaired: ActionAdjudication,
+    feedback: ValidationFeedback,
+) -> bool:
+    """放弃一个引擎刚判定为超范围的规则选项，是允许的收窄修复（#313）。
+
+    只认「有 -> 无」这一个方向。换成另一条规则等于让模型自己挑模组后果，那是
+    #226 明令留在服务端的决定；而放弃之后这一步退化成普通叙事裁决，拿不到任何
+    它原本拿不到的东西，引擎照样会把修复后的裁决整个重新校验一遍。
+    """
+
+    return (
+        feedback.code == "RULE_OUT_OF_SCOPE"
+        and original.rule_decision is not None
+        and repaired.rule_decision is None
     )
 
 

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
@@ -286,7 +286,12 @@ class ActionPlanStepContext(ContractModel):
     completed_steps: tuple[CompletedPlanStepSummary, ...] = ()
     # Set only after the Engine refused a proposal for this same step. It carries
     # a stable player-safe code/reason, never hidden module content.
-    previous_rejection: str | None = Field(default=None, min_length=1, max_length=614)
+    #
+    # 614 = 100 (`ValidationResult.code`) + 2 + 512 (`player_safe_reason`)，也就是
+    # 一条拒绝理由本身的上限。#313 之后还要追加一段与具体 id 无关的静态修复指引
+    # （`_REPAIR_HINTS`），所以留到 1024；`test_repair_hint_fits_the_step_context`
+    # 用最长的那条钉住这个余量，加长指引会先撞到那个测试而不是线上。
+    previous_rejection: str | None = Field(default=None, min_length=1, max_length=1024)
     # Controlled Keeper-side capability list for this same revision; see
     # HostAgentContext.keeper_capabilities. Never forwarded to the Narrator.
     keeper_capabilities: KeeperCapabilityView | None = None

--- a/agent-collaboration-framework/schemas/host-agent-context.schema.json
+++ b/agent-collaboration-framework/schemas/host-agent-context.schema.json
@@ -289,6 +289,19 @@
           "title": "Revision",
           "type": "string"
         },
+        "world_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "World Id"
+        },
         "information": {
           "default": [],
           "items": {

--- a/agent-collaboration-framework/schemas/keeper-capability-view.schema.json
+++ b/agent-collaboration-framework/schemas/keeper-capability-view.schema.json
@@ -372,6 +372,19 @@
       "title": "Revision",
       "type": "string"
     },
+    "world_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "World Id"
+    },
     "information": {
       "default": [],
       "items": {

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -57,6 +57,9 @@ from collaboration_framework.host.application import (
     PlayerViewProjector,
     TurnExecutionError,
 )
+from collaboration_framework.host.application.action_plan_orchestrator import (
+    _REPAIR_HINTS,
+)
 from collaboration_framework.host.ports import (
     ActionPlanBusyError,
     ActionPlanStepFailure,
@@ -1262,10 +1265,12 @@ async def test_engine_rejection_is_repaired_once_instead_of_stopping_the_plan() 
     # Step 2 was adjudicated twice: the refused proposal, then the repair that
     # carried the Engine's own reason back to the adjudicator.
     step_two = [context for context in adjudicator.contexts if context.step_index == 1]
-    assert [context.previous_rejection for context in step_two] == [
-        None,
-        "TARGET_UNAVAILABLE: 当前目标不可用于这次行动",
-    ]
+    assert step_two[0].previous_rejection is None
+    assert step_two[1].previous_rejection is not None
+    assert step_two[1].previous_rejection.startswith(
+        "TARGET_UNAVAILABLE: 当前目标不可用于这次行动"
+    )
+    assert "keeper_capabilities" in step_two[1].previous_rejection
     assert settled.run.steps[1].repair_attempts == 1
     assert settled.run.steps[1].last_validation_code == "TARGET_UNAVAILABLE"
     assert settled.run.steps[1].last_validation_message == "当前目标不可用于这次行动"
@@ -1490,6 +1495,34 @@ async def test_safe_validation_feedback_maximum_length_fits_step_context() -> No
 
 
 @pytest.mark.asyncio
+async def test_repair_hint_fits_the_step_context() -> None:
+    """最长的一条拒绝理由加上最长的一条修复指引仍要装得下（#313）。
+
+    `previous_rejection` 有 max_length，而修复指引是拼在拒绝理由后面的。指引写长了
+    应该在这里红，而不是等到线上某次修复重试直接抛 ValidationError——那会把一次本
+    来能救回来的回合变成 TURN_CONTRACT_INVALID。
+    """
+
+    _, _, projector = runtime()
+    original = player_input("max-hint-parent")
+    longest_hint = max(_REPAIR_HINTS.values(), key=len)
+    worst_case = f"{'C' * 100}: {'R' * 512}\n{longest_hint}"
+
+    context = ActionPlanStepContext(
+        player_input=original,
+        plan_id="max-hint-plan",
+        plan_goal="验证最长修复指引",
+        step_index=0,
+        step_request_id="max-hint-step",
+        step=ActionPlanStep(kind="action", semantic_goal="验证最长修复指引"),
+        player_view=await projector.project(original),
+        previous_rejection=worst_case,
+    )
+
+    assert context.previous_rejection == worst_case
+
+
+@pytest.mark.asyncio
 async def test_room_reservation_blocks_other_parent_until_plan_is_terminal() -> None:
     service, _, _, store, _ = orchestrator()
     first = player_input("first-parent")
@@ -1687,7 +1720,12 @@ async def test_single_action_auto_repair_succeeds_without_creating_plan_run() ->
     assert len(repair_adjudicator.contexts) == 1
     context = repair_adjudicator.contexts[0]
     assert context.step_request_id == original.client_action_id
-    assert context.previous_rejection == "TARGET_UNAVAILABLE: 当前目标不可用于这次行动"
+    assert context.previous_rejection is not None
+    assert context.previous_rejection.startswith(
+        "TARGET_UNAVAILABLE: 当前目标不可用于这次行动"
+    )
+    # #313：光有错误码定位不到问题，指引必须跟着一起回到修复裁决器。
+    assert "keeper_capabilities" in context.previous_rejection
     assert await plan_store.load(original.room_id, original.client_action_id) is None
     assert len(engine_store.inspect_domain_events(original.room_id)) == 1
 
@@ -1723,7 +1761,12 @@ async def test_single_travel_repair_with_changed_effect_requires_clarification()
     assert len(repair_adjudicator.contexts) == 1
     context = repair_adjudicator.contexts[0]
     assert context.step.kind == "travel"
-    assert context.previous_rejection == "TARGET_UNAVAILABLE: 当前目标不可用于这次行动"
+    assert context.previous_rejection is not None
+    assert context.previous_rejection.startswith(
+        "TARGET_UNAVAILABLE: 当前目标不可用于这次行动"
+    )
+    # #313：光有错误码定位不到问题，指引必须跟着一起回到修复裁决器。
+    assert "keeper_capabilities" in context.previous_rejection
     assert await plan_store.load(original.room_id, original.client_action_id) is None
     assert engine_store.inspect_domain_events(original.room_id) == ()
 

--- a/agent-collaboration-framework/tests/test_engine_capability_projection.py
+++ b/agent-collaboration-framework/tests/test_engine_capability_projection.py
@@ -255,6 +255,36 @@ class EngineCapabilityProjectionTests(unittest.IsolatedAsyncioTestCase):
             {"study"},
         )
 
+    async def test_keeper_capabilities_publish_the_only_legal_world_target(self) -> None:
+        """`kind="world"` 只认 `world_ref`，所以必须把它发出去（#313）。
+
+        它是规则系统 id（追书人是 `coc-7e`），PlayerView 里没有、场景里也推不出。
+        不发就等于「world 这个 target kind 对 Agent 不存在」：玩家问时间、问天气、
+        纯应答这类没有具体对象的输入，模型只能猜一个 id，然后每次都吃
+        TARGET_UNAVAILABLE。
+        """
+
+        capabilities = await self.engine.read_keeper_capabilities(SCOPE)
+
+        self.assertEqual(capabilities.world_id, self.module.world_ref)
+        # 发布出来的这个值必须真的能当目标用，而不只是多了一个字段。
+        snapshot = await self.engine.read(SCOPE)
+        await self.adjudication_engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=SCOPE.room_id,
+                player_id=SCOPE.player_id,
+                adjudication=ActionAdjudication(
+                    request_id="world-target-313",
+                    source_revision=snapshot.revision,
+                    actor_id=SCOPE.actor_id,
+                    summary="现在几点了？",
+                    target=ActionTarget(kind="world", id=capabilities.world_id or ""),
+                    method=ActionMethod(family="talk", description="询问时间"),
+                    check=NoAdjudicationCheck(),
+                ),
+            )
+        )
+
     async def test_keeper_capabilities_track_committed_effects(self) -> None:
         await self.commit("reveal-2", RevealInformationEffect(information_id="document_truth"))
         await self.commit(

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -15,6 +15,7 @@ from collaboration_framework.contracts import (
     ActionAdjudication,
     ActionMethod,
     ActionTarget,
+    AdjudicationValidationError,
     AdvanceWorldTimeEffect,
     ChangeEntityStateEffect,
     CheckDecisionRequest,
@@ -638,6 +639,92 @@ class AdjudicationAgainstV3Tests(unittest.IsolatedAsyncioTestCase):
                     method=ActionMethod(family="action", description="测试"),
                     check=NoAdjudicationCheck(),
                     success_effects=tuple(effects),
+                ),
+            )
+        )
+
+    async def test_greeting_a_neighbour_is_repairable_not_a_dead_turn(self) -> None:
+        """#313 复现：在 neighborhood 说「跟邻居打个招呼」被直接判死。
+
+        菜单是按「玩家站在哪」发布的，所以 `question_neighbors` 会出现在候选里；
+        但它另外要求 `family=interview` 且 `target=lyla`，提交时才第一次校验这两
+        项。模型把打招呼归成 `social` 是它自己的错（`fault="agent"`），而放弃
+        rule_decision 就能退回一次普通叙事裁决——没有任何理由让玩家的回合死在这。
+        """
+
+        store, engine, rules = self.build(scene_id="neighborhood")
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        capabilities = await rules.read_keeper_capabilities(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        published = {item.rule_id for item in capabilities.rule_candidates}
+        self.assertIn("question_neighbors", published)
+
+        greeting = ActionAdjudication(
+            request_id="greet-neighbour-313",
+            source_revision=snapshot.revision,
+            actor_id=ACTOR,
+            summary="跟邻居打个招呼",
+            target=ActionTarget(kind="entity", id="lyla"),
+            method=ActionMethod(family="social", description="打招呼"),
+            check=NoAdjudicationCheck(),
+            rule_decision=RuleDecisionRef(
+                rule_id="question_neighbors", option_id="fast-talk"
+            ),
+        )
+        with self.assertRaises(AdjudicationValidationError) as rejected:
+            await engine.submit(
+                SubmitAdjudicationRequest(
+                    room_id=ROOM, player_id=PLAYER, adjudication=greeting
+                )
+            )
+
+        result = rejected.exception.result
+        self.assertEqual(result.code, "RULE_OUT_OF_SCOPE")
+        self.assertEqual(result.fault, "agent")
+        # 关键断言：修复循环只认 auto_repairable / retry_with_latest_revision，
+        # hard_reject 会被直接抛出去变成 turn.failed。
+        self.assertEqual(result.repairability, "auto_repairable")
+        self.assertEqual(self.store_events(store), 0)
+
+        # 放弃这条规则之后，同一句话应当照常裁决完成。
+        repaired = greeting.model_copy(
+            update={"request_id": "greet-neighbour-313-repaired", "rule_decision": None},
+            deep=True,
+        )
+        await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM, player_id=PLAYER, adjudication=repaired
+            )
+        )
+
+    @staticmethod
+    def store_events(store: InMemoryEngineStore) -> int:
+        return len(store.inspect_domain_events(ROOM))
+
+    async def test_keeper_capabilities_publish_the_v3_world_target(self) -> None:
+        """v3 侧同样要发 world_id，否则「今天周几」这类输入没有合法目标（#313）。"""
+
+        store, engine, rules = self.build(scene_id="neighborhood")
+        scope = PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        capabilities = await rules.read_keeper_capabilities(scope)
+        self.assertEqual(capabilities.world_id, self.content.world_ref)
+
+        snapshot = await rules.read(scope)
+        await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="ask-the-date-313",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="今天周几？",
+                    target=ActionTarget(kind="world", id=capabilities.world_id or ""),
+                    method=ActionMethod(family="talk", description="询问日期"),
+                    check=NoAdjudicationCheck(),
                 ),
             )
         )

--- a/agent-collaboration-framework/tests/test_semantic_preservation.py
+++ b/agent-collaboration-framework/tests/test_semantic_preservation.py
@@ -15,6 +15,7 @@ from collaboration_framework.contracts import (
     NoAdjudicationCheck,
     PlayerInput,
     RequiredAdjudicationCheck,
+    RuleDecisionRef,
     SkillCheckCandidate,
     ValidationFeedback,
 )
@@ -396,3 +397,74 @@ def test_same_length_effect_replacement_requires_clarification() -> None:
 
     assert result.status == "requires_clarification"
     assert result.reason_code == "NEW_OR_CHANGED_EFFECT"
+
+
+def _greeting(*, rule: RuleDecisionRef | None) -> ActionAdjudication:
+    return ActionAdjudication(
+        request_id="request",
+        source_revision="0",
+        actor_id="pc_1",
+        summary="跟邻居打个招呼",
+        target=ActionTarget(kind="entity", id="bookshelf"),
+        method=ActionMethod(family="social", description="打招呼"),
+        check=NoAdjudicationCheck(),
+        rule_decision=rule,
+    )
+
+
+def _compare(original: ActionAdjudication, repaired: ActionAdjudication, code: str):
+    _, _, projector = runtime()
+    view = asyncio.run(projector.project(player_input(utterance="跟邻居打个招呼")))
+    return compare_repair_semantics(
+        player_input=player_input(utterance="跟邻居打个招呼"),
+        plan_goal="跟邻居打个招呼",
+        step=ActionPlanStep(kind="action", semantic_goal="跟邻居打个招呼"),
+        original=original,
+        repaired=repaired,
+        validation_feedback=_feedback(code=code),
+        player_view=view,
+    )
+
+
+def test_dropping_an_out_of_scope_rule_is_an_allowed_narrowing() -> None:
+    """#313：引擎判 RULE_OUT_OF_SCOPE 之后，放弃这条规则是唯一能走通的修复。
+
+    把 rule_decision 设回 None，这一步退化成普通叙事裁决——拿不到任何它原本拿不到
+    的东西。不允许的话，第 313 号那三次「跟邻居打个招呼」即使改成 auto_repairable
+    也照样死在语义保持这一关。
+    """
+
+    result = _compare(
+        _greeting(rule=RuleDecisionRef(rule_id="question_neighbors", option_id="fast-talk")),
+        _greeting(rule=None),
+        "RULE_OUT_OF_SCOPE",
+    )
+
+    assert result.status == "narrowed"
+    assert result.reason_code == "RULE_DECISION_DROPPED"
+
+
+def test_swapping_to_another_rule_still_requires_player_choice() -> None:
+    """只放行「有 -> 无」。换一条规则等于让模型自己挑模组后果（#226 §1）。"""
+
+    result = _compare(
+        _greeting(rule=RuleDecisionRef(rule_id="question_neighbors", option_id="fast-talk")),
+        _greeting(rule=RuleDecisionRef(rule_id="impress_caretaker", option_id="credit-rating")),
+        "RULE_OUT_OF_SCOPE",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "RULE_DECISION_CHANGED"
+
+
+def test_a_rule_may_not_be_dropped_for_an_unrelated_rejection() -> None:
+    """目标不存在跟规则范围无关，这时丢掉规则是模型在夹带（#313）。"""
+
+    result = _compare(
+        _greeting(rule=RuleDecisionRef(rule_id="question_neighbors", option_id="fast-talk")),
+        _greeting(rule=None),
+        "TARGET_UNAVAILABLE",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "RULE_DECISION_CHANGED"

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -777,7 +777,18 @@ def _map_turn_error(exc: Exception) -> tuple[str, str, bool]:
     if "不是可提交动作的 InGame" in message:
         return "ROOM_NOT_ACTIONABLE", "房间当前状态不允许提交动作", False
     if isinstance(exc, (ContractError, ValidationError)):
-        return "TURN_CONTRACT_INVALID", "本次动作未通过主持编排契约校验", False
+        # 可重试。这是主持链上「模型这一次的输出没通过契约」的兜底桶，同一句话
+        # 重说一遍常常就过了（#313 的实测：`TURN_CONTRACT_INVALID` 后原话重试成
+        # 功）。标成不可重试只会让前端连重试按钮都不给，把一次非确定性失败变成
+        # 玩家必须自己重新打字的死路。与上面 `MODEL_OUTPUT_UNREADABLE` 同源，
+        # 重试语义也应当一致。
+        #
+        # 重试不会重复结算，但理由不是「什么都没落库」——`adjudication.select` /
+        # `adjudication.post_roll` 上 `_emit_check_result` 就跑在引擎权威结算之后，
+        # 它抛 ContractError 时检定其实已经定了。挡住重复结算的是引擎自己：重放
+        # 同一次决定会撞上 `DECISION_ALREADY_SETTLED`（hard_reject），重放同一个
+        # clientActionId 的动作则复用已提交结果。
+        return "TURN_CONTRACT_INVALID", "本次动作未通过主持编排契约校验，请重试", True
     return "TURN_INTERNAL_ERROR", "本次动作处理失败，请稍后重试", True
 
 

--- a/trpg-backend/tests/test_action_plan_persistence.py
+++ b/trpg-backend/tests/test_action_plan_persistence.py
@@ -274,9 +274,12 @@ async def test_sql_plan_repair_state_survives_store_rebuild(
     assert repaired.repair_attempts == 1
     assert repaired.last_validation_code == "TARGET_UNAVAILABLE"
     assert repaired.last_validation_message == "当前目标不可用于这次行动"
-    assert adjudicator.contexts[-1].previous_rejection == (
-        "TARGET_UNAVAILABLE: 当前目标不可用于这次行动"
-    )
+    last_rejection = adjudicator.contexts[-1].previous_rejection
+    assert last_rejection is not None
+    assert last_rejection.startswith("TARGET_UNAVAILABLE: 当前目标不可用于这次行动")
+    # #313：修复指引跟着拒绝理由一起穿过 SQL 存储回到裁决器，落库的只有 code 和
+    # player_safe_reason，指引是读出来时按 code 现拼的。
+    assert "keeper_capabilities" in last_rejection
     assert "keeper" not in rebuilt.model_dump_json()
 
 

--- a/trpg-backend/tests/test_validation_feedback.py
+++ b/trpg-backend/tests/test_validation_feedback.py
@@ -1,8 +1,10 @@
 from collaboration_framework.contracts import (
     ActorBindingError,
     AdjudicationValidationError,
+    ContractError,
     ValidationResult,
 )
+from pydantic import BaseModel, ValidationError
 
 from app.controller.ws import _map_turn_error
 
@@ -45,6 +47,29 @@ def test_only_revision_refresh_feedback_is_client_retryable() -> None:
         "动作基于过期的玩家视图，请刷新后重试",
         True,
     )
+
+
+def test_contract_invalid_is_retryable_because_the_same_words_often_pass() -> None:
+    """#313：`TURN_CONTRACT_INVALID` 后原话重试成功，说明它是非确定性失败。
+
+    这是「模型这一次的输出没过契约」的兜底桶，和 `MODEL_OUTPUT_UNREADABLE` 同源。
+    标成不可重试会让前端连重试按钮都不给（`actionErrorRetryable`），把一次重掷就
+    能过的失败变成玩家必须自己重新打字的死路。
+    """
+
+    class _Probe(BaseModel):
+        value: int
+
+    try:
+        _Probe(value="not-an-int")
+    except ValidationError as exc:
+        validation_error: Exception = exc
+
+    for error in (ContractError("主持编排契约校验失败"), validation_error):
+        code, message, retryable = _map_turn_error(error)
+        assert code == "TURN_CONTRACT_INVALID"
+        assert retryable is True
+        assert "重试" in message
 
 
 def test_actor_binding_error_keeps_stable_public_code() -> None:


### PR DESCRIPTION
Closes #313

三类错误码是三个不同的机制，都指向同一件事：Agent 自己裁决错了，代价由玩家承担。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `contracts/keeper_view.py` | `KeeperCapabilityView` 新增 `world_id` |
| `engine/projection_v3.py`、`engine/service.py` | v3 / v2 两条投影都填 `module.world_ref` |
| `engine/adjudication.py` | 规则超范围从 `hard_reject` 改成 `auto_repairable`（`is_v3=False` 那条不变） |
| `host/application/semantic_preservation.py` | 放行「放弃超范围规则」这一个方向的收窄修复 |
| `host/application/action_plan_orchestrator.py` | `previous_rejection` 追加按错误码查表的静态修复指引 |
| `host/schemas/action_plan.py` | `previous_rejection` 上限 614 → 1024 |
| `openai_agents/action_plan_prompt.py` | 告诉模型 `world_id` 存在，以及 `rule_decision` 可以不带 |
| `controller/ws.py` | `TURN_CONTRACT_INVALID` 改为可重试 |
| `schemas/*.schema.json` | 由 Pydantic 重新导出 |

## 三个根因

先复现再下判断：用真实《追书人》v3 模组打真实 `AdjudicationEngineService.submit()`，场景 `neighborhood`。

**1. `world_ref` 从来没发给 Agent，但它是 `kind=world` 唯一合法的 id。**

```
capability 里有没有 world id? False
实际 world_ref = 'coc-7e'

kind=world id='world'       → TARGET_UNAVAILABLE
kind=world id='paper_chase' → TARGET_UNAVAILABLE
kind=world id='coc-7e'      → 通过        ← 唯一正确答案
```

`_target_kinds_matching()` 判 world 的条件是 `target_id == module_content.world_ref`，而追书人的 `world_ref` 是 `coc-7e`——一个**规则系统 id**。`PlayerView` 和 `KeeperCapabilityView` 里都没有这个字段。模型想以「世界 / 大环境」为目标（问时间、问星期、纯应答）只能猜，猜什么都是 `TARGET_UNAVAILABLE`。这是 issue 里「今天周几？」「啊哈，有了。」连续失败的原因。

**2. `RULE_OUT_OF_SCOPE` 被标成 `hard_reject`，一次修复预算都不给。**

```
发布给 Agent 的 rule_candidates:
  question_neighbors families=['interview'] target_kinds=['entity'] target_ids=['lyla']

family=social → RULE_OUT_OF_SCOPE  repairability=hard_reject  fault=agent
```

发布侧 `_rule_candidates()` 只按 `location_id` 过滤，提交侧 `agent_match_scope_admits()` 额外校验 `action_family` / `target_kind` / `target_id`。同一个谓词，但**参数不对等**——菜单发的是「这地方可能用得上的规则」，提交时才知道方法和目标合不合。

于是「跟邻居打个招呼」在 `neighborhood` 会看到 `question_neighbors`，模型选了它但把打招呼归成 `social`（菜单要 `interview`）→ 直接判死。`fault="agent"`：AI 犯的错，惩罚玩家，且不给修。#302 的修复循环只认 `auto_repairable` / `retry_with_latest_revision`。

**3. `TURN_CONTRACT_INVALID` 是兜底桶，还被硬编码成不可重试。**

同一个 `_map_turn_error` 里 `StructuredOutputError` 是 `retryable=True`，而 `ContractError | ValidationError` 是 `False`。但 issue 里这条**原话重试就过了**——它本质是模型输出的非确定性问题。前端 `actionErrorRetryable` 直接控制重试按钮显不显示（`RoomPage.tsx:2222`），所以玩家连按钮都没有，只能自己重打一遍。

**顺带一个放大器**：修复循环喂给模型的 `previous_rejection` 只有 `"TARGET_UNAVAILABLE: 当前目标不可用于这次行动"`——不说哪个 id 不存在，也不说合法的有哪些，等于让模型闭眼重掷一次，而 `max_repair_attempts` 默认是 1。这就是「重试有时过有时不过」的直接来源。

## 关键决策

**为什么只放行「丢掉规则」，不放行「换一条规则」**：换规则等于让模型自己挑模组后果，那是 #226 §1 明令留在服务端的决定。丢掉之后这一步退化成普通叙事裁决，拿不到任何它原本拿不到的东西，引擎还会把修复后的裁决整个重新校验一遍。所以 `_rule_decision_dropped()` 只认「有 → 无」，且只在 feedback code 确实是 `RULE_OUT_OF_SCOPE` 时；用别的拒绝理由顺手把规则甩掉属于夹带，仍然要玩家确认。

**为什么不放行改 `method.family` 去迁就规则**：那其实是更「正确」的修复（保留模组内容），但需要把候选菜单穿进 `compare_repair_semantics`，surface 大得多，而 `METHOD_CHANGED` 这道闸本身是有意义的。本 PR 先用收窄修复把死路打通，代价是这种情况下模组规则不触发——是降级，不是失败。见「不在本 PR 范围」。

**为什么修复指引是静态查表，不回显被拒的 id**：拒绝理由里的 id 是模型自己编的，但同批次的其它字段未必是，逐字回显等于给自己开一条把引擎内部命名回灌进提示词的口子。要定位对象，模型手上本来就有 `KeeperCapabilityView`。指引因此只讲「id 该从哪来」和「对不上就别带 rule_decision」。

**为什么 hint 放在 host 而不是做成契约字段**：`ValidationFeedback` 的 `player_safe_reason` 会被持久化成 `last_validation_message` 并展示给玩家，往里塞 Agent 专用文本会越过那条边界；另起一个契约字段则要动 contracts、engine 全部 reject 点、StepRun schema、两处持久化。而指引内容完全由 code 决定，host 拿得到 code——查表是同等效果里最小的那个改法。

**`world_id` 为什么可空**：`KeeperCapabilityView` 有默认构造的既有用法，加成必填会推着改一批与本 issue 无关的构造点。两条真实投影都无条件填了，测试直接断言等于 `world_ref`。

## 验证

- 框架：`unittest` **287 passed**（3 skipped）、`pytest` **387 passed**（3 skipped）
- 后端：**428 passed**、10 skipped；`ruff check` / `ruff format --check` / `ty check` 全过
- SDK、前端：lint / build / test 全过（本 PR 没动这两个包，跑一遍确认没连带）
- 无 DTO 改动，不需要跑 codegen；框架 `schemas/*.json` 已按规矩重新导出

### 变异检验

| 把实现改回去 | 结果 |
| --- | --- |
| 两条投影都去掉 `world_id=module.world_ref` + 规则改回 `hard_reject` | 3 个新测试红（`AssertionError: None != 'coc-7e'` 等） |
| `rule_dropped` 短路成 `False` | `test_dropping_an_out_of_scope_rule_is_an_allowed_narrowing` 红：`- narrowed / + requires_clarification` |

### 新增回归用例

三类错误各至少一条，用的是 issue 里的原话：

- `test_greeting_a_neighbour_is_repairable_not_a_dead_turn` —「跟邻居打个招呼」，断言 `repairability == "auto_repairable"`、无事件落库，且放弃规则后同一句话能裁决完成
- `test_keeper_capabilities_publish_the_v3_world_target` /
  `test_keeper_capabilities_publish_the_only_legal_world_target` —「今天周几？」，v3 / v2 两条投影都断言 `world_id` 发布出来**且真的能当目标提交**（不只是多个字段）
- `test_contract_invalid_is_retryable_because_the_same_words_often_pass` — `ContractError` 与真实 `ValidationError` 两种输入都断言 `retryable is True`
- `test_dropping_an_out_of_scope_rule_is_an_allowed_narrowing` + 两条反向用例（换规则、拿无关 code 丢规则）都仍要玩家确认
- `test_repair_hint_fits_the_step_context` — 最长拒绝理由 + 最长指引的长度预算

## 自查抓到的两个真问题

**`previous_rejection` 的 `max_length` 差点被撑破。** 614 = 100（`code` 上限）+ 2 + 512（`player_safe_reason` 上限），恰好是一条拒绝理由本身的上限，仓库里还有一条测试专门钉住这个数。追加指引会在最坏情况直接抛 `ValidationError`——而那个异常正好落进 `TURN_CONTRACT_INVALID`，等于把一次本来能救回来的回合弄死。放宽到 1024，并加了用最长指引算最坏情况的测试，以后指引写长了会先撞测试而不是撞线上。

**我给 ws.py 写的注释一开始是错的。** 原话是「这里发生在裁决提交规则引擎之前，没有权威副作用落库」。实际上 `adjudication.select` / `adjudication.post_roll` 两条分支上，`_emit_check_result` 就跑在引擎权威结算**之后**，它抛 `ContractError` 时检定已经定了。真正挡住重复结算的是引擎自己：重放同一次决定会撞 `DECISION_ALREADY_SETTLED`（hard_reject，已确认）。结论（可以重试）不变，但理由换了，注释已改成准确的说法。

## 已知限制

- `max_repair_attempts` 默认仍是 1。指引提高的是这一次的命中率，不是次数。
- 收窄修复成功时模组规则不触发。玩家真的在盘问 Lyla 而模型把 family 判成 `social`，这一轮就拿不到 `question_neighbors` 的模组内容——降级，不是回合失败。
- 修复本身仍然依赖模型读懂指引。真机上还剩多少失败率，得等实际跑一局才知道；本 PR 能证明的是「引擎不再把可修复的 Agent 错误判成死路」，不是「模型从此不犯错」。
- prompt 改动无法用确定性测试覆盖，只有真机能验。

## 不在本 PR 范围

- 允许修复时改 `method.family` 去满足规则 scope（保留模组内容的那种修复）——需要把候选菜单穿进语义比较器
- 让发布侧菜单也带上「本次 family/target 是否满足」的预判，从源头减少错选
- `previous_rejection` 携带结构化的被拒 id / 合法 id 列表（要动契约与持久化两层）
- `ActionPlanOrchestrator.adjudicate_single_repair`（`action_plan_orchestrator.py:707`）全仓库零调用方、零测试。发现了但没动，需要的话单独开 issue。
