### PR TITLE
feat(portrait): 支持角色生图后台任务与主动终止 (#325)

### DIFF
--- a/.github/workflows/trpg-backend-ci.yml
+++ b/.github/workflows/trpg-backend-ci.yml
@@ -66,6 +66,41 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
+  postgres-migration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: trpg
+          POSTGRES_PASSWORD: trpg
+          POSTGRES_DB: trpg_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U trpg -d trpg_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql+asyncpg://trpg:trpg@127.0.0.1:5432/trpg_test
+    defaults:
+      run:
+        working-directory: trpg-backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python
+        run: uv python install
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Upgrade PostgreSQL schema
+        run: uv run alembic upgrade head
+      - name: Verify portrait task index
+        run: uv run python scripts/check_portrait_postgres.py
+
   # 漂移检查（issue #75 决策 3）：重新跑一遍完整的 DTO -> JSON Schema -> TS
   # 生成管线，用 git diff 确认 trpg-sdk/src/generated/ 跟刚生成的结果一致。
   # 不一致说明有人改了后端 DTO（或手改了生成产物）却没有重新跑 codegen。

--- a/e2e/scripts/run-e2e.ts
+++ b/e2e/scripts/run-e2e.ts
@@ -51,6 +51,11 @@ const fakeModelEnv = {
   // Settings 校验阶段失败；若透传 Key 则会让 E2E 依赖外部服务并产生费用。
   HOST_MODEL_PROVIDER: 'fake',
   DEEPSEEK_API_KEY: '',
+  // 建卡背景和角色生图也必须锁定确定性实现，不能继承开发机 .env 的付费 provider。
+  CHARACTER_BACKGROUND_PROVIDER: 'deterministic',
+  PORTRAIT_PROMPT_PROVIDER: 'deterministic',
+  PORTRAIT_IMAGE_PROVIDER: 'mock',
+  CHARACTER_PORTRAIT_ENABLED: 'true',
 }
 const backendEnv = {
   ...process.env,

--- a/e2e/tests/character-build.e2e.ts
+++ b/e2e/tests/character-build.e2e.ts
@@ -88,6 +88,33 @@ test('建卡全流程：草稿 → 保存 → 读回 → 完成', async () => {
   assert.equal(derived.SAN, 50) // = POW
 })
 
+test('角色生图以后台任务创建并可通过 SDK 恢复到终态', async () => {
+  const room = await createRoomWithModule('portrait-task')
+  const { sdk } = room.host
+  const draft = await sdk.characters.createDraft(room.roomId, room.reconnectToken)
+  const attributes = { STR: 50, CON: 50, POW: 50, DEX: 50, APP: 50, SIZ: 50, INT: 50, EDU: 50, LUCK: 50 }
+  await sdk.characters.save(room.roomId, draft.characterId, legalCharacterPayload(attributes), room.reconnectToken)
+  await sdk.characters.complete(room.roomId, draft.characterId, room.reconnectToken)
+
+  const created = await sdk.characters.createPortraitGeneration(
+    room.roomId, draft.characterId, { style: 'realistic', size: '1024x1024' }, room.reconnectToken
+  )
+  assert.equal(created.status, 'queued')
+  let current = created
+  for (let attempt = 0; attempt < 300 && ['queued', 'generating', 'cancelling'].includes(current.status); attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    current = await sdk.characters.getPortraitGeneration(
+      room.roomId, draft.characterId, created.generationId, room.reconnectToken
+    )
+  }
+  assert.equal(current.status, 'completed')
+  assert.ok(current.portraitVersion)
+  const recovered = await sdk.characters.getCurrentPortraitGeneration(
+    room.roomId, draft.characterId, room.reconnectToken
+  )
+  assert.equal(recovered?.generationId, created.generationId)
+})
+
 test('🔴 属性点预算：点数购买法超预算被拒，掷骰法不受该预算约束', async () => {
   // 这两条必须成对测。只测第一条的话，一个「无条件校验总预算」的实现也能过，
   // 但那会把合法掷出来的角色卡判成非法——掷骰法 8 项总和均值约 457、范围

--- a/trpg-backend/alembic/versions/c1d2e3f4a5b6_add_portrait_generation_tasks.py
+++ b/trpg-backend/alembic/versions/c1d2e3f4a5b6_add_portrait_generation_tasks.py
@@ -1,0 +1,65 @@
+"""新增可持久跟踪的角色生图后台任务表。
+
+Revision ID: c1d2e3f4a5b6
+Revises: b8c3d4e5f6a7
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: str | Sequence[str] | None = "b8c3d4e5f6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """创建任务历史表及每个角色唯一活动任务索引。"""
+    op.create_table(
+        "portrait_generation_tasks",
+        sa.Column("generation_id", sa.Uuid(), nullable=False),
+        sa.Column("room_id", sa.Uuid(), nullable=False),
+        sa.Column("character_id", sa.Uuid(), nullable=False),
+        sa.Column("player_id", sa.Uuid(), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("cancel_requested", sa.Boolean(), nullable=False),
+        sa.Column("failure_code", sa.String(40), nullable=True),
+        sa.Column("style", sa.String(20), nullable=False),
+        sa.Column("size", sa.String(20), nullable=False),
+        sa.Column("prompt_summary", sa.String(1000), nullable=True),
+        sa.Column("prompt_source", sa.String(40), nullable=True),
+        sa.Column("portrait_version", sa.String(64), nullable=True),
+        sa.Column("provider_task_id", sa.String(200), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('queued', 'generating', 'cancelling', 'completed', 'failed', 'cancelled')",
+            name="ck_portrait_generation_tasks_status",
+        ),
+        sa.ForeignKeyConstraint(["room_id"], ["rooms.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["character_id"], ["characters.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["player_id"], ["players.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("generation_id"),
+    )
+    op.create_index(
+        "uq_portrait_generation_tasks_active_character",
+        "portrait_generation_tasks",
+        ["character_id"],
+        unique=True,
+        sqlite_where=sa.text("status IN ('queued', 'generating', 'cancelling')"),
+        postgresql_where=sa.text("status IN ('queued', 'generating', 'cancelling')"),
+    )
+
+
+def downgrade() -> None:
+    """删除角色生图任务历史。"""
+    op.drop_index(
+        "uq_portrait_generation_tasks_active_character",
+        table_name="portrait_generation_tasks",
+    )
+    op.drop_table("portrait_generation_tasks")

--- a/trpg-backend/app/adapters/image_generation.py
+++ b/trpg-backend/app/adapters/image_generation.py
@@ -13,6 +13,7 @@ import httpx
 from PIL import Image, ImageDraw
 
 from app.service.portrait_generation import (
+    ImageGenerationControl,
     ImageGenerationOutput,
     PortraitImageContentRejectedError,
     PortraitImageGenerationError,
@@ -29,7 +30,9 @@ class MockImageProvider:
         negative_prompt: str,
         size: str,
         reference_image: PortraitReferenceImage | None = None,
+        control: ImageGenerationControl | None = None,
     ) -> ImageGenerationOutput:
+        del control
         digest = hashlib.sha256(f"{prompt}\n{negative_prompt}\n{size}".encode()).hexdigest()[:16]
         palettes = (
             ("#204b5e", "#d59b72"),
@@ -78,6 +81,7 @@ class DashScopeImageProvider:
         negative_prompt: str,
         size: str,
         reference_image: PortraitReferenceImage | None = None,
+        control: ImageGenerationControl | None = None,
     ) -> ImageGenerationOutput:
         # DashScope 的当前文生图请求不接受参考图字段；服务层仍传入统一参数，
         # 这里明确忽略它并保留纯提示词生成，避免伪造一个未被上游支持的协议。
@@ -105,10 +109,14 @@ class DashScopeImageProvider:
                 )
                 response.raise_for_status()
                 task_id = self._task_id(response.json())
+                if control is not None:
+                    await control.set_provider_task_id(task_id)
 
                 while True:
                     if time.monotonic() >= deadline:
                         raise PortraitImageTimeoutError("图片生成超时")
+                    if control is not None and control.cancelled.is_set():
+                        raise asyncio.CancelledError
                     if self._poll_interval_seconds > 0:
                         await asyncio.sleep(self._poll_interval_seconds)
                     status_response = await client.get(f"{self._base_url}/tasks/{task_id}")
@@ -125,6 +133,16 @@ class DashScopeImageProvider:
             raise PortraitImageTimeoutError("图片生成超时") from exc
         except (httpx.HTTPError, KeyError, TypeError, ValueError) as exc:
             raise PortraitImageGenerationError("图片生成服务暂时不可用") from exc
+
+    async def cancel(self, task_id: str) -> None:
+        """尽力取消仍处于等待态的 DashScope 任务；运行中任务可能拒绝取消。"""
+        async with httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {self._api_key}"},
+            timeout=min(self._timeout_seconds, 30.0),
+            transport=self._transport,
+        ) as client:
+            response = await client.post(f"{self._base_url}/tasks/{task_id}/cancel")
+            response.raise_for_status()
 
     @staticmethod
     def _output(payload: object) -> dict:
@@ -206,7 +224,9 @@ class SufyImageProvider:
         negative_prompt: str,
         size: str,
         reference_image: PortraitReferenceImage | None = None,
+        control: ImageGenerationControl | None = None,
     ) -> ImageGenerationOutput:
+        del control
         # OpenAI 生图协议没有通用的 negative_prompt 字段，因此将反向约束
         # 并入主提示词，避免不同 Sufy 模型对非标准字段的支持不一致。
         combined_prompt = f"{prompt}\n\n避免出现以下内容：{negative_prompt}"

--- a/trpg-backend/app/controller/v1/portraits.py
+++ b/trpg-backend/app/controller/v1/portraits.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import get_db
 from app.core.errors import AppException, ErrorCode
 from app.dto.common import ApiResponse
-from app.dto.portrait import PortraitGenerationRequest, PortraitGenerationResult
+from app.dto.portrait import PortraitGenerationRequest, PortraitGenerationTaskRead
 from app.service import room as room_service
 from app.service.portrait_generation import (
     PortraitCharacterIncompleteError,
@@ -76,7 +76,8 @@ async def get_player_portrait(
 
 @router.post(
     "/{room_id}/characters/{character_id}/portrait-generations",
-    response_model=ApiResponse[PortraitGenerationResult],
+    response_model=ApiResponse[PortraitGenerationTaskRead],
+    status_code=status.HTTP_202_ACCEPTED,
 )
 async def generate_character_portrait(
     room_id: str,
@@ -85,9 +86,9 @@ async def generate_character_portrait(
     reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
     db: AsyncSession = Depends(get_db),
     service: PortraitGenerationService = Depends(get_portrait_generation_service),
-) -> ApiResponse[PortraitGenerationResult]:
+) -> ApiResponse[PortraitGenerationTaskRead]:
     try:
-        result = await service.generate(db, room_id, character_id, reconnect_token, payload)
+        result = await service.create(db, room_id, character_id, reconnect_token, payload)
     except PortraitGenerationDisabledError as exc:
         raise AppException(
             ErrorCode.PORTRAIT_GENERATION_DISABLED,
@@ -131,3 +132,69 @@ async def generate_character_portrait(
             status.HTTP_502_BAD_GATEWAY,
         ) from exc
     return ApiResponse.ok(result)
+
+
+async def _portrait_task_call(call):  # noqa: ANN001, ANN202
+    """把任务查询/取消共享的归属错误稳定映射到 REST 错误信封。"""
+    try:
+        return await call
+    except PortraitCharacterNotFoundError as exc:
+        raise AppException(ErrorCode.NOT_FOUND, str(exc), status.HTTP_404_NOT_FOUND) from exc
+    except room_service.RoomAuthenticationError as exc:
+        raise AppException(ErrorCode.UNAUTHORIZED, str(exc), status.HTTP_401_UNAUTHORIZED) from exc
+    except room_service.RoomAuthorizationError as exc:
+        raise AppException(ErrorCode.FORBIDDEN, str(exc), status.HTTP_403_FORBIDDEN) from exc
+
+
+@router.get(
+    "/{room_id}/characters/{character_id}/portrait-generations/current",
+    response_model=ApiResponse[PortraitGenerationTaskRead | None],
+)
+async def get_current_portrait_generation(
+    room_id: str,
+    character_id: str,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+    db: AsyncSession = Depends(get_db),
+    service: PortraitGenerationService = Depends(get_portrait_generation_service),
+) -> ApiResponse[PortraitGenerationTaskRead | None]:
+    return ApiResponse.ok(
+        await _portrait_task_call(service.get_current(db, room_id, character_id, reconnect_token))
+    )
+
+
+@router.get(
+    "/{room_id}/characters/{character_id}/portrait-generations/{generation_id}",
+    response_model=ApiResponse[PortraitGenerationTaskRead],
+)
+async def get_portrait_generation(
+    room_id: str,
+    character_id: str,
+    generation_id: str,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+    db: AsyncSession = Depends(get_db),
+    service: PortraitGenerationService = Depends(get_portrait_generation_service),
+) -> ApiResponse[PortraitGenerationTaskRead]:
+    return ApiResponse.ok(
+        await _portrait_task_call(
+            service.get_task(db, room_id, character_id, generation_id, reconnect_token)
+        )
+    )
+
+
+@router.post(
+    "/{room_id}/characters/{character_id}/portrait-generations/{generation_id}/cancel",
+    response_model=ApiResponse[PortraitGenerationTaskRead],
+)
+async def cancel_portrait_generation(
+    room_id: str,
+    character_id: str,
+    generation_id: str,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+    db: AsyncSession = Depends(get_db),
+    service: PortraitGenerationService = Depends(get_portrait_generation_service),
+) -> ApiResponse[PortraitGenerationTaskRead]:
+    return ApiResponse.ok(
+        await _portrait_task_call(
+            service.cancel(db, room_id, character_id, generation_id, reconnect_token)
+        )
+    )

--- a/trpg-backend/app/dto/portrait.py
+++ b/trpg-backend/app/dto/portrait.py
@@ -1,5 +1,6 @@
-"""Character portrait generation request, snapshot, and response models."""
+"""角色生图请求、提示词快照与后台任务响应模型。"""
 
+from datetime import datetime
 from typing import Literal
 
 from pydantic import Field, field_validator
@@ -74,12 +75,28 @@ class PortraitPrompt(PortraitPromptDraft):
     source: Literal["deepseek", "deterministic", "deterministic_fallback"]
 
 
-class PortraitGenerationResult(CamelModel):
+class PortraitGenerationTaskRead(CamelModel):
+    """可安全返回给玩家的生图任务快照。"""
+
     generation_id: str
-    status: Literal["completed"] = "completed"
-    image_url: str
-    portrait_version: str
-    prompt: str
-    negative_prompt: str
-    prompt_summary: str
-    prompt_source: Literal["deepseek", "deterministic", "deterministic_fallback"]
+    status: Literal["queued", "generating", "cancelling", "completed", "failed", "cancelled"]
+    cancel_requested: bool
+    failure_code: (
+        Literal[
+            "content_rejected",
+            "timeout",
+            "provider_failed",
+            "materialization_failed",
+            "process_restarted",
+        ]
+        | None
+    ) = None
+    portrait_version: str | None = None
+    prompt_summary: str | None = None
+    prompt_source: Literal["deepseek", "deterministic", "deterministic_fallback"] | None = None
+    style: Literal["realistic"]
+    size: Literal["1024x1024"]
+    created_at: datetime
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    updated_at: datetime

--- a/trpg-backend/app/main.py
+++ b/trpg-backend/app/main.py
@@ -27,7 +27,10 @@ from app.core.seed import ensure_seed_content
 from app.dto.common import ApiResponse
 from app.service.character_background import build_character_background_service
 from app.service.host_speech import build_host_speech_service
-from app.service.portrait_generation import build_portrait_generation_service
+from app.service.portrait_generation import (
+    PortraitGenerationService,
+    build_portrait_generation_service,
+)
 
 # 模块被导入时就把 structlog 配好（只需要配一次），后面直接用 structlog.get_logger()。
 configure_logging()
@@ -62,9 +65,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """
     async with async_session_factory() as db:
         await ensure_seed_content(db)
+    portrait_service: PortraitGenerationService = app.state.portrait_generation_service
+    await portrait_service.recover_interrupted()
     logger.info("app_started")
-    yield
-    logger.info("app_stopped")
+    try:
+        yield
+    finally:
+        await portrait_service.shutdown()
+        logger.info("app_stopped")
 
 
 def create_app() -> FastAPI:

--- a/trpg-backend/app/models/room.py
+++ b/trpg-backend/app/models/room.py
@@ -18,12 +18,14 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     LargeBinary,
     String,
     Text,
     UniqueConstraint,
     Uuid,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -237,6 +239,56 @@ class CharacterPortrait(Base):
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
         nullable=False,
+    )
+
+
+class PortraitGenerationTask(Base):
+    """角色生图后台任务；只保存恢复与裁决所需数据，不保存上游临时图片。"""
+
+    __tablename__ = "portrait_generation_tasks"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('queued', 'generating', 'cancelling', 'completed', 'failed', 'cancelled')",
+            name="ck_portrait_generation_tasks_status",
+        ),
+        # SQLite 与 PostgreSQL 都用部分唯一索引兜住多进程并发创建。
+        Index(
+            "uq_portrait_generation_tasks_active_character",
+            "character_id",
+            unique=True,
+            sqlite_where=text("status IN ('queued', 'generating', 'cancelling')"),
+            postgresql_where=text("status IN ('queued', 'generating', 'cancelling')"),
+        ),
+    )
+
+    generation_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    room_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False
+    )
+    character_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("characters.id", ondelete="CASCADE"), nullable=False
+    )
+    player_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("players.id", ondelete="CASCADE"), nullable=False
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
+    cancel_requested: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    failure_code: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    style: Mapped[str] = mapped_column(String(20), nullable=False)
+    size: Mapped[str] = mapped_column(String(20), nullable=False)
+    prompt_summary: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    prompt_source: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    portrait_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    provider_task_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
     )
 
 

--- a/trpg-backend/app/service/portrait_generation.py
+++ b/trpg-backend/app/service/portrait_generation.py
@@ -3,31 +3,34 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Protocol
+from typing import Any, Protocol, cast
 
 import structlog
 from collaboration_framework.contracts import ModuleContent, ModuleContentV3
-from sqlalchemy import select
-from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, update
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.coc7_content import build_coc7_ruleset
 from app.core.coc7_rules import evaluate_skill_base
 from app.core.config import Settings, model_client_retry_policy, secret_value
+from app.core.db import async_session_factory
 from app.dto.game import RulesetRead
 from app.dto.portrait import (
     CharacterPortraitSnapshot,
     PortraitGenerationRequest,
-    PortraitGenerationResult,
+    PortraitGenerationTaskRead,
     PortraitPrompt,
     PortraitSkillSnapshot,
 )
 from app.models.content import Scenario
 from app.models.engine import ModuleVersion
-from app.models.room import Character, CharacterPortrait, Player, Room
+from app.models.room import Character, CharacterPortrait, Player, PortraitGenerationTask, Room
 from app.service.portrait_reference import PortraitReferenceImage, load_portrait_reference_image
 from app.service.room import (
     RoomAuthorizationError,
@@ -67,6 +70,12 @@ class PortraitImageTimeoutError(PortraitImageGenerationError):
     pass
 
 
+class PortraitGenerationCancelled(RuntimeError):
+    """后台执行器内部使用的取消信号，不直接暴露给 API。"""
+
+    pass
+
+
 @dataclass(frozen=True, slots=True)
 class ImageGenerationOutput:
     image_url: str
@@ -93,6 +102,40 @@ class ImageGenerationProvider(Protocol):
         negative_prompt: str,
         size: str,
         reference_image: PortraitReferenceImage | None = None,
+    ) -> ImageGenerationOutput: ...
+
+
+class ImageGenerationControl:
+    """把上游任务 ID 安全回写数据库，并向 provider 传递取消状态。"""
+
+    def __init__(
+        self, generation_id: str, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        self.generation_id = generation_id
+        self.cancelled = asyncio.Event()
+        self._session_factory = session_factory
+
+    async def set_provider_task_id(self, task_id: str) -> None:
+        async with self._session_factory() as db:
+            await db.execute(
+                update(PortraitGenerationTask)
+                .where(PortraitGenerationTask.generation_id == self.generation_id)
+                .values(provider_task_id=task_id, updated_at=datetime.now(UTC))
+            )
+            await db.commit()
+
+
+class ControlledImageGenerationProvider(Protocol):
+    """新版 provider 可选协议；旧 provider 仍按基础协议正常工作。"""
+
+    async def generate(
+        self,
+        *,
+        prompt: str,
+        negative_prompt: str,
+        size: str,
+        reference_image: PortraitReferenceImage | None = None,
+        control: ImageGenerationControl | None = None,
     ) -> ImageGenerationOutput: ...
 
 
@@ -291,6 +334,7 @@ class PortraitGenerationService:
         image_provider: ImageGenerationProvider,
         image_materializer: PortraitImageMaterializerProtocol,
         reference_image: PortraitReferenceImage | None = None,
+        session_factory: async_sessionmaker[AsyncSession] = async_session_factory,
     ) -> None:
         self._enabled = enabled
         self._prompt_composer = prompt_composer
@@ -298,17 +342,30 @@ class PortraitGenerationService:
         self._image_provider = image_provider
         self._image_materializer = image_materializer
         self._reference_image = reference_image
-        self._in_flight: set[tuple[str, str]] = set()
-        self._in_flight_lock = asyncio.Lock()
+        self._session_factory = session_factory
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._controls: dict[str, ImageGenerationControl] = {}
+        self._stopping = False
 
-    async def generate(
+    def set_session_factory_for_testing(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """测试环境显式注入隔离数据库，避免后台协程绕过 FastAPI 依赖覆盖。"""
+        self._session_factory = session_factory
+
+    @staticmethod
+    def _read(task: PortraitGenerationTask) -> PortraitGenerationTaskRead:
+        return PortraitGenerationTaskRead.model_validate(task, from_attributes=True)
+
+    async def create(
         self,
         db: AsyncSession,
         room_id: str,
         character_id: str,
         reconnect_token: str | None,
         payload: PortraitGenerationRequest,
-    ) -> PortraitGenerationResult:
+    ) -> PortraitGenerationTaskRead:
+        """验证归属并提交 queued 记录；提交成功后才允许调度后台执行。"""
         if not self._enabled:
             raise PortraitGenerationDisabledError("角色图片生成功能未开启")
 
@@ -321,64 +378,338 @@ class PortraitGenerationService:
         if character.status != "complete":
             raise PortraitCharacterIncompleteError("请先完成建卡再生成角色图片")
 
-        room = await find_room_by_id(db, room_id)
-        ruleset = (
-            await require_ruleset(db, room.system_id)
-            if room.system_id is not None
-            else build_coc7_ruleset()
-        )
-
-        key = (room_id, character_id)
-        async with self._in_flight_lock:
-            if key in self._in_flight:
-                raise PortraitGenerationInProgressError("该角色的图片正在生成")
-            self._in_flight.add(key)
-
         try:
-            module_background = await _load_module_background(db, room)
-            snapshot = build_character_portrait_snapshot(
-                character,
-                ruleset,
-                module_background=module_background,
+            now = datetime.now(UTC)
+            task = PortraitGenerationTask(
+                generation_id=str(uuid.uuid4()),
+                room_id=room_id,
+                character_id=character_id,
+                player_id=player.id,
+                status="queued",
+                cancel_requested=False,
+                style=payload.style,
+                size=payload.size,
+                created_at=now,
+                updated_at=now,
             )
+            db.add(task)
+            await db.commit()
+        except IntegrityError as exc:
+            await db.rollback()
+            raise PortraitGenerationInProgressError("该角色的图片正在生成") from exc
+        snapshot = self._read(task)
+        self.schedule(task.generation_id)
+        return snapshot
+
+    def schedule(self, generation_id: str) -> None:
+        """登记进程内协程；数据库唯一索引而非该字典负责并发正确性。"""
+        if self._stopping or generation_id in self._tasks:
+            return
+        task = asyncio.create_task(self._run(generation_id), name=f"portrait-{generation_id}")
+        self._tasks[generation_id] = task
+        task.add_done_callback(lambda _task: self._tasks.pop(generation_id, None))
+
+    async def get_current(
+        self, db: AsyncSession, room_id: str, character_id: str, reconnect_token: str | None
+    ) -> PortraitGenerationTaskRead | None:
+        await self._authorize_character(db, room_id, character_id, reconnect_token)
+        task = await db.scalar(
+            select(PortraitGenerationTask)
+            .where(
+                PortraitGenerationTask.room_id == room_id,
+                PortraitGenerationTask.character_id == character_id,
+            )
+            .order_by(PortraitGenerationTask.created_at.desc())
+            .limit(1)
+        )
+        return self._read(task) if task else None
+
+    async def get_task(
+        self,
+        db: AsyncSession,
+        room_id: str,
+        character_id: str,
+        generation_id: str,
+        reconnect_token: str | None,
+    ) -> PortraitGenerationTaskRead:
+        await self._authorize_character(db, room_id, character_id, reconnect_token)
+        task = await db.get(PortraitGenerationTask, generation_id)
+        if task is None or task.room_id != room_id or task.character_id != character_id:
+            raise PortraitCharacterNotFoundError("生图任务不存在")
+        return self._read(task)
+
+    async def cancel(
+        self,
+        db: AsyncSession,
+        room_id: str,
+        character_id: str,
+        generation_id: str,
+        reconnect_token: str | None,
+    ) -> PortraitGenerationTaskRead:
+        """先提交权威取消状态，再尽力中断本地与上游任务。"""
+        await self._authorize_character(db, room_id, character_id, reconnect_token)
+        task = await db.scalar(
+            select(PortraitGenerationTask)
+            .where(PortraitGenerationTask.generation_id == generation_id)
+            .with_for_update()
+        )
+        if task is None or task.room_id != room_id or task.character_id != character_id:
+            raise PortraitCharacterNotFoundError("生图任务不存在")
+        if task.status in {"completed", "failed", "cancelled"}:
+            return self._read(task)
+        now = datetime.now(UTC)
+        task.cancel_requested = True
+        task.updated_at = now
+        if task.status == "queued":
+            task.status = "cancelled"
+            task.finished_at = now
+        else:
+            task.status = "cancelling"
+        provider_task_id = task.provider_task_id
+        await db.commit()
+        snapshot = self._read(task)
+        control = self._controls.get(generation_id)
+        if control:
+            control.cancelled.set()
+        cancel_method = getattr(self._image_provider, "cancel", None)
+        if provider_task_id and callable(cancel_method):
             try:
-                prompt = await self._prompt_composer.compose(snapshot)
+                await cancel_method(provider_task_id)
+            except Exception:
+                logger.warning("portrait_provider_cancel_failed", generation_id=generation_id)
+        local_task = self._tasks.get(generation_id)
+        if local_task and task.status == "cancelling":
+            local_task.cancel()
+        return snapshot
+
+    async def _authorize_character(
+        self, db: AsyncSession, room_id: str, character_id: str, reconnect_token: str | None
+    ) -> Character:
+        player = await get_player_by_reconnect_token(db, reconnect_token)
+        character = await db.get(Character, character_id)
+        if character is None or character.room_id != room_id:
+            raise PortraitCharacterNotFoundError("角色不存在")
+        if character.player_id != player.id:
+            raise RoomAuthorizationError("不能访问其他玩家的生图任务")
+        return character
+
+    async def _is_cancelled(self, generation_id: str) -> bool:
+        async with self._session_factory() as db:
+            task = await db.get(PortraitGenerationTask, generation_id)
+            return (
+                task is None or task.cancel_requested or task.status in {"cancelling", "cancelled"}
+            )
+
+    async def _run(self, generation_id: str) -> None:
+        """后台流水线：每个数据库阶段使用独立短会话，外部 IO 不占事务。"""
+        control = ImageGenerationControl(generation_id, self._session_factory)
+        self._controls[generation_id] = control
+        stage = "provider"
+        try:
+            async with self._session_factory() as db:
+                task = await db.get(PortraitGenerationTask, generation_id)
+                if task is None or task.status != "queued" or task.cancel_requested:
+                    return
+                task.status = "generating"
+                task.started_at = task.updated_at = datetime.now(UTC)
+                await db.commit()
+            if await self._is_cancelled(generation_id):
+                raise PortraitGenerationCancelled()
+            async with self._session_factory() as db:
+                task = await db.get(PortraitGenerationTask, generation_id)
+                if task is None:
+                    return
+                character = await db.get(Character, task.character_id)
+                room = await find_room_by_id(db, task.room_id)
+                if character is None:
+                    raise PortraitCharacterNotFoundError("角色不存在")
+                ruleset = (
+                    await require_ruleset(db, room.system_id)
+                    if room.system_id
+                    else build_coc7_ruleset()
+                )
+                background = await _load_module_background(db, room)
+                portrait_snapshot = build_character_portrait_snapshot(
+                    character, ruleset, module_background=background
+                )
+                size = task.size
+            try:
+                prompt = await self._prompt_composer.compose(portrait_snapshot)
             except Exception as exc:
                 logger.warning(
                     "portrait_prompt_fallback",
-                    character_id=character_id,
+                    generation_id=generation_id,
                     error_type=type(exc).__name__,
                 )
-                prompt = await self._fallback_prompt_composer.compose(snapshot)
+                prompt = await self._fallback_prompt_composer.compose(portrait_snapshot)
                 prompt = prompt.model_copy(update={"source": "deterministic_fallback"})
-
-            if self._reference_image is None:
-                output = await self._image_provider.generate(
+            async with self._session_factory() as db:
+                task = await db.get(PortraitGenerationTask, generation_id)
+                if task is None or task.cancel_requested:
+                    raise PortraitGenerationCancelled()
+                task.prompt_summary, task.prompt_source = prompt.prompt_summary, prompt.source
+                task.updated_at = datetime.now(UTC)
+                await db.commit()
+            if "control" in inspect.signature(self._image_provider.generate).parameters:
+                controlled = cast(ControlledImageGenerationProvider, self._image_provider)
+                output = await controlled.generate(
                     prompt=prompt.positive_prompt,
                     negative_prompt=prompt.negative_prompt,
-                    size=payload.size,
+                    size=size,
+                    reference_image=self._reference_image,
+                    control=control,
                 )
             else:
+                # 兼容仓库内已有的第三方/测试 provider；新版实现应接收 control。
                 output = await self._image_provider.generate(
                     prompt=prompt.positive_prompt,
                     negative_prompt=prompt.negative_prompt,
-                    size=payload.size,
+                    size=size,
                     reference_image=self._reference_image,
                 )
+            if await self._is_cancelled(generation_id):
+                raise PortraitGenerationCancelled()
+            stage = "materialization"
             materialized = await self._image_materializer.materialize(output.image_url)
-            await self._replace_portrait(db, character_id, materialized)
-            return PortraitGenerationResult(
-                generation_id=str(uuid.uuid4()),
-                image_url=output.image_url,
-                portrait_version=materialized.content_hash,
-                prompt=prompt.positive_prompt,
-                negative_prompt=prompt.negative_prompt,
-                prompt_summary=prompt.prompt_summary,
-                prompt_source=prompt.source,
+            if await self._is_cancelled(generation_id):
+                raise PortraitGenerationCancelled()
+            await self._complete(generation_id, materialized)
+        except asyncio.CancelledError:
+            # 进程关闭不是玩家取消：保留活动状态，交给下次启动标记 process_restarted。
+            if not self._stopping:
+                await self._finish_cancelled(generation_id)
+        except PortraitGenerationCancelled:
+            await self._finish_cancelled(generation_id)
+        except PortraitImageContentRejectedError:
+            await self._fail(generation_id, "content_rejected")
+        except PortraitImageTimeoutError:
+            await self._fail(generation_id, "timeout")
+        except Exception:
+            logger.exception("portrait_generation_failed", generation_id=generation_id)
+            await self._fail(
+                generation_id,
+                "materialization_failed" if stage == "materialization" else "provider_failed",
             )
         finally:
-            async with self._in_flight_lock:
-                self._in_flight.discard(key)
+            self._controls.pop(generation_id, None)
+
+    async def _complete(self, generation_id: str, image: MaterializedPortrait) -> None:
+        """条件抢占完成权并在同一事务替换头像；取消先提交则不产生写入。"""
+        async with self._session_factory() as db:
+            task = await db.scalar(
+                select(PortraitGenerationTask)
+                .where(PortraitGenerationTask.generation_id == generation_id)
+                .with_for_update()
+            )
+            if task is None or task.status != "generating" or task.cancel_requested:
+                await db.rollback()
+                await self._finish_cancelled(generation_id)
+                return
+            now = datetime.now(UTC)
+            # SQLite 的 FOR UPDATE 不提供真实行锁，因此必须先用条件 UPDATE 抢完成权；
+            # 取消若已提交，rowcount 为 0，整个头像事务立即回滚。
+            claimed = cast(
+                CursorResult[Any],
+                await db.execute(
+                    update(PortraitGenerationTask)
+                    .where(
+                        PortraitGenerationTask.generation_id == generation_id,
+                        PortraitGenerationTask.status == "generating",
+                        PortraitGenerationTask.cancel_requested.is_(False),
+                    )
+                    .values(
+                        status="completed",
+                        portrait_version=image.content_hash,
+                        finished_at=now,
+                        updated_at=now,
+                    )
+                    .execution_options(synchronize_session=False)
+                ),
+            )
+            if claimed.rowcount != 1:
+                await db.rollback()
+                await self._finish_cancelled(generation_id)
+                return
+            await db.scalar(
+                select(Character).where(Character.id == task.character_id).with_for_update()
+            )
+            portrait = await db.get(CharacterPortrait, task.character_id)
+            if portrait is None:
+                portrait = CharacterPortrait(
+                    character_id=task.character_id,
+                    content=image.content,
+                    content_type=image.content_type,
+                    size_bytes=len(image.content),
+                    content_hash=image.content_hash,
+                    created_at=now,
+                    updated_at=now,
+                )
+                db.add(portrait)
+            else:
+                portrait.content, portrait.content_type = image.content, image.content_type
+                portrait.size_bytes, portrait.content_hash, portrait.updated_at = (
+                    len(image.content),
+                    image.content_hash,
+                    now,
+                )
+            await db.commit()
+
+    async def _finish_cancelled(self, generation_id: str) -> None:
+        async with self._session_factory() as db:
+            await db.execute(
+                update(PortraitGenerationTask)
+                .where(
+                    PortraitGenerationTask.generation_id == generation_id,
+                    PortraitGenerationTask.status.in_(("queued", "generating", "cancelling")),
+                )
+                .values(
+                    status="cancelled",
+                    cancel_requested=True,
+                    finished_at=datetime.now(UTC),
+                    updated_at=datetime.now(UTC),
+                )
+            )
+            await db.commit()
+
+    async def _fail(self, generation_id: str, failure_code: str) -> None:
+        async with self._session_factory() as db:
+            now = datetime.now(UTC)
+            await db.execute(
+                update(PortraitGenerationTask)
+                .where(
+                    PortraitGenerationTask.generation_id == generation_id,
+                    PortraitGenerationTask.status.in_(("queued", "generating")),
+                )
+                .values(status="failed", failure_code=failure_code, finished_at=now, updated_at=now)
+            )
+            await db.commit()
+
+    async def recover_interrupted(self) -> None:
+        """启动时明确失败遗留活动任务，避免未知上游重复计费。"""
+        async with self._session_factory() as db:
+            now = datetime.now(UTC)
+            await db.execute(
+                update(PortraitGenerationTask)
+                .where(
+                    PortraitGenerationTask.status.in_(("queued", "generating", "cancelling")),
+                )
+                .values(
+                    status="failed",
+                    failure_code="process_restarted",
+                    finished_at=now,
+                    updated_at=now,
+                )
+            )
+            await db.commit()
+
+    async def shutdown(self, timeout_seconds: float = 5.0) -> None:
+        """有限等待本进程任务退出，遗留状态交给下次启动恢复。"""
+        self._stopping = True
+        tasks = list(self._tasks.values())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.wait(tasks, timeout=timeout_seconds)
 
     @staticmethod
     async def get_player_portrait(

--- a/trpg-backend/scripts/check_portrait_postgres.py
+++ b/trpg-backend/scripts/check_portrait_postgres.py
@@ -1,0 +1,25 @@
+"""CI 中核对 PostgreSQL 生图任务迁移及部分唯一索引。"""
+
+import asyncio
+import os
+
+import asyncpg
+
+
+async def main() -> None:
+    """连接 CI PostgreSQL，确认活动任务唯一约束按预期生成。"""
+    url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://", 1)
+    connection = await asyncpg.connect(url)
+    try:
+        definition = await connection.fetchval(
+            "SELECT indexdef FROM pg_indexes WHERE indexname = $1",
+            "uq_portrait_generation_tasks_active_character",
+        )
+        assert definition and "UNIQUE INDEX" in definition
+        assert "WHERE" in definition and "cancelling" in definition
+    finally:
+        await connection.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/trpg-backend/scripts/export_schema.py
+++ b/trpg-backend/scripts/export_schema.py
@@ -104,7 +104,7 @@ _MODELS: list[type[BaseModel]] = [
     character.CharacterComputeResult,
     # 建卡完成后的角色生图（issue #199）
     portrait.PortraitGenerationRequest,
-    portrait.PortraitGenerationResult,
+    portrait.PortraitGenerationTaskRead,
     # 游戏目录 / 规则数据（issue #77 新增，issue #84 S1 加厚 ruleset 结构）
     game.GameRead,
     game.GameSystemRead,

--- a/trpg-backend/tests/conftest.py
+++ b/trpg-backend/tests/conftest.py
@@ -63,6 +63,7 @@ app.dependency_overrides[get_db] = override_get_db
 # 测试必须与开发者本地 `.env` 解耦：一键建卡的真实背景 provider 可能产生外部
 # 请求和费用；专门注入确定性实现，真实 provider 由 adapter 单测覆盖。
 app.state.character_background_service = CharacterBackgroundService()
+app.state.test_session_factory = TestSessionLocal
 
 # WS 路由（app/controller/ws.py）是原生 websocket handler，拿不到 FastAPI 的
 # Depends(get_db)，而是直接 `async with async_session_factory() as db`——也就是

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -9,7 +9,7 @@ from pathlib import Path
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
 ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
-HEAD_REVISION = "b8c3d4e5f6a7"
+HEAD_REVISION = "c1d2e3f4a5b6"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -84,6 +84,7 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "ending_drafts",
         "ending_command_executions",
         "character_portraits",
+        "portrait_generation_tasks",
     }.issubset(tables)
     assert "decision_schema_version" in _column_names(
         database,
@@ -135,6 +136,14 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "characters",
         "id",
     ) in _foreign_keys(database, "character_portraits")
+    assert {
+        "generation_id",
+        "character_id",
+        "status",
+        "cancel_requested",
+        "portrait_version",
+    }.issubset(_column_names(database, "portrait_generation_tasks"))
+    assert ("character_id",) in _unique_column_sets(database, "portrait_generation_tasks")
     assert "correlation_id" in _column_names(database, "events")
     assert {
         "visibility",

--- a/trpg-backend/tests/test_portrait_generation.py
+++ b/trpg-backend/tests/test_portrait_generation.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 from collections.abc import Callable, Generator
+from contextlib import suppress
 from hashlib import sha256
 from io import BytesIO
 from typing import cast
@@ -156,6 +157,17 @@ class BlockingImageProvider(RecordingImageProvider):
         )
 
 
+class CancelIgnoringImageProvider(BlockingImageProvider):
+    """模拟无法终止的上游：吞掉本地取消并返回迟到结果。"""
+
+    async def generate(self, **kwargs: object) -> ImageGenerationOutput:
+        self.started.set()
+        with suppress(asyncio.CancelledError):
+            await self.release.wait()
+        self.calls.append({"prompt": str(kwargs.get("prompt", ""))})
+        return ImageGenerationOutput(image_url="https://images.example/late.png")
+
+
 @pytest.fixture
 def install_portrait_service() -> Generator[
     Callable[[PortraitGenerationService], None], None, None
@@ -163,6 +175,7 @@ def install_portrait_service() -> Generator[
     previous = app.state.portrait_generation_service
 
     def install(service: PortraitGenerationService) -> None:
+        service.set_session_factory_for_testing(app.state.test_session_factory)
         app.state.portrait_generation_service = service
 
     yield install
@@ -203,6 +216,19 @@ async def create_character(client: AsyncClient, room: dict, *, complete: bool) -
         )
         assert completed.status_code == 200
     return character_id
+
+
+async def wait_for_generation(
+    client: AsyncClient, url: str, headers: dict[str, str], generation_id: str
+) -> dict[str, object]:
+    """轮询后台任务到终态，避免测试依赖协程调度时序。"""
+    for _ in range(100):
+        response = await client.get(f"{url}/{generation_id}", headers=headers)
+        data = response.json()["data"]
+        if data["status"] in {"completed", "failed", "cancelled"}:
+            return data
+        await asyncio.sleep(0.01)
+    raise AssertionError("生图任务未在测试时限内结束")
 
 
 def test_snapshot_uses_actual_allocations_and_excludes_notes() -> None:
@@ -402,9 +428,15 @@ async def test_completed_character_generates_real_provider_result_and_prompt_fal
         headers=headers,
     )
 
-    assert response.status_code == 200
-    data = response.json()["data"]
-    assert data["imageUrl"] == "https://images.example/portrait.png"
+    assert response.status_code == 202
+    queued = response.json()["data"]
+    assert queued["status"] == "queued"
+    data = await wait_for_generation(
+        client,
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/portrait-generations",
+        headers,
+        queued["generationId"],
+    )
     assert data["portraitVersion"] == sha256(b"persisted-png").hexdigest()
     assert data["promptSource"] == "deterministic_fallback"
     assert image_provider.calls[0]["size"] == "1024x1024"
@@ -458,7 +490,13 @@ async def test_portrait_read_requires_same_room_membership(
         json={},
         headers=reconnect(room["reconnectToken"]),
     )
-    assert generated.status_code == 200
+    assert generated.status_code == 202
+    await wait_for_generation(
+        client,
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/portrait-generations",
+        reconnect(room["reconnectToken"]),
+        generated.json()["data"]["generationId"],
+    )
     teammate = await join_room(client, room["roomCode"], await register(client))
     other_room = await create_room(client)
     url = f"{ROOMS_BASE}/{room['roomId']}/players/{room['playerId']}/portrait"
@@ -489,7 +527,9 @@ async def test_failed_regeneration_keeps_previous_portrait(
     install_portrait_service(service)
     generation_url = f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/portrait-generations"
     headers = reconnect(room["reconnectToken"])
-    assert (await client.post(generation_url, json={}, headers=headers)).status_code == 200
+    first = await client.post(generation_url, json={}, headers=headers)
+    assert first.status_code == 202
+    await wait_for_generation(client, generation_url, headers, first.json()["data"]["generationId"])
 
     replacement_content = b"replacement-png"
     replacement_service = PortraitGenerationService(
@@ -501,7 +541,10 @@ async def test_failed_regeneration_keeps_previous_portrait(
     )
     install_portrait_service(replacement_service)
     replaced = await client.post(generation_url, json={}, headers=headers)
-    assert replaced.status_code == 200
+    assert replaced.status_code == 202
+    await wait_for_generation(
+        client, generation_url, headers, replaced.json()["data"]["generationId"]
+    )
 
     failing_service = PortraitGenerationService(
         enabled=True,
@@ -512,12 +555,17 @@ async def test_failed_regeneration_keeps_previous_portrait(
     )
     install_portrait_service(failing_service)
     failed = await client.post(generation_url, json={}, headers=headers)
+    assert failed.status_code == 202
+    failed_task = await wait_for_generation(
+        client, generation_url, headers, failed.json()["data"]["generationId"]
+    )
     portrait = await client.get(
         f"{ROOMS_BASE}/{room['roomId']}/players/{room['playerId']}/portrait",
         headers=headers,
     )
 
-    assert failed.status_code == 502
+    assert failed_task["status"] == "failed"
+    assert failed_task["failureCode"] == "materialization_failed"
     assert portrait.status_code == 200
     assert portrait.content == replacement_content
 
@@ -619,11 +667,62 @@ async def test_concurrent_portrait_request_is_rejected_before_second_provider_ca
     second_response = await client.post(url, json={}, headers=headers)
     image_provider.release.set()
     first_response = await first_request
+    await wait_for_generation(client, url, headers, first_response.json()["data"]["generationId"])
 
-    assert first_response.status_code == 200
+    assert first_response.status_code == 202
     assert second_response.status_code == 409
     assert second_response.json()["error"]["code"] == "PORTRAIT_GENERATION_IN_PROGRESS"
     assert len(image_provider.calls) == 1
+
+
+async def test_current_is_null_before_first_generation(
+    client: AsyncClient,
+    install_portrait_service: Callable[[PortraitGenerationService], None],
+) -> None:
+    room = await create_room(client)
+    character_id = await create_character(client, room, complete=True)
+    service, _composer, _provider = make_service()
+    install_portrait_service(service)
+    response = await client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/portrait-generations/current",
+        headers=reconnect(room["reconnectToken"]),
+    )
+    assert response.status_code == 200
+    assert response.json()["data"] is None
+
+
+async def test_cancel_discards_provider_late_result(
+    client: AsyncClient,
+    install_portrait_service: Callable[[PortraitGenerationService], None],
+) -> None:
+    room = await create_room(client)
+    character_id = await create_character(client, room, complete=True)
+    provider = CancelIgnoringImageProvider()
+    service = PortraitGenerationService(
+        enabled=True,
+        prompt_composer=FixedPromptComposer(),
+        fallback_prompt_composer=DeterministicPromptComposer(),
+        image_provider=provider,
+        image_materializer=FixedImageMaterializer(b"late-image"),
+    )
+    install_portrait_service(service)
+    url = f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/portrait-generations"
+    headers = reconnect(room["reconnectToken"])
+    created = await client.post(url, json={}, headers=headers)
+    generation_id = created.json()["data"]["generationId"]
+    await provider.started.wait()
+
+    cancelled = await client.post(f"{url}/{generation_id}/cancel", headers=headers)
+    provider.release.set()
+    terminal = await wait_for_generation(client, url, headers, generation_id)
+
+    assert cancelled.status_code == 200
+    assert cancelled.json()["data"]["status"] == "cancelling"
+    assert terminal["status"] == "cancelled"
+    portrait = await client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/players/{room['playerId']}/portrait", headers=headers
+    )
+    assert portrait.status_code == 404
 
 
 async def test_draft_character_is_rejected_without_calling_provider(
@@ -743,6 +842,25 @@ async def test_dashscope_provider_submits_and_polls_task() -> None:
     assert submitted["model"] == "wan2.2-t2i-flash"
     assert submitted["parameters"] == {"size": "1024*1024", "n": 1}
     assert output.image_url == "https://dashscope.example/portrait.png"
+
+
+async def test_dashscope_provider_cancel_calls_upstream_task_endpoint() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"output": {"task_status": "CANCELED"}})
+
+    provider = DashScopeImageProvider(
+        api_key="test-key",
+        base_url="https://dashscope.example/api/v1",
+        model="wan2.2-t2i-flash",
+        timeout_seconds=5,
+        transport=httpx.MockTransport(handler),
+    )
+    await provider.cancel("task-1")
+    assert requests[0].method == "POST"
+    assert requests[0].url.path.endswith("/tasks/task-1/cancel")
 
 
 async def test_mock_image_provider_returns_stable_inline_image() -> None:

--- a/trpg-frontend/src/App.tsx
+++ b/trpg-frontend/src/App.tsx
@@ -5,6 +5,8 @@ import { getAuthToken } from '@/services/api-client';
 import { fetchMe } from '@/services/auth';
 import { useAuthStore } from '@/stores/auth-store';
 import { ROUTES } from '@/config/routes';
+import { usePortraitGenerationCoordinator } from '@/hooks/usePortraitGeneration';
+import { PortraitGenerationNotices } from '@/features/portrait/PortraitGenerationNotices';
 
 const LoginPage = lazy(() => import('@/routes/auth/LoginPage'));
 const RegisterPage = lazy(() => import('@/routes/auth/RegisterPage'));
@@ -33,6 +35,7 @@ function LoadingFallback() {
  * 原型，业务数据全部走真实后端 + trpg-sdk，不再有 mock 模式。
  */
 function App() {
+  usePortraitGenerationCoordinator();
   const login = useAuthStore((s) => s.login);
   // auth-store 只存在内存里（不持久化），但登录 token 一直躺在 localStorage。
   // 页面刷新/HMR 全量重载后 auth-store 会被清空，若不在这里用 token 换回身份，
@@ -52,6 +55,7 @@ function App() {
 
   return (
     <PhoneLayout>
+      <PortraitGenerationNotices />
       <Suspense fallback={<LoadingFallback />}>
         <Routes>
           <Route path="/" element={<Navigate to="/auth/login" replace />} />

--- a/trpg-frontend/src/features/character/CharacterBasicInfo.tsx
+++ b/trpg-frontend/src/features/character/CharacterBasicInfo.tsx
@@ -140,12 +140,14 @@ export function CharacterBasicInfo({
   occupationName,
   attributes,
   liveResources,
+  portraitAction,
 }: {
   character: CompletedCharacter
   portraitUrl?: string
   occupationName?: string | null
   attributes: readonly RadarAttribute[]
   liveResources?: LiveResources
+  portraitAction?: { kind: 'preview' } | { kind: 'generate'; onActivate: () => void } | { kind: 'static' }
 }) {
   // 当前值优先，没有运行时投影时才落回建卡快照。
   const derivedValues = DERIVED_STAT_DEFINITIONS.map(definition => ({
@@ -188,7 +190,10 @@ export function CharacterBasicInfo({
               alt={`${character.info.name}的头像`}
               buttonClassName="h-full w-full"
               imageClassName="h-full w-full object-cover"
+              action={portraitAction}
             />
+          ) : portraitAction?.kind === 'generate' ? (
+            <button type="button" aria-label="生成角色图片" onClick={portraitAction.onActivate} className="h-full w-full text-2xl">🕵️</button>
           ) : '🕵️'}
         </div>
         <div className="character-ready-sheet__identity">

--- a/trpg-frontend/src/features/portrait/PortraitGenerationNotices.tsx
+++ b/trpg-frontend/src/features/portrait/PortraitGenerationNotices.tsx
@@ -1,0 +1,19 @@
+/** 全局非阻塞展示角色生图任务的终态通知。 */
+import { useEffect } from 'react'
+import { X } from 'lucide-react'
+import { usePortraitGenerationStore } from '@/stores/portrait-generation-store'
+
+export function PortraitGenerationNotices() {
+  const notices = usePortraitGenerationStore((s) => s.notices)
+  const dismiss = usePortraitGenerationStore((s) => s.dismissNotice)
+  useEffect(() => {
+    const timers = notices.map((notice) => window.setTimeout(() => dismiss(notice.id), 5000))
+    return () => timers.forEach(window.clearTimeout)
+  }, [notices, dismiss])
+  return <div aria-live="polite" className="fixed right-4 top-4 z-[120] flex w-[min(22rem,calc(100vw-2rem))] flex-col gap-2">
+    {notices.map((notice) => <div key={notice.id} role="status" className="flex items-center justify-between rounded-md border border-border-mid bg-white px-4 py-3 shadow-lg">
+      <span className={notice.tone === 'error' ? 'text-[#b43b3b]' : 'text-text-primary'}>{notice.message}</span>
+      <button type="button" aria-label="关闭通知" onClick={() => dismiss(notice.id)}><X className="h-4 w-4" /></button>
+    </div>)}
+  </div>
+}

--- a/trpg-frontend/src/features/portrait/PortraitImage.tsx
+++ b/trpg-frontend/src/features/portrait/PortraitImage.tsx
@@ -10,6 +10,7 @@ interface PortraitImageProps {
   alt: string
   buttonClassName?: string
   imageClassName?: string
+  action?: { kind: 'preview' } | { kind: 'generate'; onActivate: () => void } | { kind: 'static' }
 }
 
 /**
@@ -20,6 +21,7 @@ export function PortraitImage({
   alt,
   buttonClassName = '',
   imageClassName = '',
+  action = { kind: 'preview' },
 }: PortraitImageProps) {
   const [open, setOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
@@ -70,6 +72,9 @@ export function PortraitImage({
       trigger?.focus()
     }
   }, [open])
+
+  if (action.kind === 'static') return <img src={src} alt={alt} className={imageClassName} />
+  if (action.kind === 'generate') return <button type="button" aria-label={`为${alt}生成图片`} title="点击生成角色图片" onClick={action.onActivate} className={`block overflow-hidden border-0 bg-transparent p-0 ${buttonClassName}`}><img src={src} alt={alt} className={imageClassName} /></button>
 
   return (
     <>

--- a/trpg-frontend/src/hooks/usePortraitGeneration.ts
+++ b/trpg-frontend/src/hooks/usePortraitGeneration.ts
@@ -1,0 +1,29 @@
+/** 在应用顶层恢复并轮询当前玩家的角色生图后台任务。 */
+import { useEffect } from 'react'
+import { getCurrentCharacterPortraitTask } from '@/services/character/portrait-api'
+import { useRoomStore } from '@/stores/room-store'
+import { isPortraitTaskActive, portraitTaskKey, usePortraitGenerationStore } from '@/stores/portrait-generation-store'
+
+export function usePortraitGenerationCoordinator() {
+  const roomId = useRoomStore((s) => s.roomId)
+  const characterId = useRoomStore((s) => s.characterId)
+  const reconnectToken = useRoomStore((s) => s.reconnectToken)
+  const task = usePortraitGenerationStore((s) => roomId && characterId ? s.tasks[portraitTaskKey(roomId, characterId)] : null)
+  const setTask = usePortraitGenerationStore((s) => s.setTask)
+  const taskActive = isPortraitTaskActive(task)
+  const taskLoaded = task !== undefined
+  useEffect(() => {
+    if (!roomId || !characterId || !reconnectToken) return
+    let disposed = false
+    const refresh = async (notify: boolean) => {
+      try {
+        const current = await getCurrentCharacterPortraitTask(roomId, characterId)
+        if (!disposed) setTask(roomId, characterId, current, notify)
+      } catch { /* 短暂断线时保留最后一次权威快照，下一轮继续恢复。 */ }
+    }
+    void refresh(false)
+    if (!taskActive && taskLoaded) return () => { disposed = true }
+    const timer = window.setInterval(() => void refresh(true), 2000)
+    return () => { disposed = true; window.clearInterval(timer) }
+  }, [roomId, characterId, reconnectToken, taskActive, taskLoaded, setTask])
+}

--- a/trpg-frontend/src/routes/character-ready/CharacterReadyPage.test.tsx
+++ b/trpg-frontend/src/routes/character-ready/CharacterReadyPage.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchCharacter } from '@/services/character/character-api'
 import CharacterReadyPage from './CharacterReadyPage'
+import { usePortraitGenerationStore } from '@/stores/portrait-generation-store'
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -80,6 +81,7 @@ describe('CharacterReadyPage', () => {
     mocks.room.roomId = 'room-1'
     mocks.room.characterId = null
     vi.mocked(fetchCharacter).mockReset()
+    usePortraitGenerationStore.setState({ tasks: {}, cancelling: {}, notices: [], portraitVersions: {} })
   })
   afterEach(cleanup)
 
@@ -92,6 +94,18 @@ describe('CharacterReadyPage', () => {
     expect(screen.getByText('队友')).toBeInTheDocument()
     expect(screen.getByText('已建卡')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '开始游戏' })).toBeEnabled()
+  })
+
+  it('生图任务进行中仍可开始游戏，跳转不会清除任务', async () => {
+    usePortraitGenerationStore.getState().setTask('room-1', 'character-1', {
+      generationId: 'generation-1', status: 'generating', cancelRequested: false,
+      style: 'realistic', size: '1024x1024', createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    })
+    render(<CharacterReadyPage />)
+    fireEvent.click(screen.getByRole('button', { name: '开始游戏' }))
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith('/room/play'))
+    expect(usePortraitGenerationStore.getState().tasks['room-1/character-1']?.status).toBe('generating')
   })
 
   it('本人可以打开主题化角色卡并进入编辑页面', () => {

--- a/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
+++ b/trpg-frontend/src/routes/character-ready/CharacterReadyPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { PortraitGenerationResult, RoomPlayerSummary } from 'trpg-sdk'
+import type { RoomPlayerSummary } from 'trpg-sdk'
 import {
   User,
   UserPlus,
@@ -20,6 +20,7 @@ import { normalizeDerivedStats } from '@/data/derived-stats'
 import { OnboardingTrigger } from '@/features/onboarding'
 import { PortraitImage } from '@/features/portrait/PortraitImage'
 import { CharacterBasicInfo } from '@/features/character/CharacterBasicInfo'
+import { usePortraitGenerationStore } from '@/stores/portrait-generation-store'
 
 const SHEET_PAGES = [
   { key: 'info', label: '基本信息' },
@@ -123,8 +124,6 @@ export default function CharacterReadyPage() {
   const navigate = useNavigate()
   const [showSelfSheet, setShowSelfSheet] = useState(false)
   const [showPortraitGenerator, setShowPortraitGenerator] = useState(false)
-  const [portraitResult, setPortraitResult] = useState<PortraitGenerationResult | null>(null)
-  const [portraitVersionOverride, setPortraitVersionOverride] = useState<string | null>(null)
   const [starting, setStarting] = useState(false)
   const [startError, setStartError] = useState('')
   const [confirmExit, setConfirmExit] = useState(false)
@@ -194,6 +193,8 @@ export default function CharacterReadyPage() {
   const isHost = useRoomStore((s) => s.isHost)
   const playerId = useRoomStore((s) => s.playerId)
   const reconnectToken = useRoomStore((s) => s.reconnectToken)
+  const portraitVersionOverride = usePortraitGenerationStore((s) => roomId ? s.portraitVersions[roomId] : undefined)
+  const clearPortraitVersion = usePortraitGenerationStore((s) => s.clearPortraitVersion)
   const nickname = useAuthStore((s) => s.nickname)
   const hasCharacter = character !== null
   const info = useRoomPlayers(roomCode)
@@ -210,11 +211,10 @@ export default function CharacterReadyPage() {
 
   useEffect(() => {
     const current = players.find((player) => player.playerId === playerId)
-    if (portraitVersionOverride && current?.portraitVersion === portraitVersionOverride) {
-      // 房间轮询追上刚生成的版本后撤掉临时覆盖，后续跨设备重生成仍能被发现。
-      setPortraitVersionOverride(null)
+    if (roomId && portraitVersionOverride && current?.portraitVersion === portraitVersionOverride) {
+      clearPortraitVersion(roomId)
     }
-  }, [playerId, players, portraitVersionOverride])
+  }, [roomId, playerId, players, portraitVersionOverride, clearPortraitVersion])
 
   // ★ 房主点"开始游戏"之后，后端 _on_game_start 会把房间 phase 改成
   // InGame——其他玩家没有 WS 广播可用，只能靠轮询这个字段发现"游戏真的开始
@@ -449,12 +449,7 @@ export default function CharacterReadyPage() {
           roomId={roomId}
           characterId={characterId}
           characterName={character.info.name}
-          result={portraitResult}
           portraitUrl={playerId ? portraitUrls[playerId] : undefined}
-          onResult={(result) => {
-            setPortraitResult(result)
-            setPortraitVersionOverride(result.portraitVersion)
-          }}
           onClose={() => setShowPortraitGenerator(false)}
         />
       )}

--- a/trpg-frontend/src/routes/character-ready/PortraitGenerationModal.test.tsx
+++ b/trpg-frontend/src/routes/character-ready/PortraitGenerationModal.test.tsx
@@ -1,89 +1,53 @@
-import { useState } from 'react'
+/** 验证后台生图弹窗的关闭、创建和终止交互。 */
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import type { PortraitGenerationResult } from 'trpg-sdk'
+import type { PortraitGenerationTaskRead } from 'trpg-sdk'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { generateCharacterPortrait } from '@/services/character/portrait-api'
+import { createCharacterPortrait, cancelCharacterPortrait } from '@/services/character/portrait-api'
+import { usePortraitGenerationStore } from '@/stores/portrait-generation-store'
 import { PortraitGenerationModal } from './PortraitGenerationModal'
 
-vi.mock('@/services/character/portrait-api', () => ({
-  generateCharacterPortrait: vi.fn(),
-}))
-
-const generated: PortraitGenerationResult = {
-  generationId: 'generation-1',
-  status: 'completed',
-  imageUrl: 'https://images.example/portrait.png',
-  portraitVersion: 'portrait-version-1',
-  prompt: 'portrait prompt',
-  negativePrompt: 'watermark',
-  promptSummary: '私家侦探的风衣、伤疤和侦查装备',
-  promptSource: 'deepseek',
-}
-
-function Harness({ initialResult = null }: { initialResult?: PortraitGenerationResult | null }) {
-  const [result, setResult] = useState(initialResult)
-  return (
-    <PortraitGenerationModal
-      roomId="room-1"
-      characterId="character-1"
-      characterName="陈探员"
-      result={result}
-      portraitUrl={result ? 'blob:persistent-portrait' : undefined}
-      onResult={setResult}
-      onClose={vi.fn()}
-    />
-  )
-}
+vi.mock('@/services/character/portrait-api', () => ({ createCharacterPortrait: vi.fn(), cancelCharacterPortrait: vi.fn() }))
+const task = (status: PortraitGenerationTaskRead['status']): PortraitGenerationTaskRead => ({
+  generationId: 'generation-1', status, cancelRequested: status === 'cancelling', style: 'realistic',
+  size: '1024x1024', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+})
+const props = { roomId: 'room-1', characterId: 'character-1', characterName: '陈探员', onClose: vi.fn() }
 
 describe('PortraitGenerationModal', () => {
-  beforeEach(() => {
-    vi.mocked(generateCharacterPortrait).mockReset()
-  })
+  beforeEach(() => { usePortraitGenerationStore.setState({ tasks: {}, cancelling: {}, notices: [], portraitVersions: {} }); vi.clearAllMocks() })
+  afterEach(cleanup)
 
-  afterEach(() => {
-    cleanup()
-  })
-
-  it('打开弹窗时不会自动生图，由玩家主动确认', () => {
-    render(<Harness />)
-
-    expect(generateCharacterPortrait).not.toHaveBeenCalled()
-    expect(screen.getByRole('button', { name: '开始生成' })).toBeEnabled()
-  })
-
-  it('展示生成中状态、成功图片和生成依据', async () => {
-    let resolveRequest: (value: PortraitGenerationResult) => void = () => undefined
-    vi.mocked(generateCharacterPortrait).mockReturnValue(
-      new Promise((resolve) => {
-        resolveRequest = resolve
-      }),
-    )
-    render(<Harness />)
-
+  it('创建接口返回后台任务快照', async () => {
+    vi.mocked(createCharacterPortrait).mockResolvedValue(task('queued'))
+    render(<PortraitGenerationModal {...props} />)
     fireEvent.click(screen.getByRole('button', { name: '开始生成' }))
-
-    expect(screen.getByText('正在生成人物图片…')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '生成中…' })).toBeDisabled()
-    expect(generateCharacterPortrait).toHaveBeenCalledTimes(1)
-
-    resolveRequest(generated)
-    await waitFor(() => {
-      expect(screen.getByRole('img', { name: '陈探员的人物图片' })).toHaveAttribute(
-        'src',
-        'blob:persistent-portrait',
-      )
-    })
-    expect(screen.getByText(generated.promptSummary)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '重新生成' })).toBeEnabled()
+    await waitFor(() => expect(screen.getByRole('button', { name: '终止生成' })).toBeEnabled())
   })
 
-  it('生成失败后显示错误并允许重试', async () => {
-    vi.mocked(generateCharacterPortrait).mockRejectedValueOnce(new Error('阿里云生图服务暂时不可用'))
-    render(<Harness initialResult={generated} />)
+  it('生成中仍可关闭弹窗且不会隐式取消', () => {
+    usePortraitGenerationStore.getState().setTask('room-1', 'character-1', task('generating'))
+    render(<PortraitGenerationModal {...props} />)
+    expect(screen.getByText('关闭窗口不会终止任务，进入游戏后仍会继续生成')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '关闭窗口，生成将在后台继续' }))
+    expect(props.onClose).toHaveBeenCalledOnce()
+    expect(cancelCharacterPortrait).not.toHaveBeenCalled()
+  })
 
-    fireEvent.click(screen.getByRole('button', { name: '重新生成' }))
+  it('遮罩和 Esc 也只关闭窗口，不终止生成', () => {
+    usePortraitGenerationStore.getState().setTask('room-1', 'character-1', task('generating'))
+    const { container } = render(<PortraitGenerationModal {...props} />)
+    fireEvent.click(container.querySelector('[aria-hidden="true"]') as Element)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(props.onClose).toHaveBeenCalledTimes(2)
+    expect(cancelCharacterPortrait).not.toHaveBeenCalled()
+  })
 
-    expect(await screen.findByRole('alert')).toHaveTextContent('阿里云生图服务暂时不可用')
-    expect(screen.getByRole('button', { name: '重新生成' })).toBeEnabled()
+  it('终止生成防止重复提交并显示终止中', async () => {
+    usePortraitGenerationStore.getState().setTask('room-1', 'character-1', task('generating'))
+    vi.mocked(cancelCharacterPortrait).mockResolvedValue(task('cancelling'))
+    render(<PortraitGenerationModal {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: '终止生成' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: '终止中…' })).toBeDisabled())
+    expect(cancelCharacterPortrait).toHaveBeenCalledOnce()
   })
 })

--- a/trpg-frontend/src/routes/character-ready/PortraitGenerationModal.tsx
+++ b/trpg-frontend/src/routes/character-ready/PortraitGenerationModal.tsx
@@ -1,127 +1,68 @@
+/** 角色生图任务弹窗：关闭不取消，任务状态始终以服务端快照为准。 */
 import { useEffect, useState } from 'react'
-import type { PortraitGenerationResult } from 'trpg-sdk'
-import { Image, RefreshCw, Sparkles, X } from 'lucide-react'
+import { Image, RefreshCw, Sparkles, Square, X } from 'lucide-react'
 import { friendlyErrorMessage } from '@/services/api-client'
-import { generateCharacterPortrait } from '@/services/character/portrait-api'
+import { cancelCharacterPortrait, createCharacterPortrait } from '@/services/character/portrait-api'
+import { isPortraitTaskActive, portraitTaskKey, usePortraitGenerationStore } from '@/stores/portrait-generation-store'
 
-interface PortraitGenerationModalProps {
-  roomId: string
-  characterId: string
-  characterName: string
-  result: PortraitGenerationResult | null
-  portraitUrl?: string
-  onResult: (result: PortraitGenerationResult) => void
-  onClose: () => void
-}
+interface Props { roomId: string; characterId: string; characterName: string; portraitUrl?: string; onClose: () => void }
 
-export function PortraitGenerationModal({
-  roomId,
-  characterId,
-  characterName,
-  result,
-  portraitUrl,
-  onResult,
-  onClose,
-}: PortraitGenerationModalProps) {
-  const [generating, setGenerating] = useState(false)
+export function PortraitGenerationModal({ roomId, characterId, characterName, portraitUrl, onClose }: Props) {
+  const key = portraitTaskKey(roomId, characterId)
+  const task = usePortraitGenerationStore((s) => s.tasks[key])
+  const cancelling = usePortraitGenerationStore((s) => s.cancelling[key] ?? false)
+  const setTask = usePortraitGenerationStore((s) => s.setTask)
+  const setCancelling = usePortraitGenerationStore((s) => s.setCancelling)
+  const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const active = isPortraitTaskActive(task)
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !generating) onClose()
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [generating, onClose])
+    const keydown = (event: KeyboardEvent) => { if (event.key === 'Escape') onClose() }
+    window.addEventListener('keydown', keydown)
+    return () => window.removeEventListener('keydown', keydown)
+  }, [onClose])
 
-  const handleGenerate = async () => {
-    if (generating) return
-    setGenerating(true)
-    setError('')
-    try {
-      onResult(await generateCharacterPortrait(roomId, characterId))
-    } catch (err) {
-      setError(friendlyErrorMessage(err, '生成人物图片失败，请稍后重试'))
-    } finally {
-      setGenerating(false)
-    }
+  const generate = async () => {
+    if (active || submitting) return
+    setSubmitting(true); setError('')
+    try { setTask(roomId, characterId, await createCharacterPortrait(roomId, characterId)) }
+    catch (reason) { setError(friendlyErrorMessage(reason, '生成人物图片失败，请稍后重试')) }
+    finally { setSubmitting(false) }
+  }
+  const cancel = async () => {
+    if (!task || cancelling || task.status === 'cancelling') return
+    setCancelling(roomId, characterId, true); setError('')
+    try { setTask(roomId, characterId, await cancelCharacterPortrait(roomId, characterId, task.generationId)) }
+    catch (reason) { setError(friendlyErrorMessage(reason, '终止生成失败，请稍后重试')) }
+    finally { setCancelling(roomId, characterId, false) }
   }
 
-  return (
-    <>
-      <div
-        className="fixed inset-0 bg-black/55 z-40 animate-fade-in"
-        onClick={generating ? undefined : onClose}
-        aria-hidden="true"
-      />
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="portrait-dialog-title"
-        className="portrait-generation-modal fixed inset-x-0 bottom-0 z-50 max-h-[92vh] overflow-y-auto animate-slide-up"
-      >
-        <div className="mx-auto w-full max-w-md">
-          <div className="portrait-generation-modal__header mb-4 flex items-center justify-between gap-3">
-            <div className="portrait-generation-modal__heading min-w-0">
-              <h3 id="portrait-dialog-title" className="portrait-generation-modal__title truncate font-bold text-text-primary">
-                {characterName}的人物图片
-              </h3>
-              <p className="portrait-generation-modal__subtitle mt-0.5 text-text-muted">写实肖像 · 1024 × 1024</p>
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={generating}
-              aria-label="关闭人物图片生成"
-              title="关闭"
-              className="portrait-generation-modal__close flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-panel text-text-muted transition-colors disabled:opacity-40"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-
-          <div className="mx-auto flex aspect-square w-full max-w-[360px] items-center justify-center overflow-hidden rounded-md border border-border-mid bg-panel">
-            {generating ? (
-              <div className="flex flex-col items-center gap-3 text-text-muted" aria-live="polite">
-                <RefreshCw className="h-8 w-8 animate-spin text-brass" />
-                <span className="portrait-generation-modal__status">正在生成人物图片…</span>
-              </div>
-            ) : portraitUrl ? (
-              <img
-                src={portraitUrl}
-                alt={`${characterName}的人物图片`}
-                className="h-full w-full object-cover"
-                onError={() => setError('人物头像加载失败，请稍后重试')}
-              />
-            ) : (
-              <Image className="h-14 w-14 text-text-dim" strokeWidth={1.4} />
-            )}
-          </div>
-
-          {result && !generating && (
-            <div className="portrait-generation-modal__basis mt-4 border-l-2 border-brass px-3">
-              <div className="portrait-generation-modal__basis-title font-semibold text-brass-dark">生成依据</div>
-              <p className="portrait-generation-modal__basis-text mt-1 text-text-muted">{result.promptSummary}</p>
-            </div>
-          )}
-
-          {error && (
-            <p role="alert" className="portrait-generation-modal__error mt-4 text-center text-[#b43b3b]">
-              {error}
-            </p>
-          )}
-
-          <button
-            type="button"
-            onClick={handleGenerate}
-            disabled={generating}
-            className="portrait-generation-modal__action mt-5 flex min-h-11 w-full items-center justify-center gap-2 rounded-sm bg-brass px-5 py-3 font-semibold text-white transition-colors active:bg-brass-dark disabled:opacity-50"
-          >
-            {portraitUrl ? <RefreshCw className="h-4 w-4" /> : <Sparkles className="h-4 w-4" />}
-            {generating ? '生成中…' : portraitUrl ? '重新生成' : '开始生成'}
-          </button>
+  const status = task?.status === 'cancelling' || cancelling ? '终止中…'
+    : active ? '正在生成人物图片…' : task?.status === 'cancelled' ? '本次生成已终止'
+      : task?.status === 'failed' ? '本次生成失败，可重新尝试' : ''
+  return <>
+    <div className="fixed inset-0 bg-black/55 z-40 animate-fade-in" onClick={onClose} aria-hidden="true" />
+    <div role="dialog" aria-modal="true" aria-labelledby="portrait-dialog-title" className="portrait-generation-modal fixed inset-x-0 bottom-0 z-50 max-h-[92vh] overflow-y-auto animate-slide-up">
+      <div className="mx-auto w-full max-w-md">
+        <div className="portrait-generation-modal__header mb-4 flex items-center justify-between gap-3">
+          <div><h3 id="portrait-dialog-title" className="font-bold text-text-primary">{characterName}的人物图片</h3><p className="mt-0.5 text-text-muted">写实肖像 · 1024 × 1024</p></div>
+          <button type="button" onClick={onClose} aria-label="关闭窗口，生成将在后台继续" title="关闭窗口（不会终止生成）" className="flex h-8 w-8 items-center justify-center rounded-full bg-panel"><X className="h-4 w-4" /></button>
         </div>
+        <div className="mx-auto flex aspect-square w-full max-w-[360px] items-center justify-center overflow-hidden rounded-md border border-border-mid bg-panel">
+          {active ? <div className="flex flex-col items-center gap-3 text-text-muted" aria-live="polite"><RefreshCw className="h-8 w-8 animate-spin text-brass" /><span>{status}</span></div>
+            : portraitUrl ? <img src={portraitUrl} alt={`${characterName}的人物图片`} className="h-full w-full object-cover" />
+              : <Image className="h-14 w-14 text-text-dim" />}
+        </div>
+        {task?.promptSummary && <div className="mt-4 border-l-2 border-brass px-3"><div className="font-semibold text-brass-dark">生成依据</div><p className="mt-1 text-text-muted">{task.promptSummary}</p></div>}
+        {!active && status && <p className="mt-4 text-center text-text-muted" aria-live="polite">{status}</p>}
+        {active && <p className="mt-3 text-center text-xs text-text-muted">关闭窗口不会终止任务，进入游戏后仍会继续生成</p>}
+        {error && <p role="alert" className="mt-4 text-center text-[#b43b3b]">{error}</p>}
+        <button type="button" onClick={active ? cancel : generate} disabled={submitting || cancelling || task?.status === 'cancelling'} className="mt-5 flex min-h-11 w-full items-center justify-center gap-2 rounded-sm bg-brass px-5 py-3 font-semibold text-white disabled:opacity-50">
+          {active ? <Square className="h-4 w-4" /> : portraitUrl ? <RefreshCw className="h-4 w-4" /> : <Sparkles className="h-4 w-4" />}
+          {task?.status === 'cancelling' || cancelling ? '终止中…' : active ? '终止生成' : submitting ? '提交中…' : portraitUrl ? '重新生成' : '开始生成'}
+        </button>
       </div>
-    </>
-  )
+    </div>
+  </>
 }

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -1151,7 +1151,7 @@ describe('RoomPage conversation history', () => {
 
     renderRoomPage()
     fireEvent.click(screen.getByRole('button', { name: '角色卡' }))
-    expect(screen.getByRole('button', { name: '查看杜调查员的头像大图' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '为杜调查员的头像生成图片' })).toBeInTheDocument()
     for (const label of ['生命值', '理智值', '魔法值', '伤害加值', '体格', '移动力']) {
       expect(screen.getByText(new RegExp(label))).toBeInTheDocument()
     }

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { RoomSocketServerError, TurnFailedError, type AdjudicationPendingPayload, type AgentPlayerView, type AgentTurnPhase, type CheckRequestPayload, type CheckResultPayload, type EndingDraft, type NarrationPushPayload, type RoomConversationEvent, type RoomPlayerSummary } from 'trpg-sdk'
 import { ArrowLeft, Users, Map, MapPin, BookOpen, ScrollText, Star, X, SendHorizontal, Plus, Save, FlagOff, Heart, Brain, Volume2, Pause, Play, Square, RotateCcw, Mic, LoaderCircle } from 'lucide-react'
-import { useCallback, useState, useRef, useEffect, type Dispatch, type FormEvent, type SetStateAction } from 'react'
+import { useCallback, useState, useRef, useEffect, useMemo, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 import { useRoomStore } from '@/stores/room-store'
 import { useAuthStore } from '@/stores/auth-store'
 import { useCharacterStore } from '@/stores/character-store'
@@ -16,6 +16,8 @@ import { Dice3DStage, supports3DDice, type Dice3DHandle, type DiceRollToken } fr
 import { OnboardingTrigger } from '@/features/onboarding'
 import { CheckWorkflowPanel } from '@/features/adjudication'
 import { CharacterBasicInfo } from '@/features/character/CharacterBasicInfo'
+import { PortraitGenerationModal } from '@/routes/character-ready/PortraitGenerationModal'
+import { usePortraitGenerationStore } from '@/stores/portrait-generation-store'
 import type {
   CheckRunView as UiCheckRunView,
   PendingCheckDecisionView as UiPendingCheckDecisionView,
@@ -1241,6 +1243,7 @@ export default function RoomPage() {
   const roomId = useRoomStore((s) => s.roomId)
   const roomCode = useRoomStore((s) => s.roomCode)
   const playerId = useRoomStore((s) => s.playerId)
+  const characterId = useRoomStore((s) => s.characterId)
   const reconnectToken = useRoomStore((s) => s.reconnectToken)
   const nickname = useAuthStore((s) => s.nickname)
   // 按房间取角色卡，而不是直接读 s.character——本地缓存不按房间区分的话，
@@ -1250,7 +1253,17 @@ export default function RoomPage() {
   const { ruleset } = useRuleset()
   const roomInfo = useRoomPlayers(roomCode)
   const roomPlayers = roomInfo?.players ?? EMPTY_ROOM_PLAYERS
-  const portraitUrls = usePlayerPortraits(roomId, reconnectToken, roomPlayers)
+  const portraitVersionOverride = usePortraitGenerationStore((s) => roomId ? s.portraitVersions[roomId] : undefined)
+  const clearPortraitVersion = usePortraitGenerationStore((s) => s.clearPortraitVersion)
+  const portraitPlayers = useMemo(() => roomPlayers.map((player) => player.playerId === playerId && portraitVersionOverride
+    ? { ...player, hasPortrait: true, portraitVersion: portraitVersionOverride } : player), [roomPlayers, playerId, portraitVersionOverride])
+  const portraitUrls = usePlayerPortraits(roomId, reconnectToken, portraitPlayers)
+  useEffect(() => {
+    const current = roomPlayers.find((player) => player.playerId === playerId)
+    if (roomId && portraitVersionOverride && current?.portraitVersion === portraitVersionOverride) {
+      clearPortraitVersion(roomId)
+    }
+  }, [roomId, playerId, roomPlayers, portraitVersionOverride, clearPortraitVersion])
   const hostSpeech = useHostSpeech({ roomId, reconnectToken, accountToken: getAuthToken() })
   const enqueueHostSpeech = hostSpeech.enqueue
   const markHostSpeechSeen = hostSpeech.markSeen
@@ -1264,6 +1277,7 @@ export default function RoomPage() {
   const endingConfirmRequestId = useRef(randomActionId())
   const [endError, setEndError] = useState('')
   const [confirmExit, setConfirmExit] = useState(false)
+  const [showPortraitGenerator, setShowPortraitGenerator] = useState(false)
   const [messages, setMessages] = useState<Message[]>([])
   const [channel, setChannel] = useState<'action' | 'discussion'>('action')
   const isActionChannel = channel === 'action'
@@ -2383,6 +2397,7 @@ export default function RoomPage() {
                     : null}
                   attributes={ruleset?.attributes ?? []}
                   liveResources={liveResources}
+                  portraitAction={{ kind: 'generate', onActivate: () => setShowPortraitGenerator(true) }}
                 />
               </div>
             )}
@@ -2865,6 +2880,15 @@ export default function RoomPage() {
         luckValue={resourceValue(playerView, 'luck')}
         onPostRollOption={submitAdjudicationPostRoll}
       />
+      {showPortraitGenerator && character && roomId && characterId && (
+        <PortraitGenerationModal
+          roomId={roomId}
+          characterId={characterId}
+          characterName={character.info.name}
+          portraitUrl={playerId ? portraitUrls[playerId] : undefined}
+          onClose={() => setShowPortraitGenerator(false)}
+        />
+      )}
     </div>
   )
 }

--- a/trpg-frontend/src/services/character/portrait-api.ts
+++ b/trpg-frontend/src/services/character/portrait-api.ts
@@ -1,18 +1,25 @@
-import type { PortraitGenerationResult } from 'trpg-sdk'
+/** 角色生图后台任务 API；重连凭证始终从房间状态读取。 */
+import type { PortraitGenerationTaskRead } from 'trpg-sdk'
 import { useRoomStore } from '@/stores/room-store'
 import { sdk } from '../api-client'
 
-export async function generateCharacterPortrait(
-  roomId: string,
-  characterId: string,
-): Promise<PortraitGenerationResult> {
-  // 重连 token 只从房间 store 读取并发往本项目后端，前端不持有任何生图服务 Key。
+function token(): string {
   const reconnectToken = useRoomStore.getState().reconnectToken
   if (!reconnectToken) throw new Error('缺少房间重连凭证，请重新加入房间')
-  return sdk.characters.generatePortrait(
-    roomId,
-    characterId,
-    { style: 'realistic', size: '1024x1024' },
-    reconnectToken,
-  )
+  return reconnectToken
 }
+
+export function createCharacterPortrait(roomId: string, characterId: string): Promise<PortraitGenerationTaskRead> {
+  return sdk.characters.createPortraitGeneration(roomId, characterId, { style: 'realistic', size: '1024x1024' }, token())
+}
+
+export function getCurrentCharacterPortraitTask(roomId: string, characterId: string): Promise<PortraitGenerationTaskRead | null> {
+  return sdk.characters.getCurrentPortraitGeneration(roomId, characterId, token())
+}
+
+export function cancelCharacterPortrait(roomId: string, characterId: string, generationId: string): Promise<PortraitGenerationTaskRead> {
+  return sdk.characters.cancelPortraitGeneration(roomId, characterId, generationId, token())
+}
+
+/** 兼容旧调用名；返回值现在是后台任务快照。 */
+export const generateCharacterPortrait = createCharacterPortrait

--- a/trpg-frontend/src/stores/portrait-generation-store.ts
+++ b/trpg-frontend/src/stores/portrait-generation-store.ts
@@ -1,0 +1,64 @@
+/** 跨路由保存角色生图任务、头像版本覆盖和非阻塞通知。 */
+import { create } from 'zustand'
+import type { PortraitGenerationTaskRead } from 'trpg-sdk'
+
+export type PortraitNotice = { id: string; message: string; tone: 'success' | 'error' | 'neutral' }
+const active = new Set(['queued', 'generating', 'cancelling'])
+const keyOf = (roomId: string, characterId: string) => `${roomId}/${characterId}`
+const WATCHED_KEY = 'aidm-portrait-watched'
+const NOTIFIED_KEY = 'aidm-portrait-notified'
+const storedIds = (key: string): Set<string> => {
+  try { return new Set(JSON.parse(sessionStorage.getItem(key) ?? '[]') as string[]) }
+  catch { return new Set() }
+}
+const saveIds = (key: string, values: Set<string>) => {
+  try { sessionStorage.setItem(key, JSON.stringify([...values].slice(-50))) } catch { /* 存储不可用不影响任务权威状态。 */ }
+}
+
+interface State {
+  tasks: Record<string, PortraitGenerationTaskRead | null>
+  cancelling: Record<string, boolean>
+  portraitVersions: Record<string, string>
+  notices: PortraitNotice[]
+  setTask: (roomId: string, characterId: string, task: PortraitGenerationTaskRead | null, notify?: boolean) => void
+  setCancelling: (roomId: string, characterId: string, value: boolean) => void
+  dismissNotice: (id: string) => void
+  clearPortraitVersion: (roomId: string) => void
+}
+
+export const usePortraitGenerationStore = create<State>((set) => ({
+  tasks: {}, cancelling: {}, portraitVersions: {}, notices: [],
+  setTask: (roomId, characterId, task, notify = false) => set((state) => {
+    const key = keyOf(roomId, characterId)
+    const previous = state.tasks[key]
+    const notices = [...state.notices]
+    const watched = storedIds(WATCHED_KEY)
+    const notified = storedIds(NOTIFIED_KEY)
+    if (task && active.has(task.status)) { watched.add(task.generationId); saveIds(WATCHED_KEY, watched) }
+    const shouldNotify = task && !active.has(task.status) && !notified.has(task.generationId)
+      && (notify || watched.has(task.generationId)) && previous?.status !== task.status
+    if (shouldNotify && task) {
+      const message = task.status === 'completed' ? '人物图片生成完成'
+        : task.status === 'cancelled' ? '人物图片生成已终止' : '人物图片生成失败'
+      notices.push({ id: task.generationId, message, tone: task.status === 'completed' ? 'success' : task.status === 'failed' ? 'error' : 'neutral' })
+      notified.add(task.generationId); watched.delete(task.generationId)
+      saveIds(NOTIFIED_KEY, notified); saveIds(WATCHED_KEY, watched)
+    }
+    return {
+      tasks: { ...state.tasks, [key]: task },
+      portraitVersions: task?.status === 'completed' && task.portraitVersion
+        ? { ...state.portraitVersions, [roomId]: task.portraitVersion }
+        : state.portraitVersions,
+      notices,
+    }
+  }),
+  setCancelling: (roomId, characterId, value) => set((state) => ({ cancelling: { ...state.cancelling, [keyOf(roomId, characterId)]: value } })),
+  dismissNotice: (id) => set((state) => ({ notices: state.notices.filter((item) => item.id !== id) })),
+  clearPortraitVersion: (roomId) => set((state) => {
+    const versions = { ...state.portraitVersions }; delete versions[roomId]
+    return { portraitVersions: versions }
+  }),
+}))
+
+export const portraitTaskKey = keyOf
+export const isPortraitTaskActive = (task: PortraitGenerationTaskRead | null | undefined) => !!task && active.has(task.status)

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -1091,15 +1091,24 @@ export interface PortraitGenerationRequest {
   size?: "1024x1024";
 }
 
-export interface PortraitGenerationResult {
+/**
+ * 可安全返回给玩家的生图任务快照。
+ */
+export interface PortraitGenerationTaskRead {
   generationId: string;
-  status?: "completed";
-  imageUrl: string;
-  portraitVersion: string;
-  prompt: string;
-  negativePrompt: string;
-  promptSummary: string;
-  promptSource: "deepseek" | "deterministic" | "deterministic_fallback";
+  status: "queued" | "generating" | "cancelling" | "completed" | "failed" | "cancelled";
+  cancelRequested: boolean;
+  failureCode?:
+    ("content_rejected" | "timeout" | "provider_failed" | "materialization_failed" | "process_restarted") | null;
+  portraitVersion?: string | null;
+  promptSummary?: string | null;
+  promptSource?: ("deepseek" | "deterministic" | "deterministic_fallback") | null;
+  style: "realistic";
+  size: "1024x1024";
+  createdAt: string;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  updatedAt: string;
 }
 
 export interface PositionContextView {

--- a/trpg-sdk/src/resources/characters.test.ts
+++ b/trpg-sdk/src/resources/characters.test.ts
@@ -20,11 +20,12 @@ test('generatePortrait 调用角色生图接口并携带房间凭证', async () 
         success: true,
         data: {
           generationId: 'generation-1',
-          status: 'completed',
-          imageUrl: 'https://images.example/portrait.png',
-          portraitVersion: 'portrait-version-1',
-          prompt: 'portrait prompt',
-          negativePrompt: 'watermark',
+          status: 'queued',
+          cancelRequested: false,
+          style: 'realistic',
+          size: '1024x1024',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
           promptSummary: '根据职业与背景生成',
           promptSource: 'deepseek'
         },
@@ -54,6 +55,23 @@ test('generatePortrait 调用角色生图接口并携带房间凭证', async () 
     size: '1024x1024'
   });
   assert.equal(result.promptSource, 'deepseek');
+});
+
+test('任务查询与取消方法使用正确路径和凭证', async () => {
+  const calls: Array<{ url: string; method?: string; token: string | null }> = [];
+  const fakeFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(input), method: init?.method, token: new Headers(init?.headers).get('x-reconnect-token') });
+    return new Response(JSON.stringify({ success: true, data: null, error: null }));
+  }) as typeof fetch;
+  const characters = new CharactersResource(new ApiClient({ baseUrl: 'http://test/api/v1', fetch: fakeFetch }));
+  await characters.getCurrentPortraitGeneration('room-1', 'character-1', 'token-1');
+  await characters.getPortraitGeneration('room-1', 'character-1', 'generation-1', 'token-1');
+  await characters.cancelPortraitGeneration('room-1', 'character-1', 'generation-1', 'token-1');
+  assert.deepEqual(calls.map(({ url, method, token }) => [url.replace('http://test/api/v1', ''), method, token]), [
+    ['/rooms/room-1/characters/character-1/portrait-generations/current', 'GET', 'token-1'],
+    ['/rooms/room-1/characters/character-1/portrait-generations/generation-1', 'GET', 'token-1'],
+    ['/rooms/room-1/characters/character-1/portrait-generations/generation-1/cancel', 'POST', 'token-1'],
+  ]);
 });
 
 test('getPlayerPortrait 编码路径和版本并返回鉴权 Blob', async () => {

--- a/trpg-sdk/src/resources/characters.ts
+++ b/trpg-sdk/src/resources/characters.ts
@@ -3,7 +3,7 @@ import type {
   Character,
   CharacterDraftResult,
   GeneratePortraitInput,
-  PortraitGenerationResult,
+  PortraitGenerationTaskRead,
   QuickGenerateInput,
   QuickGenerateResult,
   RollAttributesResult,
@@ -82,15 +82,64 @@ export class CharactersResource {
 
   /** POST /api/v1/rooms/{roomId}/characters/{characterId}/portrait-generations —
    * 玩家主动为已完成的本人角色生成图片。 */
+  createPortraitGeneration(
+    roomId: string,
+    characterId: string,
+    payload: GeneratePortraitInput,
+    reconnectToken: string
+  ): Promise<PortraitGenerationTaskRead> {
+    return this.client.post<PortraitGenerationTaskRead>(
+      `/rooms/${roomId}/characters/${characterId}/portrait-generations`,
+      payload,
+      this.authenticated(reconnectToken)
+    );
+  }
+
+  /** 兼容旧资源命名；现在创建的是后台任务而非同步图片结果。 */
   generatePortrait(
     roomId: string,
     characterId: string,
     payload: GeneratePortraitInput,
     reconnectToken: string
-  ): Promise<PortraitGenerationResult> {
-    return this.client.post<PortraitGenerationResult>(
-      `/rooms/${roomId}/characters/${characterId}/portrait-generations`,
-      payload,
+  ): Promise<PortraitGenerationTaskRead> {
+    return this.createPortraitGeneration(roomId, characterId, payload, reconnectToken);
+  }
+
+  /** GET current — 读取活动任务；没有活动任务时返回最近终态。 */
+  getCurrentPortraitGeneration(
+    roomId: string,
+    characterId: string,
+    reconnectToken: string
+  ): Promise<PortraitGenerationTaskRead | null> {
+    return this.client.get<PortraitGenerationTaskRead | null>(
+      `/rooms/${roomId}/characters/${characterId}/portrait-generations/current`,
+      this.authenticated(reconnectToken)
+    );
+  }
+
+  /** GET generation — 读取指定任务的权威快照。 */
+  getPortraitGeneration(
+    roomId: string,
+    characterId: string,
+    generationId: string,
+    reconnectToken: string
+  ): Promise<PortraitGenerationTaskRead> {
+    return this.client.get<PortraitGenerationTaskRead>(
+      `/rooms/${roomId}/characters/${characterId}/portrait-generations/${generationId}`,
+      this.authenticated(reconnectToken)
+    );
+  }
+
+  /** POST cancel — 幂等终止任务并返回服务端权威状态。 */
+  cancelPortraitGeneration(
+    roomId: string,
+    characterId: string,
+    generationId: string,
+    reconnectToken: string
+  ): Promise<PortraitGenerationTaskRead> {
+    return this.client.post<PortraitGenerationTaskRead>(
+      `/rooms/${roomId}/characters/${characterId}/portrait-generations/${generationId}/cancel`,
+      null,
       this.authenticated(reconnectToken)
     );
   }

--- a/trpg-sdk/src/types.ts
+++ b/trpg-sdk/src/types.ts
@@ -52,7 +52,7 @@ export type {
   ValidationIssueView,
   // 建卡完成后的可选角色生图（issue #199）
   PortraitGenerationRequest as GeneratePortraitInput,
-  PortraitGenerationResult,
+  PortraitGenerationTaskRead,
   // 游戏目录 / 规则数据（issue #77）—— 对应后端 dto/game.py
   GameRead as Game,
   GameSystemRead as GameSystem,


### PR DESCRIPTION
## 关联 Issue

Closes #325

## 主要改动

- 新增可持久化的角色生图任务、Alembic 迁移、活动任务部分唯一索引和公开失败分类。
- 将同步生图接口改为 `202 Accepted` 后台任务，增加当前任务、指定任务和幂等取消接口。
- 后台执行器使用独立短会话；头像替换与完成状态在同一事务中通过条件更新裁决，取消后的迟到结果不会入库。
- 为 DashScope 增加尽力上游取消，应用启动时收敛遗留任务，关闭时有限等待本进程任务。
- 同步生成 SDK DTO，增加创建、查询和取消方法，并保留 `generatePortrait` 兼容入口。
- 前端增加应用级 Zustand 任务协调器、活动状态轮询、刷新恢复、非阻塞通知和 `portraitVersion` 刷新。
- 生图弹窗支持关闭后继续生成；只有底部“终止生成”会取消任务。游戏页本人头像和占位图可打开同一生图窗口。
- E2E 固定使用确定性/Mock provider，避免继承开发机付费 provider 配置。

## 采用该方案的原因

使用“进程内异步任务 + 数据库持久状态”满足本期跨路由恢复和取消一致性要求，同时避免引入 Celery/Redis。数据库部分唯一索引覆盖多进程并发创建；完成阶段先执行带状态条件的原子更新，再在同一事务写头像，兼容 SQLite 不支持真实 `FOR UPDATE` 的限制。

上游取消采用尽力语义：支持取消的 provider 会收到取消请求，不支持或已经开始运行的 provider 可能继续计算，但服务端保证其迟到结果不会替换头像。

## 测试与验证

- [x] 后端全量测试：`430 passed, 10 skipped`
- [x] 生图专项测试：`49 passed`
- [x] SDK 测试：`25 passed`
- [x] 前端测试：`186 passed`；补充交互回归后专项 `8 passed`
- [x] SDK → 后端角色建卡/生图 E2E：`9 passed`
- [x] Ruff、ty、SDK/前端 lint、E2E typecheck 通过
- [x] 前端生产构建通过
- [x] DTO schema 导出及 SDK codegen 无漂移
- [x] SQLite Alembic 升降级测试通过
- [ ] PostgreSQL 迁移与部分唯一索引：已新增 CI job，等待本 PR Actions 验证

## 风险与回滚

- 部署前必须执行 `alembic upgrade head`；旧客户端调用 `generatePortrait` 时返回值已从同步图片结果变为任务快照，需要随本 PR 的 SDK/前端一起发布。
- 进程重启不会自动重跑未知上游任务，遗留活动任务会变为 `failed/process_restarted`，以避免重复计费。
- 回滚应用前先确认没有活动生图任务；代码可回滚到本 PR 前版本。数据库降级会删除任务历史表，但不会删除当前 `character_portraits` 头像表。

## UI 证据

本 PR 未附静态截图：关键变化是任务生命周期交互。已通过组件测试验证底部按钮终止、右上角/遮罩/`Esc` 仅关闭窗口，以及进入游戏后任务仍保留；请 reviewer 在 Preview 环境补充人工交互验收。

## AI 使用情况

- AI 辅助范围：根据 Issue #325 设计实现任务状态机、事务竞态、SDK 接口、前端全局协调与测试，并执行差异和敏感信息复核。
- 关键约束：数据库状态为唯一权威；取消与完成只能产生一个终态；不保存密钥、完整上游响应或临时 URL；新增关键代码使用中文注释。
- 本 PR 必须经过至少一名人工 reviewer 审查后方可合并，重点检查 SQLite/PostgreSQL 竞态、生命周期清理、上游取消语义和前端恢复体验。

## 自检

- [x] 改动范围符合 Issue
- [x] 不包含无关改动
- [x] 已包含必要的测试和迁移说明
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查
- [ ] 已完成人工 Review
