### PR TITLE
feat(character): 持久化角色卡模板头像并支持跨房间继承 (#352)

### DIFF
--- a/trpg-backend/alembic/versions/a3c4d5e6f7b8_add_character_template_portraits.py
+++ b/trpg-backend/alembic/versions/a3c4d5e6f7b8_add_character_template_portraits.py
@@ -1,0 +1,43 @@
+"""add character template portraits
+
+Revision ID: a3c4d5e6f7b8
+Revises: e9a1b2c3d4f5
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a3c4d5e6f7b8"
+down_revision: str | Sequence[str] | None = "e9a1b2c3d4f5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_character_template_portraits",
+        sa.Column("template_id", sa.Uuid(as_uuid=False), nullable=False),
+        sa.Column("content", sa.LargeBinary(), nullable=False),
+        sa.Column("content_type", sa.String(length=50), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "size_bytes > 0",
+            name="ck_user_character_template_portraits_size_positive",
+        ),
+        sa.ForeignKeyConstraint(
+            ["template_id"],
+            ["user_character_templates.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("template_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_character_template_portraits")

--- a/trpg-backend/app/controller/v1/me.py
+++ b/trpg-backend/app/controller/v1/me.py
@@ -4,7 +4,7 @@
 第一等资产，房间角色卡是它的一份拷贝。
 """
 
-from fastapi import APIRouter, Body, Depends, Header, Query, status
+from fastapi import APIRouter, Body, Depends, Header, Query, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.controller.dependencies import extract_bearer_token, get_current_user
@@ -77,6 +77,15 @@ def _duplicate(exc: character_service.CharacterTemplateDuplicateError) -> AppExc
     )
 
 
+def _etag_matches(if_none_match: str | None, current_etag: str) -> bool:
+    if not if_none_match:
+        return False
+    return any(
+        candidate.strip() == "*" or candidate.strip().removeprefix("W/") == current_etag
+        for candidate in if_none_match.split(",")
+    )
+
+
 @router.get("/character-templates", response_model=ApiResponse[list[CharacterTemplateRead]])
 async def list_character_templates(
     system_id: str | None = Query(default=None, alias="systemId", min_length=1),
@@ -128,6 +137,36 @@ async def get_character_template(
     except character_service.CharacterNotFoundError as exc:
         raise _not_found(exc) from exc
     return ApiResponse.ok(template)
+
+
+@router.get("/character-templates/{template_id}/portrait", response_class=Response)
+async def get_character_template_portrait(
+    template_id: str,
+    _version: str | None = Query(default=None, alias="v"),
+    authorization: str | None = Header(default=None),
+    if_none_match: str | None = Header(default=None, alias="If-None-Match"),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """GET /me/character-templates/{templateId}/portrait —— 鉴权读取模板头像。"""
+    del _version  # 仅作为浏览器缓存分版参数，身份和内容均以后端存储为准。
+    user_id = await _require_user_id(authorization, db)
+    try:
+        portrait = await character_service.get_character_template_portrait(db, user_id, template_id)
+    except character_service.CharacterNotFoundError as exc:
+        raise _not_found(exc) from exc
+    etag = f'"{portrait.content_hash}"'
+    cache_headers = {
+        "ETag": etag,
+        "Cache-Control": "private, max-age=3600",
+        "X-Content-Type-Options": "nosniff",
+    }
+    if _etag_matches(if_none_match, etag):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=cache_headers)
+    return Response(
+        content=portrait.content,
+        media_type=portrait.content_type,
+        headers={"Content-Length": str(portrait.size_bytes), **cache_headers},
+    )
 
 
 @router.patch(

--- a/trpg-backend/app/dto/character.py
+++ b/trpg-backend/app/dto/character.py
@@ -176,6 +176,8 @@ class CharacterTemplateRead(CamelModel):
     name: str
     system_id: str
     data: dict
+    has_portrait: bool = False
+    portrait_version: str | None = None
     created_at: UtcDatetime
     updated_at: UtcDatetime
 

--- a/trpg-backend/app/models/__init__.py
+++ b/trpg-backend/app/models/__init__.py
@@ -34,7 +34,7 @@ from app.models.engine import (
 from app.models.event import CheckResult, Event
 from app.models.replay import ModuleImportJob, RoomSummary
 from app.models.room import Character, CharacterPortrait, Note, Player, Room
-from app.models.user import User, UserCharacterTemplate, UserSession
+from app.models.user import User, UserCharacterTemplate, UserCharacterTemplatePortrait, UserSession
 
 __all__ = [
     "ActionExecution",
@@ -72,6 +72,7 @@ __all__ = [
     "ScenarioScene",
     "User",
     "UserCharacterTemplate",
+    "UserCharacterTemplatePortrait",
     "UserSession",
     "World",
 ]

--- a/trpg-backend/app/models/user.py
+++ b/trpg-backend/app/models/user.py
@@ -9,7 +9,17 @@ Issue #121 起，完成房间 Character 会自动写入该表；卡库列表、�
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import JSON, DateTime, ForeignKey, String, UniqueConstraint, Uuid
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    LargeBinary,
+    String,
+    UniqueConstraint,
+    Uuid,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db import Base
@@ -103,4 +113,35 @@ class UserCharacterTemplate(Base):
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
+    )
+
+
+class UserCharacterTemplatePortrait(Base):
+    """角色卡库当前头像；与房间头像分开存储，跨房间复用时复制。"""
+
+    __tablename__ = "user_character_template_portraits"
+    __table_args__ = (
+        CheckConstraint(
+            "size_bytes > 0",
+            name="ck_user_character_template_portraits_size_positive",
+        ),
+    )
+
+    template_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False),
+        ForeignKey("user_character_templates.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    content: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    content_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
     )

--- a/trpg-backend/app/service/character.py
+++ b/trpg-backend/app/service/character.py
@@ -44,8 +44,8 @@ from app.dto.character import (
 from app.dto.character_background import CharacterBackgroundContext, CharacterBackgroundSkill
 from app.dto.game import RulesetRead
 from app.models.content import GameSystem
-from app.models.room import Character, Player, Room
-from app.models.user import UserCharacterTemplate
+from app.models.room import Character, CharacterPortrait, Player, Room
+from app.models.user import UserCharacterTemplate, UserCharacterTemplatePortrait
 from app.service.character_background import CharacterBackgroundService
 from app.service.room import (
     RoomAuthorizationError,
@@ -222,6 +222,7 @@ async def create_character_draft(
         )
 
     character = Character(room_id=room_id, player_id=player.id, status="draft")
+    template_portrait: UserCharacterTemplatePortrait | None = None
     if based_on_template_id is not None:
         if player.user_id is None:
             raise RoomAuthorizationError("匿名玩家没有角色卡库")
@@ -232,8 +233,22 @@ async def create_character_draft(
         if template.system_id != room_system_id:
             raise RoomConflictError("这张角色卡属于其他规则系统，不能用在本房间")
         _seed_character_from_template(character, template)
+        template_portrait = await db.get(UserCharacterTemplatePortrait, template.id)
     db.add(character)
     try:
+        # UUID 默认值在 INSERT 时生成；先 flush 拿到角色 id，再把模板头像复制成
+        # 房间自己的快照。之后模板换图或被删除都不会改动已经开出的角色。
+        await db.flush()
+        if template_portrait is not None:
+            db.add(
+                CharacterPortrait(
+                    character_id=character.id,
+                    content=template_portrait.content,
+                    content_type=template_portrait.content_type,
+                    size_bytes=template_portrait.size_bytes,
+                    content_hash=template_portrait.content_hash,
+                )
+            )
         await db.commit()
     except IntegrityError:
         # A concurrent request may have won the unique (room, player) insert.
@@ -643,12 +658,16 @@ async def _require_no_duplicate(
         raise CharacterTemplateDuplicateError(existing.id, "卡库里已经有一张一模一样的角色卡")
 
 
-def _template_read(template: UserCharacterTemplate) -> CharacterTemplateRead:
+def _template_read(
+    template: UserCharacterTemplate, portrait_version: str | None = None
+) -> CharacterTemplateRead:
     return CharacterTemplateRead(
         template_id=template.id,
         name=template.name,
         system_id=template.system_id,
         data=dict(template.data or {}),
+        has_portrait=portrait_version is not None,
+        portrait_version=portrait_version,
         created_at=template.created_at,
         updated_at=template.updated_at,
     )
@@ -701,11 +720,18 @@ async def list_character_templates(
     `system_id` 过滤给车卡界面用：COC7 的卡不该出现在别的规则系统的房间里，
     表结构本来就按 system 约束死了这张卡能用在哪。
     """
-    statement = select(UserCharacterTemplate).where(UserCharacterTemplate.user_id == user_id)
+    statement = (
+        select(UserCharacterTemplate, UserCharacterTemplatePortrait.content_hash)
+        .outerjoin(
+            UserCharacterTemplatePortrait,
+            UserCharacterTemplatePortrait.template_id == UserCharacterTemplate.id,
+        )
+        .where(UserCharacterTemplate.user_id == user_id)
+    )
     if system_id is not None:
         statement = statement.where(UserCharacterTemplate.system_id == system_id)
-    rows = await db.scalars(statement.order_by(UserCharacterTemplate.updated_at.desc()))
-    return [_template_read(template) for template in rows]
+    rows = await db.execute(statement.order_by(UserCharacterTemplate.updated_at.desc()))
+    return [_template_read(template, portrait_version) for template, portrait_version in rows]
 
 
 async def create_character_template(
@@ -743,7 +769,24 @@ async def create_character_template(
 async def get_character_template(
     db: AsyncSession, user_id: str, template_id: str
 ) -> CharacterTemplateRead:
-    return _template_read(await _own_template(db, user_id, template_id))
+    template = await _own_template(db, user_id, template_id)
+    portrait_version = await db.scalar(
+        select(UserCharacterTemplatePortrait.content_hash).where(
+            UserCharacterTemplatePortrait.template_id == template.id
+        )
+    )
+    return _template_read(template, portrait_version)
+
+
+async def get_character_template_portrait(
+    db: AsyncSession, user_id: str, template_id: str
+) -> UserCharacterTemplatePortrait:
+    """读取自己的模板头像；别人的模板与没有头像都返回同一种 404。"""
+    template = await _own_template(db, user_id, template_id)
+    portrait = await db.get(UserCharacterTemplatePortrait, template.id)
+    if portrait is None:
+        raise CharacterNotFoundError("角色卡头像不存在")
+    return portrait
 
 
 async def _restamp_content_hash(db: AsyncSession, template: UserCharacterTemplate) -> None:
@@ -781,7 +824,12 @@ async def update_character_template(
     # **不能静默合并**——玩家正在编辑的这张会凭空消失。明确拒绝，让前端提示。
     await _restamp_content_hash(db, template)
     await db.commit()
-    return _template_read(template)
+    portrait_version = await db.scalar(
+        select(UserCharacterTemplatePortrait.content_hash).where(
+            UserCharacterTemplatePortrait.template_id == template.id
+        )
+    )
+    return _template_read(template, portrait_version)
 
 
 async def delete_character_template(db: AsyncSession, user_id: str, template_id: str) -> None:
@@ -802,6 +850,10 @@ async def delete_character_template(db: AsyncSession, user_id: str, template_id:
         .where(Character.based_on_template_id == template_id)
         .values(based_on_template_id=None)
     )
+    # 测试和部分本地 SQLite 关闭了外键约束，不能只依赖 ON DELETE CASCADE。
+    portrait = await db.get(UserCharacterTemplatePortrait, template_id)
+    if portrait is not None:
+        await db.delete(portrait)
     await db.delete(template)
     await db.commit()
 

--- a/trpg-backend/app/service/portrait_generation.py
+++ b/trpg-backend/app/service/portrait_generation.py
@@ -31,6 +31,7 @@ from app.dto.portrait import (
 from app.models.content import Scenario
 from app.models.engine import ModuleVersion
 from app.models.room import Character, CharacterPortrait, Player, PortraitGenerationTask, Room
+from app.models.user import UserCharacterTemplate, UserCharacterTemplatePortrait
 from app.service.portrait_reference import PortraitReferenceImage, load_portrait_reference_image
 from app.service.room import (
     RoomAuthorizationError,
@@ -88,6 +89,49 @@ class StoredPortrait:
     content: bytes
     content_type: str
     content_hash: str
+
+
+async def _sync_template_portrait(
+    db: AsyncSession,
+    character: Character,
+    image: MaterializedPortrait,
+    now: datetime,
+) -> None:
+    """将模板派生角色的最新头像回写到其账号级角色卡。"""
+    if character.based_on_template_id is None:
+        return
+    user_id = await db.scalar(select(Player.user_id).where(Player.id == character.player_id))
+    if user_id is None:
+        return
+    template = await db.scalar(
+        select(UserCharacterTemplate)
+        .where(
+            UserCharacterTemplate.id == character.based_on_template_id,
+            UserCharacterTemplate.user_id == user_id,
+        )
+        .with_for_update()
+    )
+    if template is None:
+        return
+    portrait = await db.get(UserCharacterTemplatePortrait, template.id)
+    if portrait is None:
+        db.add(
+            UserCharacterTemplatePortrait(
+                template_id=template.id,
+                content=image.content,
+                content_type=image.content_type,
+                size_bytes=len(image.content),
+                content_hash=image.content_hash,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        return
+    portrait.content = image.content
+    portrait.content_type = image.content_type
+    portrait.size_bytes = len(image.content)
+    portrait.content_hash = image.content_hash
+    portrait.updated_at = now
 
 
 class PortraitPromptComposer(Protocol):
@@ -630,9 +674,13 @@ class PortraitGenerationService:
                 await db.rollback()
                 await self._finish_cancelled(generation_id)
                 return
-            await db.scalar(
+            locked_character = await db.scalar(
                 select(Character).where(Character.id == task.character_id).with_for_update()
             )
+            if locked_character is None:
+                await db.rollback()
+                await self._fail(generation_id, "materialization_failed")
+                return
             portrait = await db.get(CharacterPortrait, task.character_id)
             if portrait is None:
                 portrait = CharacterPortrait(
@@ -652,6 +700,7 @@ class PortraitGenerationService:
                     image.content_hash,
                     now,
                 )
+            await _sync_template_portrait(db, locked_character, image, now)
             await db.commit()
 
     async def _finish_cancelled(self, generation_id: str) -> None:
@@ -775,6 +824,7 @@ class PortraitGenerationService:
                 portrait.size_bytes = len(image.content)
                 portrait.content_hash = image.content_hash
                 portrait.updated_at = now
+            await _sync_template_portrait(db, locked_character, image, now)
             await db.commit()
         except PortraitCharacterNotFoundError:
             await db.rollback()

--- a/trpg-backend/tests/test_character_templates.py
+++ b/trpg-backend/tests/test_character_templates.py
@@ -1,9 +1,11 @@
 """我的角色卡库（#337）。
 
 卡库卡是玩家自己的第一等资产，房间角色卡是它的一份拷贝。这个方向决定了这里
-每一条断言：卡库能独立于房间存在、删卡不会被历史房间卡拖住、拷贝之后两边互不
-影响。
+每一条断言：卡库能独立于房间存在、删卡不会被历史房间卡拖住、普通角色字段在
+拷贝之后两边互不影响。头像是 #352 明确引入的同步例外。
 """
+
+from hashlib import sha256
 
 from httpx import AsyncClient
 from sqlalchemy import func, select
@@ -11,8 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.seed import BUILTIN_GAME_ID, BUILTIN_SYSTEM_ID
 from app.models.content import GameSystem
-from app.models.room import Character
-from app.models.user import UserCharacterTemplate
+from app.models.room import Character, CharacterPortrait
+from app.models.user import UserCharacterTemplate, UserCharacterTemplatePortrait
 from tests.helpers import ROOMS_BASE, bearer, create_room, register
 
 TEMPLATES_BASE = "/api/v1/me/character-templates"
@@ -160,6 +162,46 @@ async def test_another_players_template_is_indistinguishable_from_a_missing_one(
     assert still_there.json()["data"]["name"] == "陈探员"
 
 
+async def test_template_portrait_metadata_read_and_account_isolation(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner_token = await register(client)
+    other_token = await register(client)
+    template = await _create_template(client, owner_token)
+    content = b"template-portrait"
+    version = sha256(content).hexdigest()
+    db_session.add(
+        UserCharacterTemplatePortrait(
+            template_id=template["templateId"],
+            content=content,
+            content_type="image/png",
+            size_bytes=len(content),
+            content_hash=version,
+        )
+    )
+    await db_session.commit()
+
+    listed = await client.get(TEMPLATES_BASE, headers=bearer(owner_token))
+    entry = listed.json()["data"][0]
+    assert entry["hasPortrait"] is True
+    assert entry["portraitVersion"] == version
+
+    portrait_url = f"{TEMPLATES_BASE}/{template['templateId']}/portrait"
+    portrait = await client.get(portrait_url, headers=bearer(owner_token))
+    assert portrait.status_code == 200
+    assert portrait.content == content
+    assert portrait.headers["content-type"] == "image/png"
+    assert portrait.headers["etag"] == f'"{version}"'
+
+    cached = await client.get(
+        portrait_url,
+        headers={**bearer(owner_token), "If-None-Match": f'W/"{version}"'},
+    )
+    assert cached.status_code == 304
+    assert cached.content == b""
+    assert (await client.get(portrait_url, headers=bearer(other_token))).status_code == 404
+
+
 async def test_list_can_be_filtered_by_system(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:
@@ -221,6 +263,38 @@ async def test_seeding_a_room_draft_copies_the_card_and_then_stands_alone(
     assert stored.based_on_template_id == template["templateId"]
 
 
+async def test_seeding_a_room_draft_copies_the_template_portrait(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await register(client)
+    template = await _create_template(client, token)
+    content = b"reusable-portrait"
+    version = sha256(content).hexdigest()
+    db_session.add(
+        UserCharacterTemplatePortrait(
+            template_id=template["templateId"],
+            content=content,
+            content_type="image/png",
+            size_bytes=len(content),
+            content_hash=version,
+        )
+    )
+    await db_session.commit()
+    room = await create_room(client, token=token)
+
+    draft = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters",
+        json={"basedOnTemplateId": template["templateId"]},
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    )
+    assert draft.status_code == 201, draft.text
+
+    copied = await db_session.get(CharacterPortrait, draft.json()["data"]["characterId"])
+    assert copied is not None
+    assert copied.content == content
+    assert copied.content_hash == version
+
+
 async def test_deleting_a_referenced_card_clears_provenance_instead_of_failing(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:
@@ -239,6 +313,17 @@ async def test_deleting_a_referenced_card_clears_provenance_instead_of_failing(
         headers={"X-Reconnect-Token": room["reconnectToken"]},
     )
     character_id = draft.json()["data"]["characterId"]
+    portrait_content = b"delete-template-portrait"
+    db_session.add(
+        UserCharacterTemplatePortrait(
+            template_id=template["templateId"],
+            content=portrait_content,
+            content_type="image/png",
+            size_bytes=len(portrait_content),
+            content_hash=sha256(portrait_content).hexdigest(),
+        )
+    )
+    await db_session.commit()
 
     deleted = await client.delete(
         f"{TEMPLATES_BASE}/{template['templateId']}", headers=bearer(token)
@@ -247,6 +332,10 @@ async def test_deleting_a_referenced_card_clears_provenance_instead_of_failing(
     assert deleted.status_code == 200
     db_session.expire_all()
     assert await db_session.scalar(select(func.count()).select_from(UserCharacterTemplate)) == 0
+    assert (
+        await db_session.scalar(select(func.count()).select_from(UserCharacterTemplatePortrait))
+        == 0
+    )
     stored = await db_session.get(Character, character_id)
     assert stored is not None
     assert stored.based_on_template_id is None

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -9,7 +9,7 @@ from pathlib import Path
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
 ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
-HEAD_REVISION = "e9a1b2c3d4f5"
+HEAD_REVISION = "a3c4d5e6f7b8"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -84,6 +84,7 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "ending_drafts",
         "ending_command_executions",
         "character_portraits",
+        "user_character_template_portraits",
         "portrait_generation_tasks",
     }.issubset(tables)
     assert "decision_schema_version" in _column_names(
@@ -137,6 +138,20 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "id",
     ) in _foreign_keys(database, "character_portraits")
     assert {
+        "template_id",
+        "content",
+        "content_type",
+        "size_bytes",
+        "content_hash",
+        "created_at",
+        "updated_at",
+    } == _column_names(database, "user_character_template_portraits")
+    assert (
+        "template_id",
+        "user_character_templates",
+        "id",
+    ) in _foreign_keys(database, "user_character_template_portraits")
+    assert {
         "generation_id",
         "character_id",
         "status",
@@ -160,6 +175,7 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
     assert "version" not in _column_names(database, "characters")
     assert "occupation_choice_skill_ids" not in _column_names(database, "characters")
     assert "character_portraits" not in _table_names(database)
+    assert "user_character_template_portraits" not in _table_names(database)
     assert "correlation_id" not in _column_names(database, "events")
 
     _upgrade_or_fail(database, "head")

--- a/trpg-backend/tests/test_portrait_generation.py
+++ b/trpg-backend/tests/test_portrait_generation.py
@@ -21,7 +21,7 @@ from app.adapters.image_generation import (
 from app.adapters.portrait_prompt import DeepSeekPortraitPromptComposer
 from app.core.coc7_content import build_coc7_ruleset
 from app.core.config import Settings
-from app.core.seed import BUILTIN_MODULE_ID
+from app.core.seed import BUILTIN_MODULE_ID, BUILTIN_SYSTEM_ID
 from app.dto.portrait import CharacterPortraitSnapshot, PortraitPrompt, PortraitSkillSnapshot
 from app.main import app
 from app.models.room import Character
@@ -38,7 +38,7 @@ from app.service.portrait_generation import (
 )
 from app.service.portrait_image import MaterializedPortraitImage, PortraitImageMaterializer
 from app.service.portrait_reference import PortraitReferenceImage, load_portrait_reference_image
-from tests.helpers import ROOMS_BASE, create_room, join_room, reconnect, register
+from tests.helpers import ROOMS_BASE, bearer, create_room, join_room, reconnect, register
 
 ATTRIBUTES = {
     "STR": 70,
@@ -475,6 +475,118 @@ async def test_completed_character_generates_real_provider_result_and_prompt_fal
     )
     assert player["hasPortrait"] is True
     assert player["portraitVersion"] == data["portraitVersion"]
+
+
+async def test_template_derived_generation_updates_library_and_next_room(
+    client: AsyncClient,
+    install_portrait_service: Callable[[PortraitGenerationService], None],
+) -> None:
+    token = await register(client)
+    template_response = await client.post(
+        "/api/v1/me/character-templates",
+        json={
+            "name": "陈探员",
+            "systemId": BUILTIN_SYSTEM_ID,
+            "data": {
+                "name": BUILT_CHARACTER["name"],
+                "age": BUILT_CHARACTER["age"],
+                "gender": BUILT_CHARACTER["gender"],
+                "residence": BUILT_CHARACTER["residence"],
+                "birthplace": BUILT_CHARACTER["birthplace"],
+                "attributes": BUILT_CHARACTER["attributes"],
+                "skills": BUILT_CHARACTER["skills"],
+                "equipment": ["左轮手枪", "手电筒"],
+                "occupation": BUILT_CHARACTER["occupation"],
+                "background": BUILT_CHARACTER["background"],
+                "notes": BUILT_CHARACTER["notes"],
+            },
+        },
+        headers=bearer(token),
+    )
+    assert template_response.status_code == 201, template_response.text
+    template_id = template_response.json()["data"]["templateId"]
+
+    room = await create_room(client, token=token, max_players=1)
+    selected = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/module",
+        json={"moduleId": BUILTIN_MODULE_ID, "attributeGenMethod": "point_buy"},
+        headers=reconnect(room["reconnectToken"]),
+    )
+    assert selected.status_code == 200
+    draft = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters",
+        json={"basedOnTemplateId": template_id},
+        headers=reconnect(room["reconnectToken"]),
+    )
+    assert draft.status_code == 201, draft.text
+    character_id = draft.json()["data"]["characterId"]
+    completed = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/complete",
+        headers=reconnect(room["reconnectToken"]),
+    )
+    assert completed.status_code == 200, completed.text
+
+    service, _composer, _provider = make_service()
+    install_portrait_service(service)
+    generation_url = f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/portrait-generations"
+    created = await client.post(generation_url, json={}, headers=reconnect(room["reconnectToken"]))
+    terminal = await wait_for_generation(
+        client,
+        generation_url,
+        reconnect(room["reconnectToken"]),
+        created.json()["data"]["generationId"],
+    )
+    assert terminal["status"] == "completed"
+
+    listed = await client.get("/api/v1/me/character-templates", headers=bearer(token))
+    template = next(item for item in listed.json()["data"] if item["templateId"] == template_id)
+    assert template["hasPortrait"] is True
+    assert template["portraitVersion"] == terminal["portraitVersion"]
+    template_portrait = await client.get(
+        f"/api/v1/me/character-templates/{template_id}/portrait",
+        headers=bearer(token),
+    )
+    assert template_portrait.content == b"persisted-png"
+
+    replacement_service = PortraitGenerationService(
+        enabled=True,
+        prompt_composer=FixedPromptComposer(),
+        fallback_prompt_composer=DeterministicPromptComposer(),
+        image_provider=RecordingImageProvider(),
+        image_materializer=FixedImageMaterializer(b"regenerated-png"),
+    )
+    install_portrait_service(replacement_service)
+    regenerated = await client.post(
+        generation_url,
+        json={},
+        headers=reconnect(room["reconnectToken"]),
+    )
+    regenerated_terminal = await wait_for_generation(
+        client,
+        generation_url,
+        reconnect(room["reconnectToken"]),
+        regenerated.json()["data"]["generationId"],
+    )
+    assert regenerated_terminal["portraitVersion"] != terminal["portraitVersion"]
+    latest_template_portrait = await client.get(
+        f"/api/v1/me/character-templates/{template_id}/portrait",
+        headers=bearer(token),
+    )
+    assert latest_template_portrait.content == b"regenerated-png"
+
+    next_room = await create_room(client, token=token)
+    next_draft = await client.post(
+        f"{ROOMS_BASE}/{next_room['roomId']}/characters",
+        json={"basedOnTemplateId": template_id},
+        headers=reconnect(next_room["reconnectToken"]),
+    )
+    assert next_draft.status_code == 201, next_draft.text
+    inherited = await client.get(
+        f"{ROOMS_BASE}/{next_room['roomId']}/players/{next_room['playerId']}/portrait",
+        headers=reconnect(next_room["reconnectToken"]),
+    )
+    assert inherited.status_code == 200
+    assert inherited.content == b"regenerated-png"
 
 
 async def test_portrait_read_requires_same_room_membership(

--- a/trpg-frontend/src/hooks/useTemplatePortraits.test.tsx
+++ b/trpg-frontend/src/hooks/useTemplatePortraits.test.tsx
@@ -66,4 +66,27 @@ describe('useTemplatePortraits', () => {
     expect(result.current).toEqual({})
     expect(createObjectURL).not.toHaveBeenCalled()
   })
+
+  it('请求未完成时模板被移除，不会让旧响应重新写回头像', async () => {
+    let resolvePortrait: ((blob: Blob) => void) | undefined
+    vi.mocked(getCharacterTemplatePortrait).mockImplementation(
+      () => new Promise((resolve) => { resolvePortrait = resolve }),
+    )
+    const { result, rerender } = renderHook(
+      ({ templates }) => useTemplatePortraits(templates),
+      { initialProps: { templates: [template('version-1')] } },
+    )
+    await waitFor(() => expect(getCharacterTemplatePortrait).toHaveBeenCalledOnce())
+    const signal = vi.mocked(getCharacterTemplatePortrait).mock.calls[0]?.[2]
+
+    await act(async () => rerender({ templates: [] }))
+    expect(signal?.aborted).toBe(true)
+
+    await act(async () => {
+      resolvePortrait?.(new Blob(['stale'], { type: 'image/png' }))
+      await Promise.resolve()
+    })
+    expect(result.current).toEqual({})
+    expect(createObjectURL).not.toHaveBeenCalled()
+  })
 })

--- a/trpg-frontend/src/hooks/useTemplatePortraits.test.tsx
+++ b/trpg-frontend/src/hooks/useTemplatePortraits.test.tsx
@@ -1,0 +1,69 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import type { CharacterTemplate } from '@/services/character/template-api'
+import { getCharacterTemplatePortrait } from '@/services/character/template-api'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTemplatePortraits } from './useTemplatePortraits'
+
+vi.mock('@/services/character/template-api', () => ({
+  getCharacterTemplatePortrait: vi.fn(),
+}))
+
+const template = (version: string): CharacterTemplate => ({
+  templateId: 'template-1',
+  name: '陈探员',
+  systemId: 'system-1',
+  data: {},
+  hasPortrait: true,
+  portraitVersion: version,
+  createdAt: '2026-08-18T00:00:00Z',
+  updatedAt: '2026-08-18T00:00:00Z',
+})
+
+describe('useTemplatePortraits', () => {
+  const createObjectURL = vi.fn<(blob: Blob) => string>()
+  const revokeObjectURL = vi.fn<(url: string) => void>()
+
+  beforeEach(() => {
+    vi.mocked(getCharacterTemplatePortrait).mockReset()
+    createObjectURL.mockReset()
+    revokeObjectURL.mockReset()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('按版本加载头像，更新和卸载时释放 Object URL', async () => {
+    vi.mocked(getCharacterTemplatePortrait)
+      .mockResolvedValueOnce(new Blob(['one'], { type: 'image/png' }))
+      .mockResolvedValueOnce(new Blob(['two'], { type: 'image/png' }))
+    createObjectURL.mockReturnValueOnce('blob:one').mockReturnValueOnce('blob:two')
+    const firstTemplates = [template('version-1')]
+    const { result, rerender, unmount } = renderHook(
+      ({ templates }) => useTemplatePortraits(templates),
+      { initialProps: { templates: firstTemplates } },
+    )
+
+    await waitFor(() => expect(result.current['template-1']).toBe('blob:one'))
+    rerender({ templates: firstTemplates })
+    expect(getCharacterTemplatePortrait).toHaveBeenCalledTimes(1)
+
+    await act(async () => rerender({ templates: [template('version-2')] }))
+    await waitFor(() => expect(result.current['template-1']).toBe('blob:two'))
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:one')
+
+    unmount()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:two')
+  })
+
+  it('加载失败时保留占位状态且不抛出错误', async () => {
+    vi.mocked(getCharacterTemplatePortrait).mockRejectedValue(new TypeError('offline'))
+    const { result } = renderHook(() => useTemplatePortraits([template('version-1')]))
+
+    await waitFor(() => expect(getCharacterTemplatePortrait).toHaveBeenCalledOnce())
+    expect(result.current).toEqual({})
+    expect(createObjectURL).not.toHaveBeenCalled()
+  })
+})

--- a/trpg-frontend/src/hooks/useTemplatePortraits.ts
+++ b/trpg-frontend/src/hooks/useTemplatePortraits.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react'
+import type { CharacterTemplate } from '@/services/character/template-api'
+import { getCharacterTemplatePortrait } from '@/services/character/template-api'
+
+interface CachedPortrait {
+  version: string
+  url: string
+}
+
+function mapsEqual(current: Record<string, string>, next: Record<string, string>): boolean {
+  const currentIds = Object.keys(current)
+  const nextIds = Object.keys(next)
+  return currentIds.length === nextIds.length
+    && nextIds.every((templateId) => current[templateId] === next[templateId])
+}
+
+/** 加载账号级角色卡头像，并集中管理请求取消和 Object URL 生命周期。 */
+export function useTemplatePortraits(
+  templates: readonly CharacterTemplate[] | null,
+): Record<string, string> {
+  const cacheRef = useRef(new Map<string, CachedPortrait>())
+  const requestsRef = useRef(new Map<string, AbortController>())
+  const [urls, setUrls] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    const syncUrls = () => {
+      const next = Object.fromEntries(
+        [...cacheRef.current].map(([templateId, item]) => [templateId, item.url]),
+      )
+      setUrls((current) => mapsEqual(current, next) ? current : next)
+    }
+
+    const activeIds = new Set((templates ?? []).map((template) => template.templateId))
+    for (const [templateId, cached] of cacheRef.current) {
+      const template = templates?.find((item) => item.templateId === templateId)
+      if (
+        !activeIds.has(templateId)
+        || !template?.hasPortrait
+        || !template.portraitVersion
+        || cached.version !== template.portraitVersion
+      ) {
+        URL.revokeObjectURL(cached.url)
+        cacheRef.current.delete(templateId)
+        requestsRef.current.get(templateId)?.abort()
+        requestsRef.current.delete(templateId)
+      }
+    }
+
+    for (const template of templates ?? []) {
+      const version = template.portraitVersion
+      if (!template.hasPortrait || !version) continue
+      if (cacheRef.current.get(template.templateId)?.version === version) continue
+
+      requestsRef.current.get(template.templateId)?.abort()
+      const controller = new AbortController()
+      requestsRef.current.set(template.templateId, controller)
+      void getCharacterTemplatePortrait(template.templateId, version, controller.signal)
+        .then((blob) => {
+          if (
+            controller.signal.aborted
+            || requestsRef.current.get(template.templateId) !== controller
+          ) return
+          const url = URL.createObjectURL(blob)
+          const previous = cacheRef.current.get(template.templateId)
+          cacheRef.current.set(template.templateId, { version, url })
+          requestsRef.current.delete(template.templateId)
+          if (previous) URL.revokeObjectURL(previous.url)
+          syncUrls()
+        })
+        .catch(() => {
+          // 头像加载失败只回退到占位图，不阻断角色卡列表和选卡流程。
+          if (requestsRef.current.get(template.templateId) === controller) {
+            requestsRef.current.delete(template.templateId)
+          }
+        })
+    }
+
+    syncUrls()
+  }, [templates])
+
+  useEffect(() => () => {
+    for (const controller of requestsRef.current.values()) controller.abort()
+    for (const cached of cacheRef.current.values()) URL.revokeObjectURL(cached.url)
+    requestsRef.current.clear()
+    cacheRef.current.clear()
+  }, [])
+
+  return urls
+}

--- a/trpg-frontend/src/hooks/useTemplatePortraits.ts
+++ b/trpg-frontend/src/hooks/useTemplatePortraits.ts
@@ -7,6 +7,11 @@ interface CachedPortrait {
   url: string
 }
 
+interface PendingPortrait {
+  version: string
+  controller: AbortController
+}
+
 function mapsEqual(current: Record<string, string>, next: Record<string, string>): boolean {
   const currentIds = Object.keys(current)
   const nextIds = Object.keys(next)
@@ -19,7 +24,7 @@ export function useTemplatePortraits(
   templates: readonly CharacterTemplate[] | null,
 ): Record<string, string> {
   const cacheRef = useRef(new Map<string, CachedPortrait>())
-  const requestsRef = useRef(new Map<string, AbortController>())
+  const requestsRef = useRef(new Map<string, PendingPortrait>())
   const [urls, setUrls] = useState<Record<string, string>>({})
 
   useEffect(() => {
@@ -30,19 +35,25 @@ export function useTemplatePortraits(
       setUrls((current) => mapsEqual(current, next) ? current : next)
     }
 
-    const activeIds = new Set((templates ?? []).map((template) => template.templateId))
+    const activePortraitVersions = new Map(
+      (templates ?? [])
+        .filter((template) => template.hasPortrait && template.portraitVersion)
+        .map((template) => [template.templateId, template.portraitVersion as string]),
+    )
+
+    // 请求可能尚未进入 cacheRef。模板被删除、切换为无头像或版本变化时，也必须
+    // 立即使旧请求失效，避免它随后把过期 Blob URL 写回页面。
+    for (const [templateId, pending] of requestsRef.current) {
+      if (activePortraitVersions.get(templateId) !== pending.version) {
+        pending.controller.abort()
+        requestsRef.current.delete(templateId)
+      }
+    }
+
     for (const [templateId, cached] of cacheRef.current) {
-      const template = templates?.find((item) => item.templateId === templateId)
-      if (
-        !activeIds.has(templateId)
-        || !template?.hasPortrait
-        || !template.portraitVersion
-        || cached.version !== template.portraitVersion
-      ) {
+      if (activePortraitVersions.get(templateId) !== cached.version) {
         URL.revokeObjectURL(cached.url)
         cacheRef.current.delete(templateId)
-        requestsRef.current.get(templateId)?.abort()
-        requestsRef.current.delete(templateId)
       }
     }
 
@@ -51,14 +62,18 @@ export function useTemplatePortraits(
       if (!template.hasPortrait || !version) continue
       if (cacheRef.current.get(template.templateId)?.version === version) continue
 
-      requestsRef.current.get(template.templateId)?.abort()
+      const pending = requestsRef.current.get(template.templateId)
+      if (pending?.version === version) continue
+      pending?.controller.abort()
       const controller = new AbortController()
-      requestsRef.current.set(template.templateId, controller)
+      requestsRef.current.set(template.templateId, { version, controller })
       void getCharacterTemplatePortrait(template.templateId, version, controller.signal)
         .then((blob) => {
+          const currentRequest = requestsRef.current.get(template.templateId)
           if (
             controller.signal.aborted
-            || requestsRef.current.get(template.templateId) !== controller
+            || currentRequest?.controller !== controller
+            || currentRequest.version !== version
           ) return
           const url = URL.createObjectURL(blob)
           const previous = cacheRef.current.get(template.templateId)
@@ -69,7 +84,7 @@ export function useTemplatePortraits(
         })
         .catch(() => {
           // 头像加载失败只回退到占位图，不阻断角色卡列表和选卡流程。
-          if (requestsRef.current.get(template.templateId) === controller) {
+          if (requestsRef.current.get(template.templateId)?.controller === controller) {
             requestsRef.current.delete(template.templateId)
           }
         })
@@ -79,7 +94,7 @@ export function useTemplatePortraits(
   }, [templates])
 
   useEffect(() => () => {
-    for (const controller of requestsRef.current.values()) controller.abort()
+    for (const pending of requestsRef.current.values()) pending.controller.abort()
     for (const cached of cacheRef.current.values()) URL.revokeObjectURL(cached.url)
     requestsRef.current.clear()
     cacheRef.current.clear()

--- a/trpg-frontend/src/routes/character-library/CharacterLibraryPage.tsx
+++ b/trpg-frontend/src/routes/character-library/CharacterLibraryPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, Plus, Trash2, User } from 'lucide-react'
 import { friendlyErrorMessage } from '@/services/api-client'
+import { useTemplatePortraits } from '@/hooks/useTemplatePortraits'
 import {
   createCharacterTemplate,
   deleteCharacterTemplate,
@@ -41,6 +42,7 @@ export default function CharacterLibraryPage() {
   const [creating, setCreating] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const portraitUrls = useTemplatePortraits(templates)
 
   useEffect(() => {
     listCharacterTemplates()
@@ -121,13 +123,26 @@ export default function CharacterLibraryPage() {
                 <button
                   type="button"
                   onClick={() => navigate(`/home/characters/${template.templateId}`)}
-                  className="flex-1 min-w-0 text-left"
+                  className="flex flex-1 min-w-0 items-center gap-3 text-left"
                 >
-                  <div className="text-sm font-semibold text-text-primary truncate">
-                    {template.name}
+                  <div className="h-14 w-14 flex-shrink-0 overflow-hidden rounded-sm border border-border-light bg-input flex items-center justify-center">
+                    {portraitUrls[template.templateId] ? (
+                      <img
+                        src={portraitUrls[template.templateId]}
+                        alt={`${template.name}的人物图片`}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <User className="h-6 w-6 text-text-dim" aria-hidden="true" />
+                    )}
                   </div>
-                  <div className="text-[11px] text-text-muted mt-0.5">
-                    {summarize(template)} · {formatTime(template.updatedAt)}
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold text-text-primary truncate">
+                      {template.name}
+                    </div>
+                    <div className="text-[11px] text-text-muted mt-0.5">
+                      {summarize(template)} · {formatTime(template.updatedAt)}
+                    </div>
                   </div>
                 </button>
                 {pendingDelete === template.templateId ? (

--- a/trpg-frontend/src/services/character/template-api.ts
+++ b/trpg-frontend/src/services/character/template-api.ts
@@ -58,6 +58,14 @@ export function getCharacterTemplate(templateId: string): Promise<CharacterTempl
   return sdk.characterTemplates.get(templateId, requireAuthToken());
 }
 
+export function getCharacterTemplatePortrait(
+  templateId: string,
+  version: string,
+  signal?: AbortSignal
+): Promise<Blob> {
+  return sdk.characterTemplates.getPortrait(templateId, version, requireAuthToken(), signal);
+}
+
 export async function createCharacterTemplate(
   name: string,
   data: CharacterTemplateData = {}

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -284,6 +284,8 @@ export interface CharacterTemplateRead {
   data: {
     [k: string]: unknown;
   };
+  hasPortrait?: boolean;
+  portraitVersion?: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/trpg-sdk/src/resources/character-templates.test.ts
+++ b/trpg-sdk/src/resources/character-templates.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { ApiClient } from '../client';
+import { CharacterTemplatesResource } from './character-templates';
+
+test('getPortrait 编码路径和版本并返回账号鉴权 Blob', async () => {
+  let captured: { url: string; method?: string; headers: Headers } | undefined;
+  const fakeFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    captured = {
+      url: String(input),
+      method: init?.method,
+      headers: new Headers(init?.headers)
+    };
+    return new Response(new Blob(['template-portrait'], { type: 'image/png' }), {
+      headers: { 'Content-Type': 'image/png' }
+    });
+  }) as typeof fetch;
+  const templates = new CharacterTemplatesResource(
+    new ApiClient({ baseUrl: 'http://test/api/v1', fetch: fakeFetch })
+  );
+
+  const result = await templates.getPortrait('template /一', 'hash +/=', 'account-token');
+
+  assert.equal(
+    captured?.url,
+    'http://test/api/v1/me/character-templates/template%20%2F%E4%B8%80/portrait?v=hash%20%2B%2F%3D'
+  );
+  assert.equal(captured?.method, 'GET');
+  assert.equal(captured?.headers.get('authorization'), 'Bearer account-token');
+  assert.equal(await result.text(), 'template-portrait');
+});

--- a/trpg-sdk/src/resources/character-templates.ts
+++ b/trpg-sdk/src/resources/character-templates.ts
@@ -14,7 +14,8 @@ import type {
  * （不是房间的重连凭证）。
  *
  * #337 起卡库同时是建卡的宿主：卡库卡由玩家显式保存产生，房间角色卡是它的一份
- * 拷贝，两者之后互不影响。
+ * 拷贝。普通角色字段之后互不影响；头像是明确例外，模板派生角色生图后会更新模板
+ * 当前头像，供下一次跨房间复用。
  */
 export class CharacterTemplatesResource {
   constructor(private readonly client: ApiClient) {}
@@ -51,6 +52,21 @@ export class CharacterTemplatesResource {
       `/me/character-templates/${templateId}`,
       this.authenticated(token)
     );
+  }
+
+  /** GET /api/v1/me/character-templates/{templateId}/portrait — 读取账号级模板头像。 */
+  getPortrait(
+    templateId: string,
+    version: string,
+    token: string,
+    signal?: AbortSignal
+  ): Promise<Blob> {
+    const path = `/me/character-templates/${encodeURIComponent(templateId)}/portrait?v=${encodeURIComponent(version)}`;
+    return this.client.requestBlob(path, {
+      ...this.authenticated(token),
+      method: 'GET',
+      signal
+    });
   }
 
   /**


### PR DESCRIPTION
## 变更内容

- 为每张“我的角色卡”新增账号级人物头像持久化能力
- 从角色卡模板创建房间角色时，将模板头像复制到新的房间角色
- 模板派生角色成功生成或重新生成人物图片后，将最新图片同步回对应模板
- 在“我的角色卡”页面展示人物头像缩略图，加载失败时使用原有占位图
- 统一管理头像 Blob URL，在图片更新、角色卡移除和页面卸载时及时释放资源

## 数据库与接口

- 新增一对一表 `user_character_template_portraits`，迁移同时兼容 SQLite 和 PostgreSQL
- 角色卡模板响应新增 `hasPortrait` 和 `portraitVersion`
- 新增账号鉴权接口 `GET /api/v1/me/character-templates/{templateId}/portrait`
- 头像接口支持 ETag 和私有缓存，并校验模板所有权
- 删除角色卡模板时清理模板头像，但保留已经复制到现有房间角色上的头像

## 验证结果

- 后端迁移、角色模板及人物生图相关测试：82 项通过
- 前端：215 项测试通过，Lint 和生产构建通过
- SDK：26 项测试通过，类型检查、Lint 和构建通过
- 已在全新 SQLite 数据库验证 Alembic 正向迁移和回滚
- 已检查本地“我的角色卡”页面，页面正常加载且控制台无错误

Closes #352
