### PR TITLE
refactor(engine): 规则引擎按发布期/执行期分层，收敛成四张登记表 (#347)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -8,7 +8,6 @@ commits them without interpreting player language.
 from __future__ import annotations
 
 import logging
-from copy import deepcopy
 from typing import Literal, NoReturn
 from uuid import uuid4
 
@@ -23,37 +22,15 @@ from collaboration_framework.contracts import (
     AdjudicationRecovery,
     AdjudicationStatusView,
     AdvanceWorldTimeEffect,
-    ChangeEntityStateEffect,
     CheckDecisionRequest,
-    CommitTerminalEndingEffect,
-    ConsumeEntityEffect,
     ContractError,
-    EnsureRuntimeEntityEffect,
-    EnsureRuntimeLocationEffect,
-    EnterLocationEffect,
     GetAdjudicationStatusRequest,
-    HideInformationEffect,
-    ItemAcquisition,
-    ItemComponent,
-    ItemCustody,
-    ItemDisplay,
-    ItemInstance,
-    ItemKnowledge,
-    LocationKnowledge,
-    MarkCoreResolvedEffect,
-    MoveEntityEffect,
     NarrationEvidence,
-    NarrativeOnlyEffect,
     PendingCheckOption,
     PostRollDecisionRequest,
     PushOption,
-    RevealInformationEffect,
-    SetEndingAvailabilityEffect,
-    SetVisibilityEffect,
     SpendResourceOption,
     SubmitAdjudicationRequest,
-    TravelInterrupted,
-    TravelResolved,
 )
 from collaboration_framework.contracts.adjudication import CheckDegree, CheckRoll
 from collaboration_framework.contracts.validation import (
@@ -74,8 +51,9 @@ from .models import (
     EngineRuntimeSnapshot,
     GameState,
     PendingCheckDecision,
-    WorldTimeState,
 )
+from collaboration_framework.registry import effects as effect_registry
+
 from .navigation import resolve_location_target
 from .persistent_results import (
     committed_results_from_events,
@@ -99,6 +77,17 @@ from .rules_v3 import (
 from .timeline import advanced_to_next, next_point_after, time_advance_block_reason
 
 logger = logging.getLogger(__name__)
+
+# The engine logic `registry/effects.py` needs but may not import: it is a leaf
+# so that `module` can read the same tables at publish time (#347, and
+# docs/architecture.md §6 forbidding `module -> engine`).
+_EFFECT_SERVICES = effect_registry.EffectServices(
+    resolve_location_target=resolve_location_target,
+    advanced_to_next=advanced_to_next,
+    next_point_after=next_point_after,
+    time_advance_block_reason=time_advance_block_reason,
+    is_public_standard_state=is_public_standard_state,
+)
 
 
 def _target_kinds_matching(
@@ -159,26 +148,6 @@ def _normalize_target_kind(
     )
     return adjudication.model_copy(
         update={"target": ActionTarget(kind=resolved, id=target.id)}
-    )
-
-
-def _visibility_knowledge(
-    location_id: str,
-    *,
-    scope: str,
-    visible: bool,
-    previous: LocationKnowledge | None,
-) -> LocationKnowledge:
-    return LocationKnowledge(
-        location_id=location_id,
-        scope="actor" if scope == "actor" else "party",
-        existence="known" if visible else "unknown",
-        localization="located" if visible else "unknown",
-        access=(previous.access if visible and previous is not None else "unknown"),
-        visited=bool(visible and previous and previous.visited),
-        known_connection_ids=(
-            previous.known_connection_ids if visible and previous is not None else ()
-        ),
     )
 
 
@@ -244,103 +213,18 @@ class AdjudicationEngineService:
         branch: Literal["success", "failure", "selected"],
         check_floor: bool = False,
     ) -> tuple[AuthorityLevel | None, tuple[EffectValidationDetail, ...]]:
-        """Classify only Agent-owned effects; Rule-owned effects are explicit."""
+        """Classify only Agent-owned effects; Rule-owned effects are explicit.
+
+        The per-type authority rules live in `registry/effects.py` (#347); what
+        stays here is the sequence walk and the detail record it builds.
+        """
 
         details: list[EffectValidationDetail] = []
         levels: list[AuthorityLevel] = ["L3"] if check_floor else []
-        v3 = runtime.v3 if runtime.is_v3 else None
-        entity_specs = {item.id: item for item in v3.entities} if v3 else {}
-        information_specs = {item.id: item for item in v3.information} if v3 else {}
-        core_goal_ids = {
-            info_id
-            for goal in (v3.knowledge_goals if v3 else ())
-            if goal.required_for_core_resolution
-            for info_id in goal.target_information_ids
-        }
-        runtime_entity_ids = set(runtime.game_state.runtime_entities)
-        runtime_location_ids = set(runtime.game_state.runtime_locations)
+        classification = effect_registry.classification_context(runtime)
 
         for index, effect in enumerate(effects):
-            level: AuthorityLevel
-            target_ref: str | None = None
-            if isinstance(effect, NarrativeOnlyEffect):
-                level = "L0"
-            elif isinstance(
-                effect, (EnsureRuntimeLocationEffect, EnsureRuntimeEntityEffect)
-            ):
-                level = "L1"
-                target_ref = getattr(effect, "location_id", None) or getattr(
-                    effect, "entity_id", None
-                )
-            elif isinstance(effect, EnterLocationEffect):
-                level = "L2"
-                target_ref = effect.location_id
-            elif isinstance(effect, MoveEntityEffect):
-                level = "L3" if effect.holder_actor_id is not None else "L2"
-                target_ref = effect.entity_id
-            elif isinstance(effect, AdvanceWorldTimeEffect):
-                level = "L2"
-            elif isinstance(effect, (RevealInformationEffect, HideInformationEffect)):
-                info = information_specs.get(effect.information_id)
-                level = (
-                    "L4"
-                    if (
-                        info is not None
-                        and (
-                            info.criticality == "essential"
-                            or effect.information_id in core_goal_ids
-                        )
-                    )
-                    else "L2"
-                )
-                target_ref = effect.information_id
-            elif isinstance(effect, ChangeEntityStateEffect):
-                target_ref = effect.entity_id
-                level = "L1" if effect.entity_id in runtime_entity_ids else "L3"
-            elif isinstance(effect, ConsumeEntityEffect):
-                target_ref = effect.entity_id
-                entity = entity_specs.get(effect.entity_id)
-                level = (
-                    "L4"
-                    if entity is not None and entity.visibility == "keeper"
-                    else "L3"
-                )
-            elif isinstance(effect, SetVisibilityEffect):
-                target_ref = effect.target_id
-                if effect.target_kind == "information":
-                    info = information_specs.get(effect.target_id)
-                    level = (
-                        "L4"
-                        if (
-                            info is not None
-                            and (
-                                info.criticality == "essential"
-                                or effect.target_id in core_goal_ids
-                            )
-                        )
-                        else "L2"
-                    )
-                elif (
-                    effect.target_id in runtime_entity_ids
-                    or effect.target_id in runtime_location_ids
-                ):
-                    level = "L1"
-                elif effect.target_kind == "entity" and (
-                    entity_specs.get(effect.target_id) is not None
-                    and entity_specs[effect.target_id].visibility == "keeper"
-                ):
-                    level = "L4"
-                else:
-                    level = "L3"
-            elif isinstance(
-                effect, (MarkCoreResolvedEffect, SetEndingAvailabilityEffect)
-            ):
-                level = "L4"
-            elif isinstance(effect, CommitTerminalEndingEffect):
-                level = "L5"
-                target_ref = effect.ending_id
-            else:  # pragma: no cover - ActionEffect is a closed discriminated union.
-                continue
+            level, target_ref = effect_registry.classify(effect, classification)
             levels.append(level)
             details.append(
                 EffectValidationDetail(
@@ -1354,44 +1238,47 @@ class AdjudicationEngineService:
         runtime: EngineRuntimeSnapshot,
         effects: tuple[ActionEffect, ...],
     ) -> None:
-        information_ids = runtime.canon_information_ids
-        entity_ids = (
-            runtime.canon_entity_ids
-            | set(runtime.game_state.runtime_entities)
-            | set(runtime.game_state.item_instances)
+        """Walk one atomic sequence, checking each effect against the ids in
+        scope at that point.
+
+        The linker-style two-pass resolution of #347 §4.3: the vocabulary starts
+        as what the published module and current state already contain, and each
+        accepted effect folds its `writes` in before the next one is checked.
+        That is what makes "create the room, then walk into it" legal inside one
+        adjudication while still refusing a reference to something nothing
+        created.
+        """
+
+        vocabulary = effect_registry.ValidationVocabulary(
+            information_ids=runtime.canon_information_ids,
+            entity_ids=(
+                runtime.canon_entity_ids
+                | set(runtime.game_state.runtime_entities)
+                | set(runtime.game_state.item_instances)
+            ),
+            location_ids=(
+                runtime.canon_location_ids | set(runtime.game_state.runtime_locations)
+            ),
+            # ``holder_actor_id`` is inventory custody, not a generic entity
+            # position.  Track real portable item instances separately from the
+            # wider entity vocabulary so a Canon prop/NPC cannot acquire a
+            # holder-only shadow state that PlayerView.inventory will never read.
+            # A v3 runtime object becomes portable as soon as an earlier effect in
+            # this same atomic sequence creates it.
+            portable_item_ids=set(runtime.game_state.item_instances),
+            actor_ids=set(runtime.game_state.actors),
+            # Sleeping until 20:00 is several jumps in one adjudication, so each
+            # one has to be checked against the clock the previous jump left
+            # behind — not against the clock this action started on.
+            world_time=runtime.game_state.world_time,
         )
-        location_ids = runtime.canon_location_ids | set(
-            runtime.game_state.runtime_locations
-        )
-        # ``holder_actor_id`` is inventory custody, not a generic entity
-        # position.  Track real portable item instances separately from the
-        # wider entity vocabulary so a Canon prop/NPC cannot acquire a
-        # holder-only shadow state that PlayerView.inventory will never read.
-        # A v3 runtime object becomes portable as soon as an earlier effect in
-        # this same atomic sequence creates it.
-        portable_item_ids = set(runtime.game_state.item_instances)
-        # Sleeping until 20:00 is several jumps in one adjudication, so each one
-        # has to be checked against the clock the previous jump left behind —
-        # not against the clock this action started on.
-        world_time = runtime.game_state.world_time
         for effect in effects:
-            self._validate_effect(
-                runtime,
-                effect,
-                information_ids=information_ids,
-                entity_ids=entity_ids,
-                location_ids=location_ids,
-                portable_item_ids=portable_item_ids,
-                world_time=world_time,
-            )
-            if isinstance(effect, EnsureRuntimeLocationEffect):
-                location_ids.add(effect.location_id)
-            elif isinstance(effect, EnsureRuntimeEntityEffect):
-                entity_ids.add(effect.entity_id)
-                if runtime.is_v3 and effect.entity_kind == "object":
-                    portable_item_ids.add(effect.entity_id)
-            elif isinstance(effect, AdvanceWorldTimeEffect):
-                world_time = advanced_to_next(runtime.v3, world_time)
+            self._validate_effect(runtime, effect, vocabulary=vocabulary)
+            effect_registry.absorb_writes(effect, vocabulary, is_v3=runtime.is_v3)
+            if isinstance(effect, AdvanceWorldTimeEffect):
+                vocabulary.world_time = advanced_to_next(
+                    runtime.v3, vocabulary.world_time
+                )
 
     def _validated_options(
         self,
@@ -1461,162 +1348,11 @@ class AdjudicationEngineService:
         runtime: EngineRuntimeSnapshot,
         effect: ActionEffect,
         *,
-        information_ids: set[str],
-        entity_ids: set[str],
-        location_ids: set[str],
-        portable_item_ids: set[str],
-        world_time: WorldTimeState | None = None,
+        vocabulary: effect_registry.ValidationVocabulary,
     ) -> None:
-        state = runtime.game_state
-        if isinstance(effect, RevealInformationEffect | HideInformationEffect):
-            if effect.information_id not in information_ids:
-                self._reject_validation(
-                    "TARGET_NOT_FOUND",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前目标不可用于这次行动",
-                )
-        elif isinstance(effect, SetVisibilityEffect):
-            valid = {
-                "information": information_ids,
-                "entity": entity_ids,
-                "location": location_ids,
-            }[effect.target_kind]
-            if effect.target_id not in valid:
-                self._reject_validation(
-                    "TARGET_NOT_FOUND",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前目标不可用于这次行动",
-                )
-        elif isinstance(effect, EnterLocationEffect):
-            if effect.location_id not in location_ids:
-                self._reject_validation(
-                    "TARGET_NOT_FOUND",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前目标不可用于这次行动",
-                )
-        elif isinstance(effect, EnsureRuntimeLocationEffect):
-            if (
-                effect.location_id in location_ids
-                or effect.connected_location_id not in location_ids
-            ):
-                self._reject_validation(
-                    "CANON_SHADOW",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前目标不可用于这次行动",
-                )
-            if (
-                effect.parent_location_id is not None
-                and effect.parent_location_id not in location_ids
-            ):
-                self._reject_validation(
-                    "TARGET_NOT_FOUND",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前目标不可用于这次行动",
-                )
-        elif isinstance(effect, EnsureRuntimeEntityEffect):
-            if effect.entity_id in entity_ids or effect.location_id not in location_ids:
-                self._reject_validation(
-                    "CANON_SHADOW",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前目标不可用于这次行动",
-                )
-            if (
-                runtime.is_v3
-                and effect.entity_kind == "object"
-                and (len(effect.entity_id) > 100 or len(effect.name) > 200)
-            ):
-                self._reject_validation(
-                    "RUNTIME_ITEM_TOO_LARGE",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="临时物品描述超过当前系统限制",
-                )
-        elif isinstance(
-            effect, MoveEntityEffect | ChangeEntityStateEffect | ConsumeEntityEffect
-        ):
-            if effect.entity_id not in entity_ids:
-                self._reject_validation(
-                    "TARGET_NOT_FOUND",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前目标不可用于这次行动",
-                )
-            if isinstance(effect, MoveEntityEffect):
-                if (
-                    effect.location_id is not None
-                    and effect.location_id not in location_ids
-                ):
-                    self._reject_validation(
-                        "TARGET_NOT_FOUND",
-                        repairability="auto_repairable",
-                        fault="agent",
-                        player_safe_reason="当前目标不可用于这次行动",
-                    )
-                if (
-                    effect.holder_actor_id is not None
-                    and effect.holder_actor_id not in state.actors
-                ):
-                    self._reject_validation(
-                        "TARGET_NOT_FOUND",
-                        repairability="auto_repairable",
-                        fault="agent",
-                        player_safe_reason="当前目标不可用于这次行动",
-                    )
-                if (
-                    effect.holder_actor_id is not None
-                    and effect.entity_id not in portable_item_ids
-                ):
-                    self._reject_validation(
-                        "INVENTORY_TARGET_NOT_PORTABLE",
-                        repairability="auto_repairable",
-                        fault="agent",
-                        player_safe_reason="这个对象不是可携带物品，不能放入背包",
-                    )
-        elif isinstance(effect, AdvanceWorldTimeEffect):
-            if not runtime.is_v3:
-                self._reject_validation(
-                    "TIME_POINT_MISMATCH",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前时间目标与世界时间线不一致",
-                )
-            blocked = time_advance_block_reason(tuple(state.actors))
-            if blocked is not None:
-                self._reject_validation(
-                    "TIME_ADVANCE_BLOCKED",
-                    repairability="requires_player_choice",
-                    fault="player",
-                    player_safe_reason="当前存在需要玩家先处理的事项，不能推进时间",
-                    internal_reason=blocked,
-                )
-            target, _ = next_point_after(
-                runtime.v3, world_time if world_time is not None else state.world_time
-            )
-            if effect.to_point_id is not None and effect.to_point_id != target.id:
-                self._reject_validation(
-                    "TIME_POINT_MISMATCH",
-                    repairability="auto_repairable",
-                    fault="agent",
-                    player_safe_reason="当前时间目标与世界时间线不一致",
-                    internal_reason=(
-                        "advance_world_time 声明的时间点不是时间线上的下一个点: "
-                        f"{effect.to_point_id} != {target.id}"
-                    ),
-                )
-        elif isinstance(effect, CommitTerminalEndingEffect):
-            self._reject_validation(
-                "ENDING_REQUIRES_DRAFT",
-                repairability="hard_reject",
-                fault="agent",
-                player_safe_reason="终局必须经过明确确认后才能提交",
-                internal_reason="终局不能由行动效果直接提交，必须确认 EndingDraft",
-            )
+        """Refuse an ill-formed effect; the per-type rules live in the registry."""
+
+        effect_registry.validate(effect, vocabulary, runtime, _EFFECT_SERVICES)
 
     def _roll(self, target_value: int, difficulty: str) -> CheckRoll:
         value = self._dice.percentile()
@@ -2144,449 +1880,39 @@ class AdjudicationEngineService:
         actor_id: str,
         offset: int,
     ) -> tuple[GameState, tuple[DomainEvent, ...]]:
-        event_type: str | None = None
-        effect_event_id: str | None = None
-        payload: dict[str, JsonValue] = {}
-        if isinstance(effect, NarrativeOnlyEffect):
-            return state, ()
-        if isinstance(effect, RevealInformationEffect | HideInformationEffect):
-            reveal = isinstance(effect, RevealInformationEffect)
-            if effect.scope == "party":
-                facts = set(state.discovered_facts)
-                (facts.add if reveal else facts.discard)(effect.information_id)
-                state = state.model_copy(
-                    update={"discovered_facts": tuple(sorted(facts))},
-                    deep=True,
-                )
-            else:
-                actor_facts = deepcopy(state.actor_discovered_facts)
-                facts = set(actor_facts.get(actor_id, ()))
-                (facts.add if reveal else facts.discard)(effect.information_id)
-                actor_facts[actor_id] = tuple(sorted(facts))
-                state = state.model_copy(
-                    update={"actor_discovered_facts": actor_facts},
-                    deep=True,
-                )
-            event_type = "information.revealed" if reveal else "information.hidden"
-            payload = {"information_id": effect.information_id, "scope": effect.scope}
-        elif isinstance(effect, SetVisibilityEffect):
-            overrides = dict(state.visibility_overrides)
-            # Party scope must not be keyed by the acting actor, or no other
-            # actor could ever find the override again. Actor scope keeps the
-            # actor id and wins over the party entry when both exist
-            # (see RuleEngineService._override_allows).
-            key = (
-                f"actor:{actor_id}:{effect.target_kind}:{effect.target_id}"
-                if effect.scope == "actor"
-                else f"party:{effect.target_kind}:{effect.target_id}"
-            )
-            overrides[key] = effect.visible
-            updates: dict[str, object] = {"visibility_overrides": overrides}
-            if effect.target_kind == "location":
-                knowledge_by_scope = (
-                    deepcopy(state.actor_location_knowledge)
-                    if effect.scope == "actor"
-                    else deepcopy(state.party_location_knowledge)
-                )
-                if effect.scope == "actor":
-                    actor_knowledge = knowledge_by_scope.setdefault(actor_id, {})
-                    previous_knowledge = actor_knowledge.get(effect.target_id)
-                    actor_knowledge[effect.target_id] = _visibility_knowledge(
-                        effect.target_id,
-                        scope="actor",
-                        visible=effect.visible,
-                        previous=previous_knowledge,
-                    )
-                    updates["actor_location_knowledge"] = knowledge_by_scope
-                else:
-                    previous_knowledge = knowledge_by_scope.get(effect.target_id)
-                    knowledge_by_scope[effect.target_id] = _visibility_knowledge(
-                        effect.target_id,
-                        scope="party",
-                        visible=effect.visible,
-                        previous=previous_knowledge,
-                    )
-                    updates["party_location_knowledge"] = knowledge_by_scope
-            state = state.model_copy(update=updates, deep=True)
-            event_type = "visibility.changed"
-            payload = {
-                "target_kind": effect.target_kind,
-                "target_id": effect.target_id,
-                "visible": effect.visible,
-                "scope": effect.scope,
-            }
-        elif isinstance(effect, EnterLocationEffect):
-            if not runtime.is_v3:
-                previous = state.scene_id
-                state = state.model_copy(
-                    update={"scene_id": effect.location_id}, deep=True
-                )
-                event_type = "location.entered"
-                payload = {
-                    "location_id": effect.location_id,
-                    "from_location_id": previous,
-                }
-            else:
-                resolution = resolve_location_target(
-                    runtime.v3,
-                    state,
-                    actor_id=actor_id,
-                    target_id=effect.location_id,
-                )
-                contexts = dict(state.actor_position_contexts)
-                knowledge = dict(state.party_location_knowledge)
-                previous_knowledge = knowledge.get(effect.location_id)
-                if resolution.status == "known_reachable":
-                    contexts.pop(actor_id, None)
-                    knowledge[effect.location_id] = LocationKnowledge(
-                        location_id=effect.location_id,
-                        scope="party",
-                        existence="known",
-                        localization="located",
-                        access="reachable",
-                        visited=True,
-                        known_connection_ids=(
-                            previous_knowledge.known_connection_ids
-                            if previous_knowledge is not None
-                            else ()
-                        ),
-                    )
-                    travel = TravelResolved(
-                        destination_id=effect.location_id,
-                        path=resolution.path,
-                    )
-                    state = state.model_copy(
-                        update={
-                            "scene_id": effect.location_id,
-                            "party_location_knowledge": knowledge,
-                            "actor_position_contexts": contexts,
-                        },
-                        deep=True,
-                    )
-                    event_type = "travel.resolved"
-                    payload = {
-                        "destination_id": travel.destination_id,
-                        "path": list(travel.path),
-                    }
-                elif resolution.status == "known_blocked":
-                    assert resolution.boundary is not None
-                    assert resolution.reached_location_id is not None
-                    travel = TravelInterrupted(
-                        destination_id=effect.location_id,
-                        current_location_id=resolution.reached_location_id,
-                        path=resolution.path,
-                        reached_boundary=resolution.boundary,
-                    )
-                    contexts[actor_id] = travel
-                    knowledge[effect.location_id] = LocationKnowledge(
-                        location_id=effect.location_id,
-                        scope="party",
-                        existence="known",
-                        localization="located",
-                        access="blocked",
-                        visited=bool(previous_knowledge and previous_knowledge.visited),
-                        known_connection_ids=(
-                            previous_knowledge.known_connection_ids
-                            if previous_knowledge is not None
-                            else ()
-                        ),
-                    )
-                    state = state.model_copy(
-                        update={
-                            "scene_id": travel.current_location_id,
-                            "party_location_knowledge": knowledge,
-                            "actor_position_contexts": contexts,
-                        },
-                        deep=True,
-                    )
-                    event_type = "travel.interrupted"
-                    payload = {
-                        "destination_id": travel.destination_id,
-                        "current_location_id": travel.current_location_id,
-                        "path": list(travel.path),
-                        "reached_boundary": travel.reached_boundary.to_json_dict(),
-                    }
-                else:
-                    self._reject_validation(
-                        "TARGET_NOT_FOUND",
-                        repairability="auto_repairable",
-                        fault="agent",
-                        player_safe_reason="当前目标不可用于这次行动",
-                        internal_reason=(
-                            resolution.safe_reason or "当前没有可确认的目标路线"
-                        ),
-                    )
-        elif isinstance(effect, EnsureRuntimeLocationEffect):
-            locations = deepcopy(state.runtime_locations)
-            locations[effect.location_id] = {
-                "name": effect.name,
-                "parent_location_id": effect.parent_location_id,
-                "connected_location_id": effect.connected_location_id,
-                "provenance": "agent_adjudication",
-            }
-            knowledge = dict(state.party_location_knowledge)
-            knowledge[effect.location_id] = LocationKnowledge(
-                location_id=effect.location_id,
-                existence="known",
-                localization="located",
-                access="reachable",
-            )
-            state = state.model_copy(
-                update={
-                    "runtime_locations": locations,
-                    "party_location_knowledge": knowledge,
-                },
-                deep=True,
-            )
-            event_type = "location.created"
-            payload = {"location_id": effect.location_id}
-        elif isinstance(effect, EnsureRuntimeEntityEffect):
-            if runtime.is_v3 and effect.entity_kind == "object":
-                effect_event_id = self._new_id("evt")
-                revision = str(state.event_sequence + offset)
-                items = deepcopy(state.item_instances)
-                items[effect.entity_id] = ItemInstance(
-                    id=effect.entity_id,
-                    room_id=room_id,
-                    origin="runtime",
-                    definition_id=effect.entity_id,
-                    display=ItemDisplay(name=effect.name),
-                    item_component=ItemComponent(),
-                    custody=ItemCustody(
-                        kind="location",
-                        ref_id=effect.location_id,
-                        form="loose",
-                    ),
-                    acquisition=ItemAcquisition(
-                        source_type="runtime",
-                        source_id=effect.location_id,
-                        player_safe_label="行动中发现",
-                        event_id=effect_event_id,
-                        revision=revision,
-                    ),
-                    created_event_id=effect_event_id,
-                    last_event_id=effect_event_id,
-                    updated_revision=revision,
-                )
-                party_knowledge = deepcopy(state.party_item_knowledge)
-                party_knowledge[effect.entity_id] = ItemKnowledge(
-                    item_id=effect.entity_id,
-                    identity="recognized",
-                )
-                state = state.model_copy(
-                    update={
-                        "item_instances": items,
-                        "party_item_knowledge": party_knowledge,
-                    },
-                    deep=True,
-                )
-            else:
-                entities = deepcopy(state.runtime_entities)
-                entities[effect.entity_id] = {
-                    "kind": effect.entity_kind,
-                    "name": effect.name,
-                    "location_id": effect.location_id,
-                    "provenance": "agent_adjudication",
-                }
-                state = state.model_copy(
-                    update={"runtime_entities": entities}, deep=True
-                )
-            event_type = "entity.created"
-            payload = {"entity_id": effect.entity_id, "location_id": effect.location_id}
-        elif isinstance(effect, MoveEntityEffect):
-            item = state.item_instances.get(effect.entity_id)
-            if item is not None:
-                effect_event_id = self._new_id("evt")
-                revision = str(state.event_sequence + offset)
-                custody = (
-                    ItemCustody(
-                        kind="actor_inventory",
-                        ref_id=effect.holder_actor_id,
-                        form="carried",
-                    )
-                    if effect.holder_actor_id is not None
-                    else ItemCustody(
-                        kind="location",
-                        ref_id=effect.location_id,
-                        form="placed",
-                    )
-                )
-                items = deepcopy(state.item_instances)
-                items[effect.entity_id] = item.model_copy(
-                    update={
-                        "custody": custody,
-                        "version": item.version + 1,
-                        "last_event_id": effect_event_id,
-                        "updated_revision": revision,
-                    }
-                )
-                updates: dict[str, object] = {"item_instances": items}
-                if effect.holder_actor_id is not None:
-                    actor_knowledge = deepcopy(state.actor_item_knowledge)
-                    actor_knowledge.setdefault(effect.holder_actor_id, {})[
-                        effect.entity_id
-                    ] = ItemKnowledge(
-                        item_id=effect.entity_id,
-                        scope="actor",
-                        identity="known",
-                    )
-                    updates["actor_item_knowledge"] = actor_knowledge
-                else:
-                    party_knowledge = deepcopy(state.party_item_knowledge)
-                    party_knowledge[effect.entity_id] = ItemKnowledge(
-                        item_id=effect.entity_id,
-                        identity="recognized",
-                    )
-                    updates["party_item_knowledge"] = party_knowledge
-                state = state.model_copy(update=updates, deep=True)
-            else:
-                if effect.holder_actor_id is not None:
-                    # Defense in depth for authored/rule-owned effects and any
-                    # future caller that reaches application without the
-                    # proposal validator.  Generic entities may move between
-                    # locations, but only ItemInstances have inventory custody.
-                    self._reject_validation(
-                        "INVENTORY_TARGET_NOT_PORTABLE",
-                        repairability="auto_repairable",
-                        fault="agent",
-                        player_safe_reason="这个对象不是可携带物品，不能放入背包",
-                    )
-                runtime_entities = deepcopy(state.runtime_entities)
-                entity_states = deepcopy(state.entities)
-                target = runtime_entities.get(effect.entity_id)
-                if target is None:
-                    target = entity_states.setdefault(effect.entity_id, {})
-                target["location_id"] = effect.location_id
-                target["holder_actor_id"] = effect.holder_actor_id
-                state = state.model_copy(
-                    update={
-                        "runtime_entities": runtime_entities,
-                        "entities": entity_states,
-                    },
-                    deep=True,
-                )
-            event_type = "entity.moved"
-            payload = {
-                "entity_id": effect.entity_id,
-                "location_id": effect.location_id,
-                "holder_actor_id": effect.holder_actor_id,
-            }
-        elif isinstance(effect, ChangeEntityStateEffect):
-            item = state.item_instances.get(effect.entity_id)
-            if item is not None:
-                effect_event_id = self._new_id("evt")
-                revision = str(state.event_sequence + offset)
-                values = deepcopy(item.state.values)
-                values[effect.key] = effect.value
-                items = deepcopy(state.item_instances)
-                items[effect.entity_id] = item.model_copy(
-                    update={
-                        "state": item.state.model_copy(update={"values": values}),
-                        "version": item.version + 1,
-                        "last_event_id": effect_event_id,
-                        "updated_revision": revision,
-                    }
-                )
-                updates: dict[str, object] = {"item_instances": items}
-            else:
-                runtime_entities = deepcopy(state.runtime_entities)
-                entity_states = deepcopy(state.entities)
-                target = runtime_entities.get(effect.entity_id)
-                if target is None:
-                    target = entity_states.setdefault(effect.entity_id, {})
-                target[effect.key] = effect.value
-                updates = {
-                    "runtime_entities": runtime_entities,
-                    "entities": entity_states,
-                }
-            if is_public_standard_state(effect):
-                public_keys = deepcopy(state.public_entity_state_keys)
-                keys = set(public_keys.get(effect.entity_id, ()))
-                keys.add(effect.key)
-                public_keys[effect.entity_id] = tuple(sorted(keys))
-                updates["public_entity_state_keys"] = public_keys
-            state = state.model_copy(update=updates, deep=True)
-            event_type = "entity.state_changed"
-            payload = {
-                "entity_id": effect.entity_id,
-                "key": effect.key,
-                "value": effect.value,
-            }
-        elif isinstance(effect, ConsumeEntityEffect):
-            item = state.item_instances.get(effect.entity_id)
-            if item is not None:
-                effect_event_id = self._new_id("evt")
-                revision = str(state.event_sequence + offset)
-                items = deepcopy(state.item_instances)
-                items[effect.entity_id] = item.model_copy(
-                    update={
-                        "state": item.state.model_copy(update={"status": "retired"}),
-                        "version": item.version + 1,
-                        "last_event_id": effect_event_id,
-                        "updated_revision": revision,
-                    }
-                )
-                state = state.model_copy(update={"item_instances": items}, deep=True)
-            else:
-                runtime_entities = deepcopy(state.runtime_entities)
-                entity_states = deepcopy(state.entities)
-                target = runtime_entities.get(effect.entity_id)
-                if target is None:
-                    target = entity_states.setdefault(effect.entity_id, {})
-                target["consumed"] = True
-                state = state.model_copy(
-                    update={
-                        "runtime_entities": runtime_entities,
-                        "entities": entity_states,
-                    },
-                    deep=True,
-                )
-            event_type = "entity.consumed"
-            payload = {"entity_id": effect.entity_id}
-        elif isinstance(effect, AdvanceWorldTimeEffect):
-            advanced = advanced_to_next(runtime.v3, state.world_time)
-            state = state.model_copy(update={"world_time": advanced}, deep=True)
-            event_type = "time.point_entered"
-            payload = {
-                "point_id": advanced.current_point_id,
-                "day_index": advanced.current.day_index,
-                "hour_of_day": advanced.current.hour_of_day,
-                "time_of_day": advanced.time_of_day,
-            }
-        elif isinstance(effect, MarkCoreResolvedEffect):
-            state = state.model_copy(update={"core_resolved": True}, deep=True)
-            event_type = "core.resolved"
-        elif isinstance(effect, SetEndingAvailabilityEffect):
-            state = state.model_copy(
-                update={"ending_available": effect.available}, deep=True
-            )
-            event_type = "ending.availability_changed"
-            payload = {"available": effect.available}
-        elif isinstance(effect, CommitTerminalEndingEffect):
-            self._reject_validation(
-                "ENDING_REQUIRES_DRAFT",
-                repairability="hard_reject",
-                fault="engine",
-                player_safe_reason="终局必须经过明确确认后才能提交",
-                classification_coverage="rule_effects_excluded",
-            )
-        if event_type is None:
-            self._reject_validation(
-                "EFFECT_NOT_REGISTERED",
-                repairability="hard_reject",
-                fault="engine",
-                player_safe_reason="规则引擎无法处理当前效果",
-            )
-        return state, (
+        """Execute one already-validated effect.
+
+        The per-type state changes live in `registry/effects.py` (#347); what
+        stays here is the flow skeleton — handing the handler its context and
+        turning what it reports into a DomainEvent. A registration that declares
+        `emits_event=False` (only `narrative_only` today) commits state without
+        recording one.
+        """
+
+        result = effect_registry.apply(
+            effect,
+            effect_registry.ApplyContext(
+                runtime=runtime,
+                state=state,
+                services=_EFFECT_SERVICES,
+                room_id=room_id,
+                request_id=request_id,
+                actor_id=actor_id,
+                offset=offset,
+            ),
+        )
+        if result.event_type is None:
+            return result.state, ()
+        return result.state, (
             self._event_from_state(
-                state,
+                result.state,
                 room_id=room_id,
                 offset=offset,
                 request_id=request_id,
                 actor_id=actor_id,
-                event_type=event_type,
-                payload=payload,
-                event_id=effect_event_id,
+                event_type=result.event_type,
+                payload=result.payload,
+                event_id=result.event_id,
             ),
         )
 

--- a/agent-collaboration-framework/collaboration_framework/engine/capabilities.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/capabilities.py
@@ -67,8 +67,13 @@ def audit_runtime_capabilities(
 
     v3 needs a much shorter audit than v2: hooks and free-form operations are
     gone, and a v3 Rule can only reference registered Steps, Effects and
-    Predicates — the contract and its validator already enforce that statically
-    (#226 §1). What is left to check at load time is the world ruleset.
+    Predicates (#226 §1). Steps and Effects are enforced by their discriminated
+    unions in `contracts/module_v3.py`; Predicate *names* are enforced at
+    publish time by `module/validation_v3.py` against
+    `engine/registry/predicates.py` (#347). Until that registry existed this
+    docstring overstated the guarantee — an unregistered predicate name passed
+    every static check and only ever read false at runtime. What is left to
+    check here at load time is the world ruleset.
     """
 
     if isinstance(module_content, ModuleContentV3):

--- a/agent-collaboration-framework/collaboration_framework/engine/rules_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/rules_v3.py
@@ -28,11 +28,15 @@ from collaboration_framework.contracts import (
     RuleSpecV3,
 )
 
+from collaboration_framework.registry import predicates as predicate_registry
+
 from .models import AgendaItem, AgendaSource, DomainEvent, GameState, RuleAgenda
 
-# Predicates a rule may name. #226 §1 forbids scripts and arbitrary state paths,
-# so a rule can only ask questions the Engine registered.
-_UNKNOWN_PREDICATE_IS_FALSE = False
+# `entity_state` used to live here; it now lives in `registry/predicates.py`
+# (the shared read every predicate evaluator uses). Re-imported by name so
+# `adjudication.py` and `navigation.py` can keep doing
+# `from .rules_v3 import entity_state` unchanged.
+from collaboration_framework.registry.predicates import entity_state  # noqa: F401
 
 
 @dataclass
@@ -101,53 +105,20 @@ def _evaluate_predicate(
     state: GameState,
     actor_id: str,
 ) -> bool:
-    args = condition.args
-    if condition.predicate == "entity_state_is":
-        entity_id = args.get("entity_id")
-        key = args.get("key")
-        if not isinstance(entity_id, str) or not isinstance(key, str):
-            return False
-        expected = args.get("value", True)
-        current = entity_state(state, entity_id).get(key)
-        # An absent flag reads as False, which is how the authored `== false`
-        # conditions are meant to fire on a fresh room.
-        return (current if current is not None else False) == expected
-    if condition.predicate == "time_of_day_is":
-        return state.world_time.time_of_day == args.get("value")
-    if condition.predicate == "information_is":
-        information_id = args.get("id")
-        if not isinstance(information_id, str):
-            return False
-        return information_id in set(state.discovered_facts) | set(
-            state.actor_discovered_facts.get(actor_id, ())
-        )
-    if condition.predicate == "core_resolved":
-        return state.core_resolved is bool(args.get("value", True))
-    return _UNKNOWN_PREDICATE_IS_FALSE
+    """Delegates to `registry/predicates.py` (#347 Phase 1).
 
-
-def entity_state(state: GameState, entity_id: str) -> dict:
-    """The one authoritative read of an entity's state flags.
-
-    An entity carrying an `item_component` gets materialised into
-    `item_instances`, and `ChangeEntityStateEffect` then writes **only** to that
-    record (it is the versioned one). Reading just `runtime_entities`/`entities`
-    therefore never observes those writes: the authored defaults sit on one side
-    while every subsequent update lands on the other, so any condition gated on
-    such a flag — `visibility_conditions`, gated edges, event triggers — stays
-    frozen at its initial value forever.
-
-    Resolving here in the same precedence the write side uses (item wins) keeps
-    a single source of truth per flag. The authored state stays the base so
-    defaults survive: a fresh item instance starts with empty `values`.
+    An unregistered predicate name still reads False here, exactly as the
+    inline `_UNKNOWN_PREDICATE_IS_FALSE` fallback did before the registry
+    existed — this function's job is now just the lookup, not the four
+    branches themselves.
     """
 
-    runtime = state.runtime_entities.get(entity_id)
-    base = runtime if runtime is not None else state.entities.get(entity_id, {})
-    item = state.item_instances.get(entity_id)
-    if item is None:
-        return base
-    return {**base, **item.state.values}
+    return predicate_registry.evaluate(
+        condition.predicate,
+        condition.args,
+        state=state,
+        actor_id=actor_id,
+    )
 
 
 def walk_rule(rule: RuleSpecV3, *, branch_id: str | None = None) -> RuleWalk:

--- a/agent-collaboration-framework/collaboration_framework/engine/rules_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/rules_v3.py
@@ -16,27 +16,25 @@ from collaboration_framework.contracts import (
     AgentMatchTriggerSpec,
     AllCondition,
     AnyCondition,
-    ConditionExpr,
-    EffectStep,
     CheckStep,
+    ConditionExpr,
     ContractError,
     EventTriggerSpec,
-    FinishStep,
     ModuleContentV3,
     NotCondition,
     PredicateCondition,
     RuleSpecV3,
 )
-
 from collaboration_framework.registry import predicates as predicate_registry
-
-from .models import AgendaItem, AgendaSource, DomainEvent, GameState, RuleAgenda
+from collaboration_framework.registry import rule_steps as rule_step_registry
 
 # `entity_state` used to live here; it now lives in `registry/predicates.py`
 # (the shared read every predicate evaluator uses). Re-imported by name so
 # `adjudication.py` and `navigation.py` can keep doing
 # `from .rules_v3 import entity_state` unchanged.
 from collaboration_framework.registry.predicates import entity_state  # noqa: F401
+
+from .models import AgendaItem, AgendaSource, DomainEvent, GameState, RuleAgenda
 
 
 @dataclass
@@ -156,10 +154,11 @@ def walk_rule_from(rule: RuleSpecV3, step_id: str) -> RuleWalk:
             walk.suspended_at = cursor
             walk.suspended_kind = "unknown_step"
             return walk
-        if isinstance(step, FinishStep):
+        behavior = rule_step_registry.walk_behavior_of(step)
+        if behavior == "terminal":
             walk.completed = True
             return walk
-        if isinstance(step, EffectStep):
+        if behavior == "produces_effect_and_continues":
             walk.effects.append(step.effect)
             cursor = step.next_step_id
             continue
@@ -221,27 +220,22 @@ def agenda_item_for_event(rule: RuleSpecV3, event: DomainEvent) -> AgendaItem:
 
 
 def agenda_status_for_walk(rule: RuleSpecV3, walk: RuleWalk) -> str:
-    """Map a blocking step to the authoritative Agenda boundary."""
+    """Map a blocking step to the authoritative Agenda boundary.
+
+    The per-kind mapping lives in `registry/rule_steps.py` (#347). The three
+    outcomes handled here are not step kinds at all — they are ways the walk
+    itself failed — and a walk that never suspended is simply stable.
+    """
 
     if walk.suspended_kind in {"loop", "step_budget", "unknown_step"}:
         return "failed"
-    if walk.suspended_kind == "check":
-        step = next(
-            (item for item in rule.execution.steps if item.id == walk.suspended_at),
-            None,
-        )
-        if isinstance(step, CheckStep) and step.check.initiation_kind == "passive_rule":
-            return "awaiting_passive_check"
-        return "awaiting_active_check"
-    if walk.suspended_kind == "adjudicated_check":
-        return "awaiting_active_check"
-    if walk.suspended_kind == "presentation":
-        return "awaiting_presentation"
-    if walk.suspended_kind == "await_player_input":
-        return "awaiting_player_input"
-    if walk.suspended_at is not None:
-        return "running"
-    return "stable"
+    if walk.suspended_kind is None:
+        return "stable" if walk.suspended_at is None else "running"
+    step = next(
+        (item for item in rule.execution.steps if item.id == walk.suspended_at),
+        None,
+    )
+    return rule_step_registry.agenda_status_for(walk.suspended_kind, step)
 
 
 def agenda_claim_key(agenda: RuleAgenda) -> tuple[int, int, str, str]:

--- a/agent-collaboration-framework/collaboration_framework/module/validation_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/module/validation_v3.py
@@ -28,12 +28,15 @@ from collaboration_framework.contracts.module_v3 import (
     CreateNpcActionOpportunityStep,
     EffectStep,
     EventTriggerSpec,
+    InvokeRulesetActionStep,
     ModuleContentV3,
     NotCondition,
     PredicateCondition,
     RuleSpecV3,
+    RuleStepSpec,
 )
 from collaboration_framework.registry import predicates as predicate_registry
+from collaboration_framework.registry import rule_steps as rule_step_registry
 
 from .validation import ValidationIssue, ValidationReport
 
@@ -388,6 +391,7 @@ def _rule_issues(
                     message="检定步骤必须至少路由一个结果等级",
                 )
             )
+        issues.extend(_actor_binding_issues(step, step_path))
 
     if rule.presentation is not None:
         presentation_ids = {rule.presentation.id}
@@ -405,6 +409,33 @@ def _rule_issues(
                     )
                 )
     return issues
+
+
+def _actor_binding_issues(step: RuleStepSpec, step_path: str) -> list[ValidationIssue]:
+    """Check `actor_binding` against the registered value space (#347 §4.8).
+
+    Nothing reads this field yet — resolving a binding into actual actors is a
+    later issue. Registering the value space and rejecting anything outside it
+    is the whole of what this phase does with it, per #347 §4.7's
+    "migrate and load completely, do not implement".
+    """
+
+    if isinstance(step, CheckStep):
+        binding, path = step.check.actor_binding, f"{step_path}.check.actor_binding"
+    elif isinstance(step, InvokeRulesetActionStep):
+        binding, path = step.actor_binding, f"{step_path}.actor_binding"
+    else:
+        return []
+    if rule_step_registry.is_registered_actor_binding(binding):
+        return []
+    return [
+        ValidationIssue(
+            severity="error",
+            code="MODULE_V3_ACTOR_BINDING_UNKNOWN",
+            path=path,
+            message=f"引用了未注册的 actor_binding: {binding}",
+        )
+    ]
 
 
 def _reachable_steps(rule: RuleSpecV3) -> set[str]:

--- a/agent-collaboration-framework/collaboration_framework/module/validation_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/module/validation_v3.py
@@ -33,6 +33,7 @@ from collaboration_framework.contracts.module_v3 import (
     PredicateCondition,
     RuleSpecV3,
 )
+from collaboration_framework.registry import predicates as predicate_registry
 
 from .validation import ValidationIssue, ValidationReport
 
@@ -297,7 +298,16 @@ def _location_cycle_issues(content: ModuleContentV3) -> list[ValidationIssue]:
 
 
 def _condition_issues(condition: ConditionExpr, path: str) -> list[ValidationIssue]:
-    """Reject empty logical nodes; a predicate's name is checked at load time."""
+    """Reject empty or unregistered predicate names (#347 Phase 1).
+
+    The predicate *name* is now checked against `registry/predicates.py` —
+    the one deliberate, called-out behaviour change in issue #347's otherwise
+    pure-refactor scope: a typo'd or made-up predicate name used to pass
+    publish and just silently never fire at runtime
+    (`_UNKNOWN_PREDICATE_IS_FALSE`); it is now rejected here instead, with the
+    rule pinpointed. Argument *shape* is deliberately still not checked here
+    (see `registry/predicates.py` module docstring) — only the name.
+    """
 
     if isinstance(condition, AllCondition | AnyCondition):
         issues: list[ValidationIssue] = []
@@ -306,15 +316,25 @@ def _condition_issues(condition: ConditionExpr, path: str) -> list[ValidationIss
         return issues
     if isinstance(condition, NotCondition):
         return _condition_issues(condition.item, f"{path}.item")
-    if isinstance(condition, PredicateCondition) and not condition.predicate.strip():
-        return [
-            ValidationIssue(
-                severity="error",
-                code="MODULE_V3_PREDICATE_EMPTY",
-                path=f"{path}.predicate",
-                message="predicate 名称不能为空",
-            )
-        ]
+    if isinstance(condition, PredicateCondition):
+        if not condition.predicate.strip():
+            return [
+                ValidationIssue(
+                    severity="error",
+                    code="MODULE_V3_PREDICATE_EMPTY",
+                    path=f"{path}.predicate",
+                    message="predicate 名称不能为空",
+                )
+            ]
+        if not predicate_registry.is_registered(condition.predicate):
+            return [
+                ValidationIssue(
+                    severity="error",
+                    code="MODULE_V3_PREDICATE_UNKNOWN",
+                    path=f"{path}.predicate",
+                    message=f"引用了未注册的 predicate: {condition.predicate}",
+                )
+            ]
     return []
 
 

--- a/agent-collaboration-framework/collaboration_framework/registry/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/__init__.py
@@ -1,0 +1,21 @@
+"""Registry tables for the rule engine's publish-once, reuse-forever split.
+
+Each module in this package is a small, closed lookup table shipped with the
+Engine itself — never loaded from module content. A v3 Rule may only
+*reference* an entry that already exists here (by predicate name, effect
+type, rule step kind, or ruleset action id); module content can never define
+a new one. Supporting a genuinely new kind of any of these is an Engine
+release, not a module publish. See GitHub issue #347 §4.1/§4.2 for the full
+rationale, and §4.3/§4.4 for the linker-style two-pass reference resolution
+and ECS-style read/write declarations these tables are modelled on.
+
+**This package is a leaf.** It sits alongside `contracts/` rather than inside
+`engine/` because both `engine` (execution time) and `module` (publish-time
+validation) read from it, and `docs/architecture.md` §6 forbids
+`module -> engine`. At runtime these tables import only from `contracts`;
+where an evaluator needs an engine state model it is imported under
+`TYPE_CHECKING` for annotations only, so importing a table never drags the
+engine in behind it.
+"""
+
+from __future__ import annotations

--- a/agent-collaboration-framework/collaboration_framework/registry/effects.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/effects.py
@@ -1,0 +1,1280 @@
+"""Effect registry (#347 Phase 2): the closed set of `ActionEffect` types the
+Engine understands, and everything it knows about each one.
+
+Before this table existed, the four things the Engine knows about an effect
+were four unrelated `isinstance` chains scattered across ~620 lines of
+`engine/adjudication.py`: `_classify_effects` (what authority does proposing
+this take), `_validate_effect` (is it well-formed against the current
+vocabulary), `_apply_effect` (how does it change state), and — implicitly,
+by omission — which of its fields name something that must already exist.
+Adding an effect type meant editing all four and there was no mechanism that
+noticed if you missed one.
+
+Each entry here answers all four at once, so adding an effect type is one
+registration and a missing piece is a structural gap rather than a silent
+runtime no-op:
+
+- `authority` — the AuthorityLevel proposing it takes (internal diagnostics
+  only; see `contracts/validation.py`). Rule-owned effects deliberately never
+  reach this: only Agent-proposed effects are classified.
+- `reads` / `writes` / `must_not_exist` — the ECS-style access declaration
+  from issue #347 §4.4: which fields name an instance that must already be in
+  the vocabulary, which fields introduce a new one, and which must *not*
+  already exist. `engine` walks a whole effect sequence against these in one
+  linker-style two-pass resolution (#347 §4.3): every `writes` from an earlier
+  effect is in the vocabulary a later effect `reads` from, which is what makes
+  "create the room, then walk into it" legal inside one adjudication.
+- `validate` — content validation. Refuses; runs before anything is written.
+- `apply` — execution. Deliberately does **not** refuse (§3.2): it only ever
+  sees input `validate` already accepted. Two entries keep a defensive
+  rejection anyway, each marked at its call site with why.
+
+## Why the engine helpers arrive as `EffectServices`
+
+This package is a leaf (see `registry/__init__.py`): `module` reads these
+tables at publish time and `docs/architecture.md` §6 forbids
+`module -> engine`, so nothing here may import `engine` at runtime. A handful
+of handlers genuinely need engine logic — pathfinding, the world clock — so
+the engine passes those in as an explicit, frozen set of callables, the same
+ports-and-adapters shape `engine/ports/` and `host/ports/` already use. State
+*models* (`GameState`, `EngineRuntimeSnapshot`) are only ever read through
+attribute access and constructed by their owners, so they are imported under
+`TYPE_CHECKING` for annotations alone.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, NoReturn
+from uuid import uuid4
+
+from pydantic import JsonValue
+
+from collaboration_framework.contracts import (
+    ActionEffect,
+    AdvanceWorldTimeEffect,
+    ChangeEntityStateEffect,
+    CommitTerminalEndingEffect,
+    ConsumeEntityEffect,
+    EnsureRuntimeEntityEffect,
+    EnsureRuntimeLocationEffect,
+    EnterLocationEffect,
+    HideInformationEffect,
+    ItemAcquisition,
+    ItemComponent,
+    ItemCustody,
+    ItemDisplay,
+    ItemInstance,
+    ItemKnowledge,
+    LocationKnowledge,
+    MarkCoreResolvedEffect,
+    MoveEntityEffect,
+    NarrativeOnlyEffect,
+    RevealInformationEffect,
+    SetEndingAvailabilityEffect,
+    SetVisibilityEffect,
+    TravelInterrupted,
+    TravelResolved,
+)
+from collaboration_framework.contracts.validation import (
+    AdjudicationValidationError,
+    AuthorityLevel,
+    ClassificationCoverage,
+    Repairability,
+    ValidationResult,
+)
+
+if TYPE_CHECKING:  # annotations only — this package must not import engine.
+    from collaboration_framework.engine.models import (
+        EngineRuntimeSnapshot,
+        GameState,
+        WorldTimeState,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# rejection
+# --------------------------------------------------------------------------- #
+def reject(
+    code: str,
+    *,
+    repairability: Repairability,
+    fault: Literal["agent", "player", "engine"],
+    player_safe_reason: str,
+    internal_reason: str | None = None,
+    classification_coverage: ClassificationCoverage = "partial_validation_failure",
+) -> NoReturn:
+    """Refuse an effect. Lives here because refusing is what this table does."""
+
+    raise AdjudicationValidationError(
+        ValidationResult(
+            status="rejected",
+            code=code,
+            repairability=repairability,
+            fault=fault,
+            player_safe_reason=player_safe_reason,
+            classification_coverage=classification_coverage,
+            internal_reason=internal_reason,
+        )
+    )
+
+
+def _reject_target_not_found() -> NoReturn:
+    reject(
+        "TARGET_NOT_FOUND",
+        repairability="auto_repairable",
+        fault="agent",
+        player_safe_reason="当前目标不可用于这次行动",
+    )
+
+
+def _reject_canon_shadow() -> NoReturn:
+    reject(
+        "CANON_SHADOW",
+        repairability="auto_repairable",
+        fault="agent",
+        player_safe_reason="当前目标不可用于这次行动",
+    )
+
+
+def _reject_not_portable() -> NoReturn:
+    reject(
+        "INVENTORY_TARGET_NOT_PORTABLE",
+        repairability="auto_repairable",
+        fault="agent",
+        player_safe_reason="这个对象不是可携带物品，不能放入背包",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ports: the engine logic a handler may need
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class EffectServices:
+    """Engine-owned pure functions the tables call, injected by the engine.
+
+    Kept to the smallest possible surface: everything else a handler needs is
+    either a contracts model or plain attribute reads off the state it was
+    handed.
+    """
+
+    resolve_location_target: Callable[..., object]
+    advanced_to_next: Callable[..., object]
+    next_point_after: Callable[..., object]
+    time_advance_block_reason: Callable[..., str | None]
+    is_public_standard_state: Callable[..., bool]
+    new_event_id: Callable[[], str] = lambda: f"evt_{uuid4().hex}"
+
+
+# --------------------------------------------------------------------------- #
+# access declarations (#347 §4.4)
+# --------------------------------------------------------------------------- #
+Vocabulary = Literal["information", "entities", "locations", "portable_items", "actors"]
+
+
+@dataclass(frozen=True)
+class FieldRef:
+    """One field of an effect, and the vocabulary the id in it belongs to."""
+
+    field: str
+    vocabulary: Vocabulary
+    optional: bool = False
+
+
+# --------------------------------------------------------------------------- #
+# classification
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ClassificationContext:
+    """The module-and-state lookups every authority rule shares.
+
+    Built once per effect sequence rather than per effect — the originating
+    `_classify_effects` hoisted exactly these out of its loop.
+    """
+
+    entity_specs: dict[str, object] = field(default_factory=dict)
+    information_specs: dict[str, object] = field(default_factory=dict)
+    core_goal_ids: frozenset[str] = frozenset()
+    runtime_entity_ids: frozenset[str] = frozenset()
+    runtime_location_ids: frozenset[str] = frozenset()
+
+    def information_is_pivotal(self, information_id: str) -> bool:
+        """Essential intel, or intel a core-resolution goal depends on."""
+
+        info = self.information_specs.get(information_id)
+        if info is None:
+            return False
+        return (
+            getattr(info, "criticality", None) == "essential"
+            or information_id in self.core_goal_ids
+        )
+
+    def entity_is_keeper_only(self, entity_id: str) -> bool:
+        entity = self.entity_specs.get(entity_id)
+        return entity is not None and getattr(entity, "visibility", None) == "keeper"
+
+
+def classification_context(runtime: EngineRuntimeSnapshot) -> ClassificationContext:
+    v3 = runtime.v3 if runtime.is_v3 else None
+    return ClassificationContext(
+        entity_specs={item.id: item for item in v3.entities} if v3 else {},
+        information_specs={item.id: item for item in v3.information} if v3 else {},
+        core_goal_ids=frozenset(
+            info_id
+            for goal in (v3.knowledge_goals if v3 else ())
+            if goal.required_for_core_resolution
+            for info_id in goal.target_information_ids
+        ),
+        runtime_entity_ids=frozenset(runtime.game_state.runtime_entities),
+        runtime_location_ids=frozenset(runtime.game_state.runtime_locations),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# validation / application call shapes
+# --------------------------------------------------------------------------- #
+@dataclass
+class ValidationVocabulary:
+    """The ids legal to reference at this point in an effect sequence.
+
+    Mutable on purpose: `engine` rolls it forward as it walks the sequence,
+    folding in each effect's `writes` before validating the next one — the
+    second pass of the linker-style resolution in #347 §4.3.
+    """
+
+    information_ids: set[str]
+    entity_ids: set[str]
+    location_ids: set[str]
+    portable_item_ids: set[str]
+    actor_ids: set[str]
+    world_time: WorldTimeState | None = None
+
+
+@dataclass(frozen=True)
+class ApplyContext:
+    """Everything a handler needs to turn one effect into a state change."""
+
+    runtime: EngineRuntimeSnapshot
+    state: GameState
+    services: EffectServices
+    room_id: str
+    request_id: str
+    actor_id: str
+    offset: int
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """A handler's output: the new state, plus what to record about it.
+
+    `event_type` being None is only legal for a registration that declares
+    `emits_event=False`; the engine treats any other None as a missing
+    registration rather than letting it pass silently.
+    """
+
+    state: GameState
+    event_type: str | None = None
+    payload: dict[str, JsonValue] = field(default_factory=dict)
+    event_id: str | None = None
+
+
+EffectValidator = Callable[
+    ["ActionEffect", "ValidationVocabulary", "EngineRuntimeSnapshot", "EffectServices"],
+    None,
+]
+
+
+@dataclass(frozen=True)
+class EffectRegistration:
+    """Everything the Engine knows about one effect type."""
+
+    authority: Callable[[ActionEffect, ClassificationContext], AuthorityLevel]
+    apply: Callable[[ActionEffect, ApplyContext], ApplyResult]
+    target_ref: Callable[[ActionEffect], str | None] = lambda effect: None
+    # None means "nothing to check beyond the schema" — an explicit decision,
+    # not a branch someone forgot to write.
+    validate: EffectValidator | None = None
+    reads: tuple[FieldRef, ...] = ()
+    writes: tuple[FieldRef, ...] = ()
+    must_not_exist: tuple[FieldRef, ...] = ()
+    emits_event: bool = True
+
+
+# --------------------------------------------------------------------------- #
+# narrative_only
+# --------------------------------------------------------------------------- #
+def _apply_narrative_only(effect: NarrativeOnlyEffect, ctx: ApplyContext) -> ApplyResult:
+    return ApplyResult(state=ctx.state)
+
+
+# --------------------------------------------------------------------------- #
+# reveal_information / hide_information
+# --------------------------------------------------------------------------- #
+def _validate_information(
+    effect: RevealInformationEffect | HideInformationEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    if effect.information_id not in vocab.information_ids:
+        _reject_target_not_found()
+
+
+def _apply_information(
+    effect: RevealInformationEffect | HideInformationEffect,
+    ctx: ApplyContext,
+) -> ApplyResult:
+    state = ctx.state
+    reveal = isinstance(effect, RevealInformationEffect)
+    if effect.scope == "party":
+        facts = set(state.discovered_facts)
+        (facts.add if reveal else facts.discard)(effect.information_id)
+        state = state.model_copy(
+            update={"discovered_facts": tuple(sorted(facts))},
+            deep=True,
+        )
+    else:
+        actor_facts = deepcopy(state.actor_discovered_facts)
+        facts = set(actor_facts.get(ctx.actor_id, ()))
+        (facts.add if reveal else facts.discard)(effect.information_id)
+        actor_facts[ctx.actor_id] = tuple(sorted(facts))
+        state = state.model_copy(
+            update={"actor_discovered_facts": actor_facts},
+            deep=True,
+        )
+    return ApplyResult(
+        state=state,
+        event_type="information.revealed" if reveal else "information.hidden",
+        payload={"information_id": effect.information_id, "scope": effect.scope},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# set_visibility
+# --------------------------------------------------------------------------- #
+def _authority_set_visibility(
+    effect: SetVisibilityEffect,
+    ctx: ClassificationContext,
+) -> AuthorityLevel:
+    if effect.target_kind == "information":
+        return "L4" if ctx.information_is_pivotal(effect.target_id) else "L2"
+    if (
+        effect.target_id in ctx.runtime_entity_ids
+        or effect.target_id in ctx.runtime_location_ids
+    ):
+        return "L1"
+    if effect.target_kind == "entity" and ctx.entity_is_keeper_only(effect.target_id):
+        return "L4"
+    return "L3"
+
+
+def _validate_set_visibility(
+    effect: SetVisibilityEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    valid = {
+        "information": vocab.information_ids,
+        "entity": vocab.entity_ids,
+        "location": vocab.location_ids,
+    }[effect.target_kind]
+    if effect.target_id not in valid:
+        _reject_target_not_found()
+
+
+def _visibility_knowledge(
+    location_id: str,
+    *,
+    scope: str,
+    visible: bool,
+    previous: LocationKnowledge | None,
+) -> LocationKnowledge:
+    return LocationKnowledge(
+        location_id=location_id,
+        scope="actor" if scope == "actor" else "party",
+        existence="known" if visible else "unknown",
+        localization="located" if visible else "unknown",
+        access=(previous.access if visible and previous is not None else "unknown"),
+        visited=bool(visible and previous and previous.visited),
+        known_connection_ids=(
+            previous.known_connection_ids if visible and previous is not None else ()
+        ),
+    )
+
+
+def _apply_set_visibility(effect: SetVisibilityEffect, ctx: ApplyContext) -> ApplyResult:
+    state = ctx.state
+    overrides = dict(state.visibility_overrides)
+    # Party scope must not be keyed by the acting actor, or no other
+    # actor could ever find the override again. Actor scope keeps the
+    # actor id and wins over the party entry when both exist
+    # (see RuleEngineService._override_allows).
+    key = (
+        f"actor:{ctx.actor_id}:{effect.target_kind}:{effect.target_id}"
+        if effect.scope == "actor"
+        else f"party:{effect.target_kind}:{effect.target_id}"
+    )
+    overrides[key] = effect.visible
+    updates: dict[str, object] = {"visibility_overrides": overrides}
+    if effect.target_kind == "location":
+        knowledge_by_scope = (
+            deepcopy(state.actor_location_knowledge)
+            if effect.scope == "actor"
+            else deepcopy(state.party_location_knowledge)
+        )
+        if effect.scope == "actor":
+            actor_knowledge = knowledge_by_scope.setdefault(ctx.actor_id, {})
+            previous_knowledge = actor_knowledge.get(effect.target_id)
+            actor_knowledge[effect.target_id] = _visibility_knowledge(
+                effect.target_id,
+                scope="actor",
+                visible=effect.visible,
+                previous=previous_knowledge,
+            )
+            updates["actor_location_knowledge"] = knowledge_by_scope
+        else:
+            previous_knowledge = knowledge_by_scope.get(effect.target_id)
+            knowledge_by_scope[effect.target_id] = _visibility_knowledge(
+                effect.target_id,
+                scope="party",
+                visible=effect.visible,
+                previous=previous_knowledge,
+            )
+            updates["party_location_knowledge"] = knowledge_by_scope
+    state = state.model_copy(update=updates, deep=True)
+    return ApplyResult(
+        state=state,
+        event_type="visibility.changed",
+        payload={
+            "target_kind": effect.target_kind,
+            "target_id": effect.target_id,
+            "visible": effect.visible,
+            "scope": effect.scope,
+        },
+    )
+
+
+# --------------------------------------------------------------------------- #
+# enter_location
+# --------------------------------------------------------------------------- #
+def _validate_enter_location(
+    effect: EnterLocationEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    if effect.location_id not in vocab.location_ids:
+        _reject_target_not_found()
+
+
+def _apply_enter_location(effect: EnterLocationEffect, ctx: ApplyContext) -> ApplyResult:
+    state = ctx.state
+    if not ctx.runtime.is_v3:
+        previous = state.scene_id
+        state = state.model_copy(update={"scene_id": effect.location_id}, deep=True)
+        return ApplyResult(
+            state=state,
+            event_type="location.entered",
+            payload={
+                "location_id": effect.location_id,
+                "from_location_id": previous,
+            },
+        )
+
+    resolution = ctx.services.resolve_location_target(
+        ctx.runtime.v3,
+        state,
+        actor_id=ctx.actor_id,
+        target_id=effect.location_id,
+    )
+    contexts = dict(state.actor_position_contexts)
+    knowledge = dict(state.party_location_knowledge)
+    previous_knowledge = knowledge.get(effect.location_id)
+    if resolution.status == "known_reachable":
+        contexts.pop(ctx.actor_id, None)
+        knowledge[effect.location_id] = LocationKnowledge(
+            location_id=effect.location_id,
+            scope="party",
+            existence="known",
+            localization="located",
+            access="reachable",
+            visited=True,
+            known_connection_ids=(
+                previous_knowledge.known_connection_ids
+                if previous_knowledge is not None
+                else ()
+            ),
+        )
+        travel = TravelResolved(
+            destination_id=effect.location_id,
+            path=resolution.path,
+        )
+        state = state.model_copy(
+            update={
+                "scene_id": effect.location_id,
+                "party_location_knowledge": knowledge,
+                "actor_position_contexts": contexts,
+            },
+            deep=True,
+        )
+        return ApplyResult(
+            state=state,
+            event_type="travel.resolved",
+            payload={
+                "destination_id": travel.destination_id,
+                "path": list(travel.path),
+            },
+        )
+    if resolution.status == "known_blocked":
+        assert resolution.boundary is not None
+        assert resolution.reached_location_id is not None
+        travel = TravelInterrupted(
+            destination_id=effect.location_id,
+            current_location_id=resolution.reached_location_id,
+            path=resolution.path,
+            reached_boundary=resolution.boundary,
+        )
+        contexts[ctx.actor_id] = travel
+        knowledge[effect.location_id] = LocationKnowledge(
+            location_id=effect.location_id,
+            scope="party",
+            existence="known",
+            localization="located",
+            access="blocked",
+            visited=bool(previous_knowledge and previous_knowledge.visited),
+            known_connection_ids=(
+                previous_knowledge.known_connection_ids
+                if previous_knowledge is not None
+                else ()
+            ),
+        )
+        state = state.model_copy(
+            update={
+                "scene_id": travel.current_location_id,
+                "party_location_knowledge": knowledge,
+                "actor_position_contexts": contexts,
+            },
+            deep=True,
+        )
+        return ApplyResult(
+            state=state,
+            event_type="travel.interrupted",
+            payload={
+                "destination_id": travel.destination_id,
+                "current_location_id": travel.current_location_id,
+                "path": list(travel.path),
+                "reached_boundary": travel.reached_boundary.to_json_dict(),
+            },
+        )
+    # Reachability is a live read of the location graph, so unlike every other
+    # id check it cannot be settled by the vocabulary pass — this is the one
+    # place application still has to refuse (#347 §3.3).
+    reject(
+        "TARGET_NOT_FOUND",
+        repairability="auto_repairable",
+        fault="agent",
+        player_safe_reason="当前目标不可用于这次行动",
+        internal_reason=(resolution.safe_reason or "当前没有可确认的目标路线"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ensure_runtime_location
+# --------------------------------------------------------------------------- #
+def _validate_ensure_runtime_location(
+    effect: EnsureRuntimeLocationEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    if (
+        effect.location_id in vocab.location_ids
+        or effect.connected_location_id not in vocab.location_ids
+    ):
+        _reject_canon_shadow()
+    if (
+        effect.parent_location_id is not None
+        and effect.parent_location_id not in vocab.location_ids
+    ):
+        _reject_target_not_found()
+
+
+def _apply_ensure_runtime_location(
+    effect: EnsureRuntimeLocationEffect,
+    ctx: ApplyContext,
+) -> ApplyResult:
+    state = ctx.state
+    locations = deepcopy(state.runtime_locations)
+    locations[effect.location_id] = {
+        "name": effect.name,
+        "parent_location_id": effect.parent_location_id,
+        "connected_location_id": effect.connected_location_id,
+        "provenance": "agent_adjudication",
+    }
+    knowledge = dict(state.party_location_knowledge)
+    knowledge[effect.location_id] = LocationKnowledge(
+        location_id=effect.location_id,
+        existence="known",
+        localization="located",
+        access="reachable",
+    )
+    state = state.model_copy(
+        update={
+            "runtime_locations": locations,
+            "party_location_knowledge": knowledge,
+        },
+        deep=True,
+    )
+    return ApplyResult(
+        state=state,
+        event_type="location.created",
+        payload={"location_id": effect.location_id},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ensure_runtime_entity
+# --------------------------------------------------------------------------- #
+def _validate_ensure_runtime_entity(
+    effect: EnsureRuntimeEntityEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    if effect.entity_id in vocab.entity_ids or effect.location_id not in vocab.location_ids:
+        _reject_canon_shadow()
+    if (
+        runtime.is_v3
+        and effect.entity_kind == "object"
+        and (len(effect.entity_id) > 100 or len(effect.name) > 200)
+    ):
+        reject(
+            "RUNTIME_ITEM_TOO_LARGE",
+            repairability="auto_repairable",
+            fault="agent",
+            player_safe_reason="临时物品描述超过当前系统限制",
+        )
+
+
+def _apply_ensure_runtime_entity(
+    effect: EnsureRuntimeEntityEffect,
+    ctx: ApplyContext,
+) -> ApplyResult:
+    state = ctx.state
+    event_id: str | None = None
+    if ctx.runtime.is_v3 and effect.entity_kind == "object":
+        event_id = ctx.services.new_event_id()
+        revision = str(state.event_sequence + ctx.offset)
+        items = deepcopy(state.item_instances)
+        items[effect.entity_id] = ItemInstance(
+            id=effect.entity_id,
+            room_id=ctx.room_id,
+            origin="runtime",
+            definition_id=effect.entity_id,
+            display=ItemDisplay(name=effect.name),
+            item_component=ItemComponent(),
+            custody=ItemCustody(
+                kind="location",
+                ref_id=effect.location_id,
+                form="loose",
+            ),
+            acquisition=ItemAcquisition(
+                source_type="runtime",
+                source_id=effect.location_id,
+                player_safe_label="行动中发现",
+                event_id=event_id,
+                revision=revision,
+            ),
+            created_event_id=event_id,
+            last_event_id=event_id,
+            updated_revision=revision,
+        )
+        party_knowledge = deepcopy(state.party_item_knowledge)
+        party_knowledge[effect.entity_id] = ItemKnowledge(
+            item_id=effect.entity_id,
+            identity="recognized",
+        )
+        state = state.model_copy(
+            update={
+                "item_instances": items,
+                "party_item_knowledge": party_knowledge,
+            },
+            deep=True,
+        )
+    else:
+        entities = deepcopy(state.runtime_entities)
+        entities[effect.entity_id] = {
+            "kind": effect.entity_kind,
+            "name": effect.name,
+            "location_id": effect.location_id,
+            "provenance": "agent_adjudication",
+        }
+        state = state.model_copy(update={"runtime_entities": entities}, deep=True)
+    return ApplyResult(
+        state=state,
+        event_type="entity.created",
+        payload={"entity_id": effect.entity_id, "location_id": effect.location_id},
+        event_id=event_id,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# entity storage routing (#347 §3.3 / P3)
+# --------------------------------------------------------------------------- #
+def resolve_entity_storage(
+    state: GameState,
+    entity_id: str,
+) -> Literal["item_instance", "generic_entity"]:
+    """Which record actually holds this entity's mutable state.
+
+    An entity carrying an `item_component` is materialised into
+    `item_instances` and is the versioned record; everything else lives in
+    `runtime_entities`/`entities`. move/change_state/consume each used to
+    inline this same `.get()` check, three copies of one rule.
+
+    This is a *storage routing* question, deliberately distinct from the
+    existence question `reads`/`writes` answers. It reads live state at
+    application time on purpose: routing depends on what exists now, and the
+    submit-time vocabulary pass runs in a different transaction from
+    `decide`/`decide_post_roll`.
+    """
+
+    return "item_instance" if state.item_instances.get(entity_id) is not None else "generic_entity"
+
+
+def _mutate_generic_entity(
+    state: GameState,
+    entity_id: str,
+    mutate: Callable[[dict], None],
+) -> dict[str, object]:
+    """Apply a change to whichever generic record holds this entity."""
+
+    runtime_entities = deepcopy(state.runtime_entities)
+    entity_states = deepcopy(state.entities)
+    target = runtime_entities.get(entity_id)
+    if target is None:
+        target = entity_states.setdefault(entity_id, {})
+    mutate(target)
+    return {"runtime_entities": runtime_entities, "entities": entity_states}
+
+
+# --------------------------------------------------------------------------- #
+# move_entity
+# --------------------------------------------------------------------------- #
+def _validate_move_entity(
+    effect: MoveEntityEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    if effect.entity_id not in vocab.entity_ids:
+        _reject_target_not_found()
+    if effect.location_id is not None and effect.location_id not in vocab.location_ids:
+        _reject_target_not_found()
+    if effect.holder_actor_id is not None and effect.holder_actor_id not in vocab.actor_ids:
+        _reject_target_not_found()
+    if effect.holder_actor_id is not None and effect.entity_id not in vocab.portable_item_ids:
+        _reject_not_portable()
+
+
+def _apply_move_entity(effect: MoveEntityEffect, ctx: ApplyContext) -> ApplyResult:
+    state = ctx.state
+    event_id: str | None = None
+    if resolve_entity_storage(state, effect.entity_id) == "item_instance":
+        item = state.item_instances[effect.entity_id]
+        event_id = ctx.services.new_event_id()
+        revision = str(state.event_sequence + ctx.offset)
+        custody = (
+            ItemCustody(
+                kind="actor_inventory",
+                ref_id=effect.holder_actor_id,
+                form="carried",
+            )
+            if effect.holder_actor_id is not None
+            else ItemCustody(
+                kind="location",
+                ref_id=effect.location_id,
+                form="placed",
+            )
+        )
+        items = deepcopy(state.item_instances)
+        items[effect.entity_id] = item.model_copy(
+            update={
+                "custody": custody,
+                "version": item.version + 1,
+                "last_event_id": event_id,
+                "updated_revision": revision,
+            }
+        )
+        updates: dict[str, object] = {"item_instances": items}
+        if effect.holder_actor_id is not None:
+            actor_knowledge = deepcopy(state.actor_item_knowledge)
+            actor_knowledge.setdefault(effect.holder_actor_id, {})[effect.entity_id] = (
+                ItemKnowledge(
+                    item_id=effect.entity_id,
+                    scope="actor",
+                    identity="known",
+                )
+            )
+            updates["actor_item_knowledge"] = actor_knowledge
+        else:
+            party_knowledge = deepcopy(state.party_item_knowledge)
+            party_knowledge[effect.entity_id] = ItemKnowledge(
+                item_id=effect.entity_id,
+                identity="recognized",
+            )
+            updates["party_item_knowledge"] = party_knowledge
+        state = state.model_copy(update=updates, deep=True)
+    else:
+        if effect.holder_actor_id is not None:
+            # Defense in depth for authored/rule-owned effects and any
+            # future caller that reaches application without the
+            # proposal validator.  Generic entities may move between
+            # locations, but only ItemInstances have inventory custody.
+            _reject_not_portable()
+
+        def _place(target: dict) -> None:
+            target["location_id"] = effect.location_id
+            target["holder_actor_id"] = effect.holder_actor_id
+
+        state = state.model_copy(
+            update=_mutate_generic_entity(state, effect.entity_id, _place),
+            deep=True,
+        )
+    return ApplyResult(
+        state=state,
+        event_type="entity.moved",
+        payload={
+            "entity_id": effect.entity_id,
+            "location_id": effect.location_id,
+            "holder_actor_id": effect.holder_actor_id,
+        },
+        event_id=event_id,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# change_entity_state
+# --------------------------------------------------------------------------- #
+def _validate_entity_target(
+    effect: ChangeEntityStateEffect | ConsumeEntityEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    if effect.entity_id not in vocab.entity_ids:
+        _reject_target_not_found()
+
+
+def _apply_change_entity_state(
+    effect: ChangeEntityStateEffect,
+    ctx: ApplyContext,
+) -> ApplyResult:
+    state = ctx.state
+    event_id: str | None = None
+    if resolve_entity_storage(state, effect.entity_id) == "item_instance":
+        item = state.item_instances[effect.entity_id]
+        event_id = ctx.services.new_event_id()
+        revision = str(state.event_sequence + ctx.offset)
+        values = deepcopy(item.state.values)
+        values[effect.key] = effect.value
+        items = deepcopy(state.item_instances)
+        items[effect.entity_id] = item.model_copy(
+            update={
+                "state": item.state.model_copy(update={"values": values}),
+                "version": item.version + 1,
+                "last_event_id": event_id,
+                "updated_revision": revision,
+            }
+        )
+        updates: dict[str, object] = {"item_instances": items}
+    else:
+
+        def _set_key(target: dict) -> None:
+            target[effect.key] = effect.value
+
+        updates = _mutate_generic_entity(state, effect.entity_id, _set_key)
+    if ctx.services.is_public_standard_state(effect):
+        public_keys = deepcopy(state.public_entity_state_keys)
+        keys = set(public_keys.get(effect.entity_id, ()))
+        keys.add(effect.key)
+        public_keys[effect.entity_id] = tuple(sorted(keys))
+        updates["public_entity_state_keys"] = public_keys
+    state = state.model_copy(update=updates, deep=True)
+    return ApplyResult(
+        state=state,
+        event_type="entity.state_changed",
+        payload={
+            "entity_id": effect.entity_id,
+            "key": effect.key,
+            "value": effect.value,
+        },
+        event_id=event_id,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# consume_entity
+# --------------------------------------------------------------------------- #
+def _apply_consume_entity(effect: ConsumeEntityEffect, ctx: ApplyContext) -> ApplyResult:
+    state = ctx.state
+    event_id: str | None = None
+    if resolve_entity_storage(state, effect.entity_id) == "item_instance":
+        item = state.item_instances[effect.entity_id]
+        event_id = ctx.services.new_event_id()
+        revision = str(state.event_sequence + ctx.offset)
+        items = deepcopy(state.item_instances)
+        items[effect.entity_id] = item.model_copy(
+            update={
+                "state": item.state.model_copy(update={"status": "retired"}),
+                "version": item.version + 1,
+                "last_event_id": event_id,
+                "updated_revision": revision,
+            }
+        )
+        state = state.model_copy(update={"item_instances": items}, deep=True)
+    else:
+
+        def _consume(target: dict) -> None:
+            target["consumed"] = True
+
+        state = state.model_copy(
+            update=_mutate_generic_entity(state, effect.entity_id, _consume),
+            deep=True,
+        )
+    return ApplyResult(
+        state=state,
+        event_type="entity.consumed",
+        payload={"entity_id": effect.entity_id},
+        event_id=event_id,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# advance_world_time
+# --------------------------------------------------------------------------- #
+def _validate_advance_world_time(
+    effect: AdvanceWorldTimeEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    if not runtime.is_v3:
+        reject(
+            "TIME_POINT_MISMATCH",
+            repairability="auto_repairable",
+            fault="agent",
+            player_safe_reason="当前时间目标与世界时间线不一致",
+        )
+    blocked = services.time_advance_block_reason(tuple(vocab.actor_ids))
+    if blocked is not None:
+        reject(
+            "TIME_ADVANCE_BLOCKED",
+            repairability="requires_player_choice",
+            fault="player",
+            player_safe_reason="当前存在需要玩家先处理的事项，不能推进时间",
+            internal_reason=blocked,
+        )
+    target, _ = services.next_point_after(
+        runtime.v3,
+        vocab.world_time if vocab.world_time is not None else runtime.game_state.world_time,
+    )
+    if effect.to_point_id is not None and effect.to_point_id != target.id:
+        reject(
+            "TIME_POINT_MISMATCH",
+            repairability="auto_repairable",
+            fault="agent",
+            player_safe_reason="当前时间目标与世界时间线不一致",
+            internal_reason=(
+                "advance_world_time 声明的时间点不是时间线上的下一个点: "
+                f"{effect.to_point_id} != {target.id}"
+            ),
+        )
+
+
+def _apply_advance_world_time(
+    effect: AdvanceWorldTimeEffect,
+    ctx: ApplyContext,
+) -> ApplyResult:
+    advanced = ctx.services.advanced_to_next(ctx.runtime.v3, ctx.state.world_time)
+    state = ctx.state.model_copy(update={"world_time": advanced}, deep=True)
+    return ApplyResult(
+        state=state,
+        event_type="time.point_entered",
+        payload={
+            "point_id": advanced.current_point_id,
+            "day_index": advanced.current.day_index,
+            "hour_of_day": advanced.current.hour_of_day,
+            "time_of_day": advanced.time_of_day,
+        },
+    )
+
+
+# --------------------------------------------------------------------------- #
+# mark_core_resolved / set_ending_availability
+# --------------------------------------------------------------------------- #
+def _apply_mark_core_resolved(
+    effect: MarkCoreResolvedEffect,
+    ctx: ApplyContext,
+) -> ApplyResult:
+    state = ctx.state.model_copy(update={"core_resolved": True}, deep=True)
+    return ApplyResult(state=state, event_type="core.resolved")
+
+
+def _apply_set_ending_availability(
+    effect: SetEndingAvailabilityEffect,
+    ctx: ApplyContext,
+) -> ApplyResult:
+    state = ctx.state.model_copy(update={"ending_available": effect.available}, deep=True)
+    return ApplyResult(
+        state=state,
+        event_type="ending.availability_changed",
+        payload={"available": effect.available},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# commit_terminal_ending
+# --------------------------------------------------------------------------- #
+def _reject_terminal_ending(*_args: object, **_kwargs: object) -> NoReturn:
+    reject(
+        "ENDING_REQUIRES_DRAFT",
+        repairability="hard_reject",
+        fault="agent",
+        player_safe_reason="终局必须经过明确确认后才能提交",
+        internal_reason="终局不能由行动效果直接提交，必须确认 EndingDraft",
+    )
+
+
+def _apply_commit_terminal_ending(
+    effect: CommitTerminalEndingEffect,
+    ctx: ApplyContext,
+) -> ApplyResult:
+    # Unreachable through the validated path — validation already refuses this
+    # type outright. Kept as the same defence the original `_apply_effect`
+    # carried, for rule-owned effects that bypass proposal validation.
+    reject(
+        "ENDING_REQUIRES_DRAFT",
+        repairability="hard_reject",
+        fault="agent",
+        player_safe_reason="终局必须经过明确确认后才能提交",
+        classification_coverage="rule_effects_excluded",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# the table
+# --------------------------------------------------------------------------- #
+EFFECTS: dict[str, EffectRegistration] = {
+    "narrative_only": EffectRegistration(
+        authority=lambda effect, ctx: "L0",
+        apply=_apply_narrative_only,
+        emits_event=False,
+    ),
+    "reveal_information": EffectRegistration(
+        authority=lambda effect, ctx: (
+            "L4" if ctx.information_is_pivotal(effect.information_id) else "L2"
+        ),
+        target_ref=lambda effect: effect.information_id,
+        validate=_validate_information,
+        apply=_apply_information,
+        reads=(FieldRef("information_id", "information"),),
+    ),
+    "hide_information": EffectRegistration(
+        authority=lambda effect, ctx: (
+            "L4" if ctx.information_is_pivotal(effect.information_id) else "L2"
+        ),
+        target_ref=lambda effect: effect.information_id,
+        validate=_validate_information,
+        apply=_apply_information,
+        reads=(FieldRef("information_id", "information"),),
+    ),
+    "set_visibility": EffectRegistration(
+        authority=_authority_set_visibility,
+        target_ref=lambda effect: effect.target_id,
+        validate=_validate_set_visibility,
+        apply=_apply_set_visibility,
+        # target_id's vocabulary depends on target_kind, so the check lives in
+        # `validate` rather than in a static FieldRef.
+    ),
+    "enter_location": EffectRegistration(
+        authority=lambda effect, ctx: "L2",
+        target_ref=lambda effect: effect.location_id,
+        validate=_validate_enter_location,
+        apply=_apply_enter_location,
+        reads=(FieldRef("location_id", "locations"),),
+    ),
+    "ensure_runtime_location": EffectRegistration(
+        authority=lambda effect, ctx: "L1",
+        target_ref=lambda effect: effect.location_id,
+        validate=_validate_ensure_runtime_location,
+        apply=_apply_ensure_runtime_location,
+        reads=(
+            FieldRef("connected_location_id", "locations"),
+            FieldRef("parent_location_id", "locations", optional=True),
+        ),
+        writes=(FieldRef("location_id", "locations"),),
+        must_not_exist=(FieldRef("location_id", "locations"),),
+    ),
+    "ensure_runtime_entity": EffectRegistration(
+        authority=lambda effect, ctx: "L1",
+        target_ref=lambda effect: effect.entity_id,
+        validate=_validate_ensure_runtime_entity,
+        apply=_apply_ensure_runtime_entity,
+        reads=(FieldRef("location_id", "locations"),),
+        # A v3 object also joins the portable vocabulary; the engine folds that
+        # in because it depends on `entity_kind`, not on the field alone.
+        writes=(FieldRef("entity_id", "entities"),),
+        must_not_exist=(FieldRef("entity_id", "entities"),),
+    ),
+    "move_entity": EffectRegistration(
+        authority=lambda effect, ctx: (
+            "L3" if effect.holder_actor_id is not None else "L2"
+        ),
+        target_ref=lambda effect: effect.entity_id,
+        validate=_validate_move_entity,
+        apply=_apply_move_entity,
+        reads=(
+            FieldRef("entity_id", "entities"),
+            FieldRef("location_id", "locations", optional=True),
+            FieldRef("holder_actor_id", "actors", optional=True),
+        ),
+    ),
+    "change_entity_state": EffectRegistration(
+        authority=lambda effect, ctx: (
+            "L1" if effect.entity_id in ctx.runtime_entity_ids else "L3"
+        ),
+        target_ref=lambda effect: effect.entity_id,
+        validate=_validate_entity_target,
+        apply=_apply_change_entity_state,
+        reads=(FieldRef("entity_id", "entities"),),
+    ),
+    "consume_entity": EffectRegistration(
+        authority=lambda effect, ctx: (
+            "L4" if ctx.entity_is_keeper_only(effect.entity_id) else "L3"
+        ),
+        target_ref=lambda effect: effect.entity_id,
+        validate=_validate_entity_target,
+        apply=_apply_consume_entity,
+        reads=(FieldRef("entity_id", "entities"),),
+    ),
+    "advance_world_time": EffectRegistration(
+        authority=lambda effect, ctx: "L2",
+        validate=_validate_advance_world_time,
+        apply=_apply_advance_world_time,
+    ),
+    "mark_core_resolved": EffectRegistration(
+        authority=lambda effect, ctx: "L4",
+        # No content to validate: the effect carries no id and no argument.
+        validate=None,
+        apply=_apply_mark_core_resolved,
+    ),
+    "set_ending_availability": EffectRegistration(
+        authority=lambda effect, ctx: "L4",
+        # No content to validate: `available` is a bool the schema already pins.
+        validate=None,
+        apply=_apply_set_ending_availability,
+    ),
+    "commit_terminal_ending": EffectRegistration(
+        authority=lambda effect, ctx: "L5",
+        target_ref=lambda effect: effect.ending_id,
+        validate=_reject_terminal_ending,
+        apply=_apply_commit_terminal_ending,
+    ),
+}
+
+
+def registration_for(effect: ActionEffect) -> EffectRegistration:
+    registration = EFFECTS.get(effect.type)
+    if registration is None:
+        reject(
+            "EFFECT_NOT_REGISTERED",
+            repairability="hard_reject",
+            fault="engine",
+            player_safe_reason="规则引擎无法处理当前效果",
+        )
+    return registration
+
+
+def classify(
+    effect: ActionEffect,
+    ctx: ClassificationContext,
+) -> tuple[AuthorityLevel, str | None]:
+    """The authority proposing this effect takes, and what it points at."""
+
+    registration = registration_for(effect)
+    return registration.authority(effect, ctx), registration.target_ref(effect)
+
+
+def validate(
+    effect: ActionEffect,
+    vocab: ValidationVocabulary,
+    runtime: EngineRuntimeSnapshot,
+    services: EffectServices,
+) -> None:
+    """Refuse an ill-formed effect. A registration with no `validate` has
+    nothing to check beyond what its schema already guarantees."""
+
+    registration = registration_for(effect)
+    if registration.validate is not None:
+        registration.validate(effect, vocab, runtime, services)
+
+
+def apply(effect: ActionEffect, ctx: ApplyContext) -> ApplyResult:
+    """Execute an effect that validation already accepted."""
+
+    registration = registration_for(effect)
+    result = registration.apply(effect, ctx)
+    if registration.emits_event and result.event_type is None:
+        reject(
+            "EFFECT_NOT_REGISTERED",
+            repairability="hard_reject",
+            fault="engine",
+            player_safe_reason="规则引擎无法处理当前效果",
+        )
+    return result
+
+
+def absorb_writes(effect: ActionEffect, vocab: ValidationVocabulary, *, is_v3: bool) -> None:
+    """Fold an accepted effect's `writes` into the vocabulary.
+
+    The first pass of #347 §4.3's two-pass resolution: what an effect
+    introduces is in scope for every effect after it in the same sequence.
+    """
+
+    registration = registration_for(effect)
+    for ref in registration.writes:
+        value = getattr(effect, ref.field, None)
+        if not isinstance(value, str):
+            continue
+        if ref.vocabulary == "locations":
+            vocab.location_ids.add(value)
+        elif ref.vocabulary == "entities":
+            vocab.entity_ids.add(value)
+            # v3 materialises a runtime object into `item_instances`, which is
+            # what makes it portable; a v2 entity or an NPC never becomes one.
+            if is_v3 and getattr(effect, "entity_kind", None) == "object":
+                vocab.portable_item_ids.add(value)
+
+
+__all__ = [
+    "EFFECTS",
+    "ApplyContext",
+    "ApplyResult",
+    "ClassificationContext",
+    "EffectRegistration",
+    "EffectServices",
+    "FieldRef",
+    "ValidationVocabulary",
+    "absorb_writes",
+    "apply",
+    "classification_context",
+    "classify",
+    "reject",
+    "registration_for",
+    "resolve_entity_storage",
+    "validate",
+]

--- a/agent-collaboration-framework/collaboration_framework/registry/predicates.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/predicates.py
@@ -1,0 +1,129 @@
+"""Predicate registry (#347 Phase 1): the closed set of trigger-condition
+names a v3 Rule's ``PredicateCondition`` may reference.
+
+#226 §1 forbids scripts and arbitrary state paths in rules, so a rule can
+only ask questions the Engine registered — this table *is* that closed set.
+Each entry pairs a predicate name with the pure function that evaluates it
+against the current ``GameState``. It is the single source of truth for two
+call sites that, before this registry existed, each hand-rolled their own
+opinion of the same four names:
+
+- ``engine/rules_v3.py::evaluate_condition`` (execution-time — "does this
+  rule fire right now"). A name with no entry evaluates to ``False``, the
+  same fallback the historical ``_UNKNOWN_PREDICATE_IS_FALSE`` constant gave.
+- ``module/validation_v3.py::_condition_issues`` (publish-time — "does this
+  rule even reference something the Engine understands"). A name with no
+  entry is now a hard publish-time rejection (``MODULE_V3_PREDICATE_UNKNOWN``)
+  instead of a silent runtime no-op — the one deliberate, called-out behaviour
+  change in issue #347's otherwise pure-refactor scope.
+
+Only the predicate *name* is a closed set. Each evaluator still does its own
+light ``args`` shape-checking and returns ``False`` on a bad shape rather
+than raising — that runtime leniency is unchanged by this registry; adding
+publish-time arg-schema validation is explicitly out of scope for this phase
+(see issue #347 Phase 1 notes).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from pydantic import JsonValue
+
+if TYPE_CHECKING:  # annotations only — see this package's __init__ docstring.
+    # `module/validation_v3.py` imports this table to check predicate *names*
+    # at publish time. Importing GameState for real would make that a
+    # `module -> engine` edge, which docs/architecture.md §6 forbids.
+    from collaboration_framework.engine.models import GameState
+
+PredicateEvaluator = Callable[[dict[str, JsonValue], "GameState", str], bool]
+
+
+def entity_state(state: GameState, entity_id: str) -> dict:
+    """The one authoritative read of an entity's state flags.
+
+    An entity carrying an `item_component` gets materialised into
+    `item_instances`, and `ChangeEntityStateEffect` then writes **only** to that
+    record (it is the versioned one). Reading just `runtime_entities`/`entities`
+    therefore never observes those writes: the authored defaults sit on one side
+    while every subsequent update lands on the other, so any condition gated on
+    such a flag — `visibility_conditions`, gated edges, event triggers — stays
+    frozen at its initial value forever.
+
+    Resolving here in the same precedence the write side uses (item wins) keeps
+    a single source of truth per flag. The authored state stays the base so
+    defaults survive: a fresh item instance starts with empty `values`.
+    """
+
+    runtime = state.runtime_entities.get(entity_id)
+    base = runtime if runtime is not None else state.entities.get(entity_id, {})
+    item = state.item_instances.get(entity_id)
+    if item is None:
+        return base
+    return {**base, **item.state.values}
+
+
+def _entity_state_is(args: dict[str, JsonValue], state: GameState, actor_id: str) -> bool:
+    entity_id = args.get("entity_id")
+    key = args.get("key")
+    if not isinstance(entity_id, str) or not isinstance(key, str):
+        return False
+    expected = args.get("value", True)
+    current = entity_state(state, entity_id).get(key)
+    # An absent flag reads as False, which is how the authored `== false`
+    # conditions are meant to fire on a fresh room.
+    return (current if current is not None else False) == expected
+
+
+def _time_of_day_is(args: dict[str, JsonValue], state: GameState, actor_id: str) -> bool:
+    return state.world_time.time_of_day == args.get("value")
+
+
+def _information_is(args: dict[str, JsonValue], state: GameState, actor_id: str) -> bool:
+    information_id = args.get("id")
+    if not isinstance(information_id, str):
+        return False
+    return information_id in set(state.discovered_facts) | set(
+        state.actor_discovered_facts.get(actor_id, ())
+    )
+
+
+def _core_resolved(args: dict[str, JsonValue], state: GameState, actor_id: str) -> bool:
+    return state.core_resolved is bool(args.get("value", True))
+
+
+PREDICATES: dict[str, PredicateEvaluator] = {
+    "entity_state_is": _entity_state_is,
+    "time_of_day_is": _time_of_day_is,
+    "information_is": _information_is,
+    "core_resolved": _core_resolved,
+}
+
+
+def is_registered(name: str) -> bool:
+    return name in PREDICATES
+
+
+def evaluate(
+    name: str,
+    args: dict[str, JsonValue],
+    *,
+    state: GameState,
+    actor_id: str,
+) -> bool:
+    """Look up and run a predicate by name; an unregistered name reads False."""
+
+    evaluator = PREDICATES.get(name)
+    if evaluator is None:
+        return False
+    return evaluator(args, state, actor_id)
+
+
+__all__ = [
+    "PREDICATES",
+    "PredicateEvaluator",
+    "entity_state",
+    "evaluate",
+    "is_registered",
+]

--- a/agent-collaboration-framework/collaboration_framework/registry/rule_steps.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/rule_steps.py
@@ -1,0 +1,185 @@
+"""Rule step registry (#347 Phase 3): the closed set of step kinds a v3 Rule's
+execution graph may contain, and what the Engine does when it reaches one.
+
+Four places used to hardcode their own opinion of the ten step kinds, each
+with its own `isinstance` chain: `contracts/module_v3.py::_step_targets` (where
+can this step jump to), `engine/rules_v3.py::walk_rule_from` (does the walk
+continue, finish, or suspend here), `engine/rules_v3.py::agenda_status_for_walk`
+(which Agenda boundary does suspending here mean), and
+`module/validation_v3.py::_rule_issues` (what must hold about this step at
+publish time). A kind added to the union but missed in one of the four failed
+silently.
+
+## Scope: registration and static checking only
+
+This phase deliberately implements **no new execution**. In particular
+`invoke_ruleset_action` has no executor anywhere in the repository and must
+still have none after this: a rule reaching that step suspends, exactly as
+before, and is refused downstream as `RULE_BUDGET_EXCEEDED`. Publish-time
+validation likewise does not gain an "is there an executor for this
+action_id" check — #347 §4.7 is explicit that a declared-but-unconsumed field
+is not a publish failure. Giving that kind real behaviour is a separate issue.
+
+## Why `next_step_ids` delegates instead of owning
+
+`_step_targets` cannot move here: `RuleExecutionSpec`'s own model validator
+calls it to reject a step that jumps to a nonexistent id, and `contracts` is
+forbidden from importing any component package (docs/architecture.md §6). It
+stays the single implementation and this table surfaces it, so there is still
+one source of truth for "where can this step go".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from collaboration_framework.contracts.module_v3 import (
+    CheckStep,
+    RuleStepSpec,
+    _step_targets,
+)
+
+# What reaching a step does to a walk in progress.
+#
+# `suspends` is the overwhelming default: eight of the ten kinds park the walk
+# on the durable RuleAgenda and let something else pick it up. They are one
+# behaviour, not eight, and are registered as such rather than as eight
+# near-identical entries.
+WalkBehavior = Literal["terminal", "produces_effect_and_continues", "suspends"]
+
+# The Agenda boundary a suspension maps to. `check` is the one kind whose
+# answer is not fixed: it depends on the step's own `initiation_kind`.
+AgendaStatus = Literal[
+    "awaiting_active_check",
+    "awaiting_passive_check",
+    "awaiting_presentation",
+    "awaiting_player_input",
+    "running",
+]
+
+
+@dataclass(frozen=True)
+class RuleStepRegistration:
+    """Everything the Engine knows about one step kind."""
+
+    walk_behavior: WalkBehavior
+    # None for kinds that never suspend (`effect`, `finish`); for `check` the
+    # value here is the active-check default and `agenda_status_for` refines it.
+    agenda_status: AgendaStatus | None = None
+
+
+STEP_KINDS: dict[str, RuleStepRegistration] = {
+    "effect": RuleStepRegistration(walk_behavior="produces_effect_and_continues"),
+    "finish": RuleStepRegistration(walk_behavior="terminal"),
+    "check": RuleStepRegistration(
+        walk_behavior="suspends",
+        agenda_status="awaiting_active_check",
+    ),
+    "adjudicated_check": RuleStepRegistration(
+        walk_behavior="suspends",
+        agenda_status="awaiting_active_check",
+    ),
+    "presentation": RuleStepRegistration(
+        walk_behavior="suspends",
+        agenda_status="awaiting_presentation",
+    ),
+    "await_player_input": RuleStepRegistration(
+        walk_behavior="suspends",
+        agenda_status="awaiting_player_input",
+    ),
+    # The four below suspend onto the Agenda and currently have no worker that
+    # resumes them; `running` is what the pre-registry code reported for them
+    # and must stay that way until an issue gives them behaviour.
+    "invoke_ruleset_action": RuleStepRegistration(
+        walk_behavior="suspends",
+        agenda_status="running",
+    ),
+    "create_npc_action_opportunity": RuleStepRegistration(
+        walk_behavior="suspends",
+        agenda_status="running",
+    ),
+    "create_time_task": RuleStepRegistration(
+        walk_behavior="suspends",
+        agenda_status="running",
+    ),
+    "cancel_time_task": RuleStepRegistration(
+        walk_behavior="suspends",
+        agenda_status="running",
+    ),
+}
+
+# `RuleCheckSpec.actor_binding` / `InvokeRulesetActionStep.actor_binding` are
+# free-text today and every authored module only ever writes "actor".
+# #347 §4.8 asks for the value space to be registered and loaded completely,
+# and for nothing else: resolving a binding into an actual list of actors, and
+# letting one suspension await N results, stay out of scope. These mirror
+# `BindingSlotSpec.source`, which already enumerates the same concept for
+# agent_match triggers.
+ACTOR_BINDINGS: frozenset[str] = frozenset({"actor", "target", "scene", "location"})
+
+
+def is_registered(kind: str) -> bool:
+    return kind in STEP_KINDS
+
+
+def registration_for(step: RuleStepSpec) -> RuleStepRegistration | None:
+    return STEP_KINDS.get(step.kind)
+
+
+def walk_behavior_of(step: RuleStepSpec) -> WalkBehavior:
+    """Whether a walk ends, continues, or parks when it reaches this step.
+
+    An unregistered kind suspends: refusing to guess is what the original
+    `walk_rule_from` did with its catch-all, and a walk that parks is
+    recoverable where a walk that guessed wrong is not.
+    """
+
+    registration = STEP_KINDS.get(step.kind)
+    return registration.walk_behavior if registration is not None else "suspends"
+
+
+def agenda_status_for(kind: str, step: RuleStepSpec | None) -> AgendaStatus:
+    """The Agenda boundary that suspending on this kind means."""
+
+    registration = STEP_KINDS.get(kind)
+    if registration is None or registration.agenda_status is None:
+        return "running"
+    # A passive rule check is the Engine asking on the rule's behalf; an active
+    # one is the player's own action waiting on a roll.
+    if (
+        kind == "check"
+        and isinstance(step, CheckStep)
+        and step.check.initiation_kind == "passive_rule"
+    ):
+        return "awaiting_passive_check"
+    return registration.agenda_status
+
+
+def next_step_ids(step: RuleStepSpec) -> tuple[str, ...]:
+    """Every step id this step can hand control to.
+
+    Delegates to `contracts.module_v3._step_targets` — see this module's
+    docstring for why that implementation cannot move here.
+    """
+
+    return _step_targets(step)
+
+
+def is_registered_actor_binding(value: str) -> bool:
+    return value in ACTOR_BINDINGS
+
+
+__all__ = [
+    "ACTOR_BINDINGS",
+    "STEP_KINDS",
+    "AgendaStatus",
+    "RuleStepRegistration",
+    "WalkBehavior",
+    "agenda_status_for",
+    "is_registered",
+    "is_registered_actor_binding",
+    "next_step_ids",
+    "registration_for",
+    "walk_behavior_of",
+]

--- a/agent-collaboration-framework/collaboration_framework/registry/world_actions.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/world_actions.py
@@ -1,0 +1,49 @@
+"""World ruleset action registry (#347 Phase 4).
+
+`InvokeRulesetActionStep.action_id` is the one place a v3 Rule names a world
+ruleset action — "make this actor do the CoC-7e thing called X". It is free
+text today, nothing in the repository reads it, and no executor exists for it:
+a rule that reaches such a step suspends onto the Agenda and is ultimately
+refused as `RULE_BUDGET_EXCEEDED`.
+
+**This table is empty, and that is the correct current state.** It is not a
+half-finished implementation. There is no v3 world action the Engine can
+actually perform, so registering any name here would claim a capability that
+does not exist — exactly the "registered but unrunnable" illusion #347 warns
+about. The v2-era `_SUPPORTED_FORCE_ACTIONS` names in `engine/capabilities.py`
+are deliberately *not* migrated in: they belonged to a runtime that is gone.
+
+What this module is for is the place to put the first real one, and the
+explicit statement that today there are none.
+
+## Deliberately not wired into publish-time validation
+
+A module containing `invoke_ruleset_action` with any `action_id` publishes
+today as long as its step graph is well-formed, and it must keep publishing
+after this phase. #347 §4.7 is explicit: a field with no consumer is not a
+publish failure. Consulting this table to reject such a module would turn an
+empty registry into a content-wide outage. "No executor" stays a runtime
+outcome, on the same path it already took.
+
+Shape follows `engine/capabilities.py`'s `SUPPORTED_WORLD_REFS`: a frozenset
+of what the runtime can actually do, and a membership test.
+"""
+
+from __future__ import annotations
+
+# Empty on purpose — see the module docstring. Adding a name here is a claim
+# that the Engine can execute it, so it belongs in the same change that adds
+# the executor, never ahead of one.
+SUPPORTED_WORLD_ACTIONS: frozenset[str] = frozenset()
+
+
+def is_registered(action_id: str) -> bool:
+    """Whether the Engine has an executor for this world ruleset action.
+
+    Currently False for every input.
+    """
+
+    return action_id in SUPPORTED_WORLD_ACTIONS
+
+
+__all__ = ["SUPPORTED_WORLD_ACTIONS", "is_registered"]

--- a/agent-collaboration-framework/docs/architecture.md
+++ b/agent-collaboration-framework/docs/architecture.md
@@ -117,6 +117,7 @@ capability 看到与当前回合有关的内容。
 flowchart TD
     CONTRACTS["contracts"]
     XPORTS["ports"] --> CONTRACTS
+    REGISTRY["registry"] --> CONTRACTS
     HSCHEMA["host/schemas"] --> CONTRACTS
     HPORTS["host/ports"] --> CONTRACTS
     HAPP["host/application"] --> HSCHEMA
@@ -127,15 +128,23 @@ flowchart TD
     HADAPTER["host/adapters"] --> HPORTS
     ENGINE["engine"] --> XPORTS
     ENGINE --> CONTRACTS
+    ENGINE --> REGISTRY
     MODULE["module"] --> CONTRACTS
+    MODULE --> REGISTRY
     BACKEND["backend adapters/controllers"] --> HAPP
     BACKEND --> HPROMPT
     BACKEND --> ENGINE
 ```
 
+`registry`（#347）是引擎自带的封闭登记表：Rule 只能引用表里已登记的条目，模组数据不能定义新条目。
+它同时被 `engine`（执行期求值）和 `module`（发布期校验）读取，而 `module -> engine` 是禁止的，
+所以它与 `contracts` 同级、作为叶子存在，运行时只依赖 `contracts`；求值函数需要的引擎状态模型
+一律放在 `TYPE_CHECKING` 块里，只用于类型注解，不构成运行时依赖边。
+
 禁止反向依赖：
 
-- `contracts -> host/engine/module`
+- `contracts -> host/engine/module/registry`
+- `registry -> host/engine/module`（仅允许 `TYPE_CHECKING` 下的类型注解导入）
 - `engine -> host`
 - `host -> engine/module`
 - `module -> engine/host`

--- a/agent-collaboration-framework/tests/test_architecture.py
+++ b/agent-collaboration-framework/tests/test_architecture.py
@@ -19,9 +19,49 @@ def imports_for(path: Path) -> set[str]:
     return imports
 
 
+def runtime_imports_for(path: Path) -> set[str]:
+    """`imports_for`, minus anything only imported for type annotations.
+
+    A name imported inside `if TYPE_CHECKING:` never executes, so it creates
+    no runtime dependency edge — the distinction that lets a leaf package
+    annotate against a component's models without depending on it.
+    """
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    type_checking_nodes: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        is_type_checking = (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+            isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+        )
+        if is_type_checking:
+            for child in ast.walk(node):
+                type_checking_nodes.add(id(child))
+
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if id(node) in type_checking_nodes:
+            continue
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return imports
+
+
 class ArchitectureTests(unittest.TestCase):
     def test_modular_monolith_directories_exist(self) -> None:
-        for name in ("contracts", "ports", "host", "engine", "module", "bootstrap"):
+        for name in (
+            "contracts",
+            "ports",
+            "host",
+            "engine",
+            "module",
+            "bootstrap",
+            "registry",
+        ):
             self.assertTrue((PACKAGE / name).is_dir(), name)
 
     def test_obsolete_flat_modules_are_removed(self) -> None:
@@ -38,6 +78,7 @@ class ArchitectureTests(unittest.TestCase):
                             "collaboration_framework.engine",
                             "collaboration_framework.module",
                             "collaboration_framework.bootstrap",
+                            "collaboration_framework.registry",
                         )
                     ),
                     f"{path.name}: {imported}",
@@ -104,6 +145,33 @@ class ArchitectureTests(unittest.TestCase):
             for imported in imports_for(path):
                 self.assertFalse(
                     imported.startswith("collaboration_framework.host"),
+                    f"{path.relative_to(PACKAGE)}: {imported}",
+                )
+
+    def test_registry_stays_a_leaf(self) -> None:
+        """The #347 registry tables are engine-shipped lookup data, not
+        orchestration.
+
+        Both `engine` (execution time) and `module` (publish-time validation)
+        read these tables, and §6 of docs/architecture.md forbids
+        `module -> engine`. So the tables cannot live under `engine/`: they sit
+        alongside `contracts/` as a leaf, and must not import any component
+        package at runtime. An evaluator needing an engine state model imports
+        it under `TYPE_CHECKING` for annotations only, which is why this check
+        ignores type-checking blocks.
+        """
+
+        for path in (PACKAGE / "registry").rglob("*.py"):
+            for imported in runtime_imports_for(path):
+                self.assertFalse(
+                    imported.startswith(
+                        (
+                            "collaboration_framework.host",
+                            "collaboration_framework.engine",
+                            "collaboration_framework.module",
+                            "collaboration_framework.bootstrap",
+                        )
+                    ),
                     f"{path.relative_to(PACKAGE)}: {imported}",
                 )
 

--- a/agent-collaboration-framework/tests/test_module_content_v3.py
+++ b/agent-collaboration-framework/tests/test_module_content_v3.py
@@ -79,7 +79,15 @@ def module_payload() -> dict[str, Any]:
                 "traversal": "gated",
                 "access_point_id": "library_door",
                 "conditions": [
-                    {"op": "predicate", "predicate": "door_unlocked", "args": {"id": "library_door"}}
+                    {
+                        "op": "predicate",
+                        "predicate": "entity_state_is",
+                        "args": {
+                            "entity_id": "library_door",
+                            "key": "unlocked",
+                            "value": True,
+                        },
+                    }
                 ],
                 "travel_cost": {"minutes": 10},
             }

--- a/agent-collaboration-framework/tests/test_registry_effects.py
+++ b/agent-collaboration-framework/tests/test_registry_effects.py
@@ -1,0 +1,209 @@
+"""The effect registry's structural guarantees (issue #347 Phase 2).
+
+`engine/adjudication.py` used to answer four separate questions about an
+effect type in four unrelated `isinstance` chains, and nothing noticed when
+one of them missed a type. These tests pin the guarantee that replaced that:
+one registration per effect type, complete, or the suite fails.
+"""
+
+from __future__ import annotations
+
+import typing
+import unittest
+
+from collaboration_framework.contracts import ActionEffect
+from collaboration_framework.registry import effects as effect_registry
+
+
+def effect_type_names() -> set[str]:
+    """Every `type` literal in the ActionEffect discriminated union."""
+
+    annotated_args = typing.get_args(ActionEffect)
+    variants = typing.get_args(annotated_args[0])
+    return {variant.model_fields["type"].default for variant in variants}
+
+
+class RegistryCompletenessTests(unittest.TestCase):
+    def test_every_effect_type_is_registered(self) -> None:
+        """A new effect type with no registration must break the build.
+
+        This is the mechanism issue #347 §6 asks for: adding an effect type is
+        one registration, and forgetting it is caught here rather than showing
+        up as a silent runtime no-op.
+        """
+
+        self.assertEqual(effect_type_names(), set(effect_registry.EFFECTS))
+
+    def test_no_registration_exists_for_an_unknown_type(self) -> None:
+        self.assertNotIn("made_up_effect", effect_registry.EFFECTS)
+
+    def test_every_registration_can_apply_and_classify(self) -> None:
+        for name, registration in effect_registry.EFFECTS.items():
+            with self.subTest(effect=name):
+                self.assertTrue(callable(registration.authority))
+                self.assertTrue(callable(registration.apply))
+                self.assertTrue(callable(registration.target_ref))
+
+
+class AccessDeclarationTests(unittest.TestCase):
+    """The reads/writes declarations from #347 §4.4."""
+
+    def test_declared_fields_exist_on_their_effect_type(self) -> None:
+        variants = {
+            variant.model_fields["type"].default: variant
+            for variant in typing.get_args(typing.get_args(ActionEffect)[0])
+        }
+        for name, registration in effect_registry.EFFECTS.items():
+            model = variants[name]
+            refs = registration.reads + registration.writes + registration.must_not_exist
+            for ref in refs:
+                with self.subTest(effect=name, field=ref.field):
+                    self.assertIn(
+                        ref.field,
+                        model.model_fields,
+                        f"{name} declares a {ref.field} it does not have",
+                    )
+
+    def test_runtime_creators_declare_their_own_id_as_must_not_exist(self) -> None:
+        """`ensure_runtime_*` name an id that must NOT already exist.
+
+        That is neither a read nor a write of an existing vocabulary entry, so
+        #347 §4.4 gives it its own declaration rather than overloading either.
+        """
+
+        for name, own_field in (
+            ("ensure_runtime_location", "location_id"),
+            ("ensure_runtime_entity", "entity_id"),
+        ):
+            with self.subTest(effect=name):
+                registration = effect_registry.EFFECTS[name]
+                self.assertEqual(
+                    [ref.field for ref in registration.must_not_exist],
+                    [own_field],
+                )
+                self.assertEqual(
+                    [ref.field for ref in registration.writes],
+                    [own_field],
+                )
+
+    def test_only_runtime_creators_introduce_new_ids(self) -> None:
+        creators = {
+            name
+            for name, registration in effect_registry.EFFECTS.items()
+            if registration.writes
+        }
+        self.assertEqual(
+            creators, {"ensure_runtime_location", "ensure_runtime_entity"}
+        )
+
+
+class NoOpValidationIsExplicitTests(unittest.TestCase):
+    """Three effect types genuinely have nothing to validate.
+
+    Before the registry they were the types with no `elif` branch, so "passes
+    validation" and "someone forgot to write the branch" looked identical.
+    They now say so explicitly, and this test is what keeps that a decision
+    rather than an omission.
+    """
+
+    def test_types_without_content_to_check_declare_no_validator(self) -> None:
+        for name in ("narrative_only", "mark_core_resolved", "set_ending_availability"):
+            with self.subTest(effect=name):
+                self.assertIsNone(effect_registry.EFFECTS[name].validate)
+
+    def test_every_other_type_has_a_validator(self) -> None:
+        exempt = {"narrative_only", "mark_core_resolved", "set_ending_availability"}
+        for name, registration in effect_registry.EFFECTS.items():
+            if name in exempt:
+                continue
+            with self.subTest(effect=name):
+                self.assertIsNotNone(registration.validate)
+
+
+class EntityStorageRoutingTests(unittest.TestCase):
+    """`resolve_entity_storage` — the P3 deduplication (#347 §3.3).
+
+    move_entity / change_entity_state / consume_entity each inlined the same
+    `state.item_instances.get(...)` check, three copies of one rule. The
+    end-to-end consequence (create a runtime object, then take it, in one
+    sequence) is covered by
+    `test_projection_v3.py::AdjudicationAgainstV3Tests`; this pins the
+    extracted helper itself.
+    """
+
+    def _state(self, **overrides):
+        from collaboration_framework.engine import ActorState, GameState
+
+        base = {
+            "room_id": "room",
+            "scene_id": "start",
+            "actors": {
+                "actor": ActorState(
+                    player_id="player",
+                    name="调查员",
+                    source_character_id="character",
+                    source_character_version=1,
+                )
+            },
+            "entities": {},
+        }
+        base.update(overrides)
+        return GameState(**base)
+
+    def test_an_id_with_an_item_instance_routes_to_the_versioned_record(self) -> None:
+        from collaboration_framework.contracts import (
+            ItemComponent,
+            ItemCustody,
+            ItemDisplay,
+            ItemInstance,
+        )
+
+        item = ItemInstance(
+            id="pebble",
+            room_id="room",
+            origin="runtime",
+            definition_id="pebble",
+            display=ItemDisplay(name="一枚普通石子"),
+            item_component=ItemComponent(),
+            custody=ItemCustody(kind="location", ref_id="library", form="loose"),
+            created_event_id="evt_created",
+            last_event_id="evt_created",
+            updated_revision="1",
+        )
+        state = self._state(item_instances={"pebble": item})
+        self.assertEqual(
+            effect_registry.resolve_entity_storage(state, "pebble"), "item_instance"
+        )
+
+    def test_an_id_without_one_routes_to_the_generic_record(self) -> None:
+        state = self._state(runtime_entities={"librarian": {"kind": "npc"}})
+        self.assertEqual(
+            effect_registry.resolve_entity_storage(state, "librarian"),
+            "generic_entity",
+        )
+
+    def test_an_unknown_id_routes_to_the_generic_record(self) -> None:
+        # Existence is the vocabulary pass's job, not routing's; an id that got
+        # this far is already known to exist.
+        self.assertEqual(
+            effect_registry.resolve_entity_storage(self._state(), "nothing"),
+            "generic_entity",
+        )
+
+
+class EventEmissionTests(unittest.TestCase):
+    def test_only_narrative_only_emits_no_event(self) -> None:
+        """`event_type` used to be a local variable each branch had to remember
+        to set, with a `None` check at the end standing in for "unregistered".
+        Which types legitimately record nothing is now declared."""
+
+        silent = {
+            name
+            for name, registration in effect_registry.EFFECTS.items()
+            if not registration.emits_event
+        }
+        self.assertEqual(silent, {"narrative_only"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-collaboration-framework/tests/test_registry_rule_steps.py
+++ b/agent-collaboration-framework/tests/test_registry_rule_steps.py
@@ -1,0 +1,153 @@
+"""Rule step and world action registries (issue #347 Phases 3 and 4).
+
+These two phases are registration-and-static-checking only. The tests that
+matter most here are the ones pinning what must *not* have changed:
+`invoke_ruleset_action` still has no executor, and a module using it still
+publishes.
+"""
+
+from __future__ import annotations
+
+import typing
+import unittest
+
+from collaboration_framework.contracts.module_v3 import RuleStepSpec
+from collaboration_framework.registry import rule_steps as rule_step_registry
+from collaboration_framework.registry import world_actions as world_action_registry
+
+SUSPENDING_KINDS = {
+    "check",
+    "adjudicated_check",
+    "presentation",
+    "await_player_input",
+    "invoke_ruleset_action",
+    "create_npc_action_opportunity",
+    "create_time_task",
+    "cancel_time_task",
+}
+
+
+def step_kind_names() -> set[str]:
+    variants = typing.get_args(typing.get_args(RuleStepSpec)[0])
+    return {variant.model_fields["kind"].default for variant in variants}
+
+
+class RegistryCompletenessTests(unittest.TestCase):
+    def test_every_step_kind_is_registered(self) -> None:
+        """A kind added to the union but missed here must break the build —
+        the failure mode that used to slip through four separate dispatch
+        sites."""
+
+        self.assertEqual(step_kind_names(), set(rule_step_registry.STEP_KINDS))
+
+    def test_exactly_two_kinds_drive_the_walk(self) -> None:
+        behaviors: dict[str, set[str]] = {}
+        for kind, registration in rule_step_registry.STEP_KINDS.items():
+            behaviors.setdefault(registration.walk_behavior, set()).add(kind)
+        self.assertEqual(behaviors["terminal"], {"finish"})
+        self.assertEqual(behaviors["produces_effect_and_continues"], {"effect"})
+        self.assertEqual(behaviors["suspends"], SUSPENDING_KINDS)
+
+
+class AgendaStatusTests(unittest.TestCase):
+    def test_simple_kinds_map_to_their_boundary(self) -> None:
+        for kind, expected in (
+            ("adjudicated_check", "awaiting_active_check"),
+            ("presentation", "awaiting_presentation"),
+            ("await_player_input", "awaiting_player_input"),
+        ):
+            with self.subTest(kind=kind):
+                self.assertEqual(
+                    rule_step_registry.agenda_status_for(kind, None), expected
+                )
+
+    def test_kinds_without_a_worker_report_running(self) -> None:
+        """These four park on the Agenda with nothing to resume them. That was
+        true before the registry and must stay true after it."""
+
+        for kind in (
+            "invoke_ruleset_action",
+            "create_npc_action_opportunity",
+            "create_time_task",
+            "cancel_time_task",
+        ):
+            with self.subTest(kind=kind):
+                self.assertEqual(
+                    rule_step_registry.agenda_status_for(kind, None), "running"
+                )
+
+    def test_check_splits_on_its_own_initiation_kind(self) -> None:
+        from collaboration_framework.contracts.module_v3 import CheckStep, RuleCheckSpec
+
+        def check_step(initiation_kind: str) -> CheckStep:
+            return CheckStep(
+                id="s1",
+                check=RuleCheckSpec(
+                    profile_id="p",
+                    actor_binding="actor",
+                    initiation_kind=initiation_kind,
+                ),
+                result_routes={"regular_success": "s2"},
+            )
+
+        self.assertEqual(
+            rule_step_registry.agenda_status_for("check", check_step("passive_rule")),
+            "awaiting_passive_check",
+        )
+        self.assertEqual(
+            rule_step_registry.agenda_status_for("check", check_step("active_action")),
+            "awaiting_active_check",
+        )
+
+    def test_an_unregistered_kind_reports_running(self) -> None:
+        self.assertEqual(
+            rule_step_registry.agenda_status_for("made_up_kind", None), "running"
+        )
+
+
+class ActorBindingTests(unittest.TestCase):
+    def test_the_value_every_authored_module_uses_is_registered(self) -> None:
+        self.assertTrue(rule_step_registry.is_registered_actor_binding("actor"))
+
+    def test_unknown_bindings_are_not_registered(self) -> None:
+        self.assertFalse(rule_step_registry.is_registered_actor_binding("everyone"))
+
+    def test_the_value_space_mirrors_binding_slot_source(self) -> None:
+        """`BindingSlotSpec.source` already enumerates this same concept for
+        agent_match triggers; the two must not drift apart."""
+
+        from collaboration_framework.contracts.module_v3 import BindingSlotSpec
+
+        source_values = set(
+            typing.get_args(BindingSlotSpec.model_fields["source"].annotation)
+        )
+        self.assertEqual(rule_step_registry.ACTOR_BINDINGS, frozenset(source_values))
+
+
+class WorldActionRegistryTests(unittest.TestCase):
+    def test_the_table_is_empty(self) -> None:
+        """Empty is the correct state, not an unfinished one — see the module
+        docstring. This test exists so that adding a name is a deliberate act
+        that has to update it."""
+
+        self.assertEqual(world_action_registry.SUPPORTED_WORLD_ACTIONS, frozenset())
+
+    def test_no_action_id_is_currently_executable(self) -> None:
+        for action_id in ("coc7e.sanity_check", "attack", "anything"):
+            with self.subTest(action_id=action_id):
+                self.assertFalse(world_action_registry.is_registered(action_id))
+
+    def test_v2_force_action_names_were_not_migrated_in(self) -> None:
+        """`engine/capabilities.py` still carries v2's `_SUPPORTED_FORCE_ACTIONS`.
+        Those belong to a runtime that no longer exists; migrating them here
+        would claim v3 capabilities nothing implements."""
+
+        from collaboration_framework.engine.capabilities import _SUPPORTED_FORCE_ACTIONS
+
+        for action in _SUPPORTED_FORCE_ACTIONS:
+            with self.subTest(action=action):
+                self.assertFalse(world_action_registry.is_registered(action))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-collaboration-framework/tests/test_rules_v3_predicates.py
+++ b/agent-collaboration-framework/tests/test_rules_v3_predicates.py
@@ -1,0 +1,166 @@
+"""Direct unit coverage for ``rules_v3._evaluate_predicate`` (issue #347 Phase 0).
+
+Every known predicate branch, plus the unknown-name fallback, is exercised here
+directly against a minimal ``GameState`` — no module fixture needed. Before this
+file existed, none of the four known branches had a direct test; only the
+unknown-predicate fallback was covered indirectly via
+``test_projection_v3.py::test_an_unregistered_predicate_never_fires_a_rule``.
+This is the safety net issue #347 Phase 1 (``registry/predicates.py``) extracts
+against, so these assertions must keep passing unchanged after that refactor.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from collaboration_framework.contracts import PredicateCondition
+from collaboration_framework.engine import ActorState, GameState
+from collaboration_framework.engine.models import WorldTimePoint, WorldTimeState
+from collaboration_framework.engine.rules_v3 import _evaluate_predicate
+
+ROOM = "predicate-room"
+ACTOR = "predicate-actor"
+PLAYER = "predicate-player"
+
+
+def game_state(**overrides) -> GameState:
+    base = {
+        "room_id": ROOM,
+        "scene_id": "start",
+        "actors": {
+            ACTOR: ActorState(
+                player_id=PLAYER,
+                name="调查员",
+                source_character_id="character",
+                source_character_version=1,
+            )
+        },
+        "entities": {},
+    }
+    base.update(overrides)
+    return GameState(**base)
+
+
+def predicate(name: str, **args) -> PredicateCondition:
+    return PredicateCondition(predicate=name, args=args)
+
+
+class EntityStateIsTests(unittest.TestCase):
+    def test_matches_when_flag_equals_expected_value(self) -> None:
+        state = game_state(entities={"door": {"locked": True}})
+        condition = predicate("entity_state_is", entity_id="door", key="locked", value=True)
+        self.assertTrue(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_mismatched_value_reads_false(self) -> None:
+        state = game_state(entities={"door": {"locked": False}})
+        condition = predicate("entity_state_is", entity_id="door", key="locked", value=True)
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_missing_key_reads_false_by_default(self) -> None:
+        # The docstring on entity_state()/_evaluate_predicate says an absent flag
+        # reads as False, which is how authored `== false` conditions are meant
+        # to fire on a fresh room. A missing key defaults `value` to True, so the
+        # comparison (False == True) must be False.
+        state = game_state(entities={"door": {}})
+        condition = predicate("entity_state_is", entity_id="door", key="locked")
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_missing_key_matches_explicit_false_expectation(self) -> None:
+        state = game_state(entities={"door": {}})
+        condition = predicate("entity_state_is", entity_id="door", key="locked", value=False)
+        self.assertTrue(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_non_string_entity_id_reads_false(self) -> None:
+        state = game_state()
+        condition = predicate("entity_state_is", entity_id=1, key="locked")
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_non_string_key_reads_false(self) -> None:
+        state = game_state(entities={"door": {"locked": True}})
+        condition = predicate("entity_state_is", entity_id="door", key=1)
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+
+class TimeOfDayIsTests(unittest.TestCase):
+    def test_default_world_time_is_day(self) -> None:
+        state = game_state()  # WorldTimeState default is hour 12 -> "day"
+        condition = predicate("time_of_day_is", value="day")
+        self.assertTrue(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_default_world_time_does_not_match_night(self) -> None:
+        state = game_state()
+        condition = predicate("time_of_day_is", value="night")
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_night_hour_matches_night(self) -> None:
+        state = game_state(
+            world_time=WorldTimeState(
+                current=WorldTimePoint(day_index=0, hour_of_day=2),
+                current_point_id="hour_02",
+            )
+        )
+        condition = predicate("time_of_day_is", value="night")
+        self.assertTrue(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+
+class InformationIsTests(unittest.TestCase):
+    def test_party_wide_discovered_fact_matches(self) -> None:
+        state = game_state(discovered_facts=("clue_a",))
+        condition = predicate("information_is", id="clue_a")
+        self.assertTrue(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_actor_scoped_discovered_fact_matches(self) -> None:
+        state = game_state(actor_discovered_facts={ACTOR: ("clue_b",)})
+        condition = predicate("information_is", id="clue_b")
+        self.assertTrue(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_undiscovered_fact_reads_false(self) -> None:
+        state = game_state()
+        condition = predicate("information_is", id="clue_c")
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_another_actors_fact_does_not_leak(self) -> None:
+        state = game_state(actor_discovered_facts={"someone-else": ("clue_d",)})
+        condition = predicate("information_is", id="clue_d")
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_non_string_id_reads_false(self) -> None:
+        state = game_state()
+        condition = predicate("information_is", id=1)
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+
+class CoreResolvedTests(unittest.TestCase):
+    def test_default_args_expect_true_and_matches_resolved_state(self) -> None:
+        state = game_state(core_resolved=True)
+        condition = predicate("core_resolved")
+        self.assertTrue(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_default_args_do_not_match_unresolved_state(self) -> None:
+        state = game_state(core_resolved=False)
+        condition = predicate("core_resolved")
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_explicit_false_matches_unresolved_state(self) -> None:
+        state = game_state(core_resolved=False)
+        condition = predicate("core_resolved", value=False)
+        self.assertTrue(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+
+class UnknownPredicateFallbackTests(unittest.TestCase):
+    def test_unknown_predicate_name_reads_false(self) -> None:
+        state = game_state()
+        condition = predicate("made_up_predicate", anything="here")
+        self.assertFalse(_evaluate_predicate(condition, state=state, actor_id=ACTOR))
+
+    def test_unknown_predicate_name_does_not_raise(self) -> None:
+        state = game_state()
+        condition = predicate("another_unregistered_name")
+        try:
+            _evaluate_predicate(condition, state=state, actor_id=ACTOR)
+        except Exception as exc:  # pragma: no cover - failure path only
+            self.fail(f"unknown predicate must not raise, got {exc!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-collaboration-framework/tests/test_validation_v3.py
+++ b/agent-collaboration-framework/tests/test_validation_v3.py
@@ -1,0 +1,105 @@
+"""Publish-time predicate-name validation (issue #347 Phase 1).
+
+`module/validation_v3.py::_condition_issues` now rejects a `PredicateCondition`
+whose name is not in `engine/registry/predicates.py` — the one deliberate,
+called-out behaviour change in issue #347's otherwise pure-refactor scope
+(previously such a rule passed publish and simply never fired at runtime).
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from collaboration_framework.contracts import ModuleContentV3
+from collaboration_framework.contracts.module_v3 import (
+    AllCondition,
+    NotCondition,
+    PredicateCondition,
+)
+from collaboration_framework.module.validation_v3 import (
+    _condition_issues,
+    validate_module_v3,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = (
+    ROOT
+    / "docs"
+    / "module-parser"
+    / "examples"
+    / "module-content-validation"
+)
+
+
+class ConditionIssuesTests(unittest.TestCase):
+    def test_registered_predicate_name_has_no_issue(self) -> None:
+        condition = PredicateCondition(predicate="entity_state_is", args={})
+        self.assertEqual(_condition_issues(condition, "path"), [])
+
+    def test_unknown_predicate_name_is_rejected(self) -> None:
+        condition = PredicateCondition(predicate="made_up_predicate", args={})
+        issues = _condition_issues(condition, "rules.0.trigger.when")
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].code, "MODULE_V3_PREDICATE_UNKNOWN")
+        self.assertEqual(issues[0].path, "rules.0.trigger.when.predicate")
+
+    def test_empty_predicate_name_still_rejected_with_its_own_code(self) -> None:
+        # The empty-name check must keep winning over the unknown-name check —
+        # a blank string is not itself a registered name, but the more
+        # specific/pre-existing MODULE_V3_PREDICATE_EMPTY code is more useful.
+        # `model_construct` bypasses the pydantic field validator (min_length=1
+        # after whitespace stripping) so this shape can be exercised directly,
+        # same as `_condition_issues` already had to defend against it.
+        condition = PredicateCondition.model_construct(
+            op="predicate", predicate=" ", args={}
+        )
+        issues = _condition_issues(condition, "path")
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].code, "MODULE_V3_PREDICATE_EMPTY")
+
+    def test_unknown_predicate_nested_in_logical_combinators_is_found(self) -> None:
+        condition = NotCondition(
+            item=AllCondition(
+                items=(
+                    PredicateCondition(predicate="core_resolved", args={}),
+                    PredicateCondition(predicate="made_up_predicate", args={}),
+                )
+            )
+        )
+        issues = _condition_issues(condition, "path")
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].code, "MODULE_V3_PREDICATE_UNKNOWN")
+        self.assertEqual(issues[0].path, "path.item.items.1.predicate")
+
+
+class RealFixturesStillPublishTests(unittest.TestCase):
+    """The predicate names real, already-shipping modules use must all be
+    registered — otherwise this phase would break existing content on the day
+    it lands. This is the "grep every fixture before landing" check from the
+    implementation plan, pinned as a regression test.
+    """
+
+    def test_known_v3_fixtures_pass_validation_unchanged(self) -> None:
+        fixture_dirs = [p for p in FIXTURES.iterdir() if p.is_dir()]
+        self.assertTrue(fixture_dirs, "expected at least one v3 fixture module")
+        for directory in fixture_dirs:
+            content_path = directory / "module-content-v3.json"
+            if not content_path.exists():
+                continue
+            with self.subTest(module=directory.name):
+                content = ModuleContentV3.model_validate_json(
+                    content_path.read_text(encoding="utf-8")
+                )
+                report = validate_module_v3(content)
+                predicate_issues = [
+                    issue
+                    for issue in report.errors
+                    if issue.code
+                    in ("MODULE_V3_PREDICATE_UNKNOWN", "MODULE_V3_PREDICATE_EMPTY")
+                ]
+                self.assertEqual(predicate_issues, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-collaboration-framework/tests/test_validation_v3.py
+++ b/agent-collaboration-framework/tests/test_validation_v3.py
@@ -73,6 +73,70 @@ class ConditionIssuesTests(unittest.TestCase):
         self.assertEqual(issues[0].path, "path.item.items.1.predicate")
 
 
+class ActorBindingValidationTests(unittest.TestCase):
+    """`actor_binding` is checked against the registered value space (#347 §4.8)."""
+
+    def _check_step(self, binding: str):
+        from collaboration_framework.contracts.module_v3 import CheckStep, RuleCheckSpec
+        from collaboration_framework.module.validation_v3 import _actor_binding_issues
+
+        step = CheckStep(
+            id="s1",
+            check=RuleCheckSpec(
+                profile_id="p",
+                actor_binding=binding,
+                initiation_kind="active_action",
+            ),
+            result_routes={"regular_success": "s2"},
+        )
+        return _actor_binding_issues(step, "rules.0.execution.steps.0")
+
+    def test_registered_binding_passes(self) -> None:
+        self.assertEqual(self._check_step("actor"), [])
+
+    def test_unregistered_binding_is_rejected_with_a_path(self) -> None:
+        issues = self._check_step("everyone")
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].code, "MODULE_V3_ACTOR_BINDING_UNKNOWN")
+        self.assertEqual(
+            issues[0].path, "rules.0.execution.steps.0.check.actor_binding"
+        )
+
+    def test_steps_without_the_field_are_skipped(self) -> None:
+        from collaboration_framework.contracts.module_v3 import FinishStep
+        from collaboration_framework.module.validation_v3 import _actor_binding_issues
+
+        self.assertEqual(_actor_binding_issues(FinishStep(id="s1"), "path"), [])
+
+
+class UnimplementedStepKindsStillPublishTests(unittest.TestCase):
+    """#347 §4.7: a declared field with no consumer is not a publish failure.
+
+    `invoke_ruleset_action` has no executor and `registry/world_actions.py` is
+    empty, so it is tempting to start refusing these modules at publish time.
+    That would be a behaviour change, and a content-wide one. "No executor"
+    must stay a runtime outcome.
+    """
+
+    def test_invoke_ruleset_action_publishes_with_any_action_id(self) -> None:
+        from collaboration_framework.contracts.module_v3 import (
+            InvokeRulesetActionStep,
+        )
+        from collaboration_framework.module.validation_v3 import (
+            _actor_binding_issues,
+        )
+
+        step = InvokeRulesetActionStep(
+            id="s1",
+            action_id="an.action.no.executor.exists.for",
+            actor_binding="actor",
+            next_step_id="s2",
+        )
+        # The action_id itself is never consulted against the world action
+        # registry — only the binding, which is registered.
+        self.assertEqual(_actor_binding_issues(step, "path"), [])
+
+
 class RealFixturesStillPublishTests(unittest.TestCase):
     """The predicate names real, already-shipping modules use must all be
     registered — otherwise this phase would break existing content on the day
@@ -92,13 +156,17 @@ class RealFixturesStillPublishTests(unittest.TestCase):
                     content_path.read_text(encoding="utf-8")
                 )
                 report = validate_module_v3(content)
-                predicate_issues = [
+                registry_issues = [
                     issue
                     for issue in report.errors
                     if issue.code
-                    in ("MODULE_V3_PREDICATE_UNKNOWN", "MODULE_V3_PREDICATE_EMPTY")
+                    in (
+                        "MODULE_V3_PREDICATE_UNKNOWN",
+                        "MODULE_V3_PREDICATE_EMPTY",
+                        "MODULE_V3_ACTOR_BINDING_UNKNOWN",
+                    )
                 ]
-                self.assertEqual(predicate_issues, [])
+                self.assertEqual(registry_issues, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 关联 Issue

Refs #347

本 PR 只实现 #347 拆分后的前四步，不完整解决该 Issue，因此使用 `Refs` 而非 `Closes`。

## 拆分策略

#347 的六个问题（P1–P6）体量上放不进一个可评审的 PR，按「代码区域不重叠、可独立验证、可独立回滚」切成七步，每步一个 commit，前四步合为本 PR：

| 步骤 | 内容 | 对应 Issue 问题 | 产出 | 状态 |
|---|---|---|---|---|
| 0（前置） | 谓词求值的测试安全网 | — | `tests/test_rules_v3_predicates.py` | 本 PR · `6191b2a` |
| 1 | 谓词登记表 + 发布期校验 | P2 | `registry/predicates.py` | 本 PR · `1fbaa86` |
| 2 | 效果登记表 | P1、P3 | `registry/effects.py` | 本 PR · `2bcf920` |
| 3 | 规则步骤登记表 | P1 | `registry/rule_steps.py` | 本 PR · `18fb7b5` |
| 4 | 世界规则动作登记表 | P1 | `registry/world_actions.py` | 本 PR · `52e17a2` |
| 5 | 模组内容缓存 | P4 | `engine/adapters/` | 后续 PR |
| 6 | 规则匹配索引 | P5 | `engine/rules_v3.py`、`engine/projection_v3.py` | 后续 PR |
| 7 | 说明书生成去重 | P6 | `host/prompts/action_plan.py` | 后续 PR |

切分依据：

- **前四步必须同一个 PR。** 四张表共用同一条架构约束（registry 是只依赖 `contracts` 的叶子包）和同一个护栏测试；拆开提交会让中间状态出现「一半逻辑在表里、一半还在 `adjudication.py`」的双写期，评审反而更难判断搬迁是否等价。
- **步骤 0 必须先落地。** `_evaluate_predicate` 的四个分支此前全仓库零直接单测，先钉住行为再抽取，才能用测试证明搬迁等价。
- **后三步各自独立成 PR。** 它们改的是性能与文本生成，与前四步的结构重排既不互相依赖、代码区域也不重叠（`engine/adapters/` vs `engine/rules_v3.py`+`projection_v3.py` vs `host/prompts/`），风险类别不同，混在一起会让「结构重构无行为变化」这一评审前提失效。计划按 5 → 6 → 7 的优先级推进，理由见下方「本次不做」。

## 主要改动

- 新增叶子包 `collaboration_framework/registry/`，把 `engine/adjudication.py` 与 `engine/rules_v3.py` 中分散的判断逻辑收敛成四张封闭登记表：`predicates.py`、`effects.py`、`rule_steps.py`、`world_actions.py`。模组内容只能引用表里已有的条目，支持一种全新条目属于引擎发版，而不是模组发布。
- `registry/predicates.py`：四条 `if` 加字符串比对收敛成「谓词名 → 求值函数」查表，求值逻辑逐字迁移；`entity_state` 一并移入，并按原名从 `rules_v3` 重导出，`adjudication.py` / `navigation.py` 的导入保持不变。
- `registry/effects.py`：`_classify_effects` / `_validate_effect` / `_apply_effect` 三段互不相干的 isinstance 分支（约 620 行）收敛成以 `ActionEffect.type` 为键的一张表，每种效果的权限等级、reads/writes 访问声明、内容校验和执行写在同一条登记里，漏写由完整性测试拦截。
- `_validate_effect_sequence` 改为维护 `ValidationVocabulary` 的两趟解析（§4.3）：每条效果先按 reads 查表，通过后把 writes 并入供后续效果引用——「同一次裁决里先建房间再走进去」的合法性由这个机制承载。`ensure_runtime_*` 的「自身编号必须尚不存在」既不是读也不是写，用独立的 `must_not_exist` 声明表达。
- P3（§3.3）：move / change_state / consume 三处各自内联的 `state.item_instances.get(...)` 判别收敛成 `resolve_entity_storage` 一处，即把名字解析从「不允许拒绝」的执行侧移回校验侧。
- 隐式契约显式化：过去每个分支要记得给 `event_type` 赋值、末尾靠 `if event_type is None` 兜底当作「未注册」，现在由 `emits_event` 显式声明（目前只有 `narrative_only`）；三种此前靠「没有 elif 分支所以默认通过」的类型显式写 `validate=None`。
- `registry/rule_steps.py`：十种 step kind 此前在四处各自硬编码，现收敛成一张表。八种「挂起」语义的 kind 登记同一个 `walk_behavior` 而不是八条几乎相同的条目，`check` 是唯一需要二次分岔的。`actor_binding`（§4.8）只登记取值空间，沿用 `BindingSlotSpec.source` 已有的枚举，并有测试盯住两边不漂移。
- `registry/world_actions.py`：**空表**。v3 侧没有引擎真能执行的世界规则动作，填名字等于声称一种不存在的能力；v2 遗留的 `_SUPPORTED_FORCE_ACTIONS` 刻意不迁入，有测试盯住。
- `module/validation_v3.py` 新增两条发布期拒绝，均定位到具体规则路径：`MODULE_V3_PREDICATE_UNKNOWN`（谓词名未注册）、`MODULE_V3_ACTOR_BINDING_UNKNOWN`（绑定来源不在取值空间内）。
- `docs/architecture.md` 的依赖图与禁止反向依赖清单同步更新；`tests/test_architecture.py` 新增 `test_registry_stays_a_leaf`，其 `runtime_imports_for()` 会跳过 `TYPE_CHECKING` 块。
- `engine/capabilities.py` 更正 `audit_runtime_capabilities` 的 docstring：在登记表存在之前，未注册的谓词名能通过全部静态检查、只在运行时恒读 false，原文高估了这项保证。
- 补齐 `_evaluate_predicate` 四个已知谓词分支的直接单测（抽取前全仓库零直接覆盖），钉住包括「缺失的 flag 读作 False」在内的隐式契约。
- `engine/adjudication.py` 从 2686 行降到 2012 行。

## 采用该方案的原因

分层判据取自 #347：**这段代码能不能拒绝**。能拒绝的（权限判定、内容校验）进登记表，不允许拒绝的（真正执行、状态提交）留在 engine 的流程骨架里。这样新增一种效果是加一条登记，而不是在四处分支里同步修改、漏改无人发现。

registry 放在顶层而不是 `engine/` 下，是因为 `engine`（执行期）和 `module`（发布期校验）都要读这些表，而 `docs/architecture.md` §6 明令禁止 `module -> engine`。所以 registry 与 `contracts` 同级、作为叶子存在：运行时只依赖 `contracts`；handler 需要的 5 个 engine 纯函数（寻路、世界钟、公开状态判定）由 engine 通过 `EffectServices` 注入，用的是本仓库 `ports/` 已有的形状；`GameState` 等状态模型只在 `TYPE_CHECKING` 下用于注解。这也是 #347 §4.1 原文给出的目录位置。

`_owned_effects` 不进效果表，是对 §4.1 字面描述的一处有意偏离：它的输入不是单个 `ActionEffect` 而是整次裁决，回答的是「这次效果的源头是 AI 还是被 `rule_decision` 接管的规则」这一路由问题，按 §3.2 的判据属于编排而非查表。塞进效果表会让这张表的键从「效果类型」变成「效果类型 + 裁决上下文」两种粒度，并让 registry 意外依赖规则遍历。

主要取舍：`resolve_entity_storage` 的判别结果**刻意不**跨 submit / decide / decide_post_roll 的事务边界传递。那三个入口各自独立 `load_runtime`，把结果持久化进 `PendingCheck` 需要改 schema 并引入状态过期的新风险，为消掉三行重复不值得。

本 PR 是纯架构重构：游戏规则的判断结果、AI 裁决方式、玩家可见行为、检定流程、事件效果全部不变。唯一的可观测变化是上述两条发布期拒绝的时机——拼错的谓词名和写错的绑定来源过去能通过发布、只在运行时永远静默不触发，现在在发布期就报错。

## 本次不做

- **步骤 5 · 缓存（P4）**：v3 目前没有发布服务可挂编译期钩子（`validate_module_v3()` 成功时连构造好的 content 都没放进 `ValidationReport`）；`version` 是模组作者手填的自由字符串、无唯一性保证，直接当缓存 key 会在作者忘记改版本号时静默返回过期内容；且任何方案都必须保住 `test_loaded_models_are_deep_copy_isolated` 的隔离契约。真实开销也比 Issue 描述的更重：一次玩家行动会触发 5~10 次 `load_runtime` 深拷贝（Issue 原文写的 `model_validate(deepcopy(...))` 与实际 API 不符，实际是 `model_copy(deep=True)`）。
- **步骤 6 · 索引（P5）**：实际是两处独立的全表扫描（`rules_v3.matching_event_rules` 与 `projection_v3._rule_candidates`），索引化后必须保证 `priority DESC, id ASC`（#226 冻结行为）与线性扫描逐条一致，需要差分测试单独验证；且规则条件依赖 `state`，跨调用缓存匹配结果会引入极难复现的漏触发／误触发。
- **步骤 7 · 说明书生成（P6）**：`host/prompts/action_plan.py` 190 行里约 80% 是无法从 registry 推导的跨模块产品／安全策略叙事（否定式穷举、Runtime 创建门禁的五条准入标准、`target.id` 的来源约束等）；本仓库对它没有语义级回归测试，且没有生产代码 import 这两个函数——真正消费它的代码在外部 backend 仓库，本仓库看不到生成质量的反馈闭环。

## 测试与验证

- [x] **测试已完成**：Framework 全量 `366 passed`，无失败、无跳过；基线提交 `6c0abb1` 为 `313 passed`，净增 53 个测试（新增 4 个测试文件共 52 个用例，另有架构护栏 1 个）。
- [x] **手动验证已完成**：逐行 diff 复核四步搬迁前后的实现是否等价（这是本次唯一能证明「无行为变化」的手段，也确实抓到一处漂移，见「风险与回滚」）；发布期校验对现有 v3 fixture（含追书人、银之锁）的结果不变，已固化为回归测试。未做游戏内实跑——本 PR 不改变任何玩家可见行为。
- [x] **构建或静态检查已完成**：
  - `ty check`（在 `trpg-backend/` 下执行，其 `extra-paths` 覆盖框架）：`All checks passed`
  - `ruff check`：新增的 4 个 registry 模块与 4 个测试文件零告警
  - ruff 基线对照：改动文件上剩余 5 条告警（`adjudication.py` I001、`rules_v3.py` 3 × SIM102、`validation_v3.py` E501）在基线同位置即存在（基线为 6 条，`rules_v3.py` 的 I001 顺带消除）。本 PR 未新增告警，也未顺手修既有告警——那属于 scope creep
  - 架构护栏：`test_registry_stays_a_leaf` 确认 registry 运行时不 import `engine` / `module` / `host`
- [ ] **无覆盖本目录的测试／检查类 CI**：仓库 5 个 workflow 中只有 `PR Preview` 会在本 PR 上触发，其 `changes` job 通过、`deploy` 与 `teardown` 因未命中相关路径而 skip；Backend CI / Frontend CI / SDK CI / E2E CI 的 `paths` 过滤器均不覆盖 `agent-collaboration-framework/**`，因此没有任何自动化跑过本 PR 的测试、lint 或类型检查。上述结果全部在本地完成（macOS / Python 3.13.14），请 Reviewer 知悉自动化不提供第二道保障。

## 风险与回滚

**兼容性**：对外接口、WebSocket DTO、前端协议、玩家可见行为均无变化。`entity_state` 按原名从 `rules_v3` 重导出，既有 `from .rules_v3 import entity_state` 的调用点不需要修改。

**迁移**：无数据库迁移、无数据重写、无模组内容格式变更。已发布的模组版本不受影响。

**风险 1 · 逐字誊写漂移（最大风险面）**。Phase 2 搬迁 `_visibility_knowledge` 时，`localization` 的取值以及 `access` / `visited` / `known_connection_ids` 三处 `visible and` 条件曾被无意改写——隐藏一个已访问过的地点本会连带改变它的知识记录。该问题由逐行 diff 复核发现、已逐字改回并在 commit 中记录。请 Reviewer 优先按此方式核对搬迁前后的实现，而不是只看测试是否通过。

**风险 2 · 新增的发布期拒绝可能挡下此前能发布的模组**。落地前已扫过全仓库谓词名字面量：真实模组只用了已注册的两个；`test_module_content_v3` 的合成 fixture 里 `door_unlocked` 是虚构名字——那条门禁边的条件在运行时从来不可能成立，新校验上线第一天就抓到一处真实的静默失效，fixture 已修正。仓库外部若有未纳管的模组内容，升级后需要重跑一次发布期校验；这是有意为之的收益，不是回归。

**回滚**：五个 commit 按步骤划分，可单步或整体 revert。因不含迁移与协议变更，回滚不需要数据修复。

## UI 证据

不适用。本 PR 只改动 `agent-collaboration-framework/`，不涉及前端、玩家协议或玩家可见行为。

## AI 使用情况

本 PR 属于核心模块，使用 AI 辅助实现与自检。关键指令摘要：按 #347 的「能不能拒绝」判据分层，能拒绝的进登记表、不允许拒绝的留在 engine；搬迁必须逐字誊写，不得凭印象重写；不得改变游戏规则判断结果、AI 裁决方式、玩家可见行为、检定流程与事件效果；registry 必须保持只依赖 `contracts` 的叶子包；不顺手修既有 lint 告警。AI 辅助执行了代码迁移、测试补齐、架构护栏与文档更新、以及验证命令的执行。

搬迁过程中 AI 曾无意改写 `_visibility_knowledge` 的取值与可见性条件（见「风险与回滚」），由人工逐行 diff 复核发现并改回。作者已逐项检查实现与测试结果，并能解释每一步搬迁的等价性。合并前仍需至少一名人工 Reviewer 独立比对搬迁前后的实现与新增的发布期拒绝范围；AI 自检不替代人工 Review。

## 自检

- [x] 改动范围符合 Issue #347 拆分后的前四步
- [x] 不包含无关改动；工作区未跟踪的个人文档与演示文件未进入提交
- [x] 已包含必要的测试和文档
- [x] 不包含密钥、个人信息或非预期生成物
- [ ] 已完成 AI 辅助质量检查和人工 Review（AI 辅助质量检查已完成；人工 Review 待进行）
