### PR TITLE
perf(engine-store): 模组内容按内容指纹进程内缓存 (#347)

### DIFF
--- a/trpg-backend/app/adapters/sqlalchemy_engine_store.py
+++ b/trpg-backend/app/adapters/sqlalchemy_engine_store.py
@@ -49,6 +49,7 @@ from app.models.engine import (
     PendingCheckDecisionRecord,
 )
 from app.models.room import Room
+from app.service.module_content_cache import load_module_content
 
 # 落库 JSON 的 schema 版本。#310 给 CheckRun / CheckRunView 各加了字段，老行没有
 # 这些键，直接 model_validate 会当场失败——正卡在 awaiting_post_roll_decision 的
@@ -368,11 +369,13 @@ class _SqlAlchemyEngineTransaction(EngineTransaction):
         # life: a republished module never silently changes the meaning of a
         # session already in flight (#226 §1).
         self._content_schema_version = module_version.content_schema_version
-        payload = deepcopy(module_version.content_json)
-        module_content: ModuleContent | ModuleContentV3 = (
-            ModuleContentV3.model_validate(payload)
-            if module_version.content_schema_version == 3
-            else ModuleContent.model_validate(payload)
+        # 已发布的模组内容不可变，解析结果按 (module_id, version, 内容指纹)
+        # 复用；返回值仍与缓存和 content_json 完全隔离 (#347 P4)。
+        module_content: ModuleContent | ModuleContentV3 = load_module_content(
+            module_id=module_version.module_id,
+            version=module_version.version,
+            content_schema_version=module_version.content_schema_version,
+            content_json=module_version.content_json,
         )
         if (
             module_content.module_id != module_version.module_id

--- a/trpg-backend/app/service/module_content_cache.py
+++ b/trpg-backend/app/service/module_content_cache.py
@@ -1,0 +1,122 @@
+"""已发布模组内容的进程内缓存 (#347 P4)。
+
+每次玩家行动会触发 5~10 次 `load_runtime`，而每一次都要把整份
+`content_json` 深拷贝一遍再完整重新校验成 pydantic 树。模组一旦发布就
+不可变（`builtin_module_loader` 拒绝用不同内容覆盖同一
+`(module_id, version)`），所以这份解析结果本可以复用。
+
+**为什么缓存的是 pickle 字节而不是解析好的对象。** 调用方拿到的模组内容
+必须是彼此隔离的：任何一方就地改动都不能影响下一次读取，也不能污染
+SQLAlchemy 行上的 `content_json`。所以命中时不能直接把同一个对象发出去，
+必须现做一棵新树。实测（追书人，96KB）三种做法产出一棵隔离的树的成本：
+
+| 做法 | 单次耗时 |
+|---|---|
+| `deepcopy(content_json)` + `model_validate`（改动前） | 3.02 ms |
+| 缓存已解析对象 + `model_copy(deep=True)` | 3.08 ms |
+| 缓存 pickle 字节 + `pickle.loads` | 1.03 ms |
+
+缓存解析结果再深拷贝**比不缓存还慢**，只有 pickle 这条路是真的省。
+`pickle.loads` 每次重建一整套全新对象，隔离性与深拷贝等价。这里
+`pickle` 的输入永远是本进程自己刚 `dumps` 出来的字节，不接受任何外部
+数据，不存在反序列化不可信输入的问题。
+
+**为什么键里带内容指纹。** `version` 是模组作者手填的自由字符串，仓库层面
+没有任何自动递增或唯一性机制。只按 `(module_id, version)` 缓存的话，作者
+改了内容却忘记改版本号时，缓存会一直返回过期内容且没有任何报错信号——这
+类静默失效比多花几毫秒糟糕得多。把内容指纹并进键之后，内容一变就是一次
+未命中、重新解析，不可能读到过期结果。指纹本身约 0.5 ms，命中总成本
+1.53 ms，相比改动前仍省约一半。
+
+指纹不对键排序：同样的内容若序列化顺序不同，只会白白未命中、重新解析一
+次，不会命中到错误的内容，用 0.2 ms 换一个不必要的保证不划算。
+"""
+
+from __future__ import annotations
+
+import json
+import pickle
+from collections import OrderedDict
+from copy import deepcopy
+from hashlib import blake2b
+from typing import NamedTuple
+
+from collaboration_framework.contracts import ModuleContent, ModuleContentV3
+
+# 一个进程同时在玩的模组版本数远小于这个上限；留出余量后按 LRU 淘汰，
+# 避免作者反复改内容不改版本号时条目无限增长。单条约 60KB。
+MAX_ENTRIES = 16
+
+_CacheKey = tuple[str, str, int, bytes]
+
+_entries: OrderedDict[_CacheKey, bytes] = OrderedDict()
+_hits = 0
+_misses = 0
+
+
+class CacheInfo(NamedTuple):
+    hits: int
+    misses: int
+    size: int
+
+
+def cache_info() -> CacheInfo:
+    """当前命中计数与条目数，仅供测试与排查使用。"""
+
+    return CacheInfo(hits=_hits, misses=_misses, size=len(_entries))
+
+
+def clear() -> None:
+    """清空缓存与计数。"""
+
+    global _hits, _misses
+    _entries.clear()
+    _hits = 0
+    _misses = 0
+
+
+def _fingerprint(content_json: dict) -> bytes:
+    serialized = json.dumps(content_json, separators=(",", ":")).encode("utf-8")
+    return blake2b(serialized, digest_size=16).digest()
+
+
+def load_module_content(
+    *,
+    module_id: str,
+    version: str,
+    content_schema_version: int,
+    content_json: dict,
+) -> ModuleContent | ModuleContentV3:
+    """返回一棵与缓存、与 `content_json` 都完全隔离的模组内容树。
+
+    调用方可以随意就地修改返回值，既不会影响下一次调用，也不会写回
+    SQLAlchemy 行上的 `content_json`。
+    """
+
+    global _hits, _misses
+
+    key: _CacheKey = (
+        module_id,
+        version,
+        content_schema_version,
+        _fingerprint(content_json),
+    )
+    blob = _entries.get(key)
+    if blob is not None:
+        _entries.move_to_end(key)
+        _hits += 1
+        return pickle.loads(blob)  # noqa: S301 — 输入是本进程自己 dumps 的字节
+
+    _misses += 1
+    # 未命中时逐字沿用改动前的解析方式：先深拷贝再校验，保证行为完全一致。
+    payload = deepcopy(content_json)
+    content: ModuleContent | ModuleContentV3 = (
+        ModuleContentV3.model_validate(payload)
+        if content_schema_version == 3
+        else ModuleContent.model_validate(payload)
+    )
+    _entries[key] = pickle.dumps(content, protocol=pickle.HIGHEST_PROTOCOL)
+    _entries.move_to_end(key)
+    while len(_entries) > MAX_ENTRIES:
+        _entries.popitem(last=False)
+    return content

--- a/trpg-backend/docs/engine-persistence.md
+++ b/trpg-backend/docs/engine-persistence.md
@@ -15,6 +15,13 @@ Protocol 和 RuleKernel 的前提下，实现 `SqlAlchemyEngineStore`、完成�
 多个发布版本。房间选择模组后使用 `rooms.scenario_id + rooms.module_version` 固定
 到明确版本，不跟随目录推荐版本变化。
 
+因为发布内容不可变，`load_runtime` 不再每次都重新深拷贝并校验整份
+`content_json`：解析结果按 `(module_id, version, 内容指纹)` 在进程内缓存复用
+（`app/service/module_content_cache.py`，#347 P4）。缓存返回的仍是彼此隔离的
+新对象，调用方就地修改既不会影响下一次读取，也不会写回行上的
+`content_json`。键里带内容指纹，是因为 `version` 是模组作者手填的自由字符串：
+万一同一版本号下的内容真的变了，那是一次重新解析，而不是一次静默的过期命中。
+
 ## 权威运行数据
 
 - `game_sessions`：`room_id` 同时是主键和 Room 外键，因此一个 Room 只能运行一局；

--- a/trpg-backend/tests/test_module_content_cache.py
+++ b/trpg-backend/tests/test_module_content_cache.py
@@ -1,0 +1,135 @@
+"""模组内容进程内缓存的隔离契约与失效行为 (#347 P4)。"""
+
+import json
+from copy import deepcopy
+
+import pytest
+from collaboration_framework.contracts import ModuleContentV3
+from pydantic import ValidationError
+
+from app.service import module_content_cache
+from app.service.builtin_module_loader import PAPER_CHASE_SPEC
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    module_content_cache.clear()
+
+
+@pytest.fixture
+def content_json() -> dict:
+    return json.loads(PAPER_CHASE_SPEC.source_path.read_text(encoding="utf-8"))
+
+
+def _load(content_json: dict, *, version: str = "3.0.6") -> ModuleContentV3:
+    content = module_content_cache.load_module_content(
+        module_id="paper-chase-zh-coc7",
+        version=version,
+        content_schema_version=3,
+        content_json=content_json,
+    )
+    assert isinstance(content, ModuleContentV3)
+    return content
+
+
+def test_repeated_loads_parse_the_content_only_once(content_json: dict) -> None:
+    first = _load(content_json)
+    second = _load(content_json)
+
+    assert module_content_cache.cache_info().misses == 1
+    assert module_content_cache.cache_info().hits == 1
+    assert first == second
+
+
+def test_a_cache_hit_is_isolated_from_the_previous_caller(content_json: dict) -> None:
+    """命中缓存不能把上一位调用方的就地修改带给下一位。"""
+
+    first = _load(content_json)
+    first.entities[0].state["invented"] = True
+
+    second = _load(content_json)
+
+    assert module_content_cache.cache_info().hits == 1
+    assert "invented" not in second.entities[0].state
+
+
+def test_the_returned_tree_never_aliases_content_json(content_json: dict) -> None:
+    """就地修改返回值不能写回 SQLAlchemy 行上的 content_json。
+
+    契约模型本身是 frozen 的，属性赋值会当场报错；真正的走样途径是模型内部
+    那些仍然可变的容器（例如实体的 `state` 字典），所以这里改的是它们。
+    """
+
+    original = deepcopy(content_json)
+
+    first = _load(content_json)
+    first.entities[0].state["invented"] = True
+    second = _load(content_json)
+    second.entities[1].state["invented"] = True
+
+    assert content_json == original
+
+
+def test_changed_content_under_the_same_version_is_never_served_stale(
+    content_json: dict,
+) -> None:
+    """作者改了内容却没改版本号时，必须重新解析而不是返回旧内容。
+
+    `version` 是作者手填的自由字符串，没有唯一性保证；键里带内容指纹就是
+    为了让这种情况变成一次未命中，而不是一次静默的过期命中。
+    """
+
+    first = _load(content_json)
+    assert first.presentation.title == "追书人"
+
+    edited = deepcopy(content_json)
+    edited["presentation"]["title"] = "改过标题但没改版本号"
+
+    second = _load(edited)
+
+    assert second.presentation.title == "改过标题但没改版本号"
+    assert module_content_cache.cache_info().misses == 2
+    assert module_content_cache.cache_info().hits == 0
+
+
+def test_key_order_changes_miss_rather_than_serve_the_wrong_content(
+    content_json: dict,
+) -> None:
+    """指纹不排序：键序不同只会白白重新解析一次，不会命中到错误内容。"""
+
+    first = _load(content_json)
+    reordered = dict(reversed(list(content_json.items())))
+
+    second = _load(reordered)
+
+    assert first == second
+
+
+def test_entry_count_stays_bounded(content_json: dict) -> None:
+    for index in range(module_content_cache.MAX_ENTRIES + 3):
+        _load(content_json, version=f"3.0.{index}")
+
+    assert module_content_cache.cache_info().size == module_content_cache.MAX_ENTRIES
+
+
+def test_the_oldest_entry_is_the_one_evicted(content_json: dict) -> None:
+    _load(content_json, version="oldest")
+    for index in range(module_content_cache.MAX_ENTRIES):
+        _load(content_json, version=f"filler-{index}")
+
+    hits_before = module_content_cache.cache_info().hits
+    _load(content_json, version="oldest")
+
+    assert module_content_cache.cache_info().hits == hits_before
+
+
+def test_a_non_v3_schema_version_routes_to_the_v1_model(content_json: dict) -> None:
+    """schema version 决定用哪个契约模型解析，v3 内容不能从 v1 分支通过。"""
+
+    with pytest.raises(ValidationError):
+        module_content_cache.load_module_content(
+            module_id="paper-chase-zh-coc7",
+            version="3.0.6",
+            content_schema_version=1,
+            content_json=content_json,
+        )


### PR DESCRIPTION
## 关联 Issue

Refs #347

本 PR 交付 #347 的 P4（每次都重新解析整份模组）。P5 索引与 P6 说明书生成经实测后**建议不做**，理由见「本次不做」；该建议已在 #347 下留言，是否据此关闭 Issue 由维护者决定，因此这里用 `Refs` 而非 `Closes`。

> **与 #378 描述的一处偏离**：#378 里写的是「后三步各自独立成 PR」。实施步骤 5 时对 P5 做了测量，结论是它不值得做（下同 P6），计划因此从「三个 PR」变成「一个 PR + 两条不做的结论」。按工程规范，这里记录变更而不是假装原本就这么计划。

## 主要改动

- 新增 `trpg-backend/app/service/module_content_cache.py`：已发布模组内容的进程内缓存，键为 `(module_id, version, content_schema_version, 内容指纹)`，值为解析结果的 pickle 字节。
- `sqlalchemy_engine_store.load_runtime` 改为走该缓存，替换原先每次执行的 `deepcopy(content_json)` + `ModuleContentV3.model_validate(...)`。
- 缓存按 LRU 设上界（`MAX_ENTRIES = 16`），并提供 `cache_info()` / `clear()` 供测试与排查使用。
- `docs/engine-persistence.md` 在描述 `module_versions` 不可变性的那一节补充说明缓存如何依赖这条不变式。
- 新增 8 个用例覆盖隔离契约、指纹失效、LRU 上界与淘汰顺序、schema version 路由。

## 采用该方案的原因

**落点在 `trpg-backend`，不在 framework。** #347 §1.3 P4 写的 `ModuleContentV3.model_validate(deepcopy(content_json))` 原原本本存在于 `sqlalchemy_engine_store.py:371`。framework 的 `InMemoryEngineStore.load_runtime` 也有一次深拷贝，但它没有生产调用方——优化它不会改变任何线上行为。

**缓存 pickle 字节，而不是缓存解析好的对象。** 调用方拿到的模组内容必须彼此隔离：任何一方就地修改都不能影响下一次读取，也不能污染 SQLAlchemy 行上的 `content_json`。所以命中时不能把同一个对象发出去，必须现做一棵新树。实测（追书人，96KB）：

| 做法 | 单次产出一棵隔离的树 |
|---|---|
| `deepcopy(content_json)` + `model_validate`（改动前） | 3.19 ms |
| 缓存已解析对象 + `model_copy(deep=True)` | 3.08 ms |
| 缓存 pickle 字节 + `pickle.loads` | 1.03 ms |

**缓存解析结果再深拷贝几乎没有收益**——pydantic 的深拷贝比「反序列化一份 96KB JSON 再全量校验」还贵。只有 pickle 这条路真的省。`pickle` 的输入永远是本进程自己刚 `dumps` 出来的字节，不接受任何外部数据。

**键里带内容指纹（blake2b，约 0.5 ms）。** `version` 是模组作者手填的自由字符串，没有唯一性机制；只按 `(module_id, version)` 缓存的话，作者改了内容却没改版本号会让缓存一直返回过期内容且**没有任何报错信号**。带上指纹后内容一变就是一次未命中、重新解析。这 0.5 ms 把收益从 66% 压到 46%，换掉的是整整一类静默失效。

`builtin_module_loader` 本来就拒绝用不同内容覆盖同一 `(module_id, version)`，指纹是在那条不变式之外再加一道，不把正确性押在它永远成立上。

**取舍**：指纹不对 JSON 键排序。同样的内容若序列化顺序不同，只会白白重新解析一次，不会命中到错误的内容——用 0.2 ms 换一个不必要的保证不划算。

## 本次不做

### P5 规则匹配索引 —— 实测后建议不做

把全表扫描改成按事件类型索引，收益上限是这个扫描本身的耗时。实测（追书人，27 条规则）：

```
matching_event_rules('enter_location')      3.3 µs
matching_event_rules('information_revealed') 3.2 µs
```

对比本 PR 单次省下的 **1460 µs**，P5 的收益上限小了约 **440 倍**——而且这还是假设索引能消掉全部扫描开销，实际消不掉：条件求值依赖 `state`，不能跨调用缓存，索引只能省掉分组扫描那一段。

真实模组规模：追书人 27 条规则、银之锁 26 条。同时 P5 有实打实的风险——`priority DESC, id ASC` 是 #226 冻结的确定性行为，任何索引方案都必须逐条一致，需要专门的差分测试来验证。**风险不小、收益在微秒级，现在做不合算。** 等模组规则数量真的成为瓶颈时再做。

### P6 说明书生成 —— 建议不做

`host/prompts/action_plan.py` 190 行里只有约 20% 能从 registry 机械生成（14 种效果的字段签名，以及 `engine/persistent_results.py` 的 `_FAMILY_POLICIES`）。其余约 80% 是无法从结构化数据推导的产品/安全策略叙事：决策表里的否定式穷举、Runtime 创建门禁的五条准入标准、`target.id` 的来源约束、修复预算说明。强行生成只会得到更差的 prompt。

唯一值得消除的重复是 `_FAMILY_POLICIES`（17 个 action family → persistence_intent 的映射，prompt 里手写了一份）。但现有回归网很薄——`tests/test_openai_models.py` 对 prompt 只有 `"32 步" in instructions` 这种关键字级断言，没有语义级评测集，改完看不出有没有漂移。**收益小、验证手段不足，建议排到有 prompt 评测能力之后。**

## 测试与验证

- [x] **测试已完成**：`trpg-backend` 全量 `481 passed, 22 skipped`，零失败（其中 8 个为本次新增）；`agent-collaboration-framework` 全量 `366 passed`，零失败零跳过，未受影响。
- [x] **手动验证已完成**：在真实模组（追书人 96KB）上实测改动前后的单次耗时与未命中耗时，数据见上表；四种候选实现都实测过，据此否掉了「缓存已解析对象」这个方向。未做游戏内实跑——本 PR 不改变任何玩家可见行为。
- [x] **构建或静态检查已完成**：`uv run ruff check .` 通过；`uv run ruff format --check .` 159 个文件已格式化；`uv run ty check` All checks passed。
- [x] 新增用例覆盖：重复读取只解析一次、命中后的隔离、不写回 `content_json`、同版本改内容不返回过期、键序不同只是未命中、LRU 上界与淘汰顺序、schema version 路由。

本 PR 改动落在 `trpg-backend/**`，Backend CI 会完整运行（ruff / format / ty / pytest）。

## 风险与回滚

**兼容性**：无接口、协议、DTO 变化。`load_runtime` 的返回值语义完全不变——调用方拿到的仍是一棵与缓存、与 `content_json` 都隔离的新树。

**迁移**：无数据库迁移、无数据重写、无模组内容格式变更。

**风险 1 · 缓存返回过期内容**。这是缓存类改动的主要失效模式，用内容指纹从构造上排除：内容一变，键就变，只可能未命中，不可能命中到旧内容。有专门用例钉住。

**风险 2 · 隔离契约被破坏**。若命中时把同一个对象引用发出去，一个调用方的就地修改会串到另一个。`pickle.loads` 每次重建全新对象图，隔离性与深拷贝等价，同样有用例钉住（含「不写回 `content_json`」这一条）。补充一个实现细节：契约模型本身是 frozen 的，属性赋值会当场报错，真正的走样途径只有模型内部仍然可变的容器（如实体的 `state` 字典），用例改的就是它们。

**风险 3 · 内存**。单条 blob 约 60KB，上界 16 条，约 1MB，随进程生命周期存在。

**回滚**：单个 commit，可直接 revert。无迁移、无协议变更，回滚不需要数据修复。

## UI 证据

不适用。本 PR 不修改前端、玩家协议或任何玩家可见行为。

## AI 使用情况

本 PR 属于核心链路，使用 AI 辅助实现与自检。关键指令摘要：按 #347 P4 消除重复解析；**任何性能改动动手前必须先测量**；必须保住「调用方就地修改不影响下次读取、不污染 `content_json`」的隔离契约；`version` 不可信，缓存键不能只靠它；不顺手改无关代码。

测量直接改变了方案：最初设想的「缓存已解析对象再深拷贝」实测 3.08 ms，比不缓存的 3.19 ms 几乎没有区别，是一个负优化；改用 pickle 字节后才拿到 1.03 ms。P5 的「不做」结论同样来自实测而非估计。

合并前仍需至少一名人工 Reviewer 独立核对缓存键的完备性、隔离用例是否真的覆盖了走样途径，以及 P5/P6 不做的判断是否成立；AI 自检不替代人工 Review。

## 自检

- [x] 改动范围符合 Issue #347 的 P4
- [x] 不包含无关改动；工作区未跟踪的个人文档与演示文件未进入提交
- [x] 已包含必要的测试和文档
- [x] 不包含密钥、个人信息或非预期生成物
- [ ] 已完成 AI 辅助质量检查和人工 Review（AI 辅助质量检查已完成；人工 Review 待进行）
