### PR TITLE
feat(memory): 增加跨回合记忆与对话摘要 (#363)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/schemas/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/__init__.py
@@ -34,6 +34,7 @@ from .output import (
     NarrationOutput,
 )
 from .planner_context import HostAgentContext
+from .memory import ConversationSummary, MemoryContext, MemoryEntry
 
 __all__ = [
     "ActionPlanAdvanceResult",
@@ -44,6 +45,9 @@ __all__ = [
     "ActionPlanStepRun",
     "CompletedPlanStepSummary",
     "HostAgentContext",
+    "ConversationSummary",
+    "MemoryContext",
+    "MemoryEntry",
     "HistoryVisibility",
     "NarrationOutput",
     "OpeningNarrationContext",

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
@@ -24,6 +24,7 @@ from collaboration_framework.contracts import (
     WorldClockView,
 )
 from collaboration_framework.host.schemas.history import RecentTurnContext
+from collaboration_framework.host.schemas.memory import ConversationSummary, MemoryEntry
 from collaboration_framework.host.schemas.planner_context import _validate_keeper_scope
 
 PlanRunStatus = Literal[
@@ -322,6 +323,8 @@ class ActionPlanStepContext(ContractModel):
     # ordinary detail that was narrated in the same continuous scene; the
     # adjudicator must still materialize that detail through Runtime creation.
     recent_history: RecentTurnContext | None = None
+    memories: tuple[MemoryEntry, ...] = ()
+    conversation_summary: ConversationSummary | None = None
     # Set only after the Engine refused a proposal for this same step. It carries
     # a stable player-safe code/reason, never hidden module content.
     #

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
@@ -378,7 +378,7 @@ class SingleActionClarificationResult(ContractModel):
 
 
 class ActionPlanNarrationContext(ContractModel):
-    """Player-safe evidence for one final or partial ActionPlan narration."""
+    """Player-safe evidence and bounded memory for one ActionPlan narration."""
 
     background: str = Field(min_length=1)
     player_input: PlayerInput
@@ -392,6 +392,9 @@ class ActionPlanNarrationContext(ContractModel):
     ]
     completed_steps: tuple[CompletedPlanStepSummary, ...] = ()
     player_view: PlayerView
+    # 记忆是只读的玩家安全上下文；它不能替代当前 PlayerView 或提交事实。
+    memories: tuple[MemoryEntry, ...] = ()
+    conversation_summary: ConversationSummary | None = None
     # `player_view` is the post-turn state, so it is the *only* clock the
     # Narrator would otherwise see. This is where the turn started; each step
     # then carries the clock it ended on.
@@ -410,6 +413,14 @@ class ActionPlanNarrationContext(ContractModel):
             or self.player_input.actor_id != self.player_view.actor_id
         ):
             raise ValueError("ActionPlanNarrationContext identity scope 不一致")
+        # 记忆和摘要必须与当前玩家请求同房间、同玩家，防止只读上下文越权。
+        if any(entry.room_id != self.player_input.room_id for entry in self.memories):
+            raise ValueError("ActionPlanNarrationContext memories room_id 不一致")
+        if self.conversation_summary is not None and (
+            self.conversation_summary.room_id != self.player_input.room_id
+            or self.conversation_summary.player_id != self.player_input.player_id
+        ):
+            raise ValueError("ActionPlanNarrationContext conversation_summary 作用域不一致")
         evidence = tuple(
             ref for step in self.completed_steps for ref in step.event_refs
         )

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/memory.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/memory.py
@@ -35,6 +35,8 @@ class MemoryEntry(ContractModel):
     epistemic_status: MemoryEpistemicStatus
     visibility: MemoryVisibility
     participants: tuple[str, ...] = ()
+    # 明确在场并听到该互动的实体；空值表示系统无法证明听众。
+    listener_ids: tuple[str, ...] = ()
     location_id: str | None = None
     source_event_id: str = Field(min_length=1)
     source_sequence: int = Field(ge=0)

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/memory.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/memory.py
@@ -1,0 +1,78 @@
+"""玩家安全的长期记忆与对话摘要契约。"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from collaboration_framework.contracts import ContractModel
+
+MemoryKind = Literal[
+    "action",
+    "visit",
+    "conversation",
+    "clue",
+    "world_event",
+    "relationship_change",
+    "goal",
+]
+MemoryEpistemicStatus = Literal[
+    "confirmed", "experienced", "heard", "asserted", "presentation"
+]
+MemoryVisibility = Literal["public", "player_scoped", "entity_scoped"]
+
+
+class MemoryEntry(ContractModel):
+    """一条可追溯、只读的长期经历投影。"""
+
+    memory_id: str = Field(min_length=1)
+    room_id: str = Field(min_length=1)
+    subject_id: str = Field(min_length=1)
+    object_id: str | None = None
+    kind: MemoryKind
+    content: str = Field(min_length=1, max_length=2000)
+    epistemic_status: MemoryEpistemicStatus
+    visibility: MemoryVisibility
+    participants: tuple[str, ...] = ()
+    location_id: str | None = None
+    source_event_id: str = Field(min_length=1)
+    source_sequence: int = Field(ge=0)
+    source_revision: str | None = None
+
+
+class ConversationSummary(ContractModel):
+    """当前玩家可见的玩家与主持对话滚动摘要。"""
+
+    room_id: str = Field(min_length=1)
+    player_id: str = Field(min_length=1)
+    summary: str = Field(default="", max_length=6000)
+    unresolved_questions: tuple[str, ...] = ()
+    important_entities: tuple[str, ...] = ()
+    through_event_sequence: int = Field(default=0, ge=0)
+    source_revision: str | None = None
+    source_event_ids: tuple[str, ...] = ()
+
+
+class MemoryContext(ContractModel):
+    """绑定当前玩家作用域的有限长期记忆和对话摘要。"""
+
+    room_id: str = Field(min_length=1)
+    player_id: str = Field(min_length=1)
+    actor_id: str = Field(min_length=1)
+    as_of_revision: str = Field(min_length=1)
+    entries: tuple[MemoryEntry, ...] = ()
+    conversation_summary: ConversationSummary | None = None
+
+    @model_validator(mode="after")
+    def validate_scope(self) -> "MemoryContext":
+        """拒绝跨房间或跨玩家的长期上下文拼接。"""
+        for entry in self.entries:
+            if entry.room_id != self.room_id:
+                raise ValueError("MemoryEntry room_id 与当前上下文不一致")
+        if self.conversation_summary is not None and (
+            self.conversation_summary.room_id != self.room_id
+            or self.conversation_summary.player_id != self.player_id
+        ):
+            raise ValueError("ConversationSummary scope 与当前上下文不一致")
+        return self

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/planner_context.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/planner_context.py
@@ -11,6 +11,7 @@ from collaboration_framework.contracts import (
     PlayerView,
 )
 from collaboration_framework.host.schemas.history import RecentTurnContext
+from collaboration_framework.host.schemas.memory import ConversationSummary, MemoryEntry
 
 
 def _validate_keeper_scope(
@@ -33,6 +34,8 @@ class HostAgentContext(ContractModel):
     player_input: PlayerInput
     player_view: PlayerView
     recent_history: RecentTurnContext
+    memories: tuple[MemoryEntry, ...] = ()
+    conversation_summary: ConversationSummary | None = None
     keeper_capabilities: KeeperCapabilityView | None = None
 
     @model_validator(mode="after")

--- a/agent-collaboration-framework/schemas/host-agent-context.schema.json
+++ b/agent-collaboration-framework/schemas/host-agent-context.schema.json
@@ -204,6 +204,76 @@
       "title": "CheckpointOption",
       "type": "object"
     },
+    "ConversationSummary": {
+      "additionalProperties": false,
+      "description": "当前玩家可见的玩家与主持对话滚动摘要。",
+      "properties": {
+        "room_id": {
+          "minLength": 1,
+          "title": "Room Id",
+          "type": "string"
+        },
+        "player_id": {
+          "minLength": 1,
+          "title": "Player Id",
+          "type": "string"
+        },
+        "summary": {
+          "default": "",
+          "maxLength": 6000,
+          "title": "Summary",
+          "type": "string"
+        },
+        "unresolved_questions": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Unresolved Questions",
+          "type": "array"
+        },
+        "important_entities": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Important Entities",
+          "type": "array"
+        },
+        "through_event_sequence": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Through Event Sequence",
+          "type": "integer"
+        },
+        "source_revision": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Revision"
+        },
+        "source_event_ids": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Source Event Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "room_id",
+        "player_id"
+      ],
+      "title": "ConversationSummary",
+      "type": "object"
+    },
     "ExitDestinationView": {
       "additionalProperties": false,
       "properties": {
@@ -942,6 +1012,133 @@
         "current_location_id"
       ],
       "title": "LocationContextView",
+      "type": "object"
+    },
+    "MemoryEntry": {
+      "additionalProperties": false,
+      "description": "一条可追溯、只读的长期经历投影。",
+      "properties": {
+        "memory_id": {
+          "minLength": 1,
+          "title": "Memory Id",
+          "type": "string"
+        },
+        "room_id": {
+          "minLength": 1,
+          "title": "Room Id",
+          "type": "string"
+        },
+        "subject_id": {
+          "minLength": 1,
+          "title": "Subject Id",
+          "type": "string"
+        },
+        "object_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Object Id"
+        },
+        "kind": {
+          "enum": [
+            "action",
+            "visit",
+            "conversation",
+            "clue",
+            "world_event",
+            "relationship_change",
+            "goal"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "content": {
+          "maxLength": 2000,
+          "minLength": 1,
+          "title": "Content",
+          "type": "string"
+        },
+        "epistemic_status": {
+          "enum": [
+            "confirmed",
+            "experienced",
+            "heard",
+            "asserted",
+            "presentation"
+          ],
+          "title": "Epistemic Status",
+          "type": "string"
+        },
+        "visibility": {
+          "enum": [
+            "public",
+            "player_scoped",
+            "entity_scoped"
+          ],
+          "title": "Visibility",
+          "type": "string"
+        },
+        "participants": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Participants",
+          "type": "array"
+        },
+        "location_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location Id"
+        },
+        "source_event_id": {
+          "minLength": 1,
+          "title": "Source Event Id",
+          "type": "string"
+        },
+        "source_sequence": {
+          "minimum": 0,
+          "title": "Source Sequence",
+          "type": "integer"
+        },
+        "source_revision": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Revision"
+        }
+      },
+      "required": [
+        "memory_id",
+        "room_id",
+        "subject_id",
+        "kind",
+        "content",
+        "epistemic_status",
+        "visibility",
+        "source_event_id",
+        "source_sequence"
+      ],
+      "title": "MemoryEntry",
       "type": "object"
     },
     "NarrativeDetailView": {
@@ -1882,6 +2079,25 @@
     },
     "recent_history": {
       "$ref": "#/$defs/RecentTurnContext"
+    },
+    "memories": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/MemoryEntry"
+      },
+      "title": "Memories",
+      "type": "array"
+    },
+    "conversation_summary": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ConversationSummary"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     },
     "keeper_capabilities": {
       "anyOf": [

--- a/trpg-backend/alembic/versions/a1b2c3d4e5f6_add_memory_and_conversation_summary.py
+++ b/trpg-backend/alembic/versions/a1b2c3d4e5f6_add_memory_and_conversation_summary.py
@@ -1,0 +1,74 @@
+"""增加长期记忆和玩家独立对话摘要投影。"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "c7d8e9f0a1b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "memory_entries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("room_id", sa.Uuid(), nullable=False),
+        sa.Column("subject_id", sa.String(length=100), nullable=False),
+        sa.Column("object_id", sa.String(length=100), nullable=True),
+        sa.Column("kind", sa.String(length=40), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("epistemic_status", sa.String(length=30), nullable=False),
+        sa.Column("visibility", sa.String(length=30), nullable=False),
+        sa.Column("participants", sa.JSON(), nullable=False),
+        sa.Column("location_id", sa.String(length=100), nullable=True),
+        sa.Column("source_event_id", sa.String(length=100), nullable=False),
+        sa.Column("source_sequence", sa.BigInteger(), nullable=False),
+        sa.Column("source_revision", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["room_id"], ["game_sessions.room_id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "room_id", "subject_id", "source_event_id", "kind", name="uq_memory_entries_source"
+        ),
+    )
+    op.create_index(
+        "ix_memory_entries_scope", "memory_entries", ["room_id", "subject_id", "visibility"]
+    )
+    op.create_index(
+        "ix_memory_entries_entity", "memory_entries", ["room_id", "object_id", "location_id"]
+    )
+    op.create_table(
+        "conversation_summaries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("room_id", sa.Uuid(), nullable=False),
+        sa.Column("player_id", sa.Uuid(), nullable=False),
+        sa.Column("summary_json", sa.JSON(), nullable=False),
+        sa.Column("through_event_sequence", sa.BigInteger(), nullable=False),
+        sa.Column("pending_through_sequence", sa.BigInteger(), nullable=False),
+        sa.Column("source_revision", sa.String(length=100), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("attempt_count", sa.Integer(), nullable=False),
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("lease_owner", sa.String(length=100), nullable=True),
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["player_id"], ["players.id"]),
+        sa.ForeignKeyConstraint(["room_id"], ["game_sessions.room_id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("room_id", "player_id", name="uq_conversation_summaries_scope"),
+    )
+    op.create_index(
+        "ix_conversation_summaries_tasks", "conversation_summaries", ["status", "next_attempt_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversation_summaries_tasks", table_name="conversation_summaries")
+    op.drop_table("conversation_summaries")
+    op.drop_index("ix_memory_entries_entity", table_name="memory_entries")
+    op.drop_index("ix_memory_entries_scope", table_name="memory_entries")
+    op.drop_table("memory_entries")

--- a/trpg-backend/alembic/versions/b2c3d4e5f6a7_add_memory_listener_ids.py
+++ b/trpg-backend/alembic/versions/b2c3d4e5f6a7_add_memory_listener_ids.py
@@ -1,0 +1,28 @@
+"""为长期记忆增加可审计的 NPC 听众字段。"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 旧投影没有听众信息，空数组表示未知，不把历史玩家原话升级成 NPC 亲历。
+    op.add_column(
+        "memory_entries",
+        sa.Column("listener_ids", sa.JSON(), nullable=False, server_default="[]"),
+    )
+
+
+def downgrade() -> None:
+    # 某些旧数据库可能已标记过升级但实际缺列，回滚也必须保持幂等。
+    bind = op.get_bind()
+    columns = {row[1] for row in bind.execute(sa.text("PRAGMA table_info(memory_entries)"))}
+    if "listener_ids" in columns:
+        op.drop_column("memory_entries", "listener_ids")

--- a/trpg-backend/alembic/versions/b2c3d4e5f6a7_add_memory_listener_ids.py
+++ b/trpg-backend/alembic/versions/b2c3d4e5f6a7_add_memory_listener_ids.py
@@ -23,6 +23,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     # 某些旧数据库可能已标记过升级但实际缺列，回滚也必须保持幂等。
     bind = op.get_bind()
-    columns = {row[1] for row in bind.execute(sa.text("PRAGMA table_info(memory_entries)"))}
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("memory_entries")}
     if "listener_ids" in columns:
         op.drop_column("memory_entries", "listener_ids")

--- a/trpg-backend/alembic/versions/c3d4e5f6a7b8_reconcile_memory_listener_column.py
+++ b/trpg-backend/alembic/versions/c3d4e5f6a7b8_reconcile_memory_listener_column.py
@@ -15,9 +15,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     # 线上/本地可能已经被错误标记到 b2；检查后再补列，保证重复升级安全。
     bind = op.get_bind()
-    columns = {
-        row[1] for row in bind.execute(sa.text("PRAGMA table_info(memory_entries)"))
-    }
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("memory_entries")}
     if "listener_ids" not in columns:
         op.add_column(
             "memory_entries",
@@ -27,8 +25,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     bind = op.get_bind()
-    columns = {
-        row[1] for row in bind.execute(sa.text("PRAGMA table_info(memory_entries)"))
-    }
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("memory_entries")}
     if "listener_ids" in columns:
         op.drop_column("memory_entries", "listener_ids")

--- a/trpg-backend/alembic/versions/c3d4e5f6a7b8_reconcile_memory_listener_column.py
+++ b/trpg-backend/alembic/versions/c3d4e5f6a7b8_reconcile_memory_listener_column.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "c3d4e5f6a7b8"
-down_revision: str | None = "b2c3d4e5f6a7"
+down_revision: str | None = "c4d5e6f7a8b9"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/trpg-backend/alembic/versions/c3d4e5f6a7b8_reconcile_memory_listener_column.py
+++ b/trpg-backend/alembic/versions/c3d4e5f6a7b8_reconcile_memory_listener_column.py
@@ -1,0 +1,34 @@
+"""修复部分旧数据库已标记迁移但缺少 listener_ids 列的结构漂移。"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c3d4e5f6a7b8"
+down_revision: str | None = "b2c3d4e5f6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 线上/本地可能已经被错误标记到 b2；检查后再补列，保证重复升级安全。
+    bind = op.get_bind()
+    columns = {
+        row[1] for row in bind.execute(sa.text("PRAGMA table_info(memory_entries)"))
+    }
+    if "listener_ids" not in columns:
+        op.add_column(
+            "memory_entries",
+            sa.Column("listener_ids", sa.JSON(), nullable=False, server_default="[]"),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = {
+        row[1] for row in bind.execute(sa.text("PRAGMA table_info(memory_entries)"))
+    }
+    if "listener_ids" in columns:
+        op.drop_column("memory_entries", "listener_ids")

--- a/trpg-backend/alembic/versions/c4d5e6f7a8b9_add_memory_listener_ids.py
+++ b/trpg-backend/alembic/versions/c4d5e6f7a8b9_add_memory_listener_ids.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "b2c3d4e5f6a7"
+revision: str = "c4d5e6f7a8b9"
 down_revision: str | None = "a1b2c3d4e5f6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/trpg-backend/alembic/versions/e5f6a7b8c9d0_merge_memory_and_module_heads.py
+++ b/trpg-backend/alembic/versions/e5f6a7b8c9d0_merge_memory_and_module_heads.py
@@ -1,0 +1,16 @@
+"""合并记忆系统与 main 分支模组约束迁移的 Alembic 分叉。"""
+
+from collections.abc import Sequence
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: tuple[str, str] = ("c3d4e5f6a7b8", "d4f1a2b3c5e7")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """无数据操作，仅汇合两条已经执行的迁移历史。"""
+
+
+def downgrade() -> None:
+    """无数据操作；降级时由 Alembic 分别回退两个父分支。"""

--- a/trpg-backend/alembic/versions/e5f6a7b8c9d0_merge_memory_and_module_heads.py
+++ b/trpg-backend/alembic/versions/e5f6a7b8c9d0_merge_memory_and_module_heads.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 
 revision: str = "e5f6a7b8c9d0"
-down_revision: tuple[str, str] = ("c3d4e5f6a7b8", "d4f1a2b3c5e7")
+down_revision: tuple[str, str] = ("c3d4e5f6a7b8", "f4a5b6c7d8e9")
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/trpg-backend/app/adapters/conversation_summary.py
+++ b/trpg-backend/app/adapters/conversation_summary.py
@@ -1,0 +1,71 @@
+"""使用现有结构化 Provider 将玩家可见对话压缩为可追溯摘要。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from collaboration_framework.host.schemas import ConversationSummary
+from pydantic import ValidationError
+
+from app.adapters.openai_models import StructuredJsonClient
+
+_SUMMARY_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "summary": {"type": "string", "maxLength": 6000},
+        "unresolved_questions": {"type": "array", "items": {"type": "string"}, "maxItems": 20},
+        "important_entities": {"type": "array", "items": {"type": "string"}, "maxItems": 30},
+    },
+    "required": ["summary", "unresolved_questions", "important_entities"],
+}
+
+_INSTRUCTIONS = """你是 TRPG 对话摘要器。只压缩输入中当前玩家可见的对话和已确认信息。
+不要新增事实、地点、人物关系或行动结果。玩家没有被规则引擎确认的说法必须写成“玩家声称……”。
+保留关键行动、主持人已经描述的事件、人物、地点、线索、当前目标和未解决问题。
+只输出符合 JSON schema 的 JSON，不要输出 Markdown 或解释。"""
+
+
+class ConversationSummaryModel:
+    """Provider-neutral 的摘要模型适配器。"""
+
+    def __init__(self, client: StructuredJsonClient) -> None:
+        self._client = client
+
+    async def summarize(
+        self,
+        *,
+        room_id: str,
+        player_id: str,
+        previous: ConversationSummary | None,
+        visible_events: tuple[dict[str, Any], ...],
+        source_revision: str | None,
+        through_event_sequence: int,
+    ) -> ConversationSummary:
+        """生成摘要后补回不可由模型修改的作用域、游标和来源信息。"""
+        raw = await self._client.generate(
+            schema_name="trpg_conversation_summary",
+            schema=_SUMMARY_SCHEMA,
+            instructions=_INSTRUCTIONS,
+            input_payload={
+                "previous_summary": previous.model_dump(mode="json") if previous else None,
+                "visible_events": visible_events,
+            },
+        )
+        try:
+            return ConversationSummary(
+                room_id=room_id,
+                player_id=player_id,
+                summary=str(raw.get("summary", "")),
+                unresolved_questions=tuple(str(x) for x in raw.get("unresolved_questions", ())),
+                important_entities=tuple(str(x) for x in raw.get("important_entities", ())),
+                through_event_sequence=through_event_sequence,
+                source_revision=source_revision,
+                source_event_ids=tuple(
+                    str(item.get("id"))
+                    for item in visible_events
+                    if isinstance(item.get("id"), str)
+                ),
+            )
+        except (ValidationError, TypeError, ValueError) as exc:
+            raise ValueError("摘要模型输出不符合契约") from exc

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import UTC, datetime
 
 from collaboration_framework.host.schemas import ConversationSummary, MemoryContext, MemoryEntry
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, case, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.engine import GameEvent
@@ -163,6 +163,8 @@ class SqlAlchemyMemoryStore:
         async with self._session_factory() as session:
             conditions = [
                 MemoryEntryRecord.room_id == room_id,
+                # Engine 的内部裁决原因只服务审计，不应占用 Host 的剧情记忆预算。
+                ~MemoryEntryRecord.content.startswith("adjudication:"),
                 or_(
                     MemoryEntryRecord.visibility == "public",
                     and_(
@@ -188,6 +190,11 @@ class SqlAlchemyMemoryStore:
                         select(MemoryEntryRecord)
                         .where(*conditions)
                         .order_by(
+                            case(
+                                (MemoryEntryRecord.kind == "conversation", 0),
+                                (MemoryEntryRecord.epistemic_status == "presentation", 1),
+                                else_=2,
+                            ),
                             MemoryEntryRecord.source_sequence.desc(),
                             MemoryEntryRecord.created_at.desc(),
                         )

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -14,6 +14,22 @@ from app.models.event import Event
 from app.models.memory import ConversationSummaryRecord, MemoryEntryRecord
 
 
+def _canonical_id(value: str | None) -> str | None:
+    """统一 UUID 的连字符表示；非 UUID 的 actor/entity ID 保持原样。"""
+    if not value:
+        return value
+    try:
+        return uuid.UUID(value).hex
+    except (ValueError, AttributeError):
+        return value
+
+
+def _scope_ids(value: str) -> tuple[str, ...]:
+    """查询同时兼容历史带连字符 ID 和新 canonical ID。"""
+    canonical = _canonical_id(value) or value
+    return tuple(dict.fromkeys((value, canonical)))
+
+
 def _text(payload: dict) -> str:
     """只抽取玩家安全的展示文本，未知 payload 不升级为事实。"""
     for key in ("text", "utterance", "summary", "description", "content"):
@@ -32,17 +48,66 @@ def _memory_from_event(event: Event) -> MemoryEntry | None:
     return MemoryEntry(
         memory_id=f"event:{event.id}",
         room_id=event.room_id,
-        subject_id=event.actor_id or event.player_id or "room",
+        subject_id=_canonical_id(event.actor_id or event.player_id) or "room",
         object_id=None,
         kind=kind,
         content=text,
         epistemic_status="presentation" if kind == "conversation" else "asserted",
         visibility="player_scoped" if event.visibility == "player_scoped" else "public",
-        participants=tuple(x for x in (event.player_id, event.actor_id) if x),
+        participants=tuple(_canonical_id(x) for x in (event.player_id, event.actor_id) if x),
+        listener_ids=tuple(
+            _canonical_id(str(item)) or str(item)
+            for item in event.payload.get("listener_ids", event.payload.get("listenerIds", ()))
+            if item
+        ),
         location_id=event.scene_id,
         source_event_id=event.id,
         source_sequence=0,
         source_revision=event.view_revision,
+    )
+
+
+def _listener_memories(event: Event) -> tuple[MemoryEntry, ...]:
+    """把服务端确认的听众投影为 NPC 的亲历记忆，不依赖模型猜测。"""
+    if event.event_type != "action.broadcast":
+        return ()
+    payload = event.payload or {}
+    listener_ids = tuple(
+        _canonical_id(str(item)) or str(item)
+        for item in payload.get("listener_ids", payload.get("listenerIds", ()))
+        if item
+    )
+    utterance = str(payload.get("utterance", "")).strip()
+    speaker_id = (
+        _canonical_id(
+            str(
+                payload.get("speaker_id") or payload.get("speakerId") or event.actor_id or ""
+            ).strip()
+        )
+        or ""
+    )
+    if not listener_ids or not utterance or not speaker_id:
+        return ()
+    return tuple(
+        MemoryEntry(
+            memory_id=f"event:{event.id}:listener:{listener_id}",
+            room_id=event.room_id,
+            subject_id=listener_id,
+            object_id=None,
+            kind="conversation",
+            content=(
+                f'玩家角色 {speaker_id} 对实体 {listener_id} 说："{utterance}"；该实体在场并听到。'
+            ),
+            epistemic_status="experienced",
+            visibility="public" if event.visibility == "public" else "player_scoped",
+            participants=(speaker_id, listener_id),
+            listener_ids=(listener_id,),
+            location_id=event.scene_id,
+            source_event_id=f"{event.id}:listener:{listener_id}",
+            source_sequence=0,
+            source_revision=event.view_revision,
+        )
+        for listener_id in listener_ids
     )
 
 
@@ -68,6 +133,7 @@ def _memory_from_game_event(event: GameEvent) -> MemoryEntry | None:
         epistemic_status="confirmed",
         visibility="public" if event.visibility == "public" else "entity_scoped",
         participants=(event.actor_id,),
+        listener_ids=(),
         source_event_id=event.event_id,
         source_sequence=event.sequence,
     )
@@ -112,6 +178,9 @@ class SqlAlchemyMemoryStore:
             count = 0
             candidates = [entry for event in events if (entry := _memory_from_event(event))]
             candidates.extend(
+                listener for event in events for listener in _listener_memories(event)
+            )
+            candidates.extend(
                 entry for event in game_events if (entry := _memory_from_game_event(event))
             )
             for entry in candidates:
@@ -136,6 +205,7 @@ class SqlAlchemyMemoryStore:
                         epistemic_status=entry.epistemic_status,
                         visibility=entry.visibility,
                         participants=list(entry.participants),
+                        listener_ids=list(entry.listener_ids),
                         location_id=entry.location_id,
                         source_event_id=entry.source_event_id,
                         source_sequence=entry.source_sequence,
@@ -155,12 +225,17 @@ class SqlAlchemyMemoryStore:
         revision: str,
         entity_ids: tuple[str, ...] = (),
         location_id: str | None = None,
-        limit: int = 8,
-        max_chars: int = 2500,
+        limit: int = 12,
+        max_chars: int = 4000,
     ) -> MemoryContext:
         """按服务端作用域过滤记忆，模型不能自行扩大查询范围。"""
         await self.project_room_events(room_id)
         async with self._session_factory() as session:
+            player_scope_ids = _scope_ids(player_id)
+            actor_scope_ids = _scope_ids(actor_id)
+            entity_scope_ids = tuple(
+                item for entity_id in entity_ids for item in _scope_ids(entity_id)
+            )
             conditions = [
                 MemoryEntryRecord.room_id == room_id,
                 # Engine 的内部裁决原因只服务审计，不应占用 Host 的剧情记忆预算。
@@ -169,16 +244,23 @@ class SqlAlchemyMemoryStore:
                     MemoryEntryRecord.visibility == "public",
                     and_(
                         MemoryEntryRecord.visibility == "player_scoped",
-                        MemoryEntryRecord.participants.contains([player_id]),
+                        or_(
+                            *(
+                                MemoryEntryRecord.participants.contains([item])
+                                for item in player_scope_ids
+                            )
+                        ),
                     ),
-                    MemoryEntryRecord.subject_id.in_((player_id, actor_id, *entity_ids)),
+                    MemoryEntryRecord.subject_id.in_(
+                        (*player_scope_ids, *actor_scope_ids, *entity_scope_ids)
+                    ),
                 ),
             ]
             if location_id:
                 conditions.append(
                     or_(
                         MemoryEntryRecord.location_id == location_id,
-                        MemoryEntryRecord.object_id.in_(entity_ids),
+                        MemoryEntryRecord.object_id.in_(entity_scope_ids),
                         # 没有地点的全局权威事件仍然是可召回的长期事实；外层
                         # room/visibility/participant 条件继续负责权限隔离。
                         MemoryEntryRecord.location_id.is_(None),
@@ -191,9 +273,15 @@ class SqlAlchemyMemoryStore:
                         .where(*conditions)
                         .order_by(
                             case(
-                                (MemoryEntryRecord.kind == "conversation", 0),
-                                (MemoryEntryRecord.epistemic_status == "presentation", 1),
-                                else_=2,
+                                (
+                                    MemoryEntryRecord.epistemic_status.in_(
+                                        ("experienced", "heard")
+                                    ),
+                                    0,
+                                ),
+                                (MemoryEntryRecord.kind == "conversation", 1),
+                                (MemoryEntryRecord.epistemic_status == "presentation", 2),
+                                else_=3,
                             ),
                             MemoryEntryRecord.source_sequence.desc(),
                             MemoryEntryRecord.created_at.desc(),
@@ -216,6 +304,7 @@ class SqlAlchemyMemoryStore:
                         "epistemic_status": record.epistemic_status,
                         "visibility": record.visibility,
                         "participants": tuple(record.participants or ()),
+                        "listener_ids": tuple(record.listener_ids or ()),
                         "location_id": record.location_id,
                         "source_event_id": record.source_event_id,
                         "source_sequence": record.source_sequence,
@@ -229,7 +318,7 @@ class SqlAlchemyMemoryStore:
             summary_record = await session.scalar(
                 select(ConversationSummaryRecord).where(
                     ConversationSummaryRecord.room_id == room_id,
-                    ConversationSummaryRecord.player_id == player_id,
+                    ConversationSummaryRecord.player_id.in_(player_scope_ids),
                 )
             )
             summary = None

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -177,6 +177,9 @@ class SqlAlchemyMemoryStore:
                     or_(
                         MemoryEntryRecord.location_id == location_id,
                         MemoryEntryRecord.object_id.in_(entity_ids),
+                        # 没有地点的全局权威事件仍然是可召回的长期事实；外层
+                        # room/visibility/participant 条件继续负责权限隔离。
+                        MemoryEntryRecord.location_id.is_(None),
                     )
                 )
             records = list(

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -54,7 +54,11 @@ def _memory_from_event(event: Event) -> MemoryEntry | None:
         content=text,
         epistemic_status="presentation" if kind == "conversation" else "asserted",
         visibility="player_scoped" if event.visibility == "player_scoped" else "public",
-        participants=tuple(_canonical_id(x) for x in (event.player_id, event.actor_id) if x),
+        participants=tuple(
+            canonical
+            for x in (event.player_id, event.actor_id)
+            if (canonical := _canonical_id(x)) is not None
+        ),
         listener_ids=tuple(
             _canonical_id(str(item)) or str(item)
             for item in event.payload.get("listener_ids", event.payload.get("listenerIds", ()))

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -1,0 +1,263 @@
+"""长期记忆的确定性投影、权限查询和摘要任务状态存储。"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from collaboration_framework.host.schemas import ConversationSummary, MemoryContext, MemoryEntry
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.engine import GameEvent
+from app.models.event import Event
+from app.models.memory import ConversationSummaryRecord, MemoryEntryRecord
+
+
+def _text(payload: dict) -> str:
+    """只抽取玩家安全的展示文本，未知 payload 不升级为事实。"""
+    for key in ("text", "utterance", "summary", "description", "content"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()[:2000]
+    return ""
+
+
+def _memory_from_event(event: Event) -> MemoryEntry | None:
+    """把公开行动/叙事事件转换成可审计的 presentation 记忆。"""
+    text = _text(event.payload or {})
+    if not text:
+        return None
+    kind = "conversation" if event.event_type == "narration.push" else "action"
+    return MemoryEntry(
+        memory_id=f"event:{event.id}",
+        room_id=event.room_id,
+        subject_id=event.actor_id or event.player_id or "room",
+        object_id=None,
+        kind=kind,
+        content=text,
+        epistemic_status="presentation" if kind == "conversation" else "asserted",
+        visibility="player_scoped" if event.visibility == "player_scoped" else "public",
+        participants=tuple(x for x in (event.player_id, event.actor_id) if x),
+        location_id=event.scene_id,
+        source_event_id=event.id,
+        source_sequence=0,
+        source_revision=event.view_revision,
+    )
+
+
+def _memory_from_game_event(event: GameEvent) -> MemoryEntry | None:
+    """把公开权威事件投影为 confirmed/ex-perienced 记忆。"""
+    text = _text(event.payload or {}) or event.cause.strip()
+    if not text:
+        return None
+    if event.type == "location.entered":
+        kind = "visit"
+    elif "discover" in event.type or "fact" in event.type:
+        kind = "clue"
+    elif event.type.startswith("action."):
+        kind = "action"
+    else:
+        kind = "world_event"
+    return MemoryEntry(
+        memory_id=f"game-event:{event.event_id}",
+        room_id=event.room_id,
+        subject_id=event.actor_id,
+        kind=kind,
+        content=text[:2000],
+        epistemic_status="confirmed",
+        visibility="public" if event.visibility == "public" else "entity_scoped",
+        participants=(event.actor_id,),
+        source_event_id=event.event_id,
+        source_sequence=event.sequence,
+    )
+
+
+class SqlAlchemyMemoryStore:
+    """提供玩家安全 MemoryContext，并以唯一来源键保证重复投影幂等。"""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def project_room_events(self, room_id: str) -> int:
+        """补投影公开回放事件；规则状态仍由 Engine 自己维护。"""
+        async with self._session_factory() as session:
+            events = list(
+                (
+                    await session.scalars(
+                        select(Event)
+                        .where(
+                            Event.room_id == room_id,
+                            Event.event_type.in_(
+                                ("action.broadcast", "narration.push", "check.result")
+                            ),
+                            or_(Event.visibility == "public", Event.player_id.is_not(None)),
+                        )
+                        .order_by(Event.created_at, Event.id)
+                    )
+                ).all()
+            )
+            game_events = list(
+                (
+                    await session.scalars(
+                        select(GameEvent)
+                        .where(
+                            GameEvent.room_id == room_id,
+                            GameEvent.visibility == "public",
+                        )
+                        .order_by(GameEvent.sequence)
+                    )
+                ).all()
+            )
+            count = 0
+            candidates = [entry for event in events if (entry := _memory_from_event(event))]
+            candidates.extend(
+                entry for event in game_events if (entry := _memory_from_game_event(event))
+            )
+            for entry in candidates:
+                exists = await session.scalar(
+                    select(MemoryEntryRecord.id).where(
+                        MemoryEntryRecord.room_id == room_id,
+                        MemoryEntryRecord.subject_id == entry.subject_id,
+                        MemoryEntryRecord.source_event_id == entry.source_event_id,
+                        MemoryEntryRecord.kind == entry.kind,
+                    )
+                )
+                if exists is not None:
+                    continue
+                session.add(
+                    MemoryEntryRecord(
+                        id=str(uuid.uuid4()),
+                        room_id=entry.room_id,
+                        subject_id=entry.subject_id,
+                        object_id=entry.object_id,
+                        kind=entry.kind,
+                        content=entry.content,
+                        epistemic_status=entry.epistemic_status,
+                        visibility=entry.visibility,
+                        participants=list(entry.participants),
+                        location_id=entry.location_id,
+                        source_event_id=entry.source_event_id,
+                        source_sequence=entry.source_sequence,
+                        source_revision=entry.source_revision,
+                    )
+                )
+                count += 1
+            await session.commit()
+            return count
+
+    async def read_context(
+        self,
+        *,
+        room_id: str,
+        player_id: str,
+        actor_id: str,
+        revision: str,
+        entity_ids: tuple[str, ...] = (),
+        location_id: str | None = None,
+        limit: int = 8,
+        max_chars: int = 2500,
+    ) -> MemoryContext:
+        """按服务端作用域过滤记忆，模型不能自行扩大查询范围。"""
+        await self.project_room_events(room_id)
+        async with self._session_factory() as session:
+            conditions = [
+                MemoryEntryRecord.room_id == room_id,
+                or_(
+                    MemoryEntryRecord.visibility == "public",
+                    and_(
+                        MemoryEntryRecord.visibility == "player_scoped",
+                        MemoryEntryRecord.participants.contains([player_id]),
+                    ),
+                    MemoryEntryRecord.subject_id.in_((player_id, actor_id, *entity_ids)),
+                ),
+            ]
+            if location_id:
+                conditions.append(
+                    or_(
+                        MemoryEntryRecord.location_id == location_id,
+                        MemoryEntryRecord.object_id.in_(entity_ids),
+                    )
+                )
+            records = list(
+                (
+                    await session.scalars(
+                        select(MemoryEntryRecord)
+                        .where(*conditions)
+                        .order_by(
+                            MemoryEntryRecord.source_sequence.desc(),
+                            MemoryEntryRecord.created_at.desc(),
+                        )
+                        .limit(limit * 3)
+                    )
+                ).all()
+            )
+            entries: list[MemoryEntry] = []
+            total = 0
+            for record in records:
+                entry = MemoryEntry.model_validate(
+                    {
+                        "memory_id": record.id,
+                        "room_id": record.room_id,
+                        "subject_id": record.subject_id,
+                        "object_id": record.object_id,
+                        "kind": record.kind,
+                        "content": record.content,
+                        "epistemic_status": record.epistemic_status,
+                        "visibility": record.visibility,
+                        "participants": tuple(record.participants or ()),
+                        "location_id": record.location_id,
+                        "source_event_id": record.source_event_id,
+                        "source_sequence": record.source_sequence,
+                        "source_revision": record.source_revision,
+                    }
+                )
+                if len(entries) >= limit or total + len(entry.content) > max_chars:
+                    continue
+                entries.append(entry)
+                total += len(entry.content)
+            summary_record = await session.scalar(
+                select(ConversationSummaryRecord).where(
+                    ConversationSummaryRecord.room_id == room_id,
+                    ConversationSummaryRecord.player_id == player_id,
+                )
+            )
+            summary = None
+            if summary_record and summary_record.summary_json:
+                summary = ConversationSummary.model_validate(summary_record.summary_json)
+            return MemoryContext(
+                room_id=room_id,
+                player_id=player_id,
+                actor_id=actor_id,
+                as_of_revision=revision,
+                entries=tuple(entries),
+                conversation_summary=summary,
+            )
+
+    async def enqueue_summary(self, *, room_id: str, player_id: str, through_sequence: int) -> None:
+        """推进摘要任务目标；同一玩家只保留最新游标。"""
+        async with self._session_factory() as session:
+            record = await session.scalar(
+                select(ConversationSummaryRecord).where(
+                    ConversationSummaryRecord.room_id == room_id,
+                    ConversationSummaryRecord.player_id == player_id,
+                )
+            )
+            if record is None:
+                record = ConversationSummaryRecord(
+                    room_id=room_id,
+                    player_id=player_id,
+                    summary_json={},
+                    pending_through_sequence=through_sequence,
+                    status="pending",
+                    attempt_count=0,
+                    updated_at=datetime.now(UTC),
+                )
+                session.add(record)
+            else:
+                record.pending_through_sequence = max(
+                    record.pending_through_sequence, through_sequence
+                )
+                if record.status == "idle":
+                    record.status = "pending"
+            await session.commit()

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -780,17 +780,6 @@ async def _send_completed_turn_message(
         },
     )
     await _send_view_updated(websocket, player_id, player_view)
-    recorded = await _deliver_turn_narration(
-        db,
-        websocket,
-        room_id,
-        player_id,
-        client_action_id=client_action_id,
-        narration=narration,
-        actor_id=actor_id,
-        scene_id=player_view.scene_id,
-        view_revision=player_view.revision,
-    )
     if recorded:
         await _emit_turn_narration(
             websocket,

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -34,6 +34,7 @@ WebSocket 可能存活很久，用一个 session 包住整条连接会在这期�
 连接取消时短 session 的 close/rollback 会在 shield 中完成，避免遗留锁。
 """
 
+import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from functools import partial
@@ -135,7 +136,6 @@ from app.models.engine import (
     RoomActionReservation,
     TimeAdvanceProposalRecord,
 )
-from app.models.room import Player
 from app.service import auth as auth_service
 from app.service import chat as chat_service
 from app.service import room as room_service
@@ -633,23 +633,11 @@ async def _send_completed_turn_message(
     # 摘要是异步可重建读模型，不能阻塞本回合的权威叙事发送。
     summary_service = getattr(websocket.app.state, "conversation_summary_service", None)
     if summary_service is not None:
-        # 公开事件对房间内所有仍在场玩家可见；摘要必须逐玩家入队，
-        # 私有事件则由 enqueue_if_needed 内部再次按 player_id 过滤。
-        player_ids = list(
-            (
-                await db.scalars(
-                    select(Player.id).where(
-                        Player.room_id == room_id,
-                        Player.left_at.is_(None),
-                    )
-                )
-            ).all()
+        # 摘要是异步读模型；公开事件为所有玩家入队，但不能阻塞回合响应。
+        asyncio.create_task(
+            summary_service.enqueue_room_if_needed(room_id=room_id),
+            name=f"enqueue-conversation-summary-{room_id}",
         )
-        for visible_player_id in player_ids:
-            await summary_service.enqueue_if_needed(
-                room_id=room_id,
-                player_id=visible_player_id,
-            )
     return recorded
 
 

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -629,6 +629,10 @@ async def _send_completed_turn_message(
         scene_id=player_view.scene_id,
         view_revision=player_view.revision,
     )
+    # 摘要是异步可重建读模型，不能阻塞本回合的权威叙事发送。
+    summary_service = getattr(websocket.app.state, "conversation_summary_service", None)
+    if summary_service is not None:
+        await summary_service.enqueue_if_needed(room_id=room_id, player_id=player_id)
     return recorded
 
 

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -73,6 +73,7 @@ from starlette.websockets import WebSocketState
 from app.adapters.structured_http import StructuredOutputError, is_transient_model_error
 from app.core.action_plan_turn import (
     ActionPlanTurnResult,
+    _matching_visible_entity_ids,
     action_plan_turn_application,
 )
 from app.core.db import async_session_factory
@@ -146,6 +147,16 @@ from app.service.ws_manager import manager
 
 router = APIRouter()
 logger = structlog.get_logger()
+
+_DIRECT_SPEECH_MARKERS = ("告诉", "询问", "问", "提醒", "威胁", "喊", "说", "请")
+
+
+def _listener_ids_for_utterance(utterance: str, player_view: PlayerView) -> tuple[str, ...]:
+    """只有明确的对话动词才把可见实体认定为听众，避免把“去找 NPC”记成对话。"""
+    if not any(marker in utterance for marker in _DIRECT_SPEECH_MARKERS):
+        return ()
+    return _matching_visible_entity_ids(utterance, player_view)
+
 
 _UNAUTHORIZED_CLOSE_CODE = 4401
 _NOT_FOUND_CLOSE_CODE = 4404
@@ -1141,12 +1152,16 @@ async def _broadcast_action_utterance(
         player_input.player_id,
         fallback=nickname,
     )
+    listener_ids = _listener_ids_for_utterance(player_input.utterance, player_view)
     payload = ActionBroadcastPayload(
         player_id=player_input.player_id,
         client_action_id=player_input.client_action_id,
         nickname=nickname,
         character_name=character_name,
         utterance=player_input.utterance,
+        speaker_id=player_input.actor_id,
+        listener_ids=listener_ids,
+        participant_ids=(player_input.actor_id, *listener_ids),
     )
     recorded = await room_service.record_event(
         db,

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -135,6 +135,7 @@ from app.models.engine import (
     RoomActionReservation,
     TimeAdvanceProposalRecord,
 )
+from app.models.room import Player
 from app.service import auth as auth_service
 from app.service import chat as chat_service
 from app.service import room as room_service
@@ -632,7 +633,23 @@ async def _send_completed_turn_message(
     # 摘要是异步可重建读模型，不能阻塞本回合的权威叙事发送。
     summary_service = getattr(websocket.app.state, "conversation_summary_service", None)
     if summary_service is not None:
-        await summary_service.enqueue_if_needed(room_id=room_id, player_id=player_id)
+        # 公开事件对房间内所有仍在场玩家可见；摘要必须逐玩家入队，
+        # 私有事件则由 enqueue_if_needed 内部再次按 player_id 过滤。
+        player_ids = list(
+            (
+                await db.scalars(
+                    select(Player.id).where(
+                        Player.room_id == room_id,
+                        Player.left_at.is_(None),
+                    )
+                )
+            ).all()
+        )
+        for visible_player_id in player_ids:
+            await summary_service.enqueue_if_needed(
+                room_id=room_id,
+                player_id=visible_player_id,
+            )
     return recorded
 
 

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -66,6 +66,7 @@ from collaboration_framework.host.schemas import (
     ActionPlanStepContext,
     CompletedPlanStepSummary,
     HostAgentContext,
+    MemoryContext,
     RecentHistoryBudget,
     RecentTurnContext,
     SingleActionClarificationResult,
@@ -102,6 +103,21 @@ class _ActionAdjudicationService(Protocol):
         self,
         request: PostRollDecisionRequest,
     ) -> AdjudicationExecution: ...
+
+
+class _MemorySource(Protocol):
+    async def read_context(
+        self,
+        *,
+        room_id: str,
+        player_id: str,
+        actor_id: str,
+        revision: str,
+        entity_ids: tuple[str, ...] = (),
+        location_id: str | None = None,
+        limit: int = 8,
+        max_chars: int = 2500,
+    ) -> MemoryContext: ...
 
 
 async def _emit_phase(observer: TurnPhaseObserver | None, phase: TurnPhase) -> None:
@@ -667,6 +683,7 @@ class ActionPlanTurnApplication:
         recent_history_source: RecentHistorySource,
         recent_history_budget: RecentHistoryBudget,
         recent_history_enabled: bool,
+        memory_source: _MemorySource | None = None,
     ) -> None:
         self._store = store
         self._engine = engine
@@ -676,6 +693,7 @@ class ActionPlanTurnApplication:
         self._recent_history_source = recent_history_source
         self._recent_history_budget = recent_history_budget
         self._recent_history_enabled = recent_history_enabled
+        self._memory_source = memory_source
         self._narrator = narrator
         self._projector = PlayerViewProjector(engine)
         self._dispatcher = HostTurnDecisionExecutor(
@@ -760,12 +778,18 @@ class ActionPlanTurnApplication:
             player_input=player_input,
             player_view=view,
         )
+        memory_context = await self._read_memory_context(
+            player_input=player_input,
+            player_view=view,
+        )
         try:
             decision = await self._planner.generate(
                 HostAgentContext(
                     player_input=player_input,
                     player_view=view,
                     recent_history=recent_history,
+                    memories=memory_context.entries,
+                    conversation_summary=memory_context.conversation_summary,
                     # A single action is adjudicated right here in the planner call,
                     # so it needs the same Keeper vocabulary a plan step gets.
                     keeper_capabilities=keeper_capabilities,
@@ -1361,6 +1385,17 @@ class ActionPlanTurnApplication:
         self,
         context: ActionPlanNarrationContext,
     ) -> ActionPlanNarrationOutput:
+        if hasattr(context.player_input, "room_id") and hasattr(context.player_view, "revision"):
+            memory_context = await self._read_memory_context(
+                player_input=context.player_input,
+                player_view=context.player_view,
+            )
+            context = context.model_copy(
+                update={
+                    "memories": memory_context.entries,
+                    "conversation_summary": memory_context.conversation_summary,
+                }
+            )
         for attempt in range(2):
             try:
                 return await self._narrator.narrate(context)
@@ -1582,6 +1617,33 @@ class ActionPlanTurnApplication:
             )
         return recent_history
 
+    async def _read_memory_context(
+        self,
+        *,
+        player_input: PlayerInput,
+        player_view: PlayerView,
+    ) -> MemoryContext:
+        """读取可选长期上下文；失败只降级为空，不阻断当前回合。"""
+        empty = MemoryContext(
+            room_id=player_input.room_id,
+            player_id=player_input.player_id,
+            actor_id=player_input.actor_id,
+            as_of_revision=player_view.revision,
+        )
+        if self._memory_source is None:
+            return empty
+        try:
+            return await self._memory_source.read_context(
+                room_id=player_input.room_id,
+                player_id=player_input.player_id,
+                actor_id=player_input.actor_id,
+                revision=player_view.revision,
+                location_id=player_view.scene_id,
+            )
+        except Exception as exc:  # noqa: BLE001 - 读模型故障必须 fail-open
+            logger.warning("memory_context_degraded", error_type=type(exc).__name__)
+            return empty
+
     async def _resolve_actor_id(self, room_id: str, player_id: str) -> str:
         async with self._store.transaction(room_id) as transaction:
             runtime = await transaction.load_runtime()
@@ -1621,6 +1683,7 @@ def build_action_plan_turn_application(
     settings=None,
     client=None,
     recent_history_source: RecentHistorySource | None = None,
+    memory_source: _MemorySource | None = None,
     time_consent_session_factory=None,
 ) -> ActionPlanTurnApplication:
     """Compose the finite-plan path without changing the single-intent Engine."""
@@ -1685,6 +1748,11 @@ def build_action_plan_turn_application(
         max_chars=resolved.recent_history_max_chars,
     )
     history_source = recent_history_source or _EmptyRecentHistorySource()
+    if memory_source is None:
+        from app.adapters.sqlalchemy_memory import SqlAlchemyMemoryStore
+        from app.core.db import async_session_factory
+
+        memory_source = SqlAlchemyMemoryStore(async_session_factory)
     consent_aware_engine = adjudication_engine
     if time_consent_session_factory is not None:
         from app.service.time_advance import ConsentAwareAdjudicationEngine
@@ -1713,6 +1781,7 @@ def build_action_plan_turn_application(
         recent_history_source=history_source,
         recent_history_budget=recent_history_budget,
         recent_history_enabled=resolved.recent_history_enabled,
+        memory_source=memory_source,
     )
 
 

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -79,6 +79,18 @@ from app.core.turn_events import TurnPhase
 
 logger = structlog.get_logger()
 
+
+def _matching_visible_entity_ids(utterance: str, player_view: PlayerView) -> tuple[str, ...]:
+    """从玩家原话确定性匹配当前可见实体，供长期记忆按实体优先检索。"""
+    text = utterance.casefold()
+    matches: list[str] = []
+    for entity in player_view.scene.visible_entities:
+        names = (entity.name, *entity.aliases)
+        if any(name and name.casefold() in text for name in names):
+            matches.append(entity.id)
+    return tuple(matches)
+
+
 TurnPhaseObserver = Callable[[TurnPhase], Awaitable[None]]
 
 
@@ -1633,12 +1645,17 @@ class ActionPlanTurnApplication:
         if self._memory_source is None:
             return empty
         try:
+            entity_ids = _matching_visible_entity_ids(
+                player_input.utterance,
+                player_view,
+            )
             return await self._memory_source.read_context(
                 room_id=player_input.room_id,
                 player_id=player_input.player_id,
                 actor_id=player_input.actor_id,
                 revision=player_view.revision,
                 location_id=player_view.scene_id,
+                entity_ids=entity_ids,
             )
         except Exception as exc:  # noqa: BLE001 - 读模型故障必须 fail-open
             logger.warning("memory_context_degraded", error_type=type(exc).__name__)

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -1402,11 +1402,22 @@ class ActionPlanTurnApplication:
                 player_input=context.player_input,
                 player_view=context.player_view,
             )
-            context = context.model_copy(
-                update={
-                    "memories": memory_context.entries,
-                    "conversation_summary": memory_context.conversation_summary,
-                }
+            # 在最终调用 Narrator 前显式构造完整契约，避免依赖未知字段注入或
+            # 让记忆只存在于 Python 对象而没有进入序列化 payload。
+            context = ActionPlanNarrationContext(
+                background=context.background,
+                player_input=context.player_input,
+                plan_id=context.plan_id,
+                plan_goal=context.plan_goal,
+                termination_status=context.termination_status,
+                completed_steps=context.completed_steps,
+                player_view=context.player_view,
+                memories=memory_context.entries,
+                conversation_summary=memory_context.conversation_summary,
+                opening_world_time=context.opening_world_time,
+                allowed_evidence_refs=context.allowed_evidence_refs,
+                narration_evidence=context.narration_evidence,
+                narration_retry_hint=context.narration_retry_hint,
             )
         for attempt in range(2):
             try:

--- a/trpg-backend/app/dto/ws.py
+++ b/trpg-backend/app/dto/ws.py
@@ -265,13 +265,17 @@ class RoomActionStatePayload(CamelModel):
 
 
 class ActionBroadcastPayload(CamelModel):
-    """action.plan.submit 原话广播 payload。"""
+    """action.plan.submit 原话及服务端确认的公开互动参与者。"""
 
     player_id: str
     client_action_id: str
     nickname: str
     character_name: str | None = None
     utterance: str
+    # 只有服务端能证明当前可见实体在场并被原话明确指向时才填写。
+    speaker_id: str | None = None
+    listener_ids: tuple[str, ...] = ()
+    participant_ids: tuple[str, ...] = ()
 
 
 class TurnStartedPayload(CamelModel):

--- a/trpg-backend/app/main.py
+++ b/trpg-backend/app/main.py
@@ -27,6 +27,7 @@ from app.core.seed import ensure_seed_content
 from app.dto.common import ApiResponse
 from app.service.builtin_module_loader import load_builtin_modules
 from app.service.character_background import build_character_background_service
+from app.service.conversation_summary import build_conversation_summary_service
 from app.service.host_speech import build_host_speech_service
 from app.service.portrait_generation import (
     PortraitGenerationService,
@@ -70,11 +71,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await load_builtin_modules(db)
     portrait_service: PortraitGenerationService = app.state.portrait_generation_service
     await portrait_service.recover_interrupted()
+    await app.state.conversation_summary_service.start()
     logger.info("app_started")
     try:
         yield
     finally:
         await portrait_service.shutdown()
+        await app.state.conversation_summary_service.stop()
         logger.info("app_stopped")
 
 
@@ -101,6 +104,10 @@ def create_app() -> FastAPI:
     app.state.character_background_service = build_character_background_service(settings)
     app.state.portrait_generation_service = build_portrait_generation_service(settings)
     app.state.host_speech = build_host_speech_service(settings)
+    app.state.conversation_summary_service = build_conversation_summary_service(
+        settings,
+        async_session_factory,
+    )
 
     # 允许配置里列出的前端源发起跨域请求（本地开发场景下 Vite 默认跑在
     # 9877 端口，跟后端的 8000 端口不同源，没有这个中间件浏览器会拦截请求）。

--- a/trpg-backend/app/models/__init__.py
+++ b/trpg-backend/app/models/__init__.py
@@ -33,6 +33,7 @@ from app.models.engine import (
     TimeAdvanceProposalRecord,
 )
 from app.models.event import CheckResult, Event
+from app.models.memory import ConversationSummaryRecord, MemoryEntryRecord
 from app.models.replay import ModuleImportJob, RoomSummary
 from app.models.room import Character, CharacterPortrait, Note, Player, Room
 from app.models.user import User, UserCharacterTemplate, UserCharacterTemplatePortrait, UserSession
@@ -77,4 +78,6 @@ __all__ = [
     "UserCharacterTemplatePortrait",
     "UserSession",
     "World",
+    "ConversationSummaryRecord",
+    "MemoryEntryRecord",
 ]

--- a/trpg-backend/app/models/memory.py
+++ b/trpg-backend/app/models/memory.py
@@ -1,0 +1,95 @@
+"""长期记忆与玩家独立对话摘要的可重建数据库投影。"""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+
+
+class MemoryEntryRecord(Base):
+    """从权威事件确定性生成的一条玩家安全记忆。"""
+
+    __tablename__ = "memory_entries"
+    __table_args__ = (
+        UniqueConstraint(
+            "room_id",
+            "subject_id",
+            "source_event_id",
+            "kind",
+            name="uq_memory_entries_source",
+        ),
+        Index("ix_memory_entries_scope", "room_id", "subject_id", "visibility"),
+        Index("ix_memory_entries_entity", "room_id", "object_id", "location_id"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    room_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("game_sessions.room_id"), nullable=False
+    )
+    subject_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    object_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    kind: Mapped[str] = mapped_column(String(40), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    epistemic_status: Mapped[str] = mapped_column(String(30), nullable=False)
+    visibility: Mapped[str] = mapped_column(String(30), nullable=False)
+    participants: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    location_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    source_event_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    source_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    source_revision: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+
+class ConversationSummaryRecord(Base):
+    """每个房间/玩家一份摘要及其可恢复的异步任务状态。"""
+
+    __tablename__ = "conversation_summaries"
+    __table_args__ = (
+        UniqueConstraint("room_id", "player_id", name="uq_conversation_summaries_scope"),
+        Index("ix_conversation_summaries_tasks", "status", "next_attempt_at"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    room_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("game_sessions.room_id"), nullable=False
+    )
+    player_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("players.id"), nullable=False
+    )
+    summary_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    through_event_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    pending_through_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    source_revision: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="idle")
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    lease_owner: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    lease_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/trpg-backend/app/models/memory.py
+++ b/trpg-backend/app/models/memory.py
@@ -49,6 +49,8 @@ class MemoryEntryRecord(Base):
     epistemic_status: Mapped[str] = mapped_column(String(30), nullable=False)
     visibility: Mapped[str] = mapped_column(String(30), nullable=False)
     participants: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    # 与 participants 分开保存，避免把“共同参与”误当成“亲自听到”。
+    listener_ids: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     location_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     source_event_id: Mapped[str] = mapped_column(String(100), nullable=False)
     source_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)

--- a/trpg-backend/app/service/conversation_summary.py
+++ b/trpg-backend/app/service/conversation_summary.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.adapters.conversation_summary import ConversationSummaryModel
 from app.models.event import Event
 from app.models.memory import ConversationSummaryRecord
+from app.models.room import Player
 
 logger = structlog.get_logger()
 
@@ -108,6 +109,25 @@ class ConversationSummaryService:
                 record.status = "pending"
                 record.updated_at = datetime.now(UTC)
             await session.commit()
+
+    async def enqueue_room_if_needed(self, *, room_id: str) -> None:
+        """为房间内所有仍在场玩家推进摘要；调用方可放入后台任务。"""
+        try:
+            async with self._session_factory() as session:
+                player_ids = list(
+                    (
+                        await session.scalars(
+                            select(Player.id).where(
+                                Player.room_id == room_id,
+                                Player.left_at.is_(None),
+                            )
+                        )
+                    ).all()
+                )
+            for player_id in player_ids:
+                await self.enqueue_if_needed(room_id=room_id, player_id=player_id)
+        except Exception as exc:  # noqa: BLE001 - 后台入队失败不能影响回合
+            logger.warning("conversation_summary_enqueue_failed", error_type=type(exc).__name__)
 
     async def process_once(self) -> bool:
         """处理一个到期任务，使用短 lease 避免多 worker 重复调用。"""

--- a/trpg-backend/app/service/conversation_summary.py
+++ b/trpg-backend/app/service/conversation_summary.py
@@ -1,0 +1,268 @@
+"""玩家独立对话摘要的持久化任务处理器。"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from collaboration_framework.host.schemas import ConversationSummary
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.adapters.conversation_summary import ConversationSummaryModel
+from app.models.event import Event
+from app.models.memory import ConversationSummaryRecord
+
+logger = structlog.get_logger()
+
+
+class DeterministicConversationSummaryModel:
+    """Fake provider 的低成本摘要，保证离线测试不依赖真实模型。"""
+
+    async def summarize(self, **kwargs) -> ConversationSummary:  # noqa: ANN003
+        previous = kwargs.get("previous")
+        events = kwargs.get("visible_events", ())
+        lines = [str(item.get("text", "")).strip() for item in events if item.get("text")]
+        text = (previous.summary + "\n" if previous and previous.summary else "") + "\n".join(
+            lines[-10:]
+        )
+        return ConversationSummary(
+            room_id=kwargs["room_id"],
+            player_id=kwargs["player_id"],
+            summary=text[-6000:],
+            through_event_sequence=kwargs["through_event_sequence"],
+            source_revision=kwargs.get("source_revision"),
+            source_event_ids=tuple(str(item["id"]) for item in events if item.get("id")),
+        )
+
+
+class ConversationSummaryService:
+    """领取、重试和保存摘要任务；任务失败不影响已完成回合。"""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        model: ConversationSummaryModel | DeterministicConversationSummaryModel,
+    ) -> None:
+        self._session_factory = session_factory
+        self._model = model
+        self._worker_task: asyncio.Task[None] | None = None
+
+    async def enqueue_if_needed(self, *, room_id: str, player_id: str) -> None:
+        """根据可见事件游标判断是否达到摘要阈值。"""
+        async with self._session_factory() as session:
+            events = list(
+                (
+                    await session.scalars(
+                        select(Event)
+                        .where(
+                            Event.room_id == room_id,
+                            or_(Event.player_id == player_id, Event.visibility == "public"),
+                            Event.event_type.in_(
+                                ("action.broadcast", "narration.push", "check.result")
+                            ),
+                        )
+                        .order_by(Event.created_at, Event.id)
+                    )
+                ).all()
+            )
+            record = await session.scalar(
+                select(ConversationSummaryRecord).where(
+                    ConversationSummaryRecord.room_id == room_id,
+                    ConversationSummaryRecord.player_id == player_id,
+                )
+            )
+            current = record.pending_through_sequence if record else 0
+            scene_changed = bool(
+                current
+                and current < len(events)
+                and any(
+                    event.scene_id != events[current - 1].scene_id
+                    for event in events[current:]
+                    if event.scene_id is not None
+                )
+            )
+            if len(events) - current < 10 and not scene_changed:
+                return
+            if record is None:
+                record = ConversationSummaryRecord(
+                    room_id=room_id,
+                    player_id=player_id,
+                    summary_json={},
+                    through_event_sequence=0,
+                    pending_through_sequence=len(events),
+                    status="pending",
+                    attempt_count=0,
+                    updated_at=datetime.now(UTC),
+                )
+                session.add(record)
+            else:
+                record.pending_through_sequence = len(events)
+                record.status = "pending"
+                record.updated_at = datetime.now(UTC)
+            await session.commit()
+
+    async def process_once(self) -> bool:
+        """处理一个到期任务，使用短 lease 避免多 worker 重复调用。"""
+        owner = str(uuid.uuid4())
+        now = datetime.now(UTC)
+        async with self._session_factory() as session:
+            record = await session.scalar(
+                select(ConversationSummaryRecord)
+                .where(
+                    ConversationSummaryRecord.status.in_(("pending", "retry")),
+                    (ConversationSummaryRecord.next_attempt_at.is_(None))
+                    | (ConversationSummaryRecord.next_attempt_at <= now),
+                )
+                .order_by(ConversationSummaryRecord.updated_at)
+                .with_for_update()
+            )
+            if record is None:
+                return False
+            record.status = "running"
+            record.lease_owner = owner
+            record.lease_expires_at = now + timedelta(minutes=2)
+            await session.commit()
+            room_id, player_id = record.room_id, record.player_id
+            through = record.pending_through_sequence
+            previous = (
+                ConversationSummary.model_validate(record.summary_json)
+                if record.summary_json
+                else None
+            )
+
+        async with self._session_factory() as session:
+            events = list(
+                (
+                    await session.scalars(
+                        select(Event)
+                        .where(
+                            Event.room_id == room_id,
+                            or_(Event.player_id == player_id, Event.visibility == "public"),
+                            Event.event_type.in_(
+                                ("action.broadcast", "narration.push", "check.result")
+                            ),
+                        )
+                        .order_by(Event.created_at, Event.id)
+                    )
+                ).all()
+            )
+        visible = tuple(
+            {"id": event.id, "text": event.payload.get("text", ""), "type": event.event_type}
+            for event in events[:through]
+        )
+        try:
+            summary = await self._model.summarize(
+                room_id=room_id,
+                player_id=player_id,
+                previous=previous,
+                visible_events=visible,
+                source_revision=None,
+                through_event_sequence=through,
+            )
+        except Exception as exc:  # noqa: BLE001 - background failure is recoverable
+            async with self._session_factory() as session:
+                record = await session.scalar(
+                    select(ConversationSummaryRecord).where(
+                        ConversationSummaryRecord.room_id == room_id,
+                        ConversationSummaryRecord.player_id == player_id,
+                    )
+                )
+                if record:
+                    record.status = "retry"
+                    record.attempt_count += 1
+                    record.next_attempt_at = datetime.now(UTC) + timedelta(
+                        seconds=min(300, 2 ** min(record.attempt_count, 8))
+                    )
+                    record.lease_owner = None
+                    record.lease_expires_at = None
+                    await session.commit()
+            logger.warning("conversation_summary_failed", error_type=type(exc).__name__)
+            return False
+
+        async with self._session_factory() as session:
+            record = await session.scalar(
+                select(ConversationSummaryRecord).where(
+                    ConversationSummaryRecord.room_id == room_id,
+                    ConversationSummaryRecord.player_id == player_id,
+                )
+            )
+            if record:
+                record.summary_json = summary.model_dump(mode="json")
+                record.through_event_sequence = summary.through_event_sequence
+                record.status = "idle"
+                record.attempt_count = 0
+                record.next_attempt_at = None
+                record.lease_owner = None
+                record.lease_expires_at = None
+                record.updated_at = datetime.now(UTC)
+                await session.commit()
+        return True
+
+    async def start(self) -> None:
+        """启动轻量轮询；摘要任务自身已持久化，重启可继续。"""
+        if self._worker_task is not None:
+            return
+        self._worker_task = asyncio.create_task(self._run(), name="conversation-summary-worker")
+
+    async def stop(self) -> None:
+        if self._worker_task is None:
+            return
+        self._worker_task.cancel()
+        await asyncio.gather(self._worker_task, return_exceptions=True)
+        self._worker_task = None
+
+    async def _run(self) -> None:
+        while True:
+            await self.process_once()
+            await asyncio.sleep(1)
+
+
+def build_conversation_summary_service(settings, session_factory):  # noqa: ANN001
+    """复用 Host provider 构建摘要服务；fake 环境完全离线。"""
+    if settings.host_model_provider == "fake":
+        model = DeterministicConversationSummaryModel()
+    else:
+        from app.adapters.deepseek_models import DeepSeekChatCompletionsJsonClient
+        from app.adapters.openai_models import OpenAIResponsesJsonClient
+        from app.adapters.qwen_models import QwenChatCompletionsJsonClient
+        from app.core.config import model_client_retry_policy, secret_value
+
+        if settings.host_model_provider == "deepseek":
+            client_type, key, base_url, model_name, timeout = (
+                DeepSeekChatCompletionsJsonClient,
+                settings.deepseek_api_key,
+                settings.deepseek_base_url,
+                settings.deepseek_model,
+                settings.deepseek_timeout_seconds,
+            )
+        elif settings.host_model_provider == "qwen":
+            client_type, key, base_url, model_name, timeout = (
+                QwenChatCompletionsJsonClient,
+                settings.qwen_api_key,
+                settings.qwen_base_url,
+                settings.qwen_model,
+                settings.qwen_timeout_seconds,
+            )
+        else:
+            client_type, key, base_url, model_name, timeout = (
+                OpenAIResponsesJsonClient,
+                settings.openai_api_key,
+                settings.openai_base_url,
+                settings.openai_model,
+                settings.openai_timeout_seconds,
+            )
+        if key is None:
+            raise ValueError("摘要模型缺少 Host provider API key")
+        model = ConversationSummaryModel(
+            client_type(
+                api_key=secret_value(key),
+                base_url=base_url,
+                model=model_name,
+                timeout_seconds=timeout,
+                retry_policy=model_client_retry_policy(settings),
+            )
+        )
+    return ConversationSummaryService(session_factory, model)

--- a/trpg-backend/app/service/conversation_summary.py
+++ b/trpg-backend/app/service/conversation_summary.py
@@ -22,13 +22,40 @@ logger = structlog.get_logger()
 _MAX_ATTEMPTS = 5
 
 
+def _scope_ids(value: str) -> tuple[str, ...]:
+    """摘要查询兼容历史带连字符 UUID 与 canonical UUID。"""
+    try:
+        canonical = uuid.UUID(value).hex
+    except (ValueError, AttributeError):
+        canonical = value
+    return tuple(dict.fromkeys((value, canonical)))
+
+
+def _event_text(event: Event) -> str:
+    """统一提取摘要可见文本；action.broadcast 使用 utterance 字段。"""
+    payload = event.payload or {}
+    for key in ("text", "utterance", "summary", "description", "content"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
 class DeterministicConversationSummaryModel:
     """Fake provider 的低成本摘要，保证离线测试不依赖真实模型。"""
 
     async def summarize(self, **kwargs) -> ConversationSummary:  # noqa: ANN003
         previous = kwargs.get("previous")
         events = kwargs.get("visible_events", ())
-        lines = [str(item.get("text", "")).strip() for item in events if item.get("text")]
+        lines = []
+        for item in events:
+            text = str(item.get("text", "")).strip()
+            if not text:
+                continue
+            # Fake 摘要也必须保留主张边界，不能把玩家原话伪装成已确认事实。
+            if item.get("type") == "action.broadcast":
+                text = f"玩家声称/行动：{text}"
+            lines.append(text)
         text = (previous.summary + "\n" if previous and previous.summary else "") + "\n".join(
             lines[-10:]
         )
@@ -57,13 +84,17 @@ class ConversationSummaryService:
     async def enqueue_if_needed(self, *, room_id: str, player_id: str) -> None:
         """根据可见事件游标判断是否达到摘要阈值。"""
         async with self._session_factory() as session:
+            player_scope_ids = _scope_ids(player_id)
             events = list(
                 (
                     await session.scalars(
                         select(Event)
                         .where(
                             Event.room_id == room_id,
-                            or_(Event.player_id == player_id, Event.visibility == "public"),
+                            or_(
+                                Event.player_id.in_(player_scope_ids),
+                                Event.visibility == "public",
+                            ),
                             Event.event_type.in_(
                                 ("action.broadcast", "narration.push", "check.result")
                             ),
@@ -80,7 +111,7 @@ class ConversationSummaryService:
             )
             previous_through = record.through_event_sequence if record else 0
             new_events = events[previous_through:]
-            new_chars = sum(len(str(event.payload.get("text", ""))) for event in new_events)
+            new_chars = sum(len(_event_text(event)) for event in new_events)
             scene_changed = bool(
                 previous_through
                 and previous_through < len(events)
@@ -105,8 +136,11 @@ class ConversationSummaryService:
                 )
                 session.add(record)
             else:
-                record.pending_through_sequence = len(events)
-                record.status = "pending"
+                # 运行中的旧任务保留 lease，只推进目标游标；旧结果保存后会
+                # 自动转回 pending，交给下一次 worker 处理新增事件。
+                record.pending_through_sequence = max(record.pending_through_sequence, len(events))
+                if record.status != "running":
+                    record.status = "pending"
                 record.updated_at = datetime.now(UTC)
             await session.commit()
 
@@ -175,7 +209,10 @@ class ConversationSummaryService:
                         select(Event)
                         .where(
                             Event.room_id == room_id,
-                            or_(Event.player_id == player_id, Event.visibility == "public"),
+                            or_(
+                                Event.player_id.in_(_scope_ids(player_id)),
+                                Event.visibility == "public",
+                            ),
                             Event.event_type.in_(
                                 ("action.broadcast", "narration.push", "check.result")
                             ),
@@ -186,7 +223,7 @@ class ConversationSummaryService:
             )
         # 只压缩上次成功游标之后的新事件，避免重复发送整局记录。
         visible = tuple(
-            {"id": event.id, "text": event.payload.get("text", ""), "type": event.event_type}
+            {"id": event.id, "text": _event_text(event), "type": event.event_type}
             for event in events[previous_through:through]
         )
         try:
@@ -236,7 +273,11 @@ class ConversationSummaryService:
             if record:
                 record.summary_json = summary.model_dump(mode="json")
                 record.through_event_sequence = summary.through_event_sequence
-                record.status = "idle"
+                record.status = (
+                    "pending"
+                    if record.pending_through_sequence > summary.through_event_sequence
+                    else "idle"
+                )
                 record.attempt_count = 0
                 record.next_attempt_at = None
                 record.lease_owner = None

--- a/trpg-backend/app/service/conversation_summary.py
+++ b/trpg-backend/app/service/conversation_summary.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta
 
 import structlog
 from collaboration_framework.host.schemas import ConversationSummary
-from sqlalchemy import or_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.adapters.conversation_summary import ConversationSummaryModel
@@ -16,6 +16,9 @@ from app.models.event import Event
 from app.models.memory import ConversationSummaryRecord
 
 logger = structlog.get_logger()
+
+# 达到上限后保留失败状态，后续新事件或全量重建可以再次触发。
+_MAX_ATTEMPTS = 5
 
 
 class DeterministicConversationSummaryModel:
@@ -74,17 +77,19 @@ class ConversationSummaryService:
                     ConversationSummaryRecord.player_id == player_id,
                 )
             )
-            current = record.pending_through_sequence if record else 0
+            previous_through = record.through_event_sequence if record else 0
+            new_events = events[previous_through:]
+            new_chars = sum(len(str(event.payload.get("text", ""))) for event in new_events)
             scene_changed = bool(
-                current
-                and current < len(events)
+                previous_through
+                and previous_through < len(events)
                 and any(
-                    event.scene_id != events[current - 1].scene_id
-                    for event in events[current:]
+                    event.scene_id != events[previous_through - 1].scene_id
+                    for event in events[previous_through:]
                     if event.scene_id is not None
                 )
             )
-            if len(events) - current < 10 and not scene_changed:
+            if len(events) - previous_through < 10 and new_chars < 6000 and not scene_changed:
                 return
             if record is None:
                 record = ConversationSummaryRecord(
@@ -112,9 +117,18 @@ class ConversationSummaryService:
             record = await session.scalar(
                 select(ConversationSummaryRecord)
                 .where(
-                    ConversationSummaryRecord.status.in_(("pending", "retry")),
-                    (ConversationSummaryRecord.next_attempt_at.is_(None))
-                    | (ConversationSummaryRecord.next_attempt_at <= now),
+                    or_(
+                        and_(
+                            ConversationSummaryRecord.status.in_(("pending", "retry")),
+                            (ConversationSummaryRecord.next_attempt_at.is_(None))
+                            | (ConversationSummaryRecord.next_attempt_at <= now),
+                        ),
+                        and_(
+                            ConversationSummaryRecord.status == "running",
+                            ConversationSummaryRecord.lease_expires_at.is_not(None),
+                            ConversationSummaryRecord.lease_expires_at <= now,
+                        ),
+                    ),
                 )
                 .order_by(ConversationSummaryRecord.updated_at)
                 .with_for_update()
@@ -127,6 +141,7 @@ class ConversationSummaryService:
             await session.commit()
             room_id, player_id = record.room_id, record.player_id
             through = record.pending_through_sequence
+            previous_through = record.through_event_sequence
             previous = (
                 ConversationSummary.model_validate(record.summary_json)
                 if record.summary_json
@@ -149,9 +164,10 @@ class ConversationSummaryService:
                     )
                 ).all()
             )
+        # 只压缩上次成功游标之后的新事件，避免重复发送整局记录。
         visible = tuple(
             {"id": event.id, "text": event.payload.get("text", ""), "type": event.event_type}
-            for event in events[:through]
+            for event in events[previous_through:through]
         )
         try:
             summary = await self._model.summarize(
@@ -168,14 +184,20 @@ class ConversationSummaryService:
                     select(ConversationSummaryRecord).where(
                         ConversationSummaryRecord.room_id == room_id,
                         ConversationSummaryRecord.player_id == player_id,
+                        ConversationSummaryRecord.status == "running",
+                        ConversationSummaryRecord.lease_owner == owner,
                     )
                 )
                 if record:
-                    record.status = "retry"
                     record.attempt_count += 1
-                    record.next_attempt_at = datetime.now(UTC) + timedelta(
-                        seconds=min(300, 2 ** min(record.attempt_count, 8))
-                    )
+                    if record.attempt_count >= _MAX_ATTEMPTS:
+                        record.status = "failed"
+                        record.next_attempt_at = None
+                    else:
+                        record.status = "retry"
+                        record.next_attempt_at = datetime.now(UTC) + timedelta(
+                            seconds=min(300, 2 ** min(record.attempt_count, 8))
+                        )
                     record.lease_owner = None
                     record.lease_expires_at = None
                     await session.commit()
@@ -187,6 +209,8 @@ class ConversationSummaryService:
                 select(ConversationSummaryRecord).where(
                     ConversationSummaryRecord.room_id == room_id,
                     ConversationSummaryRecord.player_id == player_id,
+                    ConversationSummaryRecord.status == "running",
+                    ConversationSummaryRecord.lease_owner == owner,
                 )
             )
             if record:

--- a/trpg-backend/scripts/rebuild_memory_projection.py
+++ b/trpg-backend/scripts/rebuild_memory_projection.py
@@ -1,0 +1,22 @@
+"""按房间重建长期记忆投影，便于修复摘要/记忆游标或导入历史数据。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from app.adapters.sqlalchemy_memory import SqlAlchemyMemoryStore
+from app.core.db import async_session_factory
+
+
+async def _main(room_id: str) -> None:
+    """执行一次幂等补投影。"""
+    count = await SqlAlchemyMemoryStore(async_session_factory).project_room_events(room_id)
+    print(f"projected={count} room_id={room_id}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="重建指定房间的长期记忆投影")
+    parser.add_argument("room_id")
+    args = parser.parse_args()
+    asyncio.run(_main(args.room_id))

--- a/trpg-backend/tests/conftest.py
+++ b/trpg-backend/tests/conftest.py
@@ -21,6 +21,7 @@ from app.adapters import (
     SqlAlchemyEngineStore,
     SqlAlchemyRecentHistorySource,
 )
+from app.adapters.sqlalchemy_memory import SqlAlchemyMemoryStore
 from app.controller import ws as ws_controller
 from app.core.action_plan_turn import build_action_plan_turn_application
 from app.core.config import Settings
@@ -30,6 +31,10 @@ from app.core.turn import build_session_view_application
 from app.main import app
 from app.service.builtin_module_loader import load_builtin_modules
 from app.service.character_background import CharacterBackgroundService
+from app.service.conversation_summary import (
+    ConversationSummaryService,
+    DeterministicConversationSummaryModel,
+)
 from tests.content_fixtures import publish_multiplayer_module
 
 # 用临时文件 SQLite，不用 ":memory:"+StaticPool。关键原因是并发模型：异步 HTTP
@@ -64,6 +69,10 @@ app.dependency_overrides[get_db] = override_get_db
 # 请求和费用；专门注入确定性实现，真实 provider 由 adapter 单测覆盖。
 app.state.character_background_service = CharacterBackgroundService()
 app.state.test_session_factory = TestSessionLocal
+app.state.conversation_summary_service = ConversationSummaryService(
+    TestSessionLocal,
+    DeterministicConversationSummaryModel(),
+)
 
 # WS 路由（app/controller/ws.py）是原生 websocket handler，拿不到 FastAPI 的
 # Depends(get_db)，而是直接 `async with async_session_factory() as db`——也就是
@@ -84,6 +93,7 @@ ws_controller.action_plan_turn_application = build_action_plan_turn_application(
     adjudication_engine=AdjudicationEngineService(_test_turn_store),
     plan_store=_test_plan_store,
     settings=Settings(host_model_provider="fake", opening_narration_mode="template"),
+    memory_source=SqlAlchemyMemoryStore(TestSessionLocal),
     time_consent_session_factory=TestSessionLocal,
 )
 ws_controller.adjudication_engine_service = AdjudicationEngineService(_test_turn_store)

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -1,9 +1,20 @@
 """记忆契约、摘要模型和确定性降级的最小回归测试。"""
 
-import pytest
-from collaboration_framework.host.schemas import ConversationSummary, MemoryContext, MemoryEntry
+from types import SimpleNamespace
 
-from app.service.conversation_summary import DeterministicConversationSummaryModel
+import pytest
+from collaboration_framework.host.schemas import (
+    ActionPlanNarrationContext,
+    ConversationSummary,
+    MemoryContext,
+    MemoryEntry,
+)
+
+from app.adapters.sqlalchemy_memory import _listener_memories
+from app.service.conversation_summary import (
+    DeterministicConversationSummaryModel,
+    _event_text,
+)
 
 
 def test_memory_context_rejects_cross_room_entry() -> None:
@@ -36,7 +47,7 @@ async def test_fake_summary_preserves_scope_and_source_cursor() -> None:
         room_id="room-1",
         player_id="player-1",
         previous=ConversationSummary(room_id="room-1", player_id="player-1", summary="开场"),
-        visible_events=({"id": "event-2", "text": "玩家调查了旧宅"},),
+        visible_events=({"id": "event-2", "type": "action.broadcast", "text": "玩家调查了旧宅"},),
         source_revision="7",
         through_event_sequence=2,
     )
@@ -45,3 +56,76 @@ async def test_fake_summary_preserves_scope_and_source_cursor() -> None:
     assert summary.through_event_sequence == 2
     assert summary.source_event_ids == ("event-2",)
     assert "旧宅" in summary.summary
+    assert "玩家声称/行动" in summary.summary
+
+
+def test_narrator_context_serializes_memory_and_summary() -> None:
+    """Narrator 契约必须把记忆字段真正序列化，而不是挂在未知属性上。"""
+    memory = MemoryEntry(
+        memory_id="m1",
+        room_id="room-1",
+        subject_id="thomas",
+        kind="conversation",
+        content="托马斯听到了玩家说的话。",
+        epistemic_status="experienced",
+        visibility="public",
+        listener_ids=("thomas",),
+        source_event_id="event-1",
+        source_sequence=1,
+    )
+    context = ActionPlanNarrationContext.model_construct(
+        background="背景",
+        player_input=SimpleNamespace(room_id="room-1", player_id="p1", actor_id="a1"),
+        plan_goal="询问托马斯",
+        termination_status="resolved",
+        player_view=SimpleNamespace(room_id="room-1", player_id="p1", actor_id="a1"),
+        memories=(memory,),
+        conversation_summary=ConversationSummary(room_id="room-1", player_id="p1"),
+    )
+    payload = context.to_json_dict()
+    assert payload["memories"][0]["epistemic_status"] == "experienced"
+    assert payload["memories"][0]["listener_ids"] == ["thomas"]
+    assert payload["conversation_summary"]["player_id"] == "p1"
+
+
+def test_listener_event_projects_experienced_npc_memory() -> None:
+    """只有服务端确认的 listener 才能生成 NPC experienced 记忆。"""
+    event = SimpleNamespace(
+        id="event-1",
+        room_id="room-1",
+        actor_id="actor_1",
+        player_id="player-1",
+        event_type="action.broadcast",
+        visibility="public",
+        scene_id="study",
+        view_revision="2",
+        payload={
+            "utterance": "告诉托马斯：钟摆停在第三声之后。",
+            "speaker_id": "actor_1",
+            "listener_ids": ["thomas"],
+        },
+    )
+    entries = _listener_memories(event)
+    assert len(entries) == 1
+    assert entries[0].subject_id == "thomas"
+    assert entries[0].epistemic_status == "experienced"
+    assert entries[0].listener_ids == ("thomas",)
+
+
+def test_listener_projection_skips_unproven_listener() -> None:
+    """没有服务端确认听众时，玩家原话不能升级成 NPC 亲历。"""
+    event = SimpleNamespace(
+        id="event-2",
+        actor_id="actor_1",
+        event_type="action.broadcast",
+        payload={"utterance": "我检查了钟摆。"},
+    )
+    assert _listener_memories(event) == ()
+
+
+def test_summary_reads_broadcast_utterance() -> None:
+    """action.broadcast 的 utterance 也必须进入摘要字符和内容输入。"""
+    event = SimpleNamespace(
+        payload={"utterance": "告诉托马斯钟摆停在第三声之后。"},
+    )
+    assert _event_text(event) == "告诉托马斯钟摆停在第三声之后。"

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -1,6 +1,7 @@
 """记忆契约、摘要模型和确定性降级的最小回归测试。"""
 
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from collaboration_framework.host.schemas import (
@@ -11,6 +12,7 @@ from collaboration_framework.host.schemas import (
 )
 
 from app.adapters.sqlalchemy_memory import _listener_memories
+from app.models.event import Event
 from app.service.conversation_summary import (
     DeterministicConversationSummaryModel,
     _event_text,
@@ -105,7 +107,7 @@ def test_listener_event_projects_experienced_npc_memory() -> None:
             "listener_ids": ["thomas"],
         },
     )
-    entries = _listener_memories(event)
+    entries = _listener_memories(cast(Event, event))
     assert len(entries) == 1
     assert entries[0].subject_id == "thomas"
     assert entries[0].epistemic_status == "experienced"
@@ -120,7 +122,7 @@ def test_listener_projection_skips_unproven_listener() -> None:
         event_type="action.broadcast",
         payload={"utterance": "我检查了钟摆。"},
     )
-    assert _listener_memories(event) == ()
+    assert _listener_memories(cast(Event, event)) == ()
 
 
 def test_summary_reads_broadcast_utterance() -> None:
@@ -128,4 +130,4 @@ def test_summary_reads_broadcast_utterance() -> None:
     event = SimpleNamespace(
         payload={"utterance": "告诉托马斯钟摆停在第三声之后。"},
     )
-    assert _event_text(event) == "告诉托马斯钟摆停在第三声之后。"
+    assert _event_text(cast(Event, event)) == "告诉托马斯钟摆停在第三声之后。"

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -1,0 +1,47 @@
+"""记忆契约、摘要模型和确定性降级的最小回归测试。"""
+
+import pytest
+from collaboration_framework.host.schemas import ConversationSummary, MemoryContext, MemoryEntry
+
+from app.service.conversation_summary import DeterministicConversationSummaryModel
+
+
+def test_memory_context_rejects_cross_room_entry() -> None:
+    """不同房间的记忆不能进入当前玩家上下文。"""
+    entry = MemoryEntry(
+        memory_id="m1",
+        room_id="room-2",
+        subject_id="actor-1",
+        kind="conversation",
+        content="玩家说过一句话",
+        epistemic_status="asserted",
+        visibility="player_scoped",
+        source_event_id="event-1",
+        source_sequence=1,
+    )
+    with pytest.raises(ValueError, match="room_id"):
+        MemoryContext(
+            room_id="room-1",
+            player_id="player-1",
+            actor_id="actor-1",
+            as_of_revision="1",
+            entries=(entry,),
+        )
+
+
+@pytest.mark.asyncio
+async def test_fake_summary_preserves_scope_and_source_cursor() -> None:
+    """离线摘要也必须绑定玩家、游标和来源事件。"""
+    summary = await DeterministicConversationSummaryModel().summarize(
+        room_id="room-1",
+        player_id="player-1",
+        previous=ConversationSummary(room_id="room-1", player_id="player-1", summary="开场"),
+        visible_events=({"id": "event-2", "text": "玩家调查了旧宅"},),
+        source_revision="7",
+        through_event_sequence=2,
+    )
+    assert summary.room_id == "room-1"
+    assert summary.player_id == "player-1"
+    assert summary.through_event_sequence == 2
+    assert summary.source_event_ids == ("event-2",)
+    assert "旧宅" in summary.summary

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -86,8 +86,10 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "character_portraits",
         "user_character_template_portraits",
         "portrait_generation_tasks",
-        "time_advance_proposals",
-    }.issubset(tables)
+            "time_advance_proposals",
+            "memory_entries",
+            "conversation_summaries",
+        }.issubset(tables)
     assert "decision_schema_version" in _column_names(
         database,
         "pending_check_decisions",

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -86,10 +86,10 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "character_portraits",
         "user_character_template_portraits",
         "portrait_generation_tasks",
-            "time_advance_proposals",
-            "memory_entries",
-            "conversation_summaries",
-        }.issubset(tables)
+        "time_advance_proposals",
+        "memory_entries",
+        "conversation_summaries",
+    }.issubset(tables)
     assert "decision_schema_version" in _column_names(
         database,
         "pending_check_decisions",

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from pathlib import Path
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
 ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
-HEAD_REVISION = "d4f1a2b3c5e7"
+# 记忆与 main 分支的模组迁移通过 merge migration 汇合为当前 head。
+HEAD_REVISION = "e5f6a7b8c9d0"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -15,7 +15,7 @@ export interface AcceptResultOption {
 }
 
 /**
- * action.plan.submit 原话广播 payload。
+ * action.plan.submit 原话及服务端确认的公开互动参与者。
  */
 export interface ActionBroadcastPayload {
   playerId: string;
@@ -23,6 +23,9 @@ export interface ActionBroadcastPayload {
   nickname: string;
   characterName?: string | null;
   utterance: string;
+  speakerId?: string | null;
+  listenerIds?: string[];
+  participantIds?: string[];
 }
 
 /**


### PR DESCRIPTION
## 关联 Issue

Closes #363

## 主要改动

- 增加由 Engine 事件确定性投影的 `MemoryEntry`、权限过滤和房间重建脚本。
- 增加每房间/玩家独立的 `ConversationSummary` 持久化记录和异步任务 worker。
- 摘要复用现有 Host provider 的结构化 JSON client，不阻塞当前回合。
- 将 MemoryContext 和摘要接入 Planner、Narrator 与守秘人上下文，并保持 PlayerView/Engine 为最高事实优先级。
- 增加数据库迁移、幂等投影、失败退避、lease 超时恢复和测试装配。

## 采用该方案的原因

Engine 仍是唯一事实源，长期记忆不调用模型，避免模型生成事实或扩大知情范围。对话摘要只处理玩家可见事件，按玩家隔离持久化；摘要失败保留旧摘要并后台重试，不影响已提交回合。摘要任务在 10 个事件、6000 个新增可见字符或场景切换时触发，模型只接收上次摘要游标之后的新事件。

本 PR 不引入 OpenAI Agents SDK、Embedding、向量数据库、独立 NPC Agent 或复杂后台投影平台。

## 测试与验证

- `uv run pytest -q`：497 passed，21 skipped，1 warning。
- `uv run ruff check .`：通过。
- `uv run ruff format --check .`：通过。
- `uv run ty check`：通过。
- `uv run pytest -q tests/test_memory_system.py`：2 passed。
- Alembic upgrade/downgrade/upgrade：通过。
- CI：E2E、迁移、预览和 codegen 检查通过；Backend CI 已针对格式问题修正并等待重跑。

## 兼容性、迁移与回滚

- 新增 `memory_entries` 和 `conversation_summaries` 表，需执行 Alembic migration。
- 旧房间可通过 `scripts/rebuild_memory_projection.py` 补建投影；重复执行保持幂等。
- 回滚可停用摘要 worker 并回退本迁移，Engine 状态、原始 Event 和既有回合数据不受影响。
- 摘要模型失败、超时或非法 JSON 不回滚回合；达到重试上限后保留失败状态，后续新事件或重建可重新触发。

## 风险

- 历史 Event 的 payload 结构不统一，投影对未知字段只保留安全文本，不会升级为 confirmed 事实。
- 首版仍按事件表重放建立记忆，复杂历史修正需要后续补充更细粒度的事实失效投影。

## 自检清单

- [x] 改动范围与 Issue #363 一致
- [x] 已增加并运行相关测试
- [x] 已检查权限隔离、幂等、迁移和任务恢复
- [x] 未包含密钥、临时文件或无关生成物
- [ ] 等待至少一名维护者人工审查

## AI 辅助开发与人工审查声明

本 PR 使用 AI 辅助实现。作者已检查关键数据模型、权限过滤、摘要游标、任务 lease、失败恢复和迁移路径；请维护者重点人工审查多人可见性边界、历史事件投影语义以及异步 worker 的并发行为。