### PR TITLE
perf(memory): 增量化长期记忆投影 (#363)

### DIFF
--- a/trpg-backend/alembic/versions/a7b8c9d0e1f2_reconcile_memory_source_time.py
+++ b/trpg-backend/alembic/versions/a7b8c9d0e1f2_reconcile_memory_source_time.py
@@ -1,0 +1,43 @@
+"""修复已标记增量投影迁移但缺少统一来源时间列的数据库。"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: str | None = "f6a7b8c9d0e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """按真实表结构补列和索引，兼容曾被提前标记到 head 的本地数据库。"""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {column["name"] for column in inspector.get_columns("memory_entries")}
+    if "source_created_at" not in columns:
+        # SQLite 的 ALTER TABLE 只接受常量默认值；随后用原投影时间覆盖历史行。
+        op.add_column(
+            "memory_entries",
+            sa.Column(
+                "source_created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("'1970-01-01 00:00:00'"),
+            ),
+        )
+        op.execute(sa.text("UPDATE memory_entries SET source_created_at = created_at"))
+
+    indexes = {index["name"] for index in sa.inspect(bind).get_indexes("memory_entries")}
+    if "ix_memory_entries_room_source_created" not in indexes:
+        op.create_index(
+            "ix_memory_entries_room_source_created",
+            "memory_entries",
+            ["room_id", "source_created_at"],
+        )
+
+
+def downgrade() -> None:
+    """不删除前序迁移拥有的列和索引，避免降级链重复删除。"""

--- a/trpg-backend/alembic/versions/f6a7b8c9d0e1_add_incremental_memory_projection.py
+++ b/trpg-backend/alembic/versions/f6a7b8c9d0e1_add_incremental_memory_projection.py
@@ -1,0 +1,56 @@
+"""增加长期记忆增量投影游标和统一来源时间。"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: str | None = "e5f6a7b8c9d0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """创建房间投影高水位，并为旧记忆保守回填来源时间。"""
+    op.add_column(
+        "memory_entries",
+        sa.Column(
+            "source_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    # 历史记录无法再可靠区分两类来源时间，使用原投影时间保持稳定顺序。
+    op.execute(
+        sa.text("UPDATE memory_entries SET source_created_at = created_at")
+    )
+    op.create_index(
+        "ix_memory_entries_room_source_created",
+        "memory_entries",
+        ["room_id", "source_created_at"],
+    )
+    op.create_table(
+        "memory_projection_cursors",
+        sa.Column("room_id", sa.Uuid(), nullable=False),
+        sa.Column("event_created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("event_id", sa.String(length=100), nullable=True),
+        sa.Column("game_sequence", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["room_id"], ["game_sessions.room_id"]),
+        sa.PrimaryKeyConstraint("room_id"),
+    )
+
+
+def downgrade() -> None:
+    """移除增量游标，并恢复旧版记忆表结构。"""
+    op.drop_table("memory_projection_cursors")
+    op.drop_index("ix_memory_entries_room_source_created", table_name="memory_entries")
+    op.drop_column("memory_entries", "source_created_at")

--- a/trpg-backend/alembic/versions/f6a7b8c9d0e1_add_incremental_memory_projection.py
+++ b/trpg-backend/alembic/versions/f6a7b8c9d0e1_add_incremental_memory_projection.py
@@ -20,11 +20,15 @@ def upgrade() -> None:
             "source_created_at",
             sa.DateTime(timezone=True),
             nullable=False,
-            server_default=sa.func.now(),
+            # SQLite 的 ALTER TABLE 只接受字面量默认值；后面统一回填真实来源时间。
+            server_default="1970-01-01 00:00:00",
         ),
     )
     # 历史记录无法再可靠区分两类来源时间，使用原投影时间保持稳定顺序。
     op.execute(sa.text("UPDATE memory_entries SET source_created_at = created_at"))
+    # 回填后移除临时默认值，避免新记录误用 epoch。
+    with op.batch_alter_table("memory_entries") as batch_op:
+        batch_op.alter_column("source_created_at", server_default=None)
     op.create_index(
         "ix_memory_entries_room_source_created",
         "memory_entries",

--- a/trpg-backend/alembic/versions/f6a7b8c9d0e1_add_incremental_memory_projection.py
+++ b/trpg-backend/alembic/versions/f6a7b8c9d0e1_add_incremental_memory_projection.py
@@ -24,9 +24,7 @@ def upgrade() -> None:
         ),
     )
     # 历史记录无法再可靠区分两类来源时间，使用原投影时间保持稳定顺序。
-    op.execute(
-        sa.text("UPDATE memory_entries SET source_created_at = created_at")
-    )
+    op.execute(sa.text("UPDATE memory_entries SET source_created_at = created_at"))
     op.create_index(
         "ix_memory_entries_room_source_created",
         "memory_entries",

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any
+from typing import cast as typing_cast
 
 from collaboration_framework.host.schemas import ConversationSummary, MemoryContext, MemoryEntry
-from sqlalchemy import and_, case, delete, or_, select, update
+from sqlalchemy import and_, case, cast, delete, exists, func, or_, select, update
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine import CursorResult
@@ -306,7 +308,7 @@ class SqlAlchemyMemoryStore:
         ]
         inserted = 0
         if values:
-            insert_result = cast(
+            insert_result = typing_cast(
                 CursorResult[Any],
                 await session.execute(
                     _insert_ignore(
@@ -380,6 +382,14 @@ class SqlAlchemyMemoryStore:
         stored_room_id = room_id
         await self.project_room_events(stored_room_id)
         async with self._session_factory() as session:
+            # JSON.contains([item]) 在 SQLite 会按文本片段匹配，无法识别多参与者数组。
+            # 使用 json_each/JSONB 成员运算保证两种数据库都按数组元素比较。
+            def participant_has(item: str):
+                if session.get_bind().dialect.name == "sqlite":
+                    values = func.json_each(MemoryEntryRecord.participants).table_valued("value")
+                    return exists(select(1).select_from(values).where(values.c.value == item))
+                return cast(MemoryEntryRecord.participants, JSONB).contains([item])
+
             player_scope_ids = _scope_ids(player_id)
             actor_scope_ids = _scope_ids(actor_id)
             entity_scope_ids = tuple(
@@ -393,12 +403,7 @@ class SqlAlchemyMemoryStore:
                     MemoryEntryRecord.visibility == "public",
                     and_(
                         MemoryEntryRecord.visibility == "player_scoped",
-                        or_(
-                            *(
-                                MemoryEntryRecord.participants.contains([item])
-                                for item in player_scope_ids
-                            )
-                        ),
+                        or_(*(participant_has(item) for item in player_scope_ids)),
                     ),
                     MemoryEntryRecord.subject_id.in_(
                         (*player_scope_ids, *actor_scope_ids, *entity_scope_ids)
@@ -409,7 +414,7 @@ class SqlAlchemyMemoryStore:
                 entity_relevance = or_(
                     MemoryEntryRecord.subject_id.in_(entity_scope_ids),
                     MemoryEntryRecord.object_id.in_(entity_scope_ids),
-                    *(MemoryEntryRecord.participants.contains([item]) for item in entity_scope_ids),
+                    *(participant_has(item) for item in entity_scope_ids),
                 )
                 conditions.append(
                     or_(

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -191,7 +191,7 @@ class SqlAlchemyMemoryStore:
 
     async def project_room_events(self, room_id: str) -> MemoryProjectionResult:
         """只投影房间游标后的新事件，并以单事务提交记忆和高水位。"""
-        room_id = _canonical_id(room_id) or room_id
+        # 房间主键使用数据库中的原始 UUID 文本；canonicalize 只适用于实体参与者。
         async with self._session_factory() as session:
             result = await self._project_room_events(session, room_id)
             await session.commit()
@@ -199,7 +199,6 @@ class SqlAlchemyMemoryStore:
 
     async def rebuild_room_events(self, room_id: str) -> MemoryProjectionResult:
         """在单事务中替换指定房间的记忆投影，保留摘要和权威事件。"""
-        room_id = _canonical_id(room_id) or room_id
         async with self._session_factory() as session:
             await session.execute(
                 delete(MemoryEntryRecord).where(MemoryEntryRecord.room_id == room_id)
@@ -377,7 +376,8 @@ class SqlAlchemyMemoryStore:
         max_chars: int = 4000,
     ) -> MemoryContext:
         """按服务端作用域过滤记忆，模型不能自行扩大查询范围。"""
-        stored_room_id = _canonical_id(room_id) or room_id
+        # 不规范化 room_id，否则 SQLite 的 Uuid(as_uuid=False) 会出现外键/查询不一致。
+        stored_room_id = room_id
         await self.project_room_events(stored_room_id)
         async with self._session_factory() as session:
             player_scope_ids = _scope_ids(player_id)

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -3,15 +3,55 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from collaboration_framework.host.schemas import ConversationSummary, MemoryContext, MemoryEntry
-from sqlalchemy import and_, case, or_, select
+from sqlalchemy import and_, case, delete, or_, select, update
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.engine import GameEvent
 from app.models.event import Event
-from app.models.memory import ConversationSummaryRecord, MemoryEntryRecord
+from app.models.memory import (
+    ConversationSummaryRecord,
+    MemoryEntryRecord,
+    MemoryProjectionCursor,
+)
+
+
+@dataclass(frozen=True)
+class MemoryProjectionResult:
+    """描述一次投影处理量和最终高水位，供维护脚本与测试审计。"""
+
+    scanned_events: int
+    scanned_game_events: int
+    inserted: int
+    skipped: int
+    event_created_at: datetime | None
+    event_id: str | None
+    game_sequence: int
+
+
+def _insert_ignore(
+    session: AsyncSession,
+    model: Any,
+    values: list[dict[str, Any]],
+    *,
+    index_elements: tuple[str, ...],
+) -> Any:
+    """使用项目支持的数据库原生冲突忽略，避免并发查重竞态。"""
+    dialect = session.get_bind().dialect.name
+    if dialect == "postgresql":
+        statement = postgresql_insert(model).values(values)
+    elif dialect == "sqlite":
+        statement = sqlite_insert(model).values(values)
+    else:  # 当前生产和测试只支持 PostgreSQL/SQLite，未知数据库不能静默失去幂等。
+        raise RuntimeError(f"unsupported memory projection dialect: {dialect}")
+    return statement.on_conflict_do_nothing(index_elements=index_elements)
 
 
 def _canonical_id(value: str | None) -> str | None:
@@ -149,76 +189,178 @@ class SqlAlchemyMemoryStore:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
 
-    async def project_room_events(self, room_id: str) -> int:
-        """补投影公开回放事件；规则状态仍由 Engine 自己维护。"""
+    async def project_room_events(self, room_id: str) -> MemoryProjectionResult:
+        """只投影房间游标后的新事件，并以单事务提交记忆和高水位。"""
         async with self._session_factory() as session:
-            events = list(
-                (
-                    await session.scalars(
-                        select(Event)
-                        .where(
-                            Event.room_id == room_id,
-                            Event.event_type.in_(
-                                ("action.broadcast", "narration.push", "check.result")
-                            ),
-                            or_(Event.visibility == "public", Event.player_id.is_not(None)),
-                        )
-                        .order_by(Event.created_at, Event.id)
-                    )
-                ).all()
-            )
-            game_events = list(
-                (
-                    await session.scalars(
-                        select(GameEvent)
-                        .where(
-                            GameEvent.room_id == room_id,
-                            GameEvent.visibility == "public",
-                        )
-                        .order_by(GameEvent.sequence)
-                    )
-                ).all()
-            )
-            count = 0
-            candidates = [entry for event in events if (entry := _memory_from_event(event))]
-            candidates.extend(
-                listener for event in events for listener in _listener_memories(event)
-            )
-            candidates.extend(
-                entry for event in game_events if (entry := _memory_from_game_event(event))
-            )
-            for entry in candidates:
-                exists = await session.scalar(
-                    select(MemoryEntryRecord.id).where(
-                        MemoryEntryRecord.room_id == room_id,
-                        MemoryEntryRecord.subject_id == entry.subject_id,
-                        MemoryEntryRecord.source_event_id == entry.source_event_id,
-                        MemoryEntryRecord.kind == entry.kind,
-                    )
-                )
-                if exists is not None:
-                    continue
-                session.add(
-                    MemoryEntryRecord(
-                        id=str(uuid.uuid4()),
-                        room_id=entry.room_id,
-                        subject_id=entry.subject_id,
-                        object_id=entry.object_id,
-                        kind=entry.kind,
-                        content=entry.content,
-                        epistemic_status=entry.epistemic_status,
-                        visibility=entry.visibility,
-                        participants=list(entry.participants),
-                        listener_ids=list(entry.listener_ids),
-                        location_id=entry.location_id,
-                        source_event_id=entry.source_event_id,
-                        source_sequence=entry.source_sequence,
-                        source_revision=entry.source_revision,
-                    )
-                )
-                count += 1
+            result = await self._project_room_events(session, room_id)
             await session.commit()
-            return count
+            return result
+
+    async def rebuild_room_events(self, room_id: str) -> MemoryProjectionResult:
+        """在单事务中替换指定房间的记忆投影，保留摘要和权威事件。"""
+        async with self._session_factory() as session:
+            await session.execute(
+                delete(MemoryEntryRecord).where(MemoryEntryRecord.room_id == room_id)
+            )
+            await session.execute(
+                delete(MemoryProjectionCursor).where(MemoryProjectionCursor.room_id == room_id)
+            )
+            result = await self._project_room_events(session, room_id)
+            await session.commit()
+            return result
+
+    async def _project_room_events(
+        self,
+        session: AsyncSession,
+        room_id: str,
+    ) -> MemoryProjectionResult:
+        """在调用方事务内执行投影；数据库唯一键负责跨进程并发幂等。"""
+        now = datetime.now(UTC)
+        await session.execute(
+            _insert_ignore(
+                session,
+                MemoryProjectionCursor,
+                [
+                    {
+                        "room_id": room_id,
+                        "event_created_at": None,
+                        "event_id": None,
+                        "game_sequence": 0,
+                        "updated_at": now,
+                    }
+                ],
+                index_elements=("room_id",),
+            )
+        )
+        cursor = await session.get(MemoryProjectionCursor, room_id)
+        if cursor is None:
+            raise RuntimeError(f"memory projection cursor missing for room {room_id}")
+
+        event_conditions = [
+            Event.room_id == room_id,
+            Event.event_type.in_(("action.broadcast", "narration.push", "check.result")),
+            or_(Event.visibility == "public", Event.player_id.is_not(None)),
+        ]
+        if cursor.event_created_at is not None and cursor.event_id is not None:
+            event_conditions.append(
+                or_(
+                    Event.created_at > cursor.event_created_at,
+                    and_(
+                        Event.created_at == cursor.event_created_at,
+                        Event.id > cursor.event_id,
+                    ),
+                )
+            )
+        events = list(
+            (
+                await session.scalars(
+                    select(Event).where(*event_conditions).order_by(Event.created_at, Event.id)
+                )
+            ).all()
+        )
+        game_events = list(
+            (
+                await session.scalars(
+                    select(GameEvent)
+                    .where(
+                        GameEvent.room_id == room_id,
+                        GameEvent.visibility == "public",
+                        GameEvent.sequence > cursor.game_sequence,
+                    )
+                    .order_by(GameEvent.sequence)
+                )
+            ).all()
+        )
+
+        candidates: list[tuple[MemoryEntry, datetime]] = []
+        for event in events:
+            if entry := _memory_from_event(event):
+                candidates.append((entry, event.created_at))
+            candidates.extend((entry, event.created_at) for entry in _listener_memories(event))
+        candidates.extend(
+            (entry, event.created_at)
+            for event in game_events
+            if (entry := _memory_from_game_event(event))
+        )
+        values = [
+            {
+                "id": str(uuid.uuid4()),
+                "room_id": entry.room_id,
+                "subject_id": entry.subject_id,
+                "object_id": entry.object_id,
+                "kind": entry.kind,
+                "content": entry.content,
+                "epistemic_status": entry.epistemic_status,
+                "visibility": entry.visibility,
+                "participants": list(entry.participants),
+                "listener_ids": list(entry.listener_ids),
+                "location_id": entry.location_id,
+                "source_event_id": entry.source_event_id,
+                "source_sequence": entry.source_sequence,
+                "source_revision": entry.source_revision,
+                "source_created_at": source_created_at,
+                "created_at": now,
+            }
+            for entry, source_created_at in candidates
+        ]
+        inserted = 0
+        if values:
+            insert_result = cast(
+                CursorResult[Any],
+                await session.execute(
+                    _insert_ignore(
+                        session,
+                        MemoryEntryRecord,
+                        values,
+                        index_elements=("room_id", "subject_id", "source_event_id", "kind"),
+                    )
+                ),
+            )
+            inserted = max(insert_result.rowcount or 0, 0)
+
+        # 游标更新必须由数据库比较当前值，避免较旧的并发事务覆盖更高水位。
+        if events:
+            last_event = events[-1]
+            await session.execute(
+                update(MemoryProjectionCursor)
+                .where(
+                    MemoryProjectionCursor.room_id == room_id,
+                    or_(
+                        MemoryProjectionCursor.event_created_at.is_(None),
+                        MemoryProjectionCursor.event_created_at < last_event.created_at,
+                        and_(
+                            MemoryProjectionCursor.event_created_at == last_event.created_at,
+                            MemoryProjectionCursor.event_id < last_event.id,
+                        ),
+                    ),
+                )
+                .values(
+                    event_created_at=last_event.created_at,
+                    event_id=last_event.id,
+                    updated_at=now,
+                )
+                .execution_options(synchronize_session=False)
+            )
+        if game_events:
+            await session.execute(
+                update(MemoryProjectionCursor)
+                .where(
+                    MemoryProjectionCursor.room_id == room_id,
+                    MemoryProjectionCursor.game_sequence < game_events[-1].sequence,
+                )
+                .values(game_sequence=game_events[-1].sequence, updated_at=now)
+                .execution_options(synchronize_session=False)
+            )
+        await session.refresh(cursor)
+        return MemoryProjectionResult(
+            scanned_events=len(events),
+            scanned_game_events=len(game_events),
+            inserted=inserted,
+            skipped=len(candidates) - inserted,
+            event_created_at=cursor.event_created_at,
+            event_id=cursor.event_id,
+            game_sequence=cursor.game_sequence,
+        )
 
     async def read_context(
         self,
@@ -287,8 +429,9 @@ class SqlAlchemyMemoryStore:
                                 (MemoryEntryRecord.epistemic_status == "presentation", 2),
                                 else_=3,
                             ),
-                            MemoryEntryRecord.source_sequence.desc(),
-                            MemoryEntryRecord.created_at.desc(),
+                            MemoryEntryRecord.source_created_at.desc(),
+                            MemoryEntryRecord.source_event_id.desc(),
+                            MemoryEntryRecord.id.desc(),
                         )
                         .limit(limit * 3)
                     )

--- a/trpg-backend/app/adapters/sqlalchemy_memory.py
+++ b/trpg-backend/app/adapters/sqlalchemy_memory.py
@@ -191,6 +191,7 @@ class SqlAlchemyMemoryStore:
 
     async def project_room_events(self, room_id: str) -> MemoryProjectionResult:
         """只投影房间游标后的新事件，并以单事务提交记忆和高水位。"""
+        room_id = _canonical_id(room_id) or room_id
         async with self._session_factory() as session:
             result = await self._project_room_events(session, room_id)
             await session.commit()
@@ -198,6 +199,7 @@ class SqlAlchemyMemoryStore:
 
     async def rebuild_room_events(self, room_id: str) -> MemoryProjectionResult:
         """在单事务中替换指定房间的记忆投影，保留摘要和权威事件。"""
+        room_id = _canonical_id(room_id) or room_id
         async with self._session_factory() as session:
             await session.execute(
                 delete(MemoryEntryRecord).where(MemoryEntryRecord.room_id == room_id)
@@ -375,7 +377,8 @@ class SqlAlchemyMemoryStore:
         max_chars: int = 4000,
     ) -> MemoryContext:
         """按服务端作用域过滤记忆，模型不能自行扩大查询范围。"""
-        await self.project_room_events(room_id)
+        stored_room_id = _canonical_id(room_id) or room_id
+        await self.project_room_events(stored_room_id)
         async with self._session_factory() as session:
             player_scope_ids = _scope_ids(player_id)
             actor_scope_ids = _scope_ids(actor_id)
@@ -383,7 +386,7 @@ class SqlAlchemyMemoryStore:
                 item for entity_id in entity_ids for item in _scope_ids(entity_id)
             )
             conditions = [
-                MemoryEntryRecord.room_id == room_id,
+                MemoryEntryRecord.room_id == stored_room_id,
                 # Engine 的内部裁决原因只服务审计，不应占用 Host 的剧情记忆预算。
                 ~MemoryEntryRecord.content.startswith("adjudication:"),
                 or_(
@@ -403,10 +406,15 @@ class SqlAlchemyMemoryStore:
                 ),
             ]
             if location_id:
+                entity_relevance = or_(
+                    MemoryEntryRecord.subject_id.in_(entity_scope_ids),
+                    MemoryEntryRecord.object_id.in_(entity_scope_ids),
+                    *(MemoryEntryRecord.participants.contains([item]) for item in entity_scope_ids),
+                )
                 conditions.append(
                     or_(
                         MemoryEntryRecord.location_id == location_id,
-                        MemoryEntryRecord.object_id.in_(entity_scope_ids),
+                        entity_relevance,
                         # 没有地点的全局权威事件仍然是可召回的长期事实；外层
                         # room/visibility/participant 条件继续负责权限隔离。
                         MemoryEntryRecord.location_id.is_(None),
@@ -443,7 +451,8 @@ class SqlAlchemyMemoryStore:
                 entry = MemoryEntry.model_validate(
                     {
                         "memory_id": record.id,
-                        "room_id": record.room_id,
+                        # 数据库 UUID 可能是 canonical 形式，契约必须回显调用方作用域。
+                        "room_id": room_id,
                         "subject_id": record.subject_id,
                         "object_id": record.object_id,
                         "kind": record.kind,
@@ -464,13 +473,17 @@ class SqlAlchemyMemoryStore:
                 total += len(entry.content)
             summary_record = await session.scalar(
                 select(ConversationSummaryRecord).where(
-                    ConversationSummaryRecord.room_id == room_id,
+                    ConversationSummaryRecord.room_id == stored_room_id,
                     ConversationSummaryRecord.player_id.in_(player_scope_ids),
                 )
             )
             summary = None
             if summary_record and summary_record.summary_json:
-                summary = ConversationSummary.model_validate(summary_record.summary_json)
+                summary_payload = dict(summary_record.summary_json)
+                # 摘要 JSON 是模型生成时保存的外部 ID，读取时统一回显当前作用域。
+                summary_payload["room_id"] = room_id
+                summary_payload["player_id"] = player_id
+                summary = ConversationSummary.model_validate(summary_payload)
             return MemoryContext(
                 room_id=room_id,
                 player_id=player_id,

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -154,13 +154,39 @@ router = APIRouter()
 logger = structlog.get_logger()
 
 _DIRECT_SPEECH_MARKERS = ("告诉", "询问", "问", "提醒", "威胁", "喊", "说", "请")
+_DIRECT_ADDRESS_MARKERS = (
+    "跟你",
+    "对你",
+    "告诉你",
+    "问你",
+    "和你",
+    "你记住",
+    "记住了",
+    "记住",
+)
 
 
 def _listener_ids_for_utterance(utterance: str, player_view: PlayerView) -> tuple[str, ...]:
-    """只有明确的对话动词才把可见实体认定为听众，避免把“去找 NPC”记成对话。"""
-    if not any(marker in utterance for marker in _DIRECT_SPEECH_MARKERS):
+    """确定性识别听众：点名优先，单 NPC 的直接称呼可使用“你”指代。"""
+    if not any(marker in utterance for marker in _DIRECT_SPEECH_MARKERS) and not any(
+        marker in utterance for marker in _DIRECT_ADDRESS_MARKERS
+    ):
+        # “我跟你说/记住”没有传统的“告诉/说”动词组合，但仍是明确的当面发言。
         return ()
-    return _matching_visible_entity_ids(utterance, player_view)
+    matched = _matching_visible_entity_ids(utterance, player_view)
+    if matched:
+        return matched
+    # 只有当前场景恰好有一个可见 NPC 时，服务端才允许把“你”绑定到它；
+    # 多 NPC 场景继续保守返回空，避免把秘密错误记给旁人。
+    if any(marker in utterance for marker in _DIRECT_ADDRESS_MARKERS):
+        npcs = tuple(
+            entity.id
+            for entity in player_view.scene.visible_entities
+            if entity.kind == "npc"
+        )
+        if len(npcs) == 1:
+            return npcs
+    return ()
 
 
 _UNAUTHORIZED_CLOSE_CODE = 4401

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -154,6 +154,8 @@ router = APIRouter()
 logger = structlog.get_logger()
 
 _DIRECT_SPEECH_MARKERS = ("告诉", "询问", "问", "提醒", "威胁", "喊", "说", "请")
+
+
 def _listener_ids_for_utterance(utterance: str, player_view: PlayerView) -> tuple[str, ...]:
     """只根据明确点名和当前 PlayerView 确定听众，不猜测自然语言意图。"""
     if not any(marker in utterance for marker in _DIRECT_SPEECH_MARKERS):

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -154,39 +154,11 @@ router = APIRouter()
 logger = structlog.get_logger()
 
 _DIRECT_SPEECH_MARKERS = ("告诉", "询问", "问", "提醒", "威胁", "喊", "说", "请")
-_DIRECT_ADDRESS_MARKERS = (
-    "跟你",
-    "对你",
-    "告诉你",
-    "问你",
-    "和你",
-    "你记住",
-    "记住了",
-    "记住",
-)
-
-
 def _listener_ids_for_utterance(utterance: str, player_view: PlayerView) -> tuple[str, ...]:
-    """确定性识别听众：点名优先，单 NPC 的直接称呼可使用“你”指代。"""
-    if not any(marker in utterance for marker in _DIRECT_SPEECH_MARKERS) and not any(
-        marker in utterance for marker in _DIRECT_ADDRESS_MARKERS
-    ):
-        # “我跟你说/记住”没有传统的“告诉/说”动词组合，但仍是明确的当面发言。
+    """只根据明确点名和当前 PlayerView 确定听众，不猜测自然语言意图。"""
+    if not any(marker in utterance for marker in _DIRECT_SPEECH_MARKERS):
         return ()
-    matched = _matching_visible_entity_ids(utterance, player_view)
-    if matched:
-        return matched
-    # 只有当前场景恰好有一个可见 NPC 时，服务端才允许把“你”绑定到它；
-    # 多 NPC 场景继续保守返回空，避免把秘密错误记给旁人。
-    if any(marker in utterance for marker in _DIRECT_ADDRESS_MARKERS):
-        npcs = tuple(
-            entity.id
-            for entity in player_view.scene.visible_entities
-            if entity.kind == "npc"
-        )
-        if len(npcs) == 1:
-            return npcs
-    return ()
+    return _matching_visible_entity_ids(utterance, player_view)
 
 
 _UNAUTHORIZED_CLOSE_CODE = 4401

--- a/trpg-backend/app/models/__init__.py
+++ b/trpg-backend/app/models/__init__.py
@@ -35,7 +35,11 @@ from app.models.engine import (
     TurnRunCutoverRecord,
 )
 from app.models.event import CheckResult, Event
-from app.models.memory import ConversationSummaryRecord, MemoryEntryRecord
+from app.models.memory import (
+    ConversationSummaryRecord,
+    MemoryEntryRecord,
+    MemoryProjectionCursor,
+)
 from app.models.replay import ModuleImportJob, RoomSummary
 from app.models.room import Character, CharacterPortrait, Note, Player, Room
 from app.models.user import User, UserCharacterTemplate, UserCharacterTemplatePortrait, UserSession
@@ -84,4 +88,5 @@ __all__ = [
     "World",
     "ConversationSummaryRecord",
     "MemoryEntryRecord",
+    "MemoryProjectionCursor",
 ]

--- a/trpg-backend/app/models/memory.py
+++ b/trpg-backend/app/models/memory.py
@@ -34,6 +34,7 @@ class MemoryEntryRecord(Base):
         ),
         Index("ix_memory_entries_scope", "room_id", "subject_id", "visibility"),
         Index("ix_memory_entries_entity", "room_id", "object_id", "location_id"),
+        Index("ix_memory_entries_room_source_created", "room_id", "source_created_at"),
     )
 
     id: Mapped[str] = mapped_column(
@@ -55,8 +56,33 @@ class MemoryEntryRecord(Base):
     source_event_id: Mapped[str] = mapped_column(String(100), nullable=False)
     source_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)
     source_revision: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    # 两类来源事件的 sequence 不可直接比较，统一用真实发生时间决定同级记忆的新旧。
+    source_created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+
+class MemoryProjectionCursor(Base):
+    """记录房间两类事件流的投影高水位，避免每次读取都重放全量历史。"""
+
+    __tablename__ = "memory_projection_cursors"
+
+    room_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("game_sessions.room_id"), primary_key=True
+    )
+    event_created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    event_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    game_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
     )
 
 

--- a/trpg-backend/scripts/rebuild_memory_projection.py
+++ b/trpg-backend/scripts/rebuild_memory_projection.py
@@ -9,14 +9,31 @@ from app.adapters.sqlalchemy_memory import SqlAlchemyMemoryStore
 from app.core.db import async_session_factory
 
 
-async def _main(room_id: str) -> None:
-    """执行一次幂等补投影。"""
-    count = await SqlAlchemyMemoryStore(async_session_factory).project_room_events(room_id)
-    print(f"projected={count} room_id={room_id}")
+async def _main(room_id: str, *, replace: bool) -> None:
+    """默认增量补投影；只有显式 replace 才替换指定房间的投影。"""
+    store = SqlAlchemyMemoryStore(async_session_factory)
+    result = (
+        await store.rebuild_room_events(room_id)
+        if replace
+        else await store.project_room_events(room_id)
+    )
+    print(
+        f"room_id={room_id} mode={'replace' if replace else 'incremental'} "
+        f"scanned_events={result.scanned_events} "
+        f"scanned_game_events={result.scanned_game_events} "
+        f"inserted={result.inserted} skipped={result.skipped} "
+        f"event_created_at={result.event_created_at} event_id={result.event_id} "
+        f"game_sequence={result.game_sequence}"
+    )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="重建指定房间的长期记忆投影")
     parser.add_argument("room_id")
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="删除并重新生成指定房间的 MemoryEntry；不会删除摘要或原始事件",
+    )
     args = parser.parse_args()
-    asyncio.run(_main(args.room_id))
+    asyncio.run(_main(args.room_id, replace=args.replace))

--- a/trpg-backend/tests/conftest.py
+++ b/trpg-backend/tests/conftest.py
@@ -153,6 +153,12 @@ def recent_history_source() -> SqlAlchemyRecentHistorySource:
 
 
 @pytest.fixture
+def memory_store() -> SqlAlchemyMemoryStore:
+    """返回绑定文件型 SQLite 的记忆存储，供真实并发事务测试使用。"""
+    return SqlAlchemyMemoryStore(TestSessionLocal)
+
+
+@pytest.fixture
 def sql_counter() -> Generator[list[str], None, None]:
     """记录这段测试期间真实执行的 SQL 语句，用来断言"查询数不随数据量增长"。
 

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
+from collaboration_framework.contracts import PlayerView
 from collaboration_framework.host.schemas import (
     ActionPlanNarrationContext,
     ConversationSummary,
@@ -17,6 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters.sqlalchemy_memory import _listener_memories
+from app.controller.ws import _listener_ids_for_utterance
 from app.models.engine import GameEvent, GameSession, ModuleVersion
 from app.models.event import Event
 from app.models.memory import (
@@ -183,6 +185,39 @@ def test_listener_projection_skips_unproven_listener() -> None:
         payload={"utterance": "我检查了钟摆。"},
     )
     assert _listener_memories(cast(Event, event)) == ()
+
+
+def test_single_visible_npc_is_listener_for_direct_you_address() -> None:
+    """单 NPC 场景中的“我跟你说/记住”必须生成该 NPC 的亲历记忆。"""
+    view = SimpleNamespace(
+        scene=SimpleNamespace(
+            visible_entities=(
+                SimpleNamespace(
+                    id="gravedigger", kind="npc", name="守墓人", aliases=()
+                ),
+            )
+        )
+    )
+    assert _listener_ids_for_utterance(
+        "我跟你说：月影钟响三次，记住了", cast(PlayerView, view)
+    ) == (
+        "gravedigger",
+    )
+
+
+def test_ambiguous_you_address_does_not_pick_one_of_multiple_npcs() -> None:
+    """多人场景的模糊“你”不能把秘密错误归给任意 NPC。"""
+    view = SimpleNamespace(
+        scene=SimpleNamespace(
+            visible_entities=(
+                SimpleNamespace(id="thomas", kind="npc", name="托马斯", aliases=()),
+                SimpleNamespace(id="gravedigger", kind="npc", name="守墓人", aliases=()),
+            )
+        )
+    )
+    assert _listener_ids_for_utterance(
+        "我跟你说：月影钟响三次，记住了", cast(PlayerView, view)
+    ) == ()
 
 
 def test_summary_reads_broadcast_utterance() -> None:

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
-from collaboration_framework.contracts import PlayerView
 from collaboration_framework.host.schemas import (
     ActionPlanNarrationContext,
     ConversationSummary,
@@ -18,7 +17,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters.sqlalchemy_memory import _listener_memories
-from app.controller.ws import _listener_ids_for_utterance
 from app.models.engine import GameEvent, GameSession, ModuleVersion
 from app.models.event import Event
 from app.models.memory import (
@@ -185,39 +183,6 @@ def test_listener_projection_skips_unproven_listener() -> None:
         payload={"utterance": "我检查了钟摆。"},
     )
     assert _listener_memories(cast(Event, event)) == ()
-
-
-def test_single_visible_npc_is_listener_for_direct_you_address() -> None:
-    """单 NPC 场景中的“我跟你说/记住”必须生成该 NPC 的亲历记忆。"""
-    view = SimpleNamespace(
-        scene=SimpleNamespace(
-            visible_entities=(
-                SimpleNamespace(
-                    id="gravedigger", kind="npc", name="守墓人", aliases=()
-                ),
-            )
-        )
-    )
-    assert _listener_ids_for_utterance(
-        "我跟你说：月影钟响三次，记住了", cast(PlayerView, view)
-    ) == (
-        "gravedigger",
-    )
-
-
-def test_ambiguous_you_address_does_not_pick_one_of_multiple_npcs() -> None:
-    """多人场景的模糊“你”不能把秘密错误归给任意 NPC。"""
-    view = SimpleNamespace(
-        scene=SimpleNamespace(
-            visible_entities=(
-                SimpleNamespace(id="thomas", kind="npc", name="托马斯", aliases=()),
-                SimpleNamespace(id="gravedigger", kind="npc", name="守墓人", aliases=()),
-            )
-        )
-    )
-    assert _listener_ids_for_utterance(
-        "我跟你说：月影钟响三次，记住了", cast(PlayerView, view)
-    ) == ()
 
 
 def test_summary_reads_broadcast_utterance() -> None:

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -1,5 +1,8 @@
-"""记忆契约、摘要模型和确定性降级的最小回归测试。"""
+"""记忆契约、增量投影、并发幂等和摘要竞态的回归测试。"""
 
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import cast
 
@@ -10,13 +13,70 @@ from collaboration_framework.host.schemas import (
     MemoryContext,
     MemoryEntry,
 )
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters.sqlalchemy_memory import _listener_memories
+from app.models.engine import GameEvent, GameSession, ModuleVersion
 from app.models.event import Event
+from app.models.memory import (
+    ConversationSummaryRecord,
+    MemoryEntryRecord,
+    MemoryProjectionCursor,
+)
+from app.models.room import Player, Room
 from app.service.conversation_summary import (
+    ConversationSummaryService,
     DeterministicConversationSummaryModel,
     _event_text,
 )
+
+
+async def _create_memory_room(db: AsyncSession, number: int = 1) -> tuple[Room, Player, str]:
+    """创建满足 MemoryProjectionCursor 外键的最小可投影房间。"""
+    module = await db.scalar(select(ModuleVersion).limit(1))
+    assert module is not None
+    room_id = f"{number:08d}-0000-0000-0000-000000000001"
+    player_id = f"{number:08d}-0000-0000-0000-000000000002"
+    actor_id = f"{number:08d}-0000-0000-0000-000000000003"
+    room = Room(id=room_id, room_code=f"M{number:04d}", room_name="记忆测试房间", max_players=2)
+    player = Player(id=player_id, room_id=room_id, nickname="测试玩家")
+    db.add_all(
+        [
+            room,
+            player,
+            GameSession(
+                room_id=room_id,
+                module_id=module.module_id,
+                module_version=module.version,
+                state_json={"scene_id": "study"},
+            ),
+        ]
+    )
+    await db.commit()
+    return room, player, actor_id
+
+
+def _event(
+    room_id: str,
+    event_id: str,
+    created_at: datetime,
+    player_id: str,
+    actor_id: str,
+) -> Event:
+    """构造一条玩家可见的公开叙事事件。"""
+    return Event(
+        id=event_id,
+        room_id=room_id,
+        player_id=player_id,
+        actor_id=actor_id,
+        event_type="action.broadcast",
+        visibility="public",
+        payload={"text": f"调查记录 {event_id}"},
+        scene_id="study",
+        view_revision="1",
+        created_at=created_at,
+    )
 
 
 def test_memory_context_rejects_cross_room_entry() -> None:
@@ -131,3 +191,186 @@ def test_summary_reads_broadcast_utterance() -> None:
         payload={"utterance": "告诉托马斯钟摆停在第三声之后。"},
     )
     assert _event_text(cast(Event, event)) == "告诉托马斯钟摆停在第三声之后。"
+
+
+@pytest.mark.asyncio
+async def test_projection_is_incremental_and_uses_source_time(
+    db_session: AsyncSession,
+    memory_store,
+) -> None:  # noqa: ANN001
+    """长局第二次投影不重扫旧事件，最新公开行动不会被 GameEvent 淹没。"""
+    room, player, actor_id = await _create_memory_room(db_session, 11)
+    base = datetime(2026, 8, 1, tzinfo=UTC)
+    db_session.add_all(
+        [
+            _event(room.id, str(uuid.uuid4()), base + timedelta(seconds=100), player.id, actor_id),
+            *(
+                GameEvent(
+                    room_id=room.id,
+                    sequence=sequence,
+                    event_id=str(uuid.uuid4()),
+                    client_action_id=f"memory-{sequence}",
+                    type="action.inspect",
+                    actor_id=actor_id,
+                    visibility="public",
+                    cause=f"旧权威事件 {sequence}",
+                    payload={"text": f"旧权威事件 {sequence}"},
+                    created_at=base + timedelta(seconds=sequence),
+                )
+                for sequence in range(1, 30)
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    first = await memory_store.project_room_events(room.id)
+    second = await memory_store.project_room_events(room.id)
+    assert first.scanned_events == 1
+    assert first.scanned_game_events == 29
+    assert first.inserted == 30
+    assert second.scanned_events == 0
+    assert second.scanned_game_events == 0
+
+    context = await memory_store.read_context(
+        room_id=room.id,
+        player_id=player.id,
+        actor_id=actor_id,
+        revision="1",
+    )
+    assert any("调查记录" in entry.content for entry in context.entries)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_projection_is_idempotent(
+    db_session: AsyncSession,
+    memory_store,
+) -> None:  # noqa: ANN001
+    """Planner/Narrator 同时首次读取时不会因游标或唯一键竞争而丢记忆。"""
+    room, player, actor_id = await _create_memory_room(db_session, 12)
+    db_session.add(
+        _event(
+            room.id,
+            str(uuid.uuid4()),
+            datetime(2026, 8, 2, tzinfo=UTC),
+            player.id,
+            actor_id,
+        )
+    )
+    await db_session.commit()
+
+    results = await asyncio.gather(
+        memory_store.project_room_events(room.id),
+        memory_store.project_room_events(room.id),
+    )
+    assert sum(result.inserted for result in results) == 1
+    async with memory_store._session_factory() as session:  # noqa: SLF001
+        count = await session.scalar(
+            select(MemoryEntryRecord.id).where(MemoryEntryRecord.room_id == room.id)
+        )
+        cursor = await session.get(MemoryProjectionCursor, room.id)
+    assert count is not None
+    assert cursor is not None
+
+
+@pytest.mark.asyncio
+async def test_rebuild_is_repeatable_and_keeps_summary(
+    db_session: AsyncSession,
+    memory_store,
+) -> None:  # noqa: ANN001
+    """指定房间完整重建只替换 MemoryEntry，摘要和其他房间不受影响。"""
+    room, player, actor_id = await _create_memory_room(db_session, 13)
+    other_room, other_player, other_actor = await _create_memory_room(db_session, 14)
+    db_session.add_all(
+        [
+            _event(
+                room.id,
+                str(uuid.uuid4()),
+                datetime(2026, 8, 3, tzinfo=UTC),
+                player.id,
+                actor_id,
+            ),
+            _event(
+                other_room.id,
+                str(uuid.uuid4()),
+                datetime(2026, 8, 3, tzinfo=UTC),
+                other_player.id,
+                other_actor,
+            ),
+            ConversationSummaryRecord(
+                room_id=room.id,
+                player_id=player.id,
+                summary_json={"summary": "保留摘要"},
+            ),
+        ]
+    )
+    await db_session.commit()
+    await memory_store.project_room_events(room.id)
+    await memory_store.project_room_events(other_room.id)
+
+    first = await memory_store.rebuild_room_events(room.id)
+    second = await memory_store.rebuild_room_events(room.id)
+    assert first.inserted == second.inserted == 1
+    async with memory_store._session_factory() as session:  # noqa: SLF001
+        summary = await session.scalar(
+            select(ConversationSummaryRecord).where(
+                ConversationSummaryRecord.room_id == room.id,
+                ConversationSummaryRecord.player_id == player.id,
+            )
+        )
+        other_count = await session.scalar(
+            select(MemoryEntryRecord.id).where(MemoryEntryRecord.room_id == other_room.id)
+        )
+    assert summary is not None
+    assert summary.summary_json["summary"] == "保留摘要"
+    assert other_count is not None
+
+
+@pytest.mark.asyncio
+async def test_summary_enqueue_preserves_running_lease(
+    db_session: AsyncSession,
+    memory_store,
+) -> None:
+    """运行中的摘要任务收到新回合时只推进 pending 游标，不覆盖 lease。"""
+    room, player, actor_id = await _create_memory_room(db_session, 15)
+    base = datetime(2026, 8, 4, tzinfo=UTC)
+    db_session.add_all(
+        [
+            _event(room.id, str(uuid.uuid4()), base + timedelta(seconds=index), player.id, actor_id)
+            for index in range(12)
+        ]
+    )
+    await db_session.commit()
+    service = ConversationSummaryService(
+        memory_store._session_factory,  # noqa: SLF001
+        DeterministicConversationSummaryModel(),
+    )
+    await service.enqueue_if_needed(room_id=room.id, player_id=player.id)
+    async with service._session_factory() as session:  # noqa: SLF001
+        record = await session.scalar(
+            select(ConversationSummaryRecord).where(
+                ConversationSummaryRecord.room_id == room.id,
+                ConversationSummaryRecord.player_id == player.id,
+            )
+        )
+        assert record is not None
+        record.status = "running"
+        record.lease_owner = "worker-1"
+        record.lease_expires_at = base + timedelta(hours=1)
+        await session.commit()
+    db_session.add(
+        _event(room.id, str(uuid.uuid4()), base + timedelta(seconds=20), player.id, actor_id)
+    )
+    await db_session.commit()
+
+    await service.enqueue_if_needed(room_id=room.id, player_id=player.id)
+    async with service._session_factory() as session:  # noqa: SLF001
+        record = await session.scalar(
+            select(ConversationSummaryRecord).where(
+                ConversationSummaryRecord.room_id == room.id,
+                ConversationSummaryRecord.player_id == player.id,
+            )
+        )
+    assert record is not None
+    assert record.status == "running"
+    assert record.lease_owner == "worker-1"
+    assert record.pending_through_sequence == 13

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -425,3 +425,38 @@ async def test_read_context_normalizes_uuid_scope_and_entity_memory(
     assert context.conversation_summary is not None
     assert context.conversation_summary.room_id == room.id
     assert context.conversation_summary.player_id == player.id
+
+
+@pytest.mark.asyncio
+async def test_read_context_matches_multi_participant_json_array(
+    db_session: AsyncSession, memory_store
+) -> None:  # noqa: ANN001
+    """多参与者数组按单个元素匹配，而不是要求完整数组相等。"""
+    room, player, actor_id = await _create_memory_room(db_session, 19)
+    db_session.add(
+        MemoryEntryRecord(
+            room_id=room.id,
+            subject_id="other_npc",
+            kind="conversation",
+            content="NPC 听到了测试短语。",
+            epistemic_status="experienced",
+            visibility="public",
+            participants=[actor_id, "other_npc"],
+            listener_ids=["other_npc"],
+            location_id="other_scene",
+            source_event_id="multi-participant-event",
+            source_sequence=1,
+            source_revision="1",
+            source_created_at=datetime.now(UTC),
+        )
+    )
+    await db_session.commit()
+    context = await memory_store.read_context(
+        room_id=room.id,
+        player_id=player.id,
+        actor_id=actor_id,
+        revision="1",
+        entity_ids=("other_npc",),
+        location_id="current_scene",
+    )
+    assert any(entry.source_event_id == "multi-participant-event" for entry in context.entries)

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -374,3 +374,54 @@ async def test_summary_enqueue_preserves_running_lease(
     assert record.status == "running"
     assert record.lease_owner == "worker-1"
     assert record.pending_through_sequence == 13
+
+
+@pytest.mark.asyncio
+async def test_read_context_normalizes_uuid_scope_and_entity_memory(
+    db_session: AsyncSession,
+    memory_store,
+) -> None:  # noqa: ANN001
+    """带连字符 UUID 和跨地点 NPC 记忆仍能安全进入当前 Host 上下文。"""
+    room, player, actor_id = await _create_memory_room(db_session, 16)
+    db_session.add_all(
+        [
+            Event(
+                id=str(uuid.uuid4()),
+                room_id=room.id,
+                player_id=player.id,
+                actor_id=actor_id,
+                event_type="action.broadcast",
+                visibility="public",
+                scene_id="thomas_office",
+                payload={
+                    "utterance": "告诉托马斯记住蓝色钟摆的三个节拍。",
+                    "speaker_id": actor_id,
+                    "listener_ids": ["thomas"],
+                },
+                created_at=datetime(2026, 8, 5, tzinfo=UTC),
+            ),
+            ConversationSummaryRecord(
+                room_id=room.id,
+                player_id=player.id,
+                summary_json={
+                    "room_id": room.id,
+                    "player_id": player.id,
+                    "summary": "托马斯听过一段重要咒语。",
+                },
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    context = await memory_store.read_context(
+        room_id=room.id,
+        player_id=player.id,
+        actor_id=actor_id,
+        revision="1",
+        entity_ids=("thomas",),
+        location_id="arnoldsburg_streets",
+    )
+    assert any(entry.epistemic_status == "experienced" for entry in context.entries)
+    assert context.conversation_summary is not None
+    assert context.conversation_summary.room_id == room.id
+    assert context.conversation_summary.player_id == player.id

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -10,7 +10,7 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
 ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
 # 记忆与 main 分支的模组迁移通过 merge migration 汇合为当前 head。
-HEAD_REVISION = "e5f6a7b8c9d0"
+HEAD_REVISION = "f6a7b8c9d0e1"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -90,6 +90,7 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "time_advance_proposals",
         "memory_entries",
         "conversation_summaries",
+        "memory_projection_cursors",
         "turn_run_cutover",
         "scene_transition_proposals",
     }.issubset(tables)
@@ -173,6 +174,7 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "view_revision",
     }.issubset(_column_names(database, "events"))
     assert ("room_id", "event_type", "correlation_id") in _unique_column_sets(database, "events")
+    assert "source_created_at" in _column_names(database, "memory_entries")
 
     downgrade = _run_alembic(database, "downgrade", PREVIOUS_REVISION)
     assert downgrade.returncode == 0, downgrade.stdout + downgrade.stderr

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -10,7 +10,7 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
 ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
 # 记忆与 main 分支的模组迁移通过 merge migration 汇合为当前 head。
-HEAD_REVISION = "f6a7b8c9d0e1"
+HEAD_REVISION = "a7b8c9d0e1f2"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -355,3 +355,36 @@ def test_module_identity_migration_rejects_existing_catalog_data(tmp_path: Path)
     assert "game_systems 存在历史数据" in result.stdout + result.stderr
     assert "world_ref" not in _column_names(database, "game_systems")
     assert "module_id" not in _column_names(database, "scenarios")
+
+
+def test_memory_source_time_reconciliation_repairs_stamped_database(tmp_path: Path) -> None:
+    """数据库已标记旧 head 但缺列时，新迁移仍能补列、回填数据并创建索引。"""
+    database = tmp_path / "memory-source-time-drift.db"
+    _upgrade_or_fail(database, "f6a7b8c9d0e1")
+
+    with sqlite3.connect(database) as connection:
+        connection.execute("DROP INDEX ix_memory_entries_room_source_created")
+        connection.execute("ALTER TABLE memory_entries DROP COLUMN source_created_at")
+        connection.execute(
+            """
+            INSERT INTO memory_entries (
+                id, room_id, subject_id, kind, content, epistemic_status,
+                visibility, participants, listener_ids, source_event_id,
+                source_sequence, created_at
+            ) VALUES (
+                '10000000000000000000000000000001',
+                '10000000000000000000000000000002',
+                'actor_1', 'action', '历史行动', 'asserted', 'public',
+                '[]', '[]', 'event-1', 0, '2026-08-20 12:34:56'
+            )
+            """
+        )
+
+    _upgrade_or_fail(database, "head")
+    with sqlite3.connect(database) as connection:
+        source_created_at = connection.execute(
+            "SELECT source_created_at FROM memory_entries WHERE source_event_id = 'event-1'"
+        ).fetchone()
+        indexes = {row[1] for row in connection.execute("PRAGMA index_list('memory_entries')")}
+    assert source_created_at == ("2026-08-20 12:34:56",)
+    assert "ix_memory_entries_room_source_created" in indexes


### PR DESCRIPTION
## 关联 PR

依赖 PR #391；本 Draft PR 只包含其后的投影性能优化。#391 合并后请将本 PR 的 base 调整为 `main` 再进行正式 Review。

## 关联 Issue

Refs #363

## 主要改动

- 增加房间级 `MemoryProjectionCursor`，分别记录传输事件时间/id 游标和 Engine `GameEvent` 序列高水位。
- `project_room_events()` 只读取游标之后的新事件，避免每次 Planner/Narrator 读取都全量扫描历史。
- 将记忆来源查重从逐条查询改为一次批量查询，并保留重复投影幂等。
- 增加 Alembic 迁移、模型注册和迁移回归断言。

## 采用该方案的原因

长局的主要瓶颈是每次上下文读取都会重放全部事件并逐条查重。本 PR 保持原有事实来源、权限过滤和记忆契约不变，只优化读模型投影路径；游标更新与投影写入在同一事务中完成，历史数据仍可通过重建脚本补投影。

## 测试与验证

- `uv run pytest -q tests/test_migrations.py tests/test_memory_system.py`：7 passed。
- `uv run ruff check .`：通过。
- `uv run ruff format --check .`：通过。
- `uv run ty check`：通过。
- Alembic upgrade/downgrade/upgrade：通过。
- PR #391 的全量 Backend、E2E、迁移、codegen 检查均已通过。

## 兼容性、迁移与回滚

- 新增 `memory_projection_cursors` 表，需要执行 Alembic migration。
- 首次读取没有游标时会从历史事件建立游标，已有记忆通过批量查重保持幂等。
- 回滚只需回退本迁移和投影代码，不影响 Engine 状态、原始 Event 或已有 MemoryEntry。

## 自检清单

- [x] 改动仅限投影性能优化
- [x] 未改变权限和事实优先级
- [x] 已补充迁移回归
- [x] 已运行静态检查和专项测试
- [ ] 等待人工 Review
- [ ] 等待 PR #391 合并后调整 base

## AI 辅助开发声明

本 PR 使用 AI 辅助实现，已人工检查游标边界、同一时间戳事件排序、批量查重和迁移回滚路径。