### PR TITLE
fix(adjudication): 防止环境侦查误匹配守墓人

### DIFF
--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -2229,6 +2229,9 @@ def _match_rule_candidate(capabilities, text: str, target_id: str | None):
         return None, None
     scored = []
     for candidate in capabilities.rule_candidates:
+        # 面向具体实体的规则必须先有明确目标，避免环境观察被误套到 NPC 上。
+        if target_id is None and "entity" in candidate.target_kinds:
+            continue
         if target_id is not None and candidate.target_ids and target_id not in candidate.target_ids:
             continue
         family_hits = [

--- a/trpg-backend/tests/test_rule_match_adjudication.py
+++ b/trpg-backend/tests/test_rule_match_adjudication.py
@@ -227,6 +227,17 @@ async def test_natural_chinese_action_family_reaches_the_unique_rule() -> None:
     assert isinstance(adjudication.check, RequiredAdjudicationCheck)
 
 
+async def test_environment_observation_near_grave_does_not_target_caretaker() -> None:
+    """只观察墓碑周围环境时，不应凭空把目标改成守墓人。"""
+
+    adjudication = await _DeterministicStepAdjudicator().adjudicate(
+        await _cemetery_context("在墓碑附近用侦查观察周围环境")
+    )
+
+    assert adjudication.rule_decision is None
+    assert adjudication.target.kind != "entity"
+
+
 async def test_fake_single_action_uses_the_same_rule_match_view() -> None:
     """单动作不能绕过 v3 Rule Match 而静默退化成纯叙事。"""
 


### PR DESCRIPTION
## 关联 Issue

Closes #395

## 主要改动

- 当规则候选面向具体实体且玩家没有明确目标时，跳过该候选。
- 增加墓碑附近环境侦查不应命中守墓人的回归测试。

## 采用该方案的原因

问题来自规则匹配阶段缺少实体目标约束。将约束放在候选筛选处，可以阻止环境观察越过玩家意图边界，同时保留“仔细观察守墓人”等明确目标行为。

## 测试与验证

- [x] `uv run pytest -q tests/test_rule_match_adjudication.py -k 'natural_chinese or environment_observation'`：2 passed
- [x] `uv run pytest -q tests/test_rule_match_adjudication.py`：28 passed
- [ ] 手动验证：未执行
- [ ] 全量构建或静态检查：未执行

## 兼容性、风险与回滚

本改动只收紧无明确实体目标时的规则候选匹配，不改变明确实体目标或非实体规则。若需回滚， revert 提交 `b3282b5` 即可。

## UI 证据

不适用，本 PR 不涉及 UI。

## AI 使用情况

本 PR 使用 AI 辅助定位规则匹配路径、编写最小修复和回归测试；改动已检查并由提交者负责人工 Review。

## 自检

- [x] 改动范围符合 Issue
- [x] 不包含无关改动
- [x] 已包含必要的测试
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查和人工 Review
