### PR TITLE
test(turn-run): add Issue #356 validation evidence

### DIFF
--- a/trpg-backend/docs/issue-356-validation-results.md
+++ b/trpg-backend/docs/issue-356-validation-results.md
@@ -1,0 +1,79 @@
+# Issue #356 validation results
+
+Run date: 2026-08-21 (Asia/Shanghai)
+
+The reproducible harness is in
+`tests/benchmarks/issue_356_turn_run.py`; the tool commit is `e18774f`.
+Results below are sanitized aggregates. No utterance, prompt, Keeper view,
+model response, token, or credential is included. Percentiles use nearest-rank;
+latencies start after the action submit has been sent and stop at
+`turn.completed`.
+
+## Fake before/after
+
+The comparison uses the same harness and 5 samples per scenario in isolated
+worktrees:
+
+- Before: `f6ff264`, the production revision immediately before #356.
+- After: `c280b21`, the #356 implementation merge commit.
+- Both runs: 30 samples, 0 failures, fake provider.
+
+| Scenario | Before P50/P95 ms | After P50/P95 ms | Before calls (Planner/Adj/Narrator/Submit) | After calls (Planner/Adj/Narrator/Submit) | After PlanRun writes (create/CAS) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Single no-check | 52.181 / 84.856 | 80.853 / 116.078 | 1 / 0 / 1 / 1 | 1 / 0 / 1 / 1 | 1 / 3 |
+| Single pending + cancel | 87.462 / 123.372 | 124.503 / 166.287 | 1 / 0 / 1 / 1 | 1 / 0 / 1 / 1 | 1 / 3 |
+| Single validation repair | 73.869 / 114.497 | 101.841 / 131.647 | 1 / 1 / 1 / 2 | 1 / 1 / 1 / 2 | 1 / 6 |
+| Single narrator retry | 99.638 / 141.480 | 105.801 / 142.826 | 2 / 0 / 2 / 2 | 1 / 0 / 2 / 1 | 1 / 3 |
+| Commit response loss | 54.922 / 57.179 | 87.127 / 87.311 | 1 / 0 / 1 / 1 | 1 / 0 / 1 / 1 | 1 / 3 |
+| Multi-step (2) | 115.325 / 150.143 | 127.238 / 166.535 | 1 / 2 / 1 / 2 | 1 / 2 / 1 / 2 | 1 / 8 |
+
+Overall fake end-to-end latency changed from P50/P95
+`86.027/141.480 ms` to `105.801/166.287 ms`. This is the measured cost of
+creating and checkpointing the unified Run; it is not hidden as a zero-cost
+architectural change. The important call-count invariants held: normal
+single-action planner/adjudicator/narrator/submit calls stayed at `1/0/1/1`,
+and a narrator retry did not re-run Planner or Engine submit. The response-loss
+scenario reconciled exactly once through Engine status in both revisions.
+
+## Real-model smoke
+
+Run against current `origin/main` revision `2cf7528`, with
+`deepseek/deepseek-chat`, 2 samples for each of three fixed scenario labels
+(6 samples total). The action text is not retained in the report. All 6
+samples completed with failure rate `0.0`; no transport retry was observed.
+
+| Scenario classification | Samples | Step count | Planner / Adj / Narrator / Submit | PlanRun create/CAS | P50/P95 ms |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Observation | 2 | 1 | 1 / 0 / 1 / 1 | 1 / 3 | 4486.788 / 5119.781 |
+| Investigation | 2 | 1 | 1 / 0 / 1 / 1 | 1 / 3 | 3735.646 / 4450.393 |
+| Two-clause action | 2 | 2 | 1 / 2 / 1 / 2 | 1 / 8 | 8177.417 / 8226.400 |
+
+Real-model results are a smoke sample, not a provider SLA or a statistically
+representative performance claim. They demonstrate that the current provider
+can execute both one-step and two-step paths through the same WebSocket TurnRun
+chain with the expected high-level call shape.
+
+## Reproduction
+
+Fake comparison:
+
+```bash
+ISSUE_356_BENCHMARK_MODE=fake \
+ISSUE_356_BENCHMARK_REPEATS=5 \
+ISSUE_356_SUBJECT_REVISION=f6ff264 \
+ISSUE_356_BENCHMARK_OUTPUT=/tmp/issue-356-pre.json \
+uv run pytest -s tests/benchmarks/issue_356_turn_run.py
+```
+
+Run the same command at `c280b21` with
+`ISSUE_356_SUBJECT_REVISION=c280b21`. Real smoke on the current checkout:
+
+```bash
+ISSUE_356_BENCHMARK_MODE=real \
+ISSUE_356_BENCHMARK_REPEATS=2 \
+ISSUE_356_BENCHMARK_OUTPUT=/tmp/issue-356-real.json \
+uv run pytest -s tests/benchmarks/issue_356_turn_run.py
+```
+
+Raw JSON reports are intentionally kept outside Git. The checked-in table is
+the review artifact for #356 and should be linked from the Issue/validation PR.

--- a/trpg-backend/docs/issue-356-validation.md
+++ b/trpg-backend/docs/issue-356-validation.md
@@ -1,0 +1,70 @@
+# Issue #356 validation protocol
+
+This document defines the reproducible evidence pass for the 1..N TurnRun
+unification. It does not change the production execution path. The benchmark is
+an explicitly invoked WebSocket test and is excluded from normal pytest
+collection so that CI never calls a paid model accidentally.
+
+## What is measured
+
+The report contains only the subject/tool Git revisions, provider/model identifiers, scenario
+classification, step count, failure code, call counts, retry/repair counts, and
+monotonic durations. It never contains player text, prompts, Keeper capability
+data, model output, narration text, tokens, or API keys. A recursive report
+validator rejects sensitive field names before a JSON result can be written.
+
+The fake-mode scenarios are deterministic:
+
+- `single_no_check`
+- `single_pending_cancel`
+- `single_validation_repair`
+- `single_narrator_retry`
+- `commit_response_loss`
+- `multi_step`
+
+`end_to_end_ms` runs from WebSocket action submission to `turn.completed` (or a
+terminal failure). `first_narration_completion_ms` contains the same boundary
+for successful turns only. `first_pending_ms` runs to the first
+`adjudication.pending`. P50 and P95 use the nearest-rank method. Setup time for
+accounts, rooms, characters, game start, and WebSocket join is excluded.
+
+## Deterministic comparison
+
+Run current code from `trpg-backend`:
+
+```bash
+ISSUE_356_BENCHMARK_MODE=fake \
+ISSUE_356_BENCHMARK_REPEATS=10 \
+ISSUE_356_SUBJECT_REVISION=$(git rev-parse HEAD) \
+ISSUE_356_BENCHMARK_OUTPUT=/tmp/issue-356-current.json \
+uv run pytest -s tests/benchmarks/issue_356_turn_run.py
+```
+
+For the historical comparison, create an isolated worktree at `f6ff264`, copy
+the two benchmark modules into that worktree without committing them, and run
+the same command there. Do not switch the working branch or rewrite historical
+dependencies. The pre-change single-action path is expected to report zero
+PlanRun create/CAS writes; current one-step turns must report PlanRun writes
+without increasing Planner, Step Adjudicator, Narrator, or Engine submit calls.
+
+## Real-model smoke
+
+Real mode uses the provider configured by the backend `.env`. It must be run on
+the current implementation only:
+
+```bash
+ISSUE_356_BENCHMARK_MODE=real \
+ISSUE_356_BENCHMARK_REPEATS=2 \
+ISSUE_356_BENCHMARK_OUTPUT=/tmp/issue-356-real.json \
+uv run pytest -s tests/benchmarks/issue_356_turn_run.py
+```
+
+The three real scenarios submit an observation, an investigation, and a
+two-clause action. Scenario names are labels rather than assumed model output:
+the resulting `step_counts`, pending latency, failures, and actual model call
+counts show how the provider classified and executed them. Do not rerun failed
+samples selectively. Increase repeats only as an explicit cost/latency choice.
+
+Raw JSON remains outside the repository. A reviewed, aggregate Markdown table
+may be committed as release evidence, with the exact revisions, command,
+machine/runtime context, sample count, and any limitations stated plainly.

--- a/trpg-backend/tests/benchmarks/__init__.py
+++ b/trpg-backend/tests/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Explicit, non-CI benchmark entry points."""

--- a/trpg-backend/tests/benchmarks/issue_356_metrics.py
+++ b/trpg-backend/tests/benchmarks/issue_356_metrics.py
@@ -1,0 +1,129 @@
+"""Sanitized metrics helpers for the Issue #356 TurnRun validation."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+SENSITIVE_FIELD_FRAGMENTS = frozenset(
+    {
+        "api_key",
+        "capabilit",
+        "context",
+        "message_text",
+        "model_output",
+        "narration_text",
+        "player_input",
+        "prompt",
+        "raw",
+        "secret",
+        "token",
+        "utterance",
+    }
+)
+
+
+def nearest_rank_percentile(values: Iterable[float], percentile: float) -> float | None:
+    """Return the nearest-rank percentile, rounded to three decimal places."""
+
+    samples = sorted(float(value) for value in values)
+    if not samples:
+        return None
+    if not 0 < percentile <= 100:
+        raise ValueError("percentile must be in (0, 100]")
+    rank = max(1, math.ceil(percentile / 100 * len(samples)))
+    return round(samples[rank - 1], 3)
+
+
+def latency_summary(values: Iterable[float]) -> dict[str, float | int | None]:
+    samples = [round(float(value), 3) for value in values]
+    return {
+        "samples": len(samples),
+        "min": min(samples) if samples else None,
+        "p50": nearest_rank_percentile(samples, 50),
+        "p95": nearest_rank_percentile(samples, 95),
+        "max": max(samples) if samples else None,
+    }
+
+
+def count_summary(values: Iterable[int]) -> dict[str, float | int | None]:
+    samples = [int(value) for value in values]
+    return {
+        "total": sum(samples),
+        "per_sample_min": min(samples) if samples else None,
+        "per_sample_mean": round(sum(samples) / len(samples), 3) if samples else None,
+        "per_sample_max": max(samples) if samples else None,
+    }
+
+
+def assert_sanitized_report(value: object, *, path: str = "report") -> None:
+    """Reject fields that could expose player/model input or credentials."""
+
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            normalized = str(key).lower()
+            if any(fragment in normalized for fragment in SENSITIVE_FIELD_FRAGMENTS):
+                raise ValueError(f"sensitive report field at {path}.{key}")
+            assert_sanitized_report(nested, path=f"{path}.{key}")
+        return
+    if isinstance(value, (list, tuple)):
+        for index, nested in enumerate(value):
+            assert_sanitized_report(nested, path=f"{path}[{index}]")
+        return
+    if value is not None and not isinstance(value, (str, int, float, bool)):
+        raise TypeError(f"unsupported report value at {path}: {type(value).__name__}")
+
+
+def aggregate_scenario(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate already-sanitized samples without retaining per-turn identifiers."""
+
+    count_fields = (
+        "planner_calls",
+        "step_adjudicator_calls",
+        "narrator_calls",
+        "engine_submit_calls",
+        "engine_status_calls",
+        "plan_create_calls",
+        "plan_cas_calls",
+        "repair_calls",
+        "model_transport_retries",
+    )
+    result: dict[str, Any] = {
+        "sample_count": len(samples),
+        "successes": sum(sample["failure_code"] is None for sample in samples),
+        "failures": sum(sample["failure_code"] is not None for sample in samples),
+        "failure_rate": (
+            round(
+                sum(sample["failure_code"] is not None for sample in samples) / len(samples),
+                4,
+            )
+            if samples
+            else None
+        ),
+        "failure_codes": sorted(
+            {
+                str(sample["failure_code"])
+                for sample in samples
+                if sample["failure_code"] is not None
+            }
+        ),
+        "step_counts": sorted({int(sample["step_count"]) for sample in samples}),
+        "end_to_end_ms": latency_summary(
+            sample["end_to_end_ms"] for sample in samples if sample["end_to_end_ms"] is not None
+        ),
+        "first_narration_completion_ms": latency_summary(
+            sample["end_to_end_ms"]
+            for sample in samples
+            if sample["failure_code"] is None and sample["end_to_end_ms"] is not None
+        ),
+        "first_pending_ms": latency_summary(
+            sample["first_pending_ms"]
+            for sample in samples
+            if sample["first_pending_ms"] is not None
+        ),
+    }
+    for field in count_fields:
+        result[field] = count_summary(sample[field] for sample in samples)
+    assert_sanitized_report(result)
+    return result

--- a/trpg-backend/tests/benchmarks/issue_356_turn_run.py
+++ b/trpg-backend/tests/benchmarks/issue_356_turn_run.py
@@ -464,51 +464,57 @@ def _run_sample(
     failure_code: str | None = None
     first_pending_ms: float | None = None
     start = 0.0
+    end_to_end_ms = 0.0
     with _application_components(application), _mute_content_logs():
         lose_response = False if real_mode else _configure_fake(application, scenario)
         with _Probe(application, lose_first_commit_response=lose_response) as probe:
             socket, ws = _join(client, token, room)
             try:
                 start = time.perf_counter()
-                _submit(ws, room, action_id, scenario)
-                stop, _ = receive_until(
-                    ws,
-                    lambda message: (
-                        _is_completed(message)
-                        or message.get("type") in {"adjudication.pending", "turn.failed"}
-                    ),
-                    limit=60,
-                )
-                if stop.get("type") == "adjudication.pending":
-                    first_pending_ms = (time.perf_counter() - start) * 1000
-                    if scenario == "single_pending_cancel" and not real_mode:
-                        payload = stop["payload"]
-                        decision = payload["pendingDecision"]
-                        ws.send_json(
-                            {
-                                "type": "adjudication.select",
-                                "playerId": room["playerId"],
-                                "payload": {
-                                    "clientActionId": action_id,
-                                    "requestId": f"bench-cancel-{uuid.uuid4().hex[:8]}",
-                                    "sourceRevision": payload["sourceRevision"],
-                                    "decisionId": decision["decision_id"],
-                                    "decisionVersion": decision["decision_version"],
-                                    "cancel": True,
-                                },
-                            }
-                        )
-                        stop, _ = receive_until(ws, _is_completed, limit=60)
-                    else:
-                        stop, _ = _settle_pending(ws, room, stop)
-                if stop.get("type") == "turn.failed":
-                    failure_code = str(stop.get("payload", {}).get("code", "TURN_FAILED"))
-                if scenario == "single_narrator_retry" and not real_mode:
-                    if failure_code != "PLAN_NARRATOR_FAILED":
-                        raise AssertionError(f"expected narrator failure, got {failure_code}")
-                    failure_code = None
+                try:
                     _submit(ws, room, action_id, scenario)
-                    stop, _ = receive_until(ws, _is_completed, limit=60)
+                    stop, _ = receive_until(
+                        ws,
+                        lambda message: (
+                            _is_completed(message)
+                            or message.get("type") in {"adjudication.pending", "turn.failed"}
+                        ),
+                        limit=60,
+                    )
+                    if stop.get("type") == "adjudication.pending":
+                        first_pending_ms = (time.perf_counter() - start) * 1000
+                        if scenario == "single_pending_cancel" and not real_mode:
+                            payload = stop["payload"]
+                            decision = payload["pendingDecision"]
+                            ws.send_json(
+                                {
+                                    "type": "adjudication.select",
+                                    "playerId": room["playerId"],
+                                    "payload": {
+                                        "clientActionId": action_id,
+                                        "requestId": f"bench-cancel-{uuid.uuid4().hex[:8]}",
+                                        "sourceRevision": payload["sourceRevision"],
+                                        "decisionId": decision["decision_id"],
+                                        "decisionVersion": decision["decision_version"],
+                                        "cancel": True,
+                                    },
+                                }
+                            )
+                            stop, _ = receive_until(ws, _is_completed, limit=60)
+                        else:
+                            stop, _ = _settle_pending(ws, room, stop)
+                    if stop.get("type") == "turn.failed":
+                        failure_code = str(stop.get("payload", {}).get("code", "TURN_FAILED"))
+                    if scenario == "single_narrator_retry" and not real_mode:
+                        if failure_code != "PLAN_NARRATOR_FAILED":
+                            raise AssertionError(f"expected narrator failure, got {failure_code}")
+                        failure_code = None
+                        _submit(ws, room, action_id, scenario)
+                        stop, _ = receive_until(ws, _is_completed, limit=60)
+                except AssertionError:
+                    if not real_mode:
+                        raise
+                    failure_code = "BENCHMARK_TIMEOUT"
                 end_to_end_ms = (time.perf_counter() - start) * 1000
             finally:
                 socket.__exit__(None, None, None)

--- a/trpg-backend/tests/benchmarks/issue_356_turn_run.py
+++ b/trpg-backend/tests/benchmarks/issue_356_turn_run.py
@@ -1,0 +1,644 @@
+"""Explicit WebSocket benchmark for Issue #356.
+
+This file deliberately does not match pytest's default ``test_*.py`` pattern.
+Run it explicitly as documented in ``docs/issue-356-validation.md``. The JSON
+output contains counts, durations, failure codes, and provider metadata only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+import time
+import uuid
+from collections import defaultdict
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from collaboration_framework.contracts import (
+    ActionAdjudication,
+    ActionMethod,
+    ActionPlan,
+    ActionPlanStep,
+    ActionTarget,
+    JsonObject,
+    NarrativeOnlyEffect,
+    NoAdjudicationCheck,
+    RequiredAdjudicationCheck,
+    SingleActionDecision,
+    SkillCheckCandidate,
+)
+from collaboration_framework.host.application import ActionPlanNarrator
+from starlette.testclient import TestClient
+
+from app.adapters import structured_http
+from app.controller import ws as ws_controller
+from app.core.action_plan_turn import build_action_plan_turn_application
+from app.core.config import Settings
+from app.main import app
+from tests.benchmarks.issue_356_metrics import aggregate_scenario, assert_sanitized_report
+from tests.test_ws import (
+    advance_to_building,
+    complete_character,
+    create_room,
+    receive_replayed_opening,
+    receive_until,
+    register_and_login,
+    start_game,
+)
+
+COUNT_FIELDS = (
+    "planner_calls",
+    "step_adjudicator_calls",
+    "narrator_calls",
+    "engine_submit_calls",
+    "engine_status_calls",
+    "plan_create_calls",
+    "plan_cas_calls",
+    "repair_calls",
+    "model_transport_retries",
+)
+
+
+class _SingleNoCheckPlanner:
+    async def generate(self, context) -> SingleActionDecision:  # noqa: ANN001
+        text = context.player_input.utterance
+        return SingleActionDecision(
+            adjudication=ActionAdjudication(
+                request_id="application-owned",
+                source_revision=context.player_view.revision,
+                actor_id=context.player_input.actor_id,
+                summary=text,
+                target=ActionTarget(kind="location", id=context.player_view.scene.id),
+                method=ActionMethod(family="action", description=text),
+                check=NoAdjudicationCheck(),
+                success_effects=(NarrativeOnlyEffect(),),
+            )
+        )
+
+
+class _SinglePendingPlanner:
+    async def generate(self, context) -> SingleActionDecision:  # noqa: ANN001
+        text = context.player_input.utterance
+        return SingleActionDecision(
+            adjudication=ActionAdjudication(
+                request_id="application-owned",
+                source_revision=context.player_view.revision,
+                actor_id=context.player_input.actor_id,
+                summary=text,
+                target=ActionTarget(kind="location", id=context.player_view.scene.id),
+                method=ActionMethod(family="investigate", description=text),
+                check=RequiredAdjudicationCheck(
+                    candidates=(
+                        SkillCheckCandidate(
+                            candidate_id="library-use",
+                            skill_id="library-use",
+                            difficulty="regular",
+                            method_summary="inspect records",
+                            player_safe_reason="a check is required",
+                        ),
+                    )
+                ),
+                success_effects=(NarrativeOnlyEffect(),),
+            )
+        )
+
+
+class _InvalidTargetPlanner:
+    async def generate(self, context) -> SingleActionDecision:  # noqa: ANN001
+        text = context.player_input.utterance
+        return SingleActionDecision(
+            adjudication=ActionAdjudication(
+                request_id="application-owned",
+                source_revision=context.player_view.revision,
+                actor_id=context.player_input.actor_id,
+                summary=text,
+                target=ActionTarget(kind="entity", id="missing-visible-target"),
+                method=ActionMethod(family="observe", description=text),
+                check=NoAdjudicationCheck(),
+                success_effects=(NarrativeOnlyEffect(),),
+            )
+        )
+
+
+class _TwoStepPlanner:
+    async def generate(self, context) -> ActionPlan:  # noqa: ANN001
+        return ActionPlan(
+            goal=context.player_input.utterance,
+            steps=(
+                ActionPlanStep(kind="action", semantic_goal="observe the current scene"),
+                ActionPlanStep(kind="action", semantic_goal="review the visible details"),
+            ),
+        )
+
+
+class _NarrativeStepAdjudicator:
+    async def adjudicate(self, context) -> ActionAdjudication:  # noqa: ANN001
+        return ActionAdjudication(
+            request_id=context.step_request_id,
+            source_revision=context.player_view.revision,
+            actor_id=context.player_input.actor_id,
+            summary=context.step.semantic_goal,
+            target=ActionTarget(kind="location", id=context.player_view.scene.id),
+            method=ActionMethod(family="action", description=context.step.semantic_goal),
+            check=NoAdjudicationCheck(),
+            success_effects=(NarrativeOnlyEffect(),),
+        )
+
+
+class _RepairAdjudicator:
+    async def adjudicate(self, context) -> ActionAdjudication:  # noqa: ANN001
+        visible = context.player_view.scene.visible_entities
+        if not visible:
+            raise AssertionError("repair benchmark requires one visible entity")
+        target = next(
+            (entity for entity in visible if entity.name in context.player_input.utterance),
+            None,
+        )
+        if target is None:
+            raise AssertionError("repair benchmark input must name one visible entity")
+        return ActionAdjudication(
+            request_id=context.step_request_id,
+            source_revision=context.player_view.revision,
+            actor_id=context.player_input.actor_id,
+            summary=context.player_input.utterance,
+            target=ActionTarget(kind="entity", id=target.id),
+            method=ActionMethod(
+                family="observe",
+                description=context.player_input.utterance,
+            ),
+            check=NoAdjudicationCheck(),
+            success_effects=(NarrativeOnlyEffect(),),
+        )
+
+
+class _FixedNarrationModel:
+    async def generate(self, context) -> JsonObject:  # noqa: ANN001
+        del context
+        return {
+            "kind": "narration",
+            "text": "The turn reached a stable public result.",
+            "claimed_evidence_refs": [],
+            "suggested_actions": [],
+        }
+
+
+class _FailOnceNarrator:
+    def __init__(self, delegate) -> None:  # noqa: ANN001
+        self._delegate = delegate
+        self._failed = False
+
+    async def narrate(self, context):  # noqa: ANN001, ANN201
+        if not self._failed:
+            self._failed = True
+            raise RuntimeError("synthetic narrator outage")
+        return await self._delegate.narrate(context)
+
+
+class _Probe:
+    def __init__(self, application, *, lose_first_commit_response: bool = False) -> None:  # noqa: ANN001
+        self.application = application
+        self.counts: defaultdict[str, int] = defaultdict(int)
+        self._lose_first_commit_response = lose_first_commit_response
+        self._commit_response_lost = False
+        self._restores: list[tuple[object, str, object]] = []
+
+    def __enter__(self) -> _Probe:
+        self._wrap_async(self.application._planner, "generate", "planner_calls")
+        adjudicator = self.application._orchestrator._adjudicator
+        self._wrap_async(
+            adjudicator,
+            "adjudicate",
+            "step_adjudicator_calls",
+            count_repair=True,
+        )
+        self._wrap_async(self.application._narrator, "narrate", "narrator_calls")
+        executor = self.application._orchestrator._executor
+        self._wrap_async(
+            executor,
+            "submit",
+            "engine_submit_calls",
+            lose_commit_response=self._lose_first_commit_response,
+        )
+        self._wrap_async(executor, "get_status", "engine_status_calls")
+        store = self.application._orchestrator._store
+        self._wrap_async(store, "create", "plan_create_calls")
+        self._wrap_async(store, "compare_and_swap", "plan_cas_calls")
+        original_warning = structured_http.logger.warning
+
+        def measured_warning(event: str, *args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            if event == "structured_json_request_retry":
+                self.counts["model_transport_retries"] += 1
+            return original_warning(event, *args, **kwargs)
+
+        self._restores.append((structured_http.logger, "warning", original_warning))
+        structured_http.logger.warning = measured_warning
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:  # noqa: ANN001
+        del exc_type, exc, traceback
+        for target, name, original in reversed(self._restores):
+            setattr(target, name, original)
+
+    def _wrap_async(
+        self,
+        target: object,
+        name: str,
+        counter: str,
+        *,
+        count_repair: bool = False,
+        lose_commit_response: bool = False,
+    ) -> None:
+        original = getattr(target, name)
+
+        async def measured(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            self.counts[counter] += 1
+            if count_repair:
+                context = args[0] if args else kwargs.get("context")
+                if getattr(context, "previous_rejection", None) is not None:
+                    self.counts["repair_calls"] += 1
+            result = await original(*args, **kwargs)
+            if lose_commit_response and not self._commit_response_lost:
+                self._commit_response_lost = True
+                raise TimeoutError("synthetic response loss after authoritative commit")
+            return result
+
+        self._restores.append((target, name, original))
+        setattr(target, name, measured)
+
+
+@contextmanager
+def _application_components(application) -> Iterator[None]:  # noqa: ANN001
+    original = (
+        application._planner,
+        application._narrator,
+        application._orchestrator._adjudicator,
+        getattr(application._dispatcher, "_repair_adjudicator", None),
+    )
+    try:
+        yield
+    finally:
+        application._planner = original[0]
+        application._narrator = original[1]
+        application._orchestrator._adjudicator = original[2]
+        if hasattr(application._dispatcher, "_repair_adjudicator"):
+            application._dispatcher._repair_adjudicator = original[3]
+
+
+@contextmanager
+def _mute_content_logs() -> Iterator[None]:
+    names = (
+        "log_check_result",
+        "log_narration_output",
+        "log_player_input",
+        "log_state_changes",
+        "log_turn_completed",
+        "log_turn_failed",
+    )
+    originals = {
+        name: getattr(ws_controller, name) for name in names if hasattr(ws_controller, name)
+    }
+
+    def discard(**kwargs) -> None:  # noqa: ANN003
+        del kwargs
+
+    try:
+        for name in originals:
+            setattr(ws_controller, name, discard)
+        yield
+    finally:
+        for name, original in originals.items():
+            setattr(ws_controller, name, original)
+
+
+def _configure_fake(application, scenario: str) -> bool:  # noqa: ANN001
+    application._narrator = ActionPlanNarrator(_FixedNarrationModel())
+    lose_response = False
+    if scenario in {"single_no_check", "single_narrator_retry", "commit_response_loss"}:
+        application._planner = _SingleNoCheckPlanner()
+        lose_response = scenario == "commit_response_loss"
+    elif scenario == "single_pending_cancel":
+        application._planner = _SinglePendingPlanner()
+    elif scenario == "single_validation_repair":
+        application._planner = _InvalidTargetPlanner()
+        repair = _RepairAdjudicator()
+        application._orchestrator._adjudicator = repair
+        if hasattr(application._dispatcher, "_repair_adjudicator"):
+            application._dispatcher._repair_adjudicator = repair
+    elif scenario == "multi_step":
+        application._planner = _TwoStepPlanner()
+        application._orchestrator._adjudicator = _NarrativeStepAdjudicator()
+    else:
+        raise ValueError(f"unknown fake scenario: {scenario}")
+    if scenario == "single_narrator_retry":
+        application._narrator = _FailOnceNarrator(application._narrator)
+    return lose_response
+
+
+def _prepare_room(client: TestClient, label: str) -> tuple[str, dict[str, Any]]:
+    account = f"i356{label}{uuid.uuid4().hex[:8]}"[:24]
+    token = register_and_login(client, account)
+    room = create_room(client, token)
+    advance_to_building(client, room)
+    complete_character(client, room["roomId"], room["reconnectToken"])
+    start_game(client, room, token)
+    return token, room
+
+
+def _join(client: TestClient, token: str, room: dict[str, Any]):
+    socket = client.websocket_connect(f"/ws/{room['roomId']}?token={token}")
+    ws = socket.__enter__()
+    ws.send_json(
+        {
+            "type": "room.join",
+            "playerId": room["playerId"],
+            "payload": {"reconnectToken": room["reconnectToken"]},
+        }
+    )
+    ws.receive_json()
+    ws.receive_json()
+    receive_replayed_opening(ws)
+    return socket, ws
+
+
+def _submit(ws, room: dict[str, Any], action_id: str, label: str) -> None:  # noqa: ANN001
+    inputs = {
+        "single_validation_repair": "查看托马斯·金博尔",
+        "real_observation": "观察当前房间",
+        "real_investigation": "仔细检查书架上的文件",
+        "real_multi_step": "先观察房间，然后询问眼前的人",
+    }
+    ws.send_json(
+        {
+            "type": "action.plan.submit",
+            "playerId": room["playerId"],
+            "payload": {
+                "clientActionId": action_id,
+                "utterance": inputs.get(label, f"benchmark-{label}"),
+            },
+        }
+    )
+
+
+def _is_completed(message: dict[str, Any]) -> bool:
+    return (
+        message.get("type") == "turn.completed" or message.get("message_type") == "turn.completed"
+    )
+
+
+def _settle_pending(ws, room: dict[str, Any], pending: dict[str, Any]) -> tuple[dict, list[dict]]:  # noqa: ANN001
+    all_seen: list[dict] = []
+    current = pending
+    for decision_number in range(6):
+        payload = current["payload"]
+        status = payload["status"]
+        if status == "awaiting_skill_choice":
+            decision = payload["pendingDecision"]
+            ws.send_json(
+                {
+                    "type": "adjudication.select",
+                    "playerId": room["playerId"],
+                    "payload": {
+                        "clientActionId": payload["correlationId"],
+                        "requestId": f"bench-select-{decision_number}-{uuid.uuid4().hex[:8]}",
+                        "sourceRevision": payload["sourceRevision"],
+                        "decisionId": decision["decision_id"],
+                        "decisionVersion": decision["decision_version"],
+                        "candidateId": decision["options"][0]["candidate_id"],
+                    },
+                }
+            )
+        elif status == "awaiting_post_roll_decision":
+            check_run = payload["checkRun"]
+            accept = next(
+                option
+                for option in check_run["post_roll_options"]
+                if option["kind"] == "accept_result"
+            )
+            ws.send_json(
+                {
+                    "type": "adjudication.post_roll",
+                    "playerId": room["playerId"],
+                    "payload": {
+                        "clientActionId": payload["correlationId"],
+                        "requestId": f"bench-accept-{decision_number}-{uuid.uuid4().hex[:8]}",
+                        "sourceRevision": payload["sourceRevision"],
+                        "checkId": check_run["check_id"],
+                        "checkVersion": check_run["version"],
+                        "optionId": accept["option_id"],
+                    },
+                }
+            )
+        else:
+            raise AssertionError(f"unsupported pending status: {status}")
+        stop, seen = receive_until(
+            ws,
+            lambda message: (
+                _is_completed(message)
+                or message.get("type") in {"adjudication.pending", "turn.failed"}
+            ),
+            limit=60,
+        )
+        all_seen.extend(seen)
+        if _is_completed(stop) or stop.get("type") == "turn.failed":
+            return stop, all_seen
+        current = stop
+    raise AssertionError("pending workflow exceeded decision budget")
+
+
+def _run_sample(
+    client: TestClient,
+    application,
+    *,
+    scenario: str,
+    sample_number: int,
+    real_mode: bool,
+) -> dict[str, Any]:
+    token, room = _prepare_room(client, f"{sample_number:x}")
+    action_id = f"issue356-{scenario}-{sample_number}-{uuid.uuid4().hex[:8]}"
+    expected_steps = 0 if real_mode else (2 if scenario == "multi_step" else 1)
+    failure_code: str | None = None
+    first_pending_ms: float | None = None
+    start = 0.0
+    with _application_components(application), _mute_content_logs():
+        lose_response = False if real_mode else _configure_fake(application, scenario)
+        with _Probe(application, lose_first_commit_response=lose_response) as probe:
+            socket, ws = _join(client, token, room)
+            try:
+                start = time.perf_counter()
+                _submit(ws, room, action_id, scenario)
+                stop, _ = receive_until(
+                    ws,
+                    lambda message: (
+                        _is_completed(message)
+                        or message.get("type") in {"adjudication.pending", "turn.failed"}
+                    ),
+                    limit=60,
+                )
+                if stop.get("type") == "adjudication.pending":
+                    first_pending_ms = (time.perf_counter() - start) * 1000
+                    if scenario == "single_pending_cancel" and not real_mode:
+                        payload = stop["payload"]
+                        decision = payload["pendingDecision"]
+                        ws.send_json(
+                            {
+                                "type": "adjudication.select",
+                                "playerId": room["playerId"],
+                                "payload": {
+                                    "clientActionId": action_id,
+                                    "requestId": f"bench-cancel-{uuid.uuid4().hex[:8]}",
+                                    "sourceRevision": payload["sourceRevision"],
+                                    "decisionId": decision["decision_id"],
+                                    "decisionVersion": decision["decision_version"],
+                                    "cancel": True,
+                                },
+                            }
+                        )
+                        stop, _ = receive_until(ws, _is_completed, limit=60)
+                    else:
+                        stop, _ = _settle_pending(ws, room, stop)
+                if stop.get("type") == "turn.failed":
+                    failure_code = str(stop.get("payload", {}).get("code", "TURN_FAILED"))
+                if scenario == "single_narrator_retry" and not real_mode:
+                    if failure_code != "PLAN_NARRATOR_FAILED":
+                        raise AssertionError(f"expected narrator failure, got {failure_code}")
+                    failure_code = None
+                    _submit(ws, room, action_id, scenario)
+                    stop, _ = receive_until(ws, _is_completed, limit=60)
+                end_to_end_ms = (time.perf_counter() - start) * 1000
+            finally:
+                socket.__exit__(None, None, None)
+        counts = {field: probe.counts[field] for field in COUNT_FIELDS}
+
+    run = None
+    if hasattr(application, "get_plan"):
+        import anyio
+
+        run = anyio.run(application.get_plan, room["roomId"], action_id)
+    step_count = len(run.steps) if run is not None else expected_steps
+    sample = {
+        "failure_code": failure_code,
+        "step_count": step_count,
+        "end_to_end_ms": end_to_end_ms,
+        "first_pending_ms": first_pending_ms,
+        **counts,
+    }
+    assert_sanitized_report(sample)
+    return sample
+
+
+def _provider_model(settings: Settings) -> tuple[str, str | None]:
+    provider = settings.host_model_provider
+    if provider == "deepseek":
+        return provider, settings.deepseek_model
+    if provider == "qwen":
+        return provider, settings.qwen_model
+    if provider == "openai":
+        return provider, settings.openai_model
+    return provider, None
+
+
+def _git_revision() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_issue_356_turn_run_benchmark(
+    action_plan_store_factory: Callable,
+) -> None:
+    mode = os.getenv("ISSUE_356_BENCHMARK_MODE", "fake")
+    if mode not in {"fake", "real"}:
+        raise ValueError("ISSUE_356_BENCHMARK_MODE must be fake or real")
+    repeats = int(os.getenv("ISSUE_356_BENCHMARK_REPEATS", "3" if mode == "fake" else "2"))
+    if repeats < 1:
+        raise ValueError("ISSUE_356_BENCHMARK_REPEATS must be >= 1")
+    output_path = Path(
+        os.getenv("ISSUE_356_BENCHMARK_OUTPUT", f"/tmp/issue-356-{mode}-benchmark.json")
+    )
+
+    original_application = ws_controller.action_plan_turn_application
+    settings = Settings(host_model_provider="fake")
+    application = original_application
+    if mode == "real":
+        settings = Settings()
+        if settings.host_model_provider == "fake":
+            raise RuntimeError("real mode requires a configured non-fake HOST_MODEL_PROVIDER")
+        application = build_action_plan_turn_application(
+            store=original_application._store,
+            engine=original_application._engine,
+            adjudication_engine=ws_controller.adjudication_engine_service,
+            plan_store=action_plan_store_factory(),
+            settings=settings,
+            recent_history_source=original_application._recent_history_source,
+            memory_source=getattr(original_application, "_memory_source", None),
+        )
+        ws_controller.action_plan_turn_application = application
+
+    provider, model = _provider_model(settings)
+    sync_client = TestClient(app)
+    scenarios = (
+        (
+            "single_no_check",
+            "single_pending_cancel",
+            "single_validation_repair",
+            "single_narrator_retry",
+            "commit_response_loss",
+            "multi_step",
+        )
+        if mode == "fake"
+        else ("real_observation", "real_investigation", "real_multi_step")
+    )
+    sample_results: dict[str, list[dict[str, Any]]] = {scenario: [] for scenario in scenarios}
+    try:
+        sample_number = 0
+        for scenario in scenarios:
+            for _ in range(repeats):
+                sample_number += 1
+                sample_results[scenario].append(
+                    _run_sample(
+                        sync_client,
+                        application,
+                        scenario=scenario,
+                        sample_number=sample_number,
+                        real_mode=mode == "real",
+                    )
+                )
+    finally:
+        ws_controller.action_plan_turn_application = original_application
+
+    all_samples = [sample for samples in sample_results.values() for sample in samples]
+    report = {
+        "schema_version": 1,
+        "issue": 356,
+        "subject_revision": os.getenv("ISSUE_356_SUBJECT_REVISION", _git_revision()),
+        "benchmark_tool_revision": _git_revision(),
+        "mode": mode,
+        "provider": provider,
+        "model": model,
+        "runtime": {
+            "python": platform.python_version(),
+            "os": platform.system(),
+            "architecture": platform.machine(),
+        },
+        "percentile_method": "nearest-rank",
+        "scenario_repeats": repeats,
+        "overall": aggregate_scenario(all_samples),
+        "scenarios": {
+            scenario: aggregate_scenario(samples) for scenario, samples in sample_results.items()
+        },
+    }
+    assert_sanitized_report(report)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Issue #356 sanitized benchmark report: {output_path}")

--- a/trpg-backend/tests/test_issue_356_metrics.py
+++ b/trpg-backend/tests/test_issue_356_metrics.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.benchmarks.issue_356_metrics import (
+    aggregate_scenario,
+    assert_sanitized_report,
+    nearest_rank_percentile,
+)
+
+
+def test_nearest_rank_percentile_uses_a_documented_deterministic_method() -> None:
+    assert nearest_rank_percentile([], 50) is None
+    assert nearest_rank_percentile([40, 10, 30, 20], 50) == 20
+    assert nearest_rank_percentile([40, 10, 30, 20], 95) == 40
+    with pytest.raises(ValueError, match="percentile"):
+        nearest_rank_percentile([1], 0)
+
+
+def test_sanitized_report_rejects_sensitive_field_names_recursively() -> None:
+    assert_sanitized_report({"provider": "fake", "scenarios": [{"duration_ms": 1.2}]})
+    with pytest.raises(ValueError, match="sensitive report field"):
+        assert_sanitized_report({"scenarios": {"sample": {"raw_prompt": "hidden"}}})
+
+
+def test_aggregate_scenario_keeps_counts_and_percentiles_but_not_sample_data() -> None:
+    samples = [
+        {
+            "failure_code": None,
+            "step_count": 1,
+            "end_to_end_ms": duration,
+            "first_pending_ms": None,
+            "planner_calls": 1,
+            "step_adjudicator_calls": 0,
+            "narrator_calls": 1,
+            "engine_submit_calls": 1,
+            "engine_status_calls": 0,
+            "plan_create_calls": 1,
+            "plan_cas_calls": 6,
+            "repair_calls": 0,
+            "model_transport_retries": 0,
+        }
+        for duration in (10.0, 30.0, 20.0)
+    ]
+
+    summary = aggregate_scenario(samples)
+
+    assert summary["successes"] == 3
+    assert summary["failure_rate"] == 0.0
+    assert summary["end_to_end_ms"]["p50"] == 20.0
+    assert summary["first_narration_completion_ms"]["p95"] == 30.0
+    assert summary["end_to_end_ms"]["p95"] == 30.0
+    assert summary["planner_calls"]["per_sample_mean"] == 1.0
+    assert "samples" not in summary


### PR DESCRIPTION
Refs #356

## Scope

This PR adds reproducible validation evidence for the already-merged #356 implementation. It does not modify production execution logic.

- Explicit WebSocket benchmark for fake deterministic scenarios: no-check, pending/cancel, validation repair, narrator retry, commit-response-loss reconciliation, and 2-step regression.
- Sanitized report validation and nearest-rank P50/P95 helpers.
- Reproduction protocol and reviewed aggregate results.
- Real-model smoke runner is opt-in and never collected by default pytest.

## Evidence

- Before f6ff264: 30/30 fake samples succeeded; single-action PlanRun create/CAS was 0; narrator retry re-ran Planner/Engine (2/2).
- After c280b21: 30/30 fake samples succeeded; normal single action remained Planner/Adj/Narrator/Submit 1/0/1/1; PlanRun create/CAS was 1/3; narrator retry remained Planner/Submit 1/1.
- Fake overall P50/P95: 86.027/141.480 ms before, 105.801/166.287 ms after. The added persistence/CAS cost is recorded explicitly.
- Real smoke on 2cf7528, DeepSeek deepseek-chat: 6/6 succeeded, failure rate 0.0, no transport retries; one-step and two-step classifications both used the unified Run chain.

## Verification

- Backend: 518 passed, 21 skipped
- Backend ruff check: passed
- Backend ruff format --check: passed
- Backend ty check: passed
- Metrics unit tests: 3 passed
- Framework: 292 passed, 2 pre-existing failures on current origin/main (architecture document missing the already-present memories field; exported schema drift unrelated to this PR)

Raw JSON remains outside Git under /tmp; the checked-in result table contains no prompts, utterances, model output, capabilities, tokens, or secrets. Please review the evidence before closing #356; this PR does not close the Issue automatically.