### PR TITLE
feat(narration): 多人房间用角色名叙述，禁止错位第二人称

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
@@ -79,7 +79,10 @@ class ActionPlanNarrator:
         rejection = narration_text_rejection_reason(output.text)
         if rejection is not None:
             raise ActionPlanNarrationValidationError(rejection)
-        subject_rejection = narration_subject_rejection_reason(output.text)
+        subject_rejection = narration_subject_rejection_reason(
+            output.text,
+            addressing_mode=getattr(context, "addressing_mode", "second_person"),
+        )
         if subject_rejection is not None:
             raise ActionPlanNarrationValidationError(subject_rejection)
         committed_results = tuple(

--- a/agent-collaboration-framework/collaboration_framework/host/application/narration_policy.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/narration_policy.py
@@ -96,6 +96,7 @@ _QUOTED_SPAN_DELIMITERS = {
     "《": "》",
 }
 _FIRST_PERSON_RE = re.compile(r"[我咱]")
+_SECOND_PERSON_RE = re.compile(r"您(?!们)|你(?!们)")
 
 
 def normalize_narration_text(text: str) -> str:
@@ -185,8 +186,14 @@ def narration_text_rejection_reason(
 
 def narration_subject_rejection_reason(
     text: str,
+    *,
+    addressing_mode: Literal["second_person", "named_actor"] = "second_person",
 ) -> Literal["subject_ownership"] | None:
-    """Reject first-person ownership in prose while preserving quoted speech."""
+    """Reject first-person ownership in prose while preserving quoted speech.
+
+    In named_actor mode, also reject unquoted second-person references to the
+    acting character. Quoted dialogue may still contain 你/您.
+    """
 
     quoted = [False] * len(text)
     for opening, closing in _QUOTED_SPAN_DELIMITERS.items():
@@ -209,5 +216,7 @@ def narration_subject_rejection_reason(
 
     prose = "".join(character for index, character in enumerate(text) if not quoted[index])
     if _FIRST_PERSON_RE.search(prose):
+        return "subject_ownership"
+    if addressing_mode == "named_actor" and _SECOND_PERSON_RE.search(prose):
         return "subject_ownership"
     return None

--- a/agent-collaboration-framework/collaboration_framework/host/application/opening_narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/opening_narrator.py
@@ -11,7 +11,11 @@ from collaboration_framework.host.schemas import (
     OpeningNarrationContext,
 )
 
-from .narration_policy import narration_text_rejection_reason, normalize_narration_text
+from .narration_policy import (
+    narration_subject_rejection_reason,
+    narration_text_rejection_reason,
+    normalize_narration_text,
+)
 
 OpeningRejectionReason = Literal[
     "outer_schema",
@@ -19,6 +23,7 @@ OpeningRejectionReason = Literal[
     "participant_coverage",
     "protocol_tail",
     "schema_fragment",
+    "subject_ownership",
 ]
 
 
@@ -55,6 +60,12 @@ class OpeningNarrator:
         rejection_reason = narration_text_rejection_reason(output.text)
         if rejection_reason is not None:
             raise OpeningNarrationValidationError(rejection_reason)
+        subject_rejection = narration_subject_rejection_reason(
+            output.text,
+            addressing_mode=getattr(context, "addressing_mode", "second_person"),
+        )
+        if subject_rejection is not None:
+            raise OpeningNarrationValidationError("subject_ownership")
         if any(
             participant.name not in output.text for participant in context.participants
         ):

--- a/agent-collaboration-framework/collaboration_framework/host/application/opening_narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/opening_narrator.py
@@ -78,11 +78,16 @@ def deterministic_opening_narration(
 ) -> NarrationOutput:
     """Build a public, deterministic opening without exposing private actor data."""
 
-    scene_lines = [
-        line
-        for line in (context.scene.name.strip(), context.scene.description.strip())
-        if line
-    ]
+    addressing_mode = getattr(context, "addressing_mode", "second_person")
+    scene_name = context.scene.name.strip()
+    scene_description = context.scene.description.strip()
+    if scene_description and narration_subject_rejection_reason(
+        scene_description,
+        addressing_mode=addressing_mode,
+    ):
+        # 模组可见描述可能含未加引号的「你」；named_actor 下整段丢掉，不改写原文。
+        scene_description = ""
+    scene_lines = [line for line in (scene_name, scene_description) if line]
     participant_labels = []
     for participant in context.participants:
         public_details = [

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
@@ -410,6 +410,8 @@ class ActionPlanNarrationContext(ContractModel):
     ]
     completed_steps: tuple[CompletedPlanStepSummary, ...] = ()
     player_view: PlayerView
+    addressing_mode: Literal["second_person", "named_actor"] = "second_person"
+    acting_character_name: str = ""
     # 记忆是只读的玩家安全上下文；它不能替代当前 PlayerView 或提交事实。
     memories: tuple[MemoryEntry, ...] = ()
     conversation_summary: ConversationSummary | None = None

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/context.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/context.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field, model_validator
 
 from collaboration_framework.contracts import (
@@ -39,6 +41,7 @@ class OpeningNarrationContext(ContractModel):
     scene: OpeningSceneContext
     participants: tuple[OpeningParticipant, ...] = Field(min_length=1)
     solo_background_summary: str = ""
+    addressing_mode: Literal["second_person", "named_actor"] = "second_person"
 
     @model_validator(mode="after")
     def validate_public_scope(self) -> OpeningNarrationContext:

--- a/agent-collaboration-framework/docs/数据模型设计.md
+++ b/agent-collaboration-framework/docs/数据模型设计.md
@@ -77,11 +77,14 @@ pending request、安全失败码和 retry count。
 
 ### 3.3 Narration and history
 
-`ActionPlanNarrationContext` 只携带已提交 execution/evidence、当前 PlayerView 和安全历史。
-`ActionPlanNarrationOutput` 最终映射为 `NarrationOutput`。后者的 `kind/text/claimed_fact_ids/
-suggested_actions` 会经过 evidence、主体所有权、协议残留和文本 policy 校验。
+`ActionPlanNarrationContext` 只携带已提交 execution/evidence、当前 PlayerView、安全历史，
+以及 `addressing_mode` / `acting_character_name`。多人房用角色名叙述行动者，单人房仍可用
+第二人称。`ActionPlanNarrationOutput` 最终映射为 `NarrationOutput`。后者的
+`kind/text/claimed_fact_ids/suggested_actions` 会经过 evidence、主体所有权、协议残留和文本
+policy 校验；`named_actor` 下引号外的「你/您」同样是 `subject_ownership`。
 
-`OpeningNarrationContext` 只用于开场，包含安全场景、参与者与背景；它不会伪造行动结果。
+`OpeningNarrationContext` 只用于开场，包含安全场景、参与者、背景与同一套
+`addressing_mode`；它不会伪造行动结果。
 
 `RecentTurnContext` 由 room、viewer、as-of revision 和若干 `RecentTurn` 构成。其他玩家回合
 只能投影公共原话和公共叙事；私有结果、完整 Event、状态变化和 Keeper 信息不得进入历史。

--- a/agent-collaboration-framework/schemas/host-agent-context.schema.json
+++ b/agent-collaboration-framework/schemas/host-agent-context.schema.json
@@ -1092,6 +1092,14 @@
           "title": "Participants",
           "type": "array"
         },
+        "listener_ids": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Listener Ids",
+          "type": "array"
+        },
         "location_id": {
           "anyOf": [
             {

--- a/agent-collaboration-framework/schemas/opening-narration-context.schema.json
+++ b/agent-collaboration-framework/schemas/opening-narration-context.schema.json
@@ -145,6 +145,15 @@
       "default": "",
       "title": "Solo Background Summary",
       "type": "string"
+    },
+    "addressing_mode": {
+      "default": "second_person",
+      "enum": [
+        "second_person",
+        "named_actor"
+      ],
+      "title": "Addressing Mode",
+      "type": "string"
     }
   },
   "required": [

--- a/agent-collaboration-framework/tests/test_narrator_policy.py
+++ b/agent-collaboration-framework/tests/test_narrator_policy.py
@@ -125,6 +125,44 @@ class NarrationTextPolicyTests(unittest.TestCase):
                     "subject_ownership",
                 )
 
+    def test_named_actor_rejects_unquoted_second_person(self) -> None:
+        self.assertEqual(
+            narration_subject_rejection_reason(
+                "你打开了抽屉。",
+                addressing_mode="named_actor",
+            ),
+            "subject_ownership",
+        )
+        self.assertEqual(
+            narration_subject_rejection_reason(
+                "陈探员打开了抽屉。",
+                addressing_mode="named_actor",
+            ),
+            None,
+        )
+
+    def test_named_actor_allows_second_person_in_dialogue(self) -> None:
+        self.assertIsNone(
+            narration_subject_rejection_reason(
+                "托马斯问：「你是谁？」",
+                addressing_mode="named_actor",
+            )
+        )
+        self.assertIsNone(
+            narration_subject_rejection_reason(
+                "陈探员对托马斯说：“我会保护你们。”",
+                addressing_mode="named_actor",
+            )
+        )
+
+    def test_second_person_mode_still_allows_unquoted_you(self) -> None:
+        self.assertIsNone(
+            narration_subject_rejection_reason(
+                "你打开了抽屉。",
+                addressing_mode="second_person",
+            )
+        )
+
     def test_allows_first_person_in_dialogue_and_quoted_titles(self) -> None:
         cases = (
             "你对托马斯说：“我会保护你们。”",
@@ -188,6 +226,19 @@ class PersistentNarrationPolicyTests(unittest.IsolatedAsyncioTestCase):
             player_view=view,
             allowed_evidence_refs=("event-1",),
         )
+
+    async def test_named_actor_mode_rejects_unquoted_you(self):
+        context = self._context().model_copy(
+            update={
+                "addressing_mode": "named_actor",
+                "acting_character_name": "陈探员",
+            }
+        )
+        with self.assertRaises(ActionPlanNarrationValidationError) as raised:
+            await ActionPlanNarrator(
+                _PersistentNarrationModel("你打开了抽屉。")
+            ).narrate(context)
+        self.assertEqual(raised.exception.reason, "subject_ownership")
 
     async def test_rejects_uncommitted_unconscious_claim(self):
         with self.assertRaises(ActionPlanNarrationValidationError):

--- a/agent-collaboration-framework/tests/test_opening_narration.py
+++ b/agent-collaboration-framework/tests/test_opening_narration.py
@@ -19,6 +19,7 @@ from collaboration_framework.host.application import (
     OpeningNarrationValidationError,
     OpeningNarrator,
     deterministic_opening_narration,
+    narration_subject_rejection_reason,
 )
 from collaboration_framework.host.schemas import (
     OpeningNarrationContext,
@@ -209,3 +210,46 @@ class OpeningNarratorTests(unittest.IsolatedAsyncioTestCase):
         for expected in ("旧宅门厅", "昏黄灯光", "杜明", "记者", "林夏", "医生"):
             with self.subTest(expected=expected):
                 self.assertIn(expected, text)
+
+    def test_named_actor_opening_fallback_omits_second_person_scene_description(
+        self,
+    ) -> None:
+        context = OpeningNarrationContext(
+            background="1920 年代的阿卡姆。",
+            scene=OpeningSceneContext(
+                id="kimball-house-outside",
+                name="金博尔宅外",
+                description="夜色笼罩着金博尔宅与通往公墓的道路，你可以在阴影中观察周围动静。",
+            ),
+            participants=(
+                OpeningParticipant(actor_id="actor-1", name="陈探员", occupation="警探"),
+                OpeningParticipant(actor_id="actor-2", name="杜明", occupation="记者"),
+            ),
+            addressing_mode="named_actor",
+        )
+        text = deterministic_opening_narration(context).text
+
+        self.assertIn("金博尔宅外", text)
+        self.assertIn("陈探员", text)
+        self.assertIn("杜明", text)
+        self.assertNotIn("你可以在阴影中观察周围动静", text)
+        self.assertIsNone(
+            narration_subject_rejection_reason(text, addressing_mode="named_actor")
+        )
+
+    def test_second_person_opening_fallback_keeps_scene_description(self) -> None:
+        context = OpeningNarrationContext(
+            background="1920 年代的阿卡姆。",
+            scene=OpeningSceneContext(
+                id="kimball-house-outside",
+                name="金博尔宅外",
+                description="夜色笼罩着金博尔宅与通往公墓的道路，你可以在阴影中观察周围动静。",
+            ),
+            participants=(
+                OpeningParticipant(actor_id="actor-1", name="陈探员", occupation="警探"),
+            ),
+            addressing_mode="second_person",
+        )
+        text = deterministic_opening_narration(context).text
+
+        self.assertIn("你可以在阴影中观察周围动静", text)

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -290,10 +290,13 @@ JSON/schema 字段和值重复写入正文。
 
 【叙事主体】
 - 你是守秘人，不是玩家角色。player_input、plan_goal 或 semantic_goal 中玩家使用的
-  “我”始终指 player_view.self_actor；叙述该角色的行动时使用“你”或角色名，不得把
-  玩家第一人称改写成守秘人的自述。
+  “我”始终指 player_view.self_actor。不得把玩家第一人称改写成守秘人的自述。
+- addressing_mode=second_person 时，叙述该角色的行动可以使用“你”或 acting_character_name。
+- addressing_mode=named_actor 时，叙述行动、状态和结果必须使用 acting_character_name，
+  引号外不得用“你”或“您”指代该角色。对白中的第二人称合法，例如 NPC 说“你是谁？”。
 - 玩家声明的职业、经历、能力、态度和承诺只属于玩家角色。例如玩家说“我保护你们，
-  我是退役军官”，可以写成“你表示会保护同行者”或明确引用为玩家对白；不得写成
+  我是退役军官”，second_person 可写成“你表示会保护同行者”，named_actor 必须写成
+  “{acting_character_name}表示会保护同行者”或明确引用为玩家对白；不得写成
   守秘人“我保护你们”“我当过兵”。
 - 玩家说“你们”或“我们”时，可以指已由可信素材确认的同行 NPC 或在场角色；应按
   实际参与者自然转述，不得把它误解成守秘人与玩家组成的“我们”，也不得凭空增加
@@ -335,6 +338,8 @@ solo_background_summary，多人开场不得推断或补写任何角色的私密
 作出选择。输出 kind 必须为 narration，claimed_fact_ids 和 suggested_actions 必须
 为空数组。text 只能包含自然的角色内叙事，不得包含 JSON、schema、字段名、Markdown
 代码块、协议说明或自检内容。
+若 addressing_mode 为 named_actor，不得用“你”或“您”称呼任何玩家角色，应使用
+participants 中的姓名；对白中的第二人称合法。
 """
 
 

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -604,14 +604,27 @@ def _deterministic_clarification_text(context: ActionPlanNarrationContext) -> st
         _explicit_travel_phrase(getattr(step, "semantic_goal", "")) is not None
         for step in successful_steps
     )
+    actor = _acting_address(context)
     if completed_travel:
         scene_name = getattr(context.player_view.scene, "name", "") or "当前地点"
-        return f"你已经抵达{scene_name}，但后续行动尚未形成可确认的结果。"
+        return f"{actor}已经抵达{scene_name}，但后续行动尚未形成可确认的结果。"
     if successful_steps:
         return "此前已经完成的行动仍然有效，但后续行动尚未形成可确认的结果。"
     if _explicit_travel_phrase(context.player_input.utterance) is not None:
-        return "你没有在当前能够确认的道路和周边找到与描述相符的地点，因此仍停留在原处。"
-    return "你暂时无法确认这次行动的具体对象或结果。"
+        return f"{actor}没有在当前能够确认的道路和周边找到与描述相符的地点，因此仍停留在原处。"
+    return f"{actor}暂时无法确认这次行动的具体对象或结果。"
+
+
+def _acting_address(context: ActionPlanNarrationContext) -> str:
+    if getattr(context, "addressing_mode", "second_person") == "named_actor":
+        name = getattr(context, "acting_character_name", "") or ""
+        if name:
+            return name
+    return "你"
+
+
+def _view_actor_name(player_view: PlayerView) -> str:
+    return getattr(getattr(player_view, "self_actor", None), "name", None) or "你"
 
 
 def _best_label_overlap(text: str, labels: tuple[str, ...]) -> str | None:
@@ -646,13 +659,14 @@ class DeterministicActionPlanNarrationModel:
             kind = "narration"
         else:
             goal = completed or _quote_action_summary(context.plan_goal)
-            text = f"你依次完成了：{goal}。"
+            text = f"{_acting_address(context)}依次完成了：{goal}。"
             kind = "narration"
         required_refs = tuple(
             item.ref for item in context.narration_evidence if item.required_in_narration
         )
         required_text = "；".join(
-            f"你发现了{item.subject_name}" + (f"：{item.description}" if item.description else "")
+            f"{_acting_address(context)}发现了{item.subject_name}"
+            + (f"：{item.description}" if item.description else "")
             for item in context.narration_evidence
             if item.required_in_narration
         )
@@ -841,7 +855,11 @@ class ActionPlanTurnApplication:
             status="needs_clarification",
             narration=ActionPlanNarrationOutput(
                 kind="clarification",
-                text="我暂时没能准确理解这次行动。请再明确一下你想做什么，以及行动的对象或地点。",
+                text=(
+                    "我暂时没能准确理解这次行动。"
+                    f"请再明确一下{_view_actor_name(player_view)}"
+                    "想做什么，以及行动的对象或地点。"
+                ),
             ),
         )
 
@@ -1297,7 +1315,10 @@ class ActionPlanTurnApplication:
         self,
         context: ActionPlanNarrationContext,
     ) -> ActionPlanNarrationOutput:
-        if hasattr(context.player_input, "room_id") and hasattr(context.player_view, "revision"):
+        addressing_mode, acting_character_name = await self._narration_addressing(context)
+        if isinstance(context, ActionPlanNarrationContext) and hasattr(
+            context.player_view, "revision"
+        ):
             memory_context = await self._read_memory_context(
                 player_input=context.player_input,
                 player_view=context.player_view,
@@ -1312,12 +1333,21 @@ class ActionPlanTurnApplication:
                 termination_status=context.termination_status,
                 completed_steps=context.completed_steps,
                 player_view=context.player_view,
+                addressing_mode=addressing_mode,
+                acting_character_name=acting_character_name,
                 memories=memory_context.entries,
                 conversation_summary=memory_context.conversation_summary,
                 opening_world_time=context.opening_world_time,
                 allowed_evidence_refs=context.allowed_evidence_refs,
                 narration_evidence=context.narration_evidence,
                 narration_retry_hint=context.narration_retry_hint,
+            )
+        elif isinstance(context, ActionPlanNarrationContext):
+            context = context.model_copy(
+                update={
+                    "addressing_mode": addressing_mode,
+                    "acting_character_name": acting_character_name,
+                }
             )
         for attempt in range(2):
             try:
@@ -1385,7 +1415,9 @@ class ActionPlanTurnApplication:
             )
         sentences: list[str] = []
         for item in required:
-            sentences.append(f"随着调查深入，你很快辨认出{item.subject_name}。")
+            sentences.append(
+                f"随着调查深入，{_acting_address(context)}很快辨认出{item.subject_name}。"
+            )
             description = item.description.strip()
             if description:
                 sentences.append(description.rstrip("。！？!?；;，,") + "。")
@@ -1416,7 +1448,8 @@ class ActionPlanTurnApplication:
                 return ActionPlanNarrationOutput(
                     kind="clarification",
                     text=(
-                        f"{names}的尸体就在当前场景中。你想检查尸体、搜查随身物品，还是处理现场？"
+                        f"{names}的尸体就在当前场景中。"
+                        f"{_acting_address(context)}是想检查尸体、搜查随身物品，还是处理现场？"
                     ),
                 )
             return ActionPlanNarrationOutput(
@@ -1455,7 +1488,8 @@ class ActionPlanTurnApplication:
             if result.kind == "inventory" and result.target_id in inventory_names
         )
         statements.extend(
-            f"{inventory_names[result.target_id]}已经放入你的背包。" for result in inventory_results
+            f"{inventory_names[result.target_id]}已经放入{_acting_address(context)}的背包。"
+            for result in inventory_results
         )
         refs = tuple(
             result.event_ref
@@ -1571,6 +1605,27 @@ class ActionPlanTurnApplication:
         except Exception as exc:  # noqa: BLE001 - 读模型故障必须 fail-open
             logger.warning("memory_context_degraded", error_type=type(exc).__name__)
             return empty
+
+    async def _narration_addressing(
+        self,
+        context: ActionPlanNarrationContext,
+    ) -> tuple[Literal["second_person", "named_actor"], str]:
+        acting_name = ""
+        self_actor = getattr(context.player_view, "self_actor", None)
+        if self_actor is not None:
+            acting_name = getattr(self_actor, "name", "") or ""
+        mode = "second_person"
+        room_id = getattr(context.player_input, "room_id", None)
+        if room_id:
+            try:
+                async with self._store.transaction(room_id) as transaction:
+                    runtime = await transaction.load_runtime()
+                bound = [actor for actor in runtime.game_state.actors.values() if actor.player_id]
+                if len(bound) >= 2:
+                    mode = "named_actor"
+            except Exception:  # noqa: BLE001 - 读不到运行时时按单人称呼，避免阻断叙事
+                mode = "second_person"
+        return mode, acting_name
 
     async def _resolve_actor_id(self, room_id: str, player_id: str) -> str:
         async with self._store.transaction(room_id) as transaction:

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -52,6 +52,7 @@ from collaboration_framework.host.application import (
     HostTurnDecisionExecutor,
     PlayerViewProjector,
     TurnExecutionError,
+    narration_subject_rejection_reason,
 )
 from collaboration_framework.host.ports import (
     ActionPlanStepAdjudicator,
@@ -1414,13 +1415,22 @@ class ActionPlanTurnApplication:
                 retryable=True,
             )
         sentences: list[str] = []
+        addressing_mode = getattr(context, "addressing_mode", "second_person")
         for item in required:
             sentences.append(
                 f"随着调查深入，{_acting_address(context)}很快辨认出{item.subject_name}。"
             )
             description = item.description.strip()
             if description:
-                sentences.append(description.rstrip("。！？!?；;，,") + "。")
+                sentence = description.rstrip("。！？!?；;，,") + "。"
+                if (
+                    narration_subject_rejection_reason(
+                        sentence,
+                        addressing_mode=addressing_mode,
+                    )
+                    is None
+                ):
+                    sentences.append(sentence)
         return ActionPlanNarrationOutput(
             text="".join(sentences),
             claimed_evidence_refs=tuple(item.ref for item in required),

--- a/trpg-backend/app/core/turn.py
+++ b/trpg-backend/app/core/turn.py
@@ -162,6 +162,17 @@ class SessionViewApplication:
         """Generate a validated opening, with a deterministic public fallback."""
 
         context = ContextAssembler().for_opening(player_view)
+        addressing_mode = "second_person"
+        try:
+            async with self.store.transaction(player_view.room_id) as transaction:
+                runtime = await transaction.load_runtime()
+            bound = [actor for actor in runtime.game_state.actors.values() if actor.player_id]
+            if len(bound) >= 2:
+                addressing_mode = "named_actor"
+        except Exception:  # noqa: BLE001 - 开场人数读失败时保持单人第二人称
+            addressing_mode = "second_person"
+        if addressing_mode != context.addressing_mode:
+            context = context.model_copy(update={"addressing_mode": addressing_mode})
         started_at = time.perf_counter()
         failure_category: str | None = None
         result: Literal["model", "template", "fallback"]

--- a/trpg-backend/tests/test_action_plan_turn_recovery.py
+++ b/trpg-backend/tests/test_action_plan_turn_recovery.py
@@ -316,6 +316,52 @@ async def test_narration_falls_back_to_required_player_safe_evidence() -> None:
     assert "。。" not in narration.text
 
 
+def test_required_evidence_fallback_omits_second_person_description_in_named_actor() -> None:
+    context = SimpleNamespace(
+        addressing_mode="named_actor",
+        acting_character_name="陈探员",
+        narration_evidence=(
+            NarrationEvidence(
+                ref="evt-road-discovered",
+                kind="entity_discovered",
+                subject_id="kimball-road",
+                subject_name="宅外道路",
+                description="你可以在阴影中观察周围动静。",
+                required_in_narration=True,
+            ),
+        ),
+    )
+
+    output = ActionPlanTurnApplication._required_evidence_fallback(cast(Any, context))
+
+    assert "陈探员" in output.text
+    assert "宅外道路" in output.text
+    assert "你可以在阴影中观察周围动静" not in output.text
+    assert output.claimed_evidence_refs == ("evt-road-discovered",)
+
+
+def test_required_evidence_fallback_keeps_description_in_second_person() -> None:
+    context = SimpleNamespace(
+        addressing_mode="second_person",
+        acting_character_name="陈探员",
+        narration_evidence=(
+            NarrationEvidence(
+                ref="evt-road-discovered",
+                kind="entity_discovered",
+                subject_id="kimball-road",
+                subject_name="宅外道路",
+                description="你可以在阴影中观察周围动静。",
+                required_in_narration=True,
+            ),
+        ),
+    )
+
+    output = ActionPlanTurnApplication._required_evidence_fallback(cast(Any, context))
+
+    assert "你可以在阴影中观察周围动静" in output.text
+    assert output.claimed_evidence_refs == ("evt-road-discovered",)
+
+
 @pytest.mark.asyncio
 async def test_required_evidence_fallback_never_changes_clarification_scope() -> None:
     application = object.__new__(ActionPlanTurnApplication)

--- a/trpg-backend/tests/test_chat_ws.py
+++ b/trpg-backend/tests/test_chat_ws.py
@@ -99,12 +99,15 @@ class _ConversationClarificationIntentModel:
         }
 
 
+_PUBLIC_CLARIFICATION_TEXT = "陈探员是想去吃午饭，还是晚饭？"
+
+
 class _PublicClarificationNarrationModel:
     async def generate(self, context):  # noqa: ANN001
         del context
         return {
             "kind": "clarification",
-            "text": "你是想去吃午饭，还是晚饭？",
+            "text": _PUBLIC_CLARIFICATION_TEXT,
             "claimed_evidence_refs": [],
             "suggested_actions": [],
         }
@@ -232,7 +235,7 @@ def test_clarification_narration_is_visible_to_other_players(
 
     assert narration["type"] == "narration.push"
     assert narration["payload"]["messageId"] == action_id
-    assert narration["payload"]["text"] == "你是想去吃午饭，还是晚饭？"
+    assert narration["payload"]["text"] == _PUBLIC_CLARIFICATION_TEXT
     assert all(message.get("type") != "turn.failed" for message in seen)
 
     guest_headers = {"X-Reconnect-Token": guest["reconnectToken"]}
@@ -246,7 +249,7 @@ def test_clarification_narration_is_visible_to_other_players(
         if event["type"] == "narration.push" and event["payload"].get("messageId") == action_id
     ]
     assert len(guest_narrations) == 1
-    assert guest_narrations[0]["payload"]["text"] == "你是想去吃午饭，还是晚饭？"
+    assert guest_narrations[0]["payload"]["text"] == _PUBLIC_CLARIFICATION_TEXT
 
     guest_replay = sync_client.get(
         f"{ROOMS_BASE}/{room['roomId']}/replay",
@@ -258,7 +261,7 @@ def test_clarification_narration_is_visible_to_other_players(
         if event["eventType"] == "narration.push" and event["payload"].get("messageId") == action_id
     ]
     assert len(replay_narrations) == 1
-    assert replay_narrations[0]["payload"]["text"] == "你是想去吃午饭，还是晚饭？"
+    assert replay_narrations[0]["payload"]["text"] == _PUBLIC_CLARIFICATION_TEXT
 
 
 # ── 行动锁 ───────────────────────────────────────────

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -42,6 +42,7 @@ from pydantic import ValidationError
 from app.adapters.deepseek_models import DeepSeekChatCompletionsJsonClient
 from app.adapters.openai_models import (
     _ACTION_PLAN_NARRATION_INSTRUCTIONS,
+    _OPENING_NARRATION_INSTRUCTIONS,
     OpenAIResponsesJsonClient,
     PromptActionPlanStepAdjudicator,
     PromptHostTurnDecisionModel,
@@ -67,6 +68,16 @@ def test_action_plan_narration_uses_final_post_roll_outcome() -> None:
     assert "消耗幸运" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
     assert "outcome=success" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
     assert "最终权威结果" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
+
+
+def test_action_plan_narration_requires_named_actor_in_multiplayer() -> None:
+    assert "addressing_mode=named_actor" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
+    assert "acting_character_name" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
+    assert "对白中的第二人称合法" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
+
+
+def test_opening_narration_mentions_named_actor_mode() -> None:
+    assert "addressing_mode 为 named_actor" in _OPENING_NARRATION_INSTRUCTIONS
 
 
 def test_action_plan_narration_preserves_completed_travel_before_clarification() -> None:


### PR DESCRIPTION
Closes #409

多人房间的公共叙事用行动角色显示名，不再对所有听众说「你」。

## 改了什么

| 模块 | 改动 |
| --- | --- |
| 契约 | `ActionPlanNarrationContext` / `OpeningNarrationContext` 增加 `addressing_mode` 与 `acting_character_name` |
| 校验 | `narration_subject_rejection_reason` 在 `named_actor` 下拒绝引号外的「你/您」；引号内对白仍合法 |
| Prompt | `_ACTION_PLAN_NARRATION_INSTRUCTIONS` / `_OPENING_NARRATION_INSTRUCTIONS` 显式写入 mode，不让模型自己猜 |
| 生产链 | `ActionPlanTurnApplication._narrate` 与 `SessionViewApplication.generate_opening` 按 `GameState.actors` 中已绑定 `player_id` 的人数选 mode |
| 回退文案 | 确定性 fallback 用 `_acting_address`：多人写角色名，单人仍写「你」 |
| Schema | 导出 `opening-narration-context.schema.json`；同一条 `schema_export` 补上 main 漏掉的 `host-agent-context.listener_ids` |
| Tests | 主体校验、Narrator、prompt；两人房澄清 stub 改为「陈探员是想去吃午饭，还是晚饭？」 |

## 关键决策

**为什么不按收件人各写一份：**
同一条 `narration.push` 全房间一份。分视角是 #365 明确不做的。

**为什么人数看 `GameState.actors` 的 `player_id`，不看房间座位：**
叙事主体是局内角色。已绑定玩家的 actor ≥ 2 才切 `named_actor`。空座位或未入角不算。

**为什么错位「你」走 `subject_ownership` 重试，不替换字符串：**
#409 要求 fail-closed。替换会改模型用词，也可能切坏对白边界。重试用现有预算，不落成权威 `narration.push`。

**为什么「你们」不算错位第二人称：**
正则是 `您(?!们)|你(?!们)`。集体称呼不是把叙事主体说成「你」。

**为什么只改生产 ActionPlan / Opening，不复制 v2 Narrator：**
`Orchestrator.run()` 不是生产主链。#409 要求只改 `_ACTION_PLAN_NARRATION_INSTRUCTIONS` 与 `ActionPlanNarrator` 使用的校验。

**为什么两人房澄清不再写「你」：**
全量 pytest 复现：stub 输出「你是想去吃午饭，还是晚饭？」被 `named_actor` 拒绝，回退成通用成功叙事。澄清对全员可见，必须写成角色名。

## 验证

- Backend `ruff check` / `ruff format --check` / `ty check`：通过
- Backend pytest：本分支相关路径绿。全量 `531 passed, 21 skipped`；另 3 条红是本地把追书人 `players_max` 临时改成 3，不在本 PR diff。第 4 条曾红（两人房澄清 stub 仍写「你」），已修
- Framework `narrator_policy` / `opening_narration` / schema export：通过
- Frontend / SDK：未改，未跑

变异：两人房澄清若输出引号外「你」，`ActionPlanNarrator` 以 `subject_ownership` 拒绝，权威叙事不会落成那句。

## 已知限制

- 读不到 runtime 时 `addressing_mode` 保持 `second_person`，避免开场/叙事因投影失败整段中断。多人房若这次读失败会暂时用「你」，人数可读后下一回合仍切回 `named_actor`
- `named_actor` 且 `acting_character_name` 为空时，确定性 fallback 仍退回「你」
- 未做真机联机走查

## 不在本 PR 范围

- 按收件人切换人称
- 追书人放到 1–4 人
- 确认期取消边界
- 代述、分视角、私密线索
- 带检定的场景切换、场景与时间复合计划
