### PR TITLE
feat(multiplayer): 增加输入路由与结构化接收者契约

### DIFF
--- a/e2e/tests/action-plan-acceptance.e2e.ts
+++ b/e2e/tests/action-plan-acceptance.e2e.ts
@@ -16,6 +16,7 @@ const LEGAL_ATTRIBUTES = {
   STR: 50, CON: 50, POW: 50, DEX: 50,
   APP: 50, SIZ: 50, INT: 50, EDU: 50, LUCK: 50,
 }
+const EXPLICIT_KEEPER = { kind: 'keeper', entityId: null, explicit: true } as const
 
 /**
  * 真实 provider 一次结构化输出要几十秒，一个两步计划要跑 planner + 两次步骤裁决
@@ -304,7 +305,7 @@ for (const canon of CANON_CASES) {
       )
       const turnPromise = room.host.sdk.roomSocket.submitPlannedAction(
         room.hostPlayerId,
-        { clientActionId: actionId, utterance: canon.utterance },
+        { clientActionId: actionId, utterance: canon.utterance, recipient: EXPLICIT_KEEPER },
       )
       const pendingEvent = await pendingPromise
       assert.equal(pendingEvent.type, 'adjudication.pending')
@@ -437,6 +438,7 @@ test('Issue #246 恢复：断线重连后用原 parent 恢复 pending，重复�
     const lostTurn = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: actionId,
       utterance: '去图书馆查旧报纸',
+      recipient: EXPLICIT_KEEPER,
     })
     const pending = await firstPending
     assert.equal(pending.type, 'adjudication.pending')
@@ -466,6 +468,7 @@ test('Issue #246 恢复：断线重连后用原 parent 恢复 pending，重复�
     const recoveredTurn = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: actionId,
       utterance: '去图书馆查旧报纸',
+      recipient: EXPLICIT_KEEPER,
     })
     const resumed = await resumedPending
     assert.equal(resumed.type, 'adjudication.pending')
@@ -552,6 +555,7 @@ test('Issue #246 恢复：取消保留已提交 travel 且停止剩余步骤', {
     const turnPromise = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: actionId,
       utterance: '去书房用侦查搜索线索',
+      recipient: EXPLICIT_KEEPER,
     })
     await pending
     const completedEvent = waitForEvent(

--- a/e2e/tests/discussion-chat.e2e.ts
+++ b/e2e/tests/discussion-chat.e2e.ts
@@ -9,7 +9,10 @@
  */
 import assert from 'node:assert/strict'
 import { randomUUID } from 'node:crypto'
+import { dirname, resolve } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
 import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 import { type ServerToClientEvent } from 'trpg-sdk'
 
@@ -20,6 +23,10 @@ const LEGAL_ATTRIBUTES = {
   APP: 50, SIZ: 50, INT: 50, EDU: 50, LUCK: 50,
 }
 const EXPLICIT_KEEPER = { kind: 'keeper', entityId: null, explicit: true } as const
+const DB_FILE = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../trpg-backend/e2e.db'
+)
 
 function waitForEvent(
   socketOwner: { roomSocket: { onMessage: (h: (e: ServerToClientEvent) => void) => () => void } },
@@ -131,6 +138,128 @@ test('🔴 重发相同 clientMessageId 不产生重复记录（重连去重）'
     assert.equal(history.length, 1)
   } finally {
     room.host.sdk.roomSocket.disconnect()
+  }
+})
+
+test('多人 roleplay 不调用主持，也不写入权威事件、记忆或摘要', async () => {
+  const room = await createRoomWithModule('roleplay', 2)
+  const guest = await registerPlayer('roleplayguest')
+  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '扮演访客' }, guest.token)
+  const roleplayId = `roleplay-${randomUUID()}`
+  const roleplayText = `伊莱亚斯敲了两下桌面-${randomUUID()}`
+
+  await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
+  await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken)
+  await buildCharacter(guest.sdk, room.roomId, joined.reconnectToken)
+
+  try {
+    await bindSocket(
+      room.host.sdk, room.roomId, room.host.token, room.hostPlayerId, room.reconnectToken
+    )
+    await bindSocket(guest.sdk, room.roomId, guest.token, joined.playerId, joined.reconnectToken)
+
+    const hostOpening = waitForEvent(room.host.sdk, (e) => e.type === 'narration.push')
+    const guestOpening = waitForEvent(guest.sdk, (e) => e.type === 'narration.push')
+    room.host.sdk.roomSocket.startGame(room.hostPlayerId)
+    await Promise.all([hostOpening, guestOpening])
+
+    const observedTypes: string[] = []
+    const off = guest.sdk.roomSocket.onMessage((event) => observedTypes.push(event.type))
+    const hostHearsRoleplay = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'chat.message' && event.payload.text === roleplayText,
+    )
+    guest.sdk.roomSocket.sendActionChat(joined.playerId, {
+      text: roleplayText,
+      clientMessageId: roleplayId,
+    })
+    const roleplay = await hostHearsRoleplay
+    assert.equal(roleplay.type, 'chat.message')
+    if (roleplay.type === 'chat.message') {
+      assert.equal(roleplay.payload.channel, 'roleplay')
+      assert.ok(roleplay.payload.actorId)
+      assert.equal(roleplay.payload.actorName, 'E2E 调查员')
+    }
+
+    // 用后一条讨论消息作为屏障：收到它时，前一条 roleplay 的服务端处理已完整结束。
+    const barrierText = `处理屏障-${randomUUID()}`
+    const barrier = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'chat.message' && event.payload.text === barrierText,
+    )
+    guest.sdk.roomSocket.sendChat(joined.playerId, {
+      text: barrierText,
+      clientMessageId: randomUUID(),
+    })
+    await barrier
+    off()
+    assert.equal(observedTypes.includes('turn.started'), false)
+    assert.equal(observedTypes.includes('narration.push'), false)
+
+    const conversation = await room.host.sdk.rooms.listConversation(
+      room.roomId,
+      room.reconnectToken,
+    )
+    assert.equal(
+      conversation.some(
+        (event) =>
+          event.type === 'chat.message' &&
+          event.payload.channel === 'roleplay' &&
+          event.payload.text === roleplayText,
+      ),
+      true,
+    )
+
+    const db = new DatabaseSync(DB_FILE, { readOnly: true })
+    try {
+      const marker = `%${roleplayText}%`
+      const traces = [
+        [
+          'events',
+          'SELECT COUNT(*) AS count FROM events WHERE room_id = ? AND (correlation_id = ? OR CAST(payload AS TEXT) LIKE ?)',
+          [room.roomId, roleplayId, marker],
+        ],
+        [
+          'game_events',
+          'SELECT COUNT(*) AS count FROM game_events WHERE room_id = ? AND (client_action_id = ? OR CAST(payload AS TEXT) LIKE ?)',
+          [room.roomId, roleplayId, marker],
+        ],
+        [
+          'action_executions',
+          'SELECT COUNT(*) AS count FROM action_executions WHERE room_id = ? AND request_id = ?',
+          [room.roomId, roleplayId],
+        ],
+        [
+          'action_plan_runs',
+          'SELECT COUNT(*) AS count FROM action_plan_runs WHERE room_id = ? AND parent_action_id = ?',
+          [room.roomId, roleplayId],
+        ],
+        [
+          'host_action_queue',
+          'SELECT COUNT(*) AS count FROM host_action_queue WHERE room_id = ? AND client_action_id = ?',
+          [room.roomId, roleplayId],
+        ],
+        [
+          'memory_entries',
+          'SELECT COUNT(*) AS count FROM memory_entries WHERE room_id = ? AND content LIKE ?',
+          [room.roomId, marker],
+        ],
+        [
+          'conversation_summaries',
+          'SELECT COUNT(*) AS count FROM conversation_summaries WHERE room_id = ? AND CAST(summary_json AS TEXT) LIKE ?',
+          [room.roomId, marker],
+        ],
+      ] as const
+      for (const [table, sql, parameters] of traces) {
+        const row = db.prepare(sql).get(...parameters) as { count: number }
+        assert.equal(row.count, 0, `${table} 不应留下 roleplay 痕迹`)
+      }
+    } finally {
+      db.close()
+    }
+  } finally {
+    room.host.sdk.roomSocket.disconnect()
+    guest.sdk.roomSocket.disconnect()
   }
 })
 

--- a/e2e/tests/discussion-chat.e2e.ts
+++ b/e2e/tests/discussion-chat.e2e.ts
@@ -19,6 +19,7 @@ const LEGAL_ATTRIBUTES = {
   STR: 50, CON: 50, POW: 50, DEX: 50,
   APP: 50, SIZ: 50, INT: 50, EDU: 50, LUCK: 50,
 }
+const EXPLICIT_KEEPER = { kind: 'keeper', entityId: null, explicit: true } as const
 
 function waitForEvent(
   socketOwner: { roomSocket: { onMessage: (h: (e: ServerToClientEvent) => void) => () => void } },
@@ -164,6 +165,7 @@ test('🔴 所有人都能看到发起者的原话 + 守秘人回复（修"聊�
     const completed = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: 'discussion-echo-host',
       utterance: '我与托马斯交谈',
+      recipient: EXPLICIT_KEEPER,
     })
     const echo = await guestSeesUtterance
     if (echo.type === 'action.broadcast') {
@@ -212,6 +214,7 @@ test('行动锁：处理中他人提交进入队列，完成后自动出队', as
     const hostCompleted = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: 'action-lock-host',
       utterance: '我与托马斯交谈',
+      recipient: EXPLICIT_KEEPER,
     })
     await hostEcho
 
@@ -229,6 +232,7 @@ test('行动锁：处理中他人提交进入队列，完成后自动出队', as
     const queuedAction = guest.sdk.roomSocket.submitPlannedAction(joined.playerId, {
       clientActionId: 'action-lock-guest-queued',
       utterance: '我翻抽屉',
+      recipient: EXPLICIT_KEEPER,
     })
     await Promise.all([guestQueued, guestEcho])
 

--- a/e2e/tests/multiplayer-ws.e2e.ts
+++ b/e2e/tests/multiplayer-ws.e2e.ts
@@ -16,6 +16,7 @@ const LEGAL_ATTRIBUTES = {
   STR: 50, CON: 50, POW: 50, DEX: 50,
   APP: 50, SIZ: 50, INT: 50, EDU: 50, LUCK: 50,
 }
+const EXPLICIT_KEEPER = { kind: 'keeper', entityId: null, explicit: true } as const
 
 /** 等一个满足条件的服务端事件，超时就失败——不要用固定 sleep。 */
 function waitForEvent(
@@ -302,6 +303,7 @@ test('三人推进时间需全员确认，最后一票只提交一次并恢复�
       {
         clientActionId: actionId,
         utterance: '全队等待到下一个时间点',
+        recipient: EXPLICIT_KEEPER,
       },
     )
     const [hostPending, guestPending, thirdPending] = await Promise.all([
@@ -422,6 +424,7 @@ test('提交行动会广播给房间里的所有人（不只是发起者）', as
     const completed = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: actionId,
       utterance: '我询问托马斯藏书的情况',
+      recipient: EXPLICIT_KEEPER,
     })
     const [guestNarration, turn] = await Promise.all([guestHears, completed])
     assert.equal(guestNarration.type, 'narration.push')
@@ -523,6 +526,7 @@ test('三客户端串行动作、私有检定与重连快照保持隔离', async
     const travelled = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: travelActionId,
       utterance: '我前往阿诺兹堡图书馆',
+      recipient: EXPLICIT_KEEPER,
     })
     await guestSeesProcessing
     const queuedActionId = `three-client-queued-${Date.now()}`
@@ -536,6 +540,7 @@ test('三客户端串行动作、私有检定与重连快照保持隔离', async
     const queuedSubmit = guest.sdk.roomSocket.submitPlannedAction(joined.playerId, {
       clientActionId: queuedActionId,
       utterance: '我同时翻查书架',
+      recipient: EXPLICIT_KEEPER,
     })
     await guestSeesQueued
     guest.sdk.roomSocket.cancelActionPlan(joined.playerId, {
@@ -619,6 +624,7 @@ test('三客户端串行动作、私有检定与重连快照保持隔离', async
     const retried = await guest.sdk.roomSocket.submitPlannedAction(joined.playerId, {
       clientActionId: `three-client-retry-${Date.now()}`,
       utterance: '我在图书馆整理刚才的路线',
+      recipient: EXPLICIT_KEEPER,
     })
     assert.equal(retried.player_id, joined.playerId)
 
@@ -645,6 +651,7 @@ test('三客户端串行动作、私有检定与重连快照保持隔离', async
     const checked = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: checkActionId,
       utterance: '我查阅当地旧报档案',
+      recipient: EXPLICIT_KEEPER,
     })
     const pending = await checkRequested
     assert.equal(pending.type, 'adjudication.pending')
@@ -729,11 +736,13 @@ test('追书人纵切：首场景 → 托马斯 → 图书馆 → 旧报检定 �
     await room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: `ask-thomas-${Date.now()}`,
       utterance: '我询问托马斯失踪藏书和叔叔的情况',
+      recipient: EXPLICIT_KEEPER,
     })
 
     const travelled = await room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: `travel-library-${Date.now()}`,
       utterance: '我前往阿诺兹堡图书馆',
+      recipient: EXPLICIT_KEEPER,
     })
     assert.equal(travelled.player_view.scene.id, 'library')
     assert.equal(room.host.sdk.roomSocket.getPlayerView()?.scene.id, 'library')
@@ -749,6 +758,7 @@ test('追书人纵切：首场景 → 托马斯 → 图书馆 → 旧报检定 �
     const completed = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: checkActionId,
       utterance: '我查阅当地旧报档案，研究报纸旧刊',
+      recipient: EXPLICIT_KEEPER,
     })
     const request = await checkRequested
     assert.equal(request.type, 'adjudication.pending')
@@ -820,6 +830,7 @@ test('v3 规则检定完成后仍可继续提交行动', async () => {
     await room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: `travel-library-continuation-${Date.now()}`,
       utterance: '我前往阿诺兹堡图书馆',
+      recipient: EXPLICIT_KEEPER,
     })
 
     const researchActionId = `research-library-continuation-${Date.now()}`
@@ -833,6 +844,7 @@ test('v3 规则检定完成后仍可继续提交行动', async () => {
     const checkedAction = room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: researchActionId,
       utterance: '我查阅当地旧报档案',
+      recipient: EXPLICIT_KEEPER,
     })
     const request = await checkRequested
     assert.equal(request.type, 'adjudication.pending')
@@ -855,6 +867,7 @@ test('v3 规则检定完成后仍可继续提交行动', async () => {
     const nextTurn = await room.host.sdk.roomSocket.submitPlannedAction(room.hostPlayerId, {
       clientActionId: `after-v3-check-${Date.now()}`,
       utterance: '我在图书馆整理刚才查到的资料',
+      recipient: EXPLICIT_KEEPER,
     })
     assert.equal(nextTurn.player_id, room.hostPlayerId)
     assert.doesNotMatch(nextTurn.narration.text, /CHECK_PENDING|契约校验/)

--- a/trpg-backend/alembic/versions/c0d1e2f3a4b5_add_message_channels_and_action_recipient.py
+++ b/trpg-backend/alembic/versions/c0d1e2f3a4b5_add_message_channels_and_action_recipient.py
@@ -1,0 +1,77 @@
+"""为玩家消息增加频道，并持久化主持行动的结构化接收者。"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c0d1e2f3a4b5"
+down_revision: str | Sequence[str] | None = "b9c0d1e2f3a4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """保守回填旧数据后，用数据库约束固定频道和接收者组合。"""
+
+    with op.batch_alter_table("chat_messages") as batch_op:
+        batch_op.add_column(
+            sa.Column("channel", sa.String(length=20), server_default="discussion", nullable=False)
+        )
+        batch_op.add_column(sa.Column("actor_id", sa.String(length=100), nullable=True))
+        batch_op.create_check_constraint(
+            "ck_chat_messages_channel",
+            "channel IN ('discussion', 'roleplay')",
+        )
+        batch_op.create_check_constraint(
+            "ck_chat_messages_channel_actor",
+            "(channel = 'discussion' AND actor_id IS NULL) OR "
+            "(channel = 'roleplay' AND actor_id IS NOT NULL)",
+        )
+
+    with op.batch_alter_table("host_action_queue") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "recipient_kind",
+                sa.String(length=20),
+                server_default="keeper",
+                nullable=False,
+            )
+        )
+        batch_op.add_column(sa.Column("recipient_entity_id", sa.String(length=200), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "recipient_explicit",
+                sa.Boolean(),
+                server_default=sa.true(),
+                nullable=False,
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_host_action_queue_recipient_kind",
+            "recipient_kind IN ('keeper', 'npc')",
+        )
+        batch_op.create_check_constraint(
+            "ck_host_action_queue_recipient",
+            "(recipient_kind = 'keeper' AND recipient_entity_id IS NULL) OR "
+            "(recipient_kind = 'npc' AND recipient_entity_id IS NOT NULL "
+            "AND length(trim(recipient_entity_id)) > 0 AND recipient_explicit)",
+        )
+
+
+def downgrade() -> None:
+    """删除本 PR 新增的约束和字段，保留原有消息及队列数据。"""
+
+    with op.batch_alter_table("host_action_queue") as batch_op:
+        batch_op.drop_constraint("ck_host_action_queue_recipient", type_="check")
+        batch_op.drop_constraint("ck_host_action_queue_recipient_kind", type_="check")
+        batch_op.drop_column("recipient_explicit")
+        batch_op.drop_column("recipient_entity_id")
+        batch_op.drop_column("recipient_kind")
+
+    with op.batch_alter_table("chat_messages") as batch_op:
+        batch_op.drop_constraint("ck_chat_messages_channel_actor", type_="check")
+        batch_op.drop_constraint("ck_chat_messages_channel", type_="check")
+        batch_op.drop_column("actor_id")
+        batch_op.drop_column("channel")

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -38,7 +38,7 @@ import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from functools import partial
-from typing import Literal
+from typing import Literal, cast
 
 import anyio
 import structlog
@@ -100,6 +100,7 @@ from app.core.turn_observability import (
 from app.dto.ws import (
     ActionBroadcastPayload,
     ActionPlanCancelPayload,
+    ActionRecipientPayload,
     ActionSubmitPayload,
     AdjudicationChoicePayload,
     AdjudicationPendingPayload,
@@ -387,6 +388,7 @@ async def _enqueue_host_action(
     client_action_id: str,
     utterance: str,
     player_view: PlayerView,
+    recipient: ActionRecipientPayload,
 ) -> None:
     try:
         item, created = await host_action_queue_service.enqueue(
@@ -396,6 +398,7 @@ async def _enqueue_host_action(
             actor_id=actor_id,
             client_action_id=client_action_id,
             utterance=utterance,
+            recipient=recipient,
         )
     except HostActionQueueError as exc:
         await _send_error(
@@ -430,6 +433,16 @@ async def _drain_host_action_queue(room_id: str) -> None:
                 item = await host_action_queue_service.peek_next(db, room_id)
                 if item is None:
                     return
+                # PR1 尚未实现 NPC 对话；即使数据库被手工写入也不能误走 Keeper 主链。
+                if item.recipient_kind != "keeper":
+                    logger.error(
+                        "unsupported_host_queue_recipient",
+                        room_id=room_id,
+                        client_action_id=item.client_action_id,
+                        recipient_kind=item.recipient_kind,
+                    )
+                    await host_action_queue_service.discard(db, item)
+                    continue
                 try:
                     view = await session_view_application.current_player_view(
                         room_id=room_id,
@@ -1628,11 +1641,22 @@ async def _handle_chat_send(
         player_id,
         text,
         payload.client_message_id,
+        channel="discussion",
+    )
+    # 幂等键跨两个聊天入口共享；若旧请求已经落成 roleplay，广播必须忠实返回
+    # 数据库中的原消息，不能按本次 chat.send 入口伪造频道或角色身份。
+    actor_name = (
+        await room_service.get_player_character_name(db, player_id, fallback=player.nickname)
+        if message.channel == "roleplay"
+        else None
     )
     chat_payload = ChatMessagePayload(
         message_id=message.id,
         player_id=message.player_id,
         nickname=player.nickname,
+        channel=cast(Literal["discussion", "roleplay"], message.channel),
+        actor_id=message.actor_id,
+        actor_name=actor_name,
         text=message.text,
         sent_at=message.created_at,
         client_message_id=message.client_message_id,
@@ -1651,7 +1675,7 @@ async def _handle_action_chat_send(
     player_id: str,
     payload: ChatSendPayload,
 ) -> None:
-    """行动区普通消息：落成 action.broadcast，不调模型、不占行动槽。"""
+    """多人行动区普通消息：保存为角色扮演聊天，不进入事件或 Host 上下文。"""
 
     text = payload.text.strip()
     if not text:
@@ -1663,30 +1687,60 @@ async def _handle_action_chat_send(
     if room.phase == "Completed":
         await _send_error(websocket, "FORBIDDEN", "游戏已结束，无法发送消息")
         return
-    actor_id: str | None = None
-    scene_id: str | None = None
-    view_revision: str | None = None
-    view: PlayerView | None = None
+    if room.max_players == 1:
+        await _send_error(
+            websocket,
+            "BAD_REQUEST",
+            "单人游戏行动区输入应提交给守秘人",
+            correlation_id=payload.client_message_id,
+        )
+        return
     try:
         view = await session_view_application.current_player_view(
             room_id=room_id,
             player_id=player_id,
         )
-        actor_id = view.self_actor.id
-        scene_id = view.scene_id
-        view_revision = view.revision
     except Exception:
-        view = None
-    await _broadcast_action_line(
+        await _send_error(
+            websocket,
+            "BAD_REQUEST",
+            "当前无法确认角色身份，请稍后重试",
+            correlation_id=payload.client_message_id,
+        )
+        return
+    message = await chat_service.save_chat_message(
         db,
-        room_id=room_id,
-        player_id=player_id,
-        client_action_id=payload.client_message_id,
-        utterance=text,
-        actor_id=actor_id,
-        scene_id=scene_id,
-        view_revision=view_revision,
-        player_view=view,
+        room_id,
+        player_id,
+        text,
+        payload.client_message_id,
+        channel="roleplay",
+        actor_id=view.self_actor.id,
+    )
+    # 重试若撞到同一玩家先前的 discussion 消息，以已落库频道为准，避免
+    # 返回 roleplay + 空 actor 或 discussion + 非空 actor 的非法组合。
+    actor_name = (
+        await room_service.get_player_character_name(db, player_id, fallback=player.nickname)
+        if message.channel == "roleplay"
+        else None
+    )
+    chat_payload = ChatMessagePayload(
+        message_id=message.id,
+        player_id=message.player_id,
+        nickname=player.nickname,
+        channel=cast(Literal["discussion", "roleplay"], message.channel),
+        actor_id=message.actor_id,
+        actor_name=actor_name,
+        text=message.text,
+        sent_at=message.created_at,
+        client_message_id=message.client_message_id,
+    )
+    await manager.broadcast(
+        room_id,
+        ServerEnvelope(
+            type="chat.message",
+            payload=chat_payload.model_dump(by_alias=True, mode="json"),
+        ).model_dump(by_alias=True),
     )
 
 
@@ -2164,6 +2218,25 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 )
                     elif event_type == "action.plan.submit":
                         submit_payload = ActionSubmitPayload.model_validate(raw_payload)
+                        # 接收者决定后续执行边界，必须在恢复旧 Turn、读取 PlayerView、
+                        # 写事件或入队之前完成拒绝，绝不能把 NPC 请求回退到 Keeper。
+                        if submit_payload.recipient.kind == "npc":
+                            await _send_error(
+                                websocket,
+                                "NOT_IMPLEMENTED",
+                                "NPC 对话将在下一阶段开放",
+                                correlation_id=submit_payload.client_action_id,
+                            )
+                            continue
+                        room = await room_service.find_room_by_id(db, room_id)
+                        if room.max_players > 1 and not submit_payload.recipient.explicit:
+                            await _send_error(
+                                websocket,
+                                "BAD_REQUEST",
+                                "多人游戏必须明确 @守秘人 后才能提交主持行动",
+                                correlation_id=submit_payload.client_action_id,
+                            )
+                            continue
                         if submit_payload.visibility == "private":
                             await _send_error(
                                 websocket,
@@ -2212,6 +2285,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 client_action_id=submit_payload.client_action_id,
                                 utterance=submit_payload.utterance,
                                 player_view=action_view,
+                                recipient=submit_payload.recipient,
                             )
                             continue
                         if decision == "reject":
@@ -2239,6 +2313,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 client_action_id=submit_payload.client_action_id,
                                 utterance=submit_payload.utterance,
                                 player_view=action_view,
+                                recipient=submit_payload.recipient,
                             )
                             continue
                         try:
@@ -2268,6 +2343,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                     client_action_id=submit_payload.client_action_id,
                                     utterance=submit_payload.utterance,
                                     player_view=action_view,
+                                    recipient=submit_payload.recipient,
                                 )
                                 continue
                             await _send_turn_event(
@@ -2564,6 +2640,16 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                         event_type=event_type,
                         validation_error_count=exc.error_count(),
                     )
+                    if event_type == "action.plan.submit":
+                        correlation_id = raw_payload.get("clientActionId")
+                        await _send_error(
+                            websocket,
+                            "VALIDATION_ERROR",
+                            "行动接收者或输入格式无效",
+                            correlation_id=(
+                                correlation_id if isinstance(correlation_id, str) else None
+                            ),
+                        )
                     continue
     except WebSocketDisconnect:
         pass

--- a/trpg-backend/app/dto/chat.py
+++ b/trpg-backend/app/dto/chat.py
@@ -1,21 +1,26 @@
-"""讨论区消息的 REST DTO（issue #107）。
+"""临时聊天消息的 REST DTO（issue #107）。
 
 `GET /rooms/{roomId}/messages` 的返回体。字段跟 WS 广播的
-`ChatMessagePayload`（app/dto/ws.py）保持一致——同一条消息不管是实时广播
+`ChatMessagePayload`（app/dto/ws.py）保持一致——同一条 discussion 消息不管是实时广播
 收到的还是刷新后从历史接口拉回的，客户端看到的形状都一样，渲染层不需要
 两套适配逻辑。
 """
+
+from typing import Literal
 
 from app.dto.common import CamelModel, UtcDatetime
 
 
 class ChatMessageRead(CamelModel):
-    """讨论区一条消息。`sent_at` 用 UtcDatetime（对外时间字段的统一约定，
+    """讨论区分页接口的一条消息。`sent_at` 用 UtcDatetime（对外时间字段的统一约定，
     见 app/dto/common.py）。"""
 
     message_id: str
     player_id: str
     nickname: str
+    channel: Literal["discussion", "roleplay"]
+    actor_id: str | None = None
+    actor_name: str | None = None
     text: str
     sent_at: UtcDatetime
     client_message_id: str

--- a/trpg-backend/app/dto/ws.py
+++ b/trpg-backend/app/dto/ws.py
@@ -78,6 +78,29 @@ class GameStartPayload(CamelModel):
     """
 
 
+class ActionRecipientPayload(CamelModel):
+    """玩家输入的结构化接收者；自然语言 mention 只允许在客户端解析一次。"""
+
+    kind: Literal["keeper", "npc"]
+    entity_id: str | None = Field(default=None, max_length=200)
+    explicit: bool
+
+    @model_validator(mode="after")
+    def validate_recipient(self) -> "ActionRecipientPayload":
+        """保证接收者种类、实体 ID 和显式选择三者不会形成歧义组合。"""
+
+        if self.kind == "keeper":
+            if self.entity_id is not None:
+                raise ValueError("守秘人接收者不能携带实体 ID")
+            return self
+        if self.entity_id is None or not self.entity_id.strip():
+            raise ValueError("NPC 接收者必须携带实体 ID")
+        if not self.explicit:
+            raise ValueError("NPC 接收者必须由玩家显式选择")
+        self.entity_id = self.entity_id.strip()
+        return self
+
+
 class ActionSubmitPayload(CamelModel):
     """action.plan.submit 事件 payload。
 
@@ -87,6 +110,7 @@ class ActionSubmitPayload(CamelModel):
 
     client_action_id: str = Field(..., min_length=1, max_length=200)
     utterance: str = Field(..., min_length=1, max_length=2000)
+    recipient: ActionRecipientPayload
     summarized_from: list[str] | None = None
     visibility: Literal["public", "private"] | None = None
 
@@ -218,11 +242,14 @@ class OpeningStartedPayload(CamelModel):
 
 
 class ChatMessagePayload(CamelModel):
-    """chat.message 讨论区广播 payload。"""
+    """chat.message 广播 payload；channel 区分玩家讨论和角色扮演。"""
 
     message_id: str
     player_id: str
     nickname: str
+    channel: Literal["discussion", "roleplay"]
+    actor_id: str | None = None
+    actor_name: str | None = None
     text: str
     sent_at: UtcDatetime
     client_message_id: str
@@ -283,6 +310,7 @@ class RoomActionQueueItemPayload(CamelModel):
     player_id: str
     actor_id: str
     client_action_id: str
+    recipient: ActionRecipientPayload
     position: int = Field(..., ge=1)
     utterance: str
     accepted_at: UtcDatetime

--- a/trpg-backend/app/models/chat.py
+++ b/trpg-backend/app/models/chat.py
@@ -1,10 +1,10 @@
-"""玩家讨论区消息 ORM 模型（issue #107 地基）。
+"""玩家临时聊天 ORM 模型（issue #107 地基）。
 
-`ChatMessage` 是玩家之间闲聊/讨论用的消息，跟 `events`（`app/models/event.py`）
+`ChatMessage` 是玩家之间讨论或角色扮演用的临时消息，跟 `events`（`app/models/event.py`）
 性质完全不同，这正是单开一张表、不复用 `events` 的原因：
 
-- **AI 完全不读这张表**：讨论区的设计前提是"AI 主持人听不见玩家私下讨论"
-  （issue #107 决策），讨论内容不会拼进任何 LLM 上下文。`events` 则相反，
+- **AI 完全不读这张表**：讨论和角色扮演消息都不进入 Host/Memory 上下文；
+  讨论区的设计前提是"AI 主持人听不见玩家私下讨论"（issue #107 决策）。`events` 则相反，
   是给编排层/复盘消费的裁决记录。
 - **退房即清空、不进复盘**：`POST /rooms/{roomId}/end` 会把这张表里属于该
   房间的行整表删除，是名副其实的"临时工作记忆"；`events` 是只增不改的
@@ -17,14 +17,14 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, Text, UniqueConstraint, Uuid
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, String, Text, UniqueConstraint, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db import Base
 
 
 class ChatMessage(Base):
-    """房间内玩家讨论区的一条消息。"""
+    """房间内一条 discussion 或 roleplay 临时消息。"""
 
     __tablename__ = "chat_messages"
 
@@ -33,6 +33,15 @@ class ChatMessage(Base):
     # 不可靠（PR #110 review 里 players 表唯一约束的教训同样适用这里）。
     __table_args__ = (
         UniqueConstraint("player_id", "client_message_id", name="uq_chat_messages_player_client"),
+        CheckConstraint(
+            "channel IN ('discussion', 'roleplay')",
+            name="ck_chat_messages_channel",
+        ),
+        CheckConstraint(
+            "(channel = 'discussion' AND actor_id IS NULL) OR "
+            "(channel = 'roleplay' AND actor_id IS NOT NULL)",
+            name="ck_chat_messages_channel_actor",
+        ),
     )
 
     id: Mapped[str] = mapped_column(
@@ -47,6 +56,11 @@ class ChatMessage(Base):
     # 客户端生成的去重键（比如一个本地自增序号或 UUID），重连重发同一条消息时
     # 靠 (player_id, client_message_id) 的唯一约束挡掉重复插入。
     client_message_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    # 频道由服务端事件类型决定，客户端不能直接提交，避免伪造角色身份。
+    channel: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="discussion", server_default="discussion"
+    )
+    actor_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     text: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC)

--- a/trpg-backend/app/models/engine.py
+++ b/trpg-backend/app/models/engine.py
@@ -535,6 +535,16 @@ class HostActionQueueItem(Base):
             "status IN ('queued', 'started', 'cancelled', 'discarded')",
             name="ck_host_action_queue_status",
         ),
+        CheckConstraint(
+            "recipient_kind IN ('keeper', 'npc')",
+            name="ck_host_action_queue_recipient_kind",
+        ),
+        CheckConstraint(
+            "(recipient_kind = 'keeper' AND recipient_entity_id IS NULL) OR "
+            "(recipient_kind = 'npc' AND recipient_entity_id IS NOT NULL "
+            "AND length(trim(recipient_entity_id)) > 0 AND recipient_explicit)",
+            name="ck_host_action_queue_recipient",
+        ),
         Index(
             "ix_host_action_queue_room_status_position",
             "room_id",
@@ -559,6 +569,14 @@ class HostActionQueueItem(Base):
     player_id: Mapped[str] = mapped_column(String(100), nullable=False)
     actor_id: Mapped[str] = mapped_column(String(100), nullable=False)
     utterance: Mapped[str] = mapped_column(Text, nullable=False)
+    # 接收者必须随队列项持久化，服务重启后不能重新从原话猜测路由。
+    recipient_kind: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="keeper", server_default="keeper"
+    )
+    recipient_entity_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    recipient_explicit: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
     position: Mapped[int] = mapped_column(Integer, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
     created_at: Mapped[datetime] = mapped_column(

--- a/trpg-backend/app/service/chat.py
+++ b/trpg-backend/app/service/chat.py
@@ -1,6 +1,6 @@
-"""玩家讨论区的 service 层（issue #107）。
+"""玩家临时聊天的 service 层（issue #107）。
 
-讨论区跟「对 AI 主持人说话」是两条独立通道（两个界面）：这里的消息只在
+讨论区/角色扮演聊天跟「对 AI 主持人说话」是独立通道：这里的消息只在
 玩家之间流转，**永远不进任何 LLM 上下文**——这条约定要靠代码结构保证：
 AI 相关代码（narrator / 未来的编排层）没有任何 import 指向本模块或
 `ChatMessage` 模型，一旦有人"顺手把聊天也塞进 prompt"，成本和玩法两个
@@ -17,7 +17,14 @@ from app.models.room import Player
 
 
 async def save_chat_message(
-    db: AsyncSession, room_id: str, player_id: str, text: str, client_message_id: str
+    db: AsyncSession,
+    room_id: str,
+    player_id: str,
+    text: str,
+    client_message_id: str,
+    *,
+    channel: str = "discussion",
+    actor_id: str | None = None,
 ) -> ChatMessage:
     """落一条讨论区消息；重发（相同 `(player_id, client_message_id)`）幂等地
     返回已存在的那条，不产生重复记录。
@@ -29,7 +36,12 @@ async def save_chat_message(
     同 `join_room` 的处理方式）。
     """
     message = ChatMessage(
-        room_id=room_id, player_id=player_id, text=text, client_message_id=client_message_id
+        room_id=room_id,
+        player_id=player_id,
+        text=text,
+        client_message_id=client_message_id,
+        channel=channel,
+        actor_id=actor_id,
     )
     try:
         async with db.begin_nested():
@@ -60,7 +72,11 @@ async def list_chat_messages(
     的消息，补上主键作次序钉死全序。`before` 传上一页最后一条的 message_id。
     """
     query = select(ChatMessage, Player.nickname).join(Player, ChatMessage.player_id == Player.id)
-    query = query.where(ChatMessage.room_id == room_id)
+    # `/messages` 是原有讨论区分页接口；角色扮演历史统一由 `/conversation` 恢复。
+    query = query.where(
+        ChatMessage.room_id == room_id,
+        ChatMessage.channel == "discussion",
+    )
 
     if before is not None:
         anchor = await db.get(ChatMessage, before)
@@ -80,6 +96,9 @@ async def list_chat_messages(
             message_id=message.id,
             player_id=message.player_id,
             nickname=nickname,
+            channel=message.channel,
+            actor_id=None,
+            actor_name=None,
             text=message.text,
             sent_at=message.created_at,
             client_message_id=message.client_message_id,

--- a/trpg-backend/app/service/host_action_queue.py
+++ b/trpg-backend/app/service/host_action_queue.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from typing import Literal, cast
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dto.ws import RoomActionQueueItemPayload
+from app.dto.ws import ActionRecipientPayload, RoomActionQueueItemPayload
 from app.models.engine import HostActionQueueItem
 from app.models.room import Player
 
@@ -28,6 +29,11 @@ def _payload(item: HostActionQueueItem) -> RoomActionQueueItemPayload:
         player_id=item.player_id,
         actor_id=item.actor_id,
         client_action_id=item.client_action_id,
+        recipient=ActionRecipientPayload(
+            kind=cast(Literal["keeper", "npc"], item.recipient_kind),
+            entity_id=item.recipient_entity_id,
+            explicit=item.recipient_explicit,
+        ),
         position=item.position,
         utterance=item.utterance,
         accepted_at=item.created_at,
@@ -73,6 +79,7 @@ async def enqueue(
     actor_id: str,
     client_action_id: str,
     utterance: str,
+    recipient: ActionRecipientPayload | None = None,
 ) -> tuple[HostActionQueueItem, bool]:
     """Accept a host action into the room FIFO.
 
@@ -82,6 +89,9 @@ async def enqueue(
     utterance can be published.
     """
 
+    # 直接调用这个 service 的旧内部任务没有 recipient 时，按历史 Keeper 行为兼容；
+    # WebSocket 边界仍要求 DTO 显式携带 recipient，不能靠这里绕过校验。
+    recipient = recipient or ActionRecipientPayload(kind="keeper", entity_id=None, explicit=True)
     existing_id = await get_queued_by_client_action(db, room_id, client_action_id)
     if existing_id is not None:
         return existing_id, False
@@ -98,6 +108,9 @@ async def enqueue(
         own.client_action_id = client_action_id
         own.actor_id = actor_id
         own.utterance = utterance
+        own.recipient_kind = recipient.kind
+        own.recipient_entity_id = recipient.entity_id
+        own.recipient_explicit = recipient.explicit
         own.updated_at = now
         await db.commit()
         await db.refresh(own)
@@ -130,6 +143,9 @@ async def enqueue(
         player_id=player_id,
         actor_id=actor_id,
         utterance=utterance,
+        recipient_kind=recipient.kind,
+        recipient_entity_id=recipient.entity_id,
+        recipient_explicit=recipient.explicit,
         position=(max_position or 0) + 1,
         status=_QUEUED,
         created_at=now,

--- a/trpg-backend/app/service/host_action_queue.py
+++ b/trpg-backend/app/service/host_action_queue.py
@@ -79,7 +79,7 @@ async def enqueue(
     actor_id: str,
     client_action_id: str,
     utterance: str,
-    recipient: ActionRecipientPayload | None = None,
+    recipient: ActionRecipientPayload,
 ) -> tuple[HostActionQueueItem, bool]:
     """Accept a host action into the room FIFO.
 
@@ -89,9 +89,6 @@ async def enqueue(
     utterance can be published.
     """
 
-    # 直接调用这个 service 的旧内部任务没有 recipient 时，按历史 Keeper 行为兼容；
-    # WebSocket 边界仍要求 DTO 显式携带 recipient，不能靠这里绕过校验。
-    recipient = recipient or ActionRecipientPayload(kind="keeper", entity_id=None, explicit=True)
     existing_id = await get_queued_by_client_action(db, room_id, client_action_id)
     if existing_id is not None:
         return existing_id, False

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -1101,8 +1101,15 @@ async def list_conversation_events(
 
     chat_rows = (
         await db.execute(
-            select(ChatMessage, Player.nickname)
+            select(ChatMessage, Player.nickname, Character.name, Character.status)
             .join(Player, ChatMessage.player_id == Player.id)
+            .outerjoin(
+                Character,
+                and_(
+                    Character.room_id == ChatMessage.room_id,
+                    Character.player_id == ChatMessage.player_id,
+                ),
+            )
             .where(ChatMessage.room_id == room_id)
             .order_by(ChatMessage.created_at, ChatMessage.id)
         )
@@ -1111,18 +1118,30 @@ async def list_conversation_events(
         RoomConversationEventRead(
             id=message.id,
             type="chat.message",
-            channel="discussion",
+            channel="action" if message.channel == "roleplay" else "discussion",
             payload={
                 "messageId": message.id,
                 "playerId": message.player_id,
                 "nickname": nickname,
+                "channel": message.channel,
+                "actorId": message.actor_id,
+                "actorName": (
+                    character_name.strip()
+                    if message.channel == "roleplay"
+                    and character_status == "complete"
+                    and isinstance(character_name, str)
+                    and character_name.strip()
+                    else nickname
+                    if message.channel == "roleplay"
+                    else None
+                ),
                 "text": message.text,
                 "sentAt": message.created_at,
                 "clientMessageId": message.client_message_id,
             },
             created_at=message.created_at,
         )
-        for message, nickname in chat_rows
+        for message, nickname, character_name, character_status in chat_rows
     ]
 
     event_rows = (

--- a/trpg-backend/tests/benchmarks/issue_356_turn_run.py
+++ b/trpg-backend/tests/benchmarks/issue_356_turn_run.py
@@ -379,6 +379,7 @@ def _submit(ws, room: dict[str, Any], action_id: str, label: str) -> None:  # no
             "payload": {
                 "clientActionId": action_id,
                 "utterance": inputs.get(label, f"benchmark-{label}"),
+                "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
             },
         }
     )

--- a/trpg-backend/tests/test_action_routing_contract.py
+++ b/trpg-backend/tests/test_action_routing_contract.py
@@ -1,0 +1,39 @@
+"""PR1 输入路由 DTO 的结构化接收者契约测试。"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.dto.ws import ActionRecipientPayload, ActionSubmitPayload
+
+
+def test_recipient_accepts_keeper_and_explicit_npc_shape() -> None:
+    """Keeper 可隐式/显式使用，NPC 只能带实体 ID 且必须显式选择。"""
+
+    assert ActionRecipientPayload(kind="keeper", explicit=False).entity_id is None
+    assert ActionRecipientPayload(kind="keeper", explicit=True).entity_id is None
+    assert (
+        ActionRecipientPayload(kind="npc", entity_id=" thomas ", explicit=True).entity_id
+        == "thomas"
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"kind": "keeper", "entity_id": "thomas", "explicit": True},
+        {"kind": "npc", "entity_id": None, "explicit": True},
+        {"kind": "npc", "entity_id": "thomas", "explicit": False},
+    ],
+)
+def test_recipient_rejects_ambiguous_shapes(payload: dict[str, object]) -> None:
+    """非法 recipient 必须在 WebSocket 业务处理前被 Pydantic 拒绝。"""
+
+    with pytest.raises(ValidationError):
+        ActionRecipientPayload.model_validate(payload)
+
+
+def test_action_submit_requires_recipient() -> None:
+    """新协议不允许服务端从玩家原话猜测接收者。"""
+
+    with pytest.raises(ValidationError):
+        ActionSubmitPayload.model_validate({"clientActionId": "action-1", "utterance": "查看房间"})

--- a/trpg-backend/tests/test_chat_ws.py
+++ b/trpg-backend/tests/test_chat_ws.py
@@ -68,7 +68,11 @@ def _submit_action(ws, player: dict, utterance: str) -> None:
         {
             "type": "action.plan.submit",
             "playerId": player["playerId"],
-            "payload": {"clientActionId": str(uuid4()), "utterance": utterance},
+            "payload": {
+                "clientActionId": str(uuid4()),
+                "utterance": utterance,
+                "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
+            },
         }
     )
 
@@ -157,6 +161,179 @@ def test_chat_send_is_idempotent_on_duplicate_client_message_id(
     assert len(history) == 1
 
 
+def test_multiplayer_action_chat_is_roleplay_and_not_host_event(
+    sync_client: TestClient,
+) -> None:
+    """多人行动区无接收者时只保存角色扮演消息，不触发主持或记忆事件。"""
+
+    token = register_and_login(sync_client, "roleplay_host")
+    room = create_room(sync_client, token, max_players=2)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        _join_ws(ws, room)
+        ws.send_json(
+            {
+                "type": "action.chat.send",
+                "playerId": room["playerId"],
+                "payload": {"text": "我对队友点了点头", "clientMessageId": "roleplay-1"},
+            }
+        )
+        message = receive_until(ws, lambda item: item.get("type") == "chat.message")[0]
+
+    assert message["payload"]["channel"] == "roleplay"
+    assert message["payload"]["actorId"]
+    assert message["payload"]["actorName"] == "陈探员"
+    conversation = sync_client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/conversation",
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    ).json()["data"]
+    roleplay = [item for item in conversation if item["payload"].get("channel") == "roleplay"]
+    assert len(roleplay) == 1
+    assert all(item["type"] != "action.broadcast" for item in conversation)
+    messages = sync_client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/messages",
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    ).json()["data"]
+    assert messages == []
+
+
+def test_chat_idempotency_keeps_original_channel_and_actor_shape(
+    sync_client: TestClient,
+) -> None:
+    """同一幂等键跨入口重试时，实时回显仍以首次落库的频道和身份为准。"""
+
+    token = register_and_login(sync_client, "cross_channel_retry")
+    room = create_room(sync_client, token, max_players=2)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        _join_ws(ws, room)
+        _send_chat(ws, room, "首次落成讨论消息", "shared-id-1")
+        first = receive_until(ws, lambda item: item.get("type") == "chat.message")[0]
+        ws.send_json(
+            {
+                "type": "action.chat.send",
+                "playerId": room["playerId"],
+                "payload": {"text": "不会覆盖首次消息", "clientMessageId": "shared-id-1"},
+            }
+        )
+        retried = receive_until(ws, lambda item: item.get("type") == "chat.message")[0]
+
+    assert retried["payload"]["messageId"] == first["payload"]["messageId"]
+    assert retried["payload"]["channel"] == "discussion"
+    assert retried["payload"]["actorId"] is None
+    assert retried["payload"]["actorName"] is None
+
+
+def test_single_player_action_chat_is_rejected(sync_client: TestClient) -> None:
+    """单人旧 action.chat.send 路径不能绕过默认 Keeper 路由。"""
+
+    token = register_and_login(sync_client, "single_roleplay_reject")
+    room = create_room(sync_client, token, max_players=1)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        _join_ws(ws, room)
+        ws.send_json(
+            {
+                "type": "action.chat.send",
+                "playerId": room["playerId"],
+                "payload": {"text": "不应降级", "clientMessageId": "roleplay-single-1"},
+            }
+        )
+        error = receive_until(ws, lambda item: item.get("type") == "error")[0]
+
+    assert error["payload"]["code"] == "BAD_REQUEST"
+
+
+def test_npc_recipient_is_rejected_before_host_processing(sync_client: TestClient) -> None:
+    """PR1 只预留 NPC recipient，不能误入 Keeper 主链。"""
+
+    token = register_and_login(sync_client, "npc_recipient_reject")
+    room = create_room(sync_client, token, max_players=1)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        _join_ws(ws, room)
+        ws.send_json(
+            {
+                "type": "action.plan.submit",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "npc-recipient-1",
+                    "utterance": "你好",
+                    "recipient": {"kind": "npc", "entityId": "thomas", "explicit": True},
+                },
+            }
+        )
+        error = receive_until(ws, lambda item: item.get("type") == "error")[0]
+
+    assert error["payload"]["code"] == "NOT_IMPLEMENTED"
+
+
+def test_single_player_accepts_implicit_keeper_recipient(sync_client: TestClient) -> None:
+    """单人模式允许前端明确提交 implicit Keeper，但 recipient 字段本身仍然必填。"""
+
+    token = register_and_login(sync_client, "implicit_keeper_single")
+    room = create_room(sync_client, token, max_players=1)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        _join_ws(ws, room)
+        ws.send_json(
+            {
+                "type": "action.plan.submit",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "implicit-keeper-1",
+                    "utterance": "查看托马斯",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": False},
+                },
+            }
+        )
+        echo = receive_until(ws, lambda item: item.get("type") == "action.broadcast")[0]
+
+    assert echo["payload"]["clientActionId"] == "implicit-keeper-1"
+
+
+def test_multiplayer_rejects_implicit_keeper_recipient(sync_client: TestClient) -> None:
+    """多人模式必须明确 @守秘人，服务端不能信任客户端路由。"""
+
+    token = register_and_login(sync_client, "implicit_keeper_multi")
+    room = create_room(sync_client, token, max_players=2)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
+        _join_ws(ws, room)
+        ws.send_json(
+            {
+                "type": "action.plan.submit",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "implicit-keeper-multi-1",
+                    "utterance": "查看托马斯",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": False},
+                },
+            }
+        )
+        error = receive_until(ws, lambda item: item.get("type") == "error")[0]
+
+    assert error["payload"]["code"] == "BAD_REQUEST"
+
+
 # ── action.plan.submit：原话广播 + 叙事回复 ───────────
 
 
@@ -218,6 +395,7 @@ def test_clarification_narration_is_visible_to_other_players(
                 "payload": {
                     "clientActionId": action_id,
                     "utterance": "我要去吃饭",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )

--- a/trpg-backend/tests/test_host_action_queue.py
+++ b/trpg-backend/tests/test_host_action_queue.py
@@ -10,9 +10,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.controller import ws as ws_controller
 from app.core.turn import ActorResolutionError
+from app.dto.ws import ActionRecipientPayload
 from app.service import host_action_queue
 from app.service.host_action_queue import HostActionQueueError
 from tests.test_engine_runtime import _start_room
+
+_KEEPER_RECIPIENT = ActionRecipientPayload(kind="keeper", entity_id=None, explicit=True)
 
 
 @pytest.mark.asyncio
@@ -31,6 +34,7 @@ async def test_enqueue_is_fifo_and_idempotent(db_session: AsyncSession) -> None:
         actor_id="actor-a",
         client_action_id="action-a",
         utterance="我搜查客厅",
+        recipient=_KEEPER_RECIPIENT,
     )
     assert created
     second, created = await host_action_queue.enqueue(
@@ -40,6 +44,7 @@ async def test_enqueue_is_fifo_and_idempotent(db_session: AsyncSession) -> None:
         actor_id="actor-b",
         client_action_id="action-b",
         utterance="我查看书桌",
+        recipient=_KEEPER_RECIPIENT,
     )
     assert created
     again, created = await host_action_queue.enqueue(
@@ -49,6 +54,7 @@ async def test_enqueue_is_fifo_and_idempotent(db_session: AsyncSession) -> None:
         actor_id="actor-a",
         client_action_id="action-a",
         utterance="我搜查客厅",
+        recipient=_KEEPER_RECIPIENT,
     )
     assert not created
     assert again.item_id == first.item_id
@@ -75,6 +81,7 @@ async def test_player_can_replace_queued_item_without_losing_place(
         actor_id="actor-a",
         client_action_id="action-a1",
         utterance="我先看窗",
+        recipient=_KEEPER_RECIPIENT,
     )
     await host_action_queue.enqueue(
         db_session,
@@ -83,6 +90,7 @@ async def test_player_can_replace_queued_item_without_losing_place(
         actor_id="actor-b",
         client_action_id="action-b",
         utterance="我搜查抽屉",
+        recipient=_KEEPER_RECIPIENT,
     )
     replaced, created = await host_action_queue.enqueue(
         db_session,
@@ -91,6 +99,7 @@ async def test_player_can_replace_queued_item_without_losing_place(
         actor_id="actor-a",
         client_action_id="action-a2",
         utterance="我改去翻书架",
+        recipient=_KEEPER_RECIPIENT,
     )
     assert created
     assert replaced.item_id == first.item_id
@@ -117,6 +126,7 @@ async def test_queue_rejects_when_every_player_already_has_an_item(
         actor_id="actor-a",
         client_action_id="action-a",
         utterance="我搜查客厅",
+        recipient=_KEEPER_RECIPIENT,
     )
     await host_action_queue.enqueue(
         db_session,
@@ -125,6 +135,7 @@ async def test_queue_rejects_when_every_player_already_has_an_item(
         actor_id="actor-b",
         client_action_id="action-b",
         utterance="我查看书桌",
+        recipient=_KEEPER_RECIPIENT,
     )
     with pytest.raises(HostActionQueueError) as raised:
         await host_action_queue.enqueue(
@@ -134,6 +145,7 @@ async def test_queue_rejects_when_every_player_already_has_an_item(
             actor_id="actor-ghost",
             client_action_id="action-overflow",
             utterance="这句不该进队",
+            recipient=_KEEPER_RECIPIENT,
         )
     assert raised.value.code == "ACTION_QUEUE_FULL"
     # replace keeps the cap: same player updating the existing item is allowed
@@ -144,6 +156,7 @@ async def test_queue_rejects_when_every_player_already_has_an_item(
         actor_id="actor-b",
         client_action_id="action-b2",
         utterance="我改口搜查书桌",
+        recipient=_KEEPER_RECIPIENT,
     )
     assert replaced.client_action_id == "action-b2"
 
@@ -163,6 +176,7 @@ async def test_cancel_and_discard_player_queued_items(db_session: AsyncSession) 
         actor_id="actor-a",
         client_action_id="action-a",
         utterance="我搜查客厅",
+        recipient=_KEEPER_RECIPIENT,
     )
     await host_action_queue.enqueue(
         db_session,
@@ -171,6 +185,7 @@ async def test_cancel_and_discard_player_queued_items(db_session: AsyncSession) 
         actor_id="actor-b",
         client_action_id="action-b",
         utterance="我查看书桌",
+        recipient=_KEEPER_RECIPIENT,
     )
     assert await host_action_queue.cancel(
         db_session,
@@ -211,6 +226,7 @@ async def _enqueue_one(db_session: AsyncSession, room_number: int) -> tuple[str,
         actor_id="actor-a",
         client_action_id="queued-action",
         utterance="我搜查客厅",
+        recipient=_KEEPER_RECIPIENT,
     )
     return room.id, players[0].id
 

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -10,7 +10,7 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
 ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
 # 记忆链 head 是 a7b8c9d0e1f2；主持队列接在它后面。
-HEAD_REVISION = "b9c0d1e2f3a4"
+HEAD_REVISION = "c0d1e2f3a4b5"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -114,6 +114,12 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
     )
     assert ("room_id",) in _unique_column_sets(database, "room_action_reservations")
     assert ("room_id", "client_action_id") in _unique_column_sets(database, "host_action_queue")
+    assert {
+        "recipient_kind",
+        "recipient_entity_id",
+        "recipient_explicit",
+    }.issubset(_column_names(database, "host_action_queue"))
+    assert {"channel", "actor_id"}.issubset(_column_names(database, "chat_messages"))
     assert "room_sessions" not in tables
     assert {"status", "name_en", "story_label", "subtitle", "story_pages"}.issubset(
         _column_names(database, "scenarios")
@@ -256,6 +262,51 @@ def test_recent_history_migration_backfills_visibility_conservatively(
         "ix_events_room_created",
         "ix_events_room_visibility_player_created",
     }.issubset(indexes)
+
+
+def test_message_channel_and_recipient_migration_backfills_old_rows(tmp_path: Path) -> None:
+    """PR1 迁移必须让既有讨论消息和主持队列继续保持原来的语义。"""
+
+    database = tmp_path / "message-recipient-backfill.db"
+    _upgrade_or_fail(database, "b9c0d1e2f3a4")
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """
+            INSERT INTO chat_messages (
+                id, room_id, player_id, client_message_id, text, created_at
+            ) VALUES (
+                '80000000-0000-0000-0000-000000000001',
+                'room-1', 'player-1', 'old-chat', '旧讨论消息', '2026-08-23 00:00:00'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO host_action_queue (
+                room_id, item_id, client_action_id, player_id, actor_id,
+                utterance, position, status, created_at, updated_at
+            ) VALUES (
+                'room-1', 'old-item', 'old-action', 'player-1', 'actor-1',
+                '旧主持行动', 1, 'queued',
+                '2026-08-23 00:00:00', '2026-08-23 00:00:00'
+            )
+            """
+        )
+
+    _upgrade_or_fail(database, "head")
+    with sqlite3.connect(database) as connection:
+        chat = connection.execute(
+            "SELECT channel, actor_id FROM chat_messages WHERE client_message_id = 'old-chat'"
+        ).fetchone()
+        recipient = connection.execute(
+            """
+            SELECT recipient_kind, recipient_entity_id, recipient_explicit
+            FROM host_action_queue WHERE client_action_id = 'old-action'
+            """
+        ).fetchone()
+
+    assert chat == ("discussion", None)
+    assert recipient == ("keeper", None, 1)
 
 
 def test_migration_rejects_duplicate_characters_before_ddl(tmp_path: Path) -> None:

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -695,6 +695,7 @@ def test_action_submit_broadcasts_narration_to_room_only(sync_client: TestClient
                 "payload": {
                     "clientActionId": "action-broadcast-122",
                     "utterance": "我看看托马斯",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )
@@ -722,6 +723,7 @@ def test_action_submit_broadcasts_narration_to_room_only(sync_client: TestClient
                 "payload": {
                     "clientActionId": "action-broadcast-122",
                     "utterance": "我看看托马斯",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )
@@ -906,6 +908,7 @@ def test_disconnected_socket_does_not_lose_the_turn_narration(
                 "payload": {
                     "clientActionId": action_id,
                     "utterance": "先观察房间，然后询问眼前的人",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )
@@ -977,6 +980,7 @@ def test_a_send_failure_that_is_not_a_disconnect_still_fails_the_turn(
                 "payload": {
                     "clientActionId": "send-failure-not-disconnect",
                     "utterance": "先观察房间，然后询问眼前的人",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )
@@ -1016,6 +1020,7 @@ def test_action_plan_submit_emits_safe_progress_and_one_parent_completion(
                 "payload": {
                     "clientActionId": "parent-plan-ws-225",
                     "utterance": "先观察房间，然后询问眼前的人",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )
@@ -1115,6 +1120,7 @@ def test_single_action_pending_resumes_through_one_step_plan_run(
                 "payload": {
                     "clientActionId": action_id,
                     "utterance": "仔细检查书架上的文件",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )
@@ -1214,6 +1220,7 @@ def test_single_action_pending_resumes_through_one_step_plan_run(
                 "payload": {
                     "clientActionId": action_id,
                     "utterance": "仔细检查书架上的文件",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )
@@ -1317,6 +1324,7 @@ def test_action_plan_narrator_failure_retries_narration_without_replaying_steps(
         "payload": {
             "clientActionId": "plan-narrator-retry-246",
             "utterance": "先观察房间，然后询问眼前的人",
+            "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
         },
     }
 
@@ -1394,6 +1402,7 @@ def test_subject_ownership_failure_retries_before_publishing_narration(
                 "payload": {
                     "clientActionId": action_id,
                     "utterance": "带托马斯去墓地",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )

--- a/trpg-backend/tests/test_ws_engine_capabilities.py
+++ b/trpg-backend/tests/test_ws_engine_capabilities.py
@@ -123,6 +123,7 @@ def _play_one_action(
                 "payload": {
                     "clientActionId": f"{account}-action",
                     "utterance": "我按自己的想法行动",
+                    "recipient": {"kind": "keeper", "entityId": None, "explicit": True},
                 },
             }
         )

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -806,6 +806,25 @@ describe('RoomPage conversation history', () => {
     ))
   })
 
+  it('accepts Chinese punctuation after a leading keeper mention', async () => {
+    mockSubmitPlannedAction.mockReturnValue(new Promise(() => undefined))
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    const actionField = screen.getByPlaceholderText('输入消息…')
+    fireEvent.change(actionField, { target: { value: '@守秘人：我查看窗外' } })
+    fireEvent.submit(actionField.closest('form')!)
+
+    await waitFor(() => expect(mockSubmitPlannedAction).toHaveBeenCalledWith(
+      'player-1',
+      expect.objectContaining({
+        utterance: '我查看窗外',
+        recipient: { kind: 'keeper', entityId: null, explicit: true },
+      }),
+    ))
+    expect(mockSendActionChat).not.toHaveBeenCalled()
+  })
+
   it('disables action submission until room mode is known but keeps discussion available', async () => {
     roomInfoState.maxPlayers = null
     renderRoomPage()
@@ -834,6 +853,20 @@ describe('RoomPage conversation history', () => {
     expect(mockSubmitPlannedAction.mock.calls[0][1]).toEqual(
       expect.objectContaining({ utterance: '我搜查书桌' }),
     )
+  })
+
+  it('action channel @ button moves a mid-text mention to the routing position', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    const actionField = screen.getByPlaceholderText('输入消息…')
+    fireEvent.change(actionField, { target: { value: '我稍后再问@主持人' } })
+    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
+    expect(actionField).toHaveValue('@主持人 我稍后再问@主持人')
+
+    fireEvent.change(actionField, { target: { value: '@守秘人 我查看窗外' } })
+    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
+    expect(actionField).toHaveValue('@守秘人 我查看窗外')
   })
 
   it('long-pressing the keeper avatar inserts @主持人', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -117,6 +117,7 @@ const {
   dice3dSupported,
   dice3dBehavior,
   dice3dRolls,
+  roomInfoState,
 } = vi.hoisted(() => {
   const handlers = new Set<(event: ServerToClientEvent) => void>()
   return {
@@ -124,6 +125,7 @@ const {
     dice3dSupported: { value: false },
     dice3dBehavior: { value: 'unsupported' as 'unsupported' | 'manual' },
     dice3dRolls: [] as Array<{ token: string; settle: (value: number) => void }>,
+    roomInfoState: { maxPlayers: 2 as number | null },
     emitWsMessage: (event: ServerToClientEvent) => {
       for (const handler of handlers) handler(event)
     },
@@ -259,7 +261,8 @@ vi.mock('@/features/dice3d', async () => {
 })
 
 vi.mock('@/hooks/useRoomPlayers', () => ({
-  useRoomPlayers: () => ({
+  useRoomPlayers: () => roomInfoState.maxPlayers === null ? null : ({
+    maxPlayers: roomInfoState.maxPlayers,
     phase: 'InGame',
     moduleTitle: '追书人',
     players: [
@@ -430,6 +433,7 @@ describe('RoomPage conversation history', () => {
     dice3dSupported.value = false
     dice3dBehavior.value = 'unsupported'
     dice3dRolls.length = 0
+    roomInfoState.maxPlayers = 2
     Object.defineProperty(window, 'speechSynthesis', { configurable: true, value: undefined })
     Object.defineProperty(window, 'SpeechSynthesisUtterance', { configurable: true, value: undefined })
     Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
@@ -650,6 +654,7 @@ describe('RoomPage conversation history', () => {
             playerId: 'player-1',
             actorId: 'actor-1',
             clientActionId: 'action-queued',
+            recipient: { kind: 'keeper', entityId: null, explicit: true },
             position: 1,
             utterance: '我翻书桌',
             acceptedAt: '2026-08-19T10:00:01Z',
@@ -757,6 +762,63 @@ describe('RoomPage conversation history', () => {
       expect.objectContaining({ text: '@主持人 讨论区这句不能进主持' }),
     ))
     expect(mockSubmitPlannedAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('single-player action input defaults to an implicit keeper recipient', async () => {
+    roomInfoState.maxPlayers = 1
+    mockSubmitPlannedAction.mockReturnValue(new Promise(() => undefined))
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    const actionField = screen.getByPlaceholderText('输入消息…')
+    fireEvent.change(actionField, { target: { value: '我检查门锁' } })
+    fireEvent.submit(actionField.closest('form')!)
+
+    await waitFor(() => expect(mockSubmitPlannedAction).toHaveBeenCalledWith(
+      'player-1',
+      expect.objectContaining({
+        utterance: '我检查门锁',
+        recipient: { kind: 'keeper', entityId: null, explicit: false },
+      }),
+    ))
+    expect(mockSendActionChat).not.toHaveBeenCalled()
+  })
+
+  it('only treats a leading keeper mention as explicit host routing', async () => {
+    mockSubmitPlannedAction.mockReturnValue(new Promise(() => undefined))
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+    const actionField = screen.getByPlaceholderText('输入消息…')
+
+    fireEvent.change(actionField, { target: { value: '我告诉队友稍后再问@主持人' } })
+    fireEvent.submit(actionField.closest('form')!)
+    await waitFor(() => expect(mockSendActionChat).toHaveBeenCalled())
+    expect(mockSubmitPlannedAction).not.toHaveBeenCalled()
+
+    fireEvent.change(actionField, { target: { value: '@守秘人 我查看窗外' } })
+    fireEvent.submit(actionField.closest('form')!)
+    await waitFor(() => expect(mockSubmitPlannedAction).toHaveBeenCalledWith(
+      'player-1',
+      expect.objectContaining({
+        utterance: '我查看窗外',
+        recipient: { kind: 'keeper', entityId: null, explicit: true },
+      }),
+    ))
+  })
+
+  it('disables action submission until room mode is known but keeps discussion available', async () => {
+    roomInfoState.maxPlayers = null
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    expect(screen.getByPlaceholderText('输入消息…')).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: '讨论区' }))
+    const discussionField = screen.getByPlaceholderText('输入行动…')
+    expect(discussionField).not.toBeDisabled()
+    fireEvent.change(discussionField, { target: { value: '@主持人 这里只是玩家讨论' } })
+    fireEvent.submit(discussionField.closest('form')!)
+    await waitFor(() => expect(mockSendChat).toHaveBeenCalled())
+    expect(mockSubmitPlannedAction).not.toHaveBeenCalled()
   })
 
   it('action channel @ button inserts a host mention', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -131,10 +131,11 @@ function checkResultContent(payload: CheckResultPayload): string {
   return `${payload.skillName} ${payload.targetValue}% · D100 ${payload.rollValue}${resolutionLabel}`
 }
 
-function hostUtteranceFromActionInput(text: string): string | null {
-  if (!text.includes('@主持人')) return null
-  const rest = text.split('@主持人').join(' ').replace(/\s+/g, ' ').trim()
-  return rest.length > 0 ? rest : null
+function hostUtteranceFromActionInput(text: string): { utterance: string; explicit: true } | null {
+  const mention = /^\s*@(主持人|守秘人)(?=\s|$)/u.exec(text)
+  if (!mention) return null
+  const rest = text.slice(mention[0].length).replace(/\s+/g, ' ').trim()
+  return { utterance: rest, explicit: true }
 }
 
 const HOST_MENTION_LONG_PRESS_MS = 450
@@ -459,15 +460,18 @@ function conversationEventToMessage(
       messageId: string
       playerId: string
       nickname: string
+      channel?: 'discussion' | 'roleplay'
+      actorId?: string | null
+      actorName?: string | null
       text: string
       sentAt: string
       clientMessageId: string
     }
     return {
       type: 'player',
-      channel: 'discussion',
+      channel: payload.channel === 'roleplay' ? 'action' : 'discussion',
       messageId: conversationMessageId(event.type, event.id),
-      sender: payload.nickname,
+      sender: displayName(payload.actorName, payload.nickname),
       content: payload.text,
       time: formatRoomTime(payload.sentAt),
       isSelf: payload.playerId === selfPlayerId,
@@ -1354,7 +1358,11 @@ export default function RoomPage() {
   // 单独取稳定方法，避免 effect 依赖每次渲染都会新建的 Hook 返回对象。
   const cancelSpeechInput = speechInput.cancel
   const [typing, setTyping] = useState(false)
-  const [pendingAction, setPendingAction] = useState<{ clientActionId: string; utterance: string } | null>(null)
+  const [pendingAction, setPendingAction] = useState<{
+    clientActionId: string
+    utterance: string
+    recipient: { kind: 'keeper'; entityId: null; explicit: boolean }
+  } | null>(null)
   const [pendingCheck, setPendingCheck] = useState<CheckRequestPayload | null>(null)
   const [pendingAdjudication, setPendingAdjudication] =
     useState<AdjudicationPendingPayload | null>(null)
@@ -1459,7 +1467,7 @@ export default function RoomPage() {
     roomActionState !== null &&
     roomActionState.status !== 'idle' &&
     (roomActionState.status === 'processing' || waitingForPlayerAction)
-  const composerDisabled = suspended
+  const composerDisabled = suspended || (isActionChannel && roomInfo === null)
   const actionOwnerName = roomActionState?.playerId === playerId
     ? senderName
     : displayName(
@@ -1720,9 +1728,9 @@ export default function RoomPage() {
           if (prev.some((item) => item.messageId === messageId)) return prev
           return appendLiveMessage(prev, {
             type: 'player',
-            channel: 'discussion',
+            channel: envelope.payload.channel === 'roleplay' ? 'action' : 'discussion',
             messageId,
-            sender: envelope.payload.nickname,
+            sender: displayName(envelope.payload.actorName, envelope.payload.nickname),
             content: envelope.payload.text,
             time: formatRoomTime(envelope.payload.sentAt),
             isSelf: envelope.payload.playerId === playerId,
@@ -1926,7 +1934,11 @@ export default function RoomPage() {
     return off
   }, [clearBackendProgress, clearSettledAction, enqueueHostSpeech, handleHostSpeechSettingsUpdated, openDiceForCheck, playerId, senderName, showBackendPhase])
 
-  const submitPlayerAction = (action: { clientActionId: string; utterance: string }) => {
+  const submitPlayerAction = (action: {
+    clientActionId: string
+    utterance: string
+    recipient: { kind: 'keeper'; entityId: null; explicit: boolean }
+  }) => {
     if (!playerId || suspended || actionSubmissionBlocked) return
     pendingNarrationActionIdRef.current = action.clientActionId
     setPendingAction(action)
@@ -2004,6 +2016,9 @@ export default function RoomPage() {
     e?.preventDefault()
     const text = input.trim()
     if (!text || !playerId || suspended) return
+    const hostRequest = channel === 'action' ? hostUtteranceFromActionInput(text) : null
+    // 只有 mention 没有正文时保留草稿，避免在多人房间误发成 roleplay。
+    if (hostRequest && !hostRequest.utterance) return
     // 发送前先关闭识别结果闸门，防止浏览器稍后返回的文本写入已清空的输入框。
     cancelSpeechInput()
     setInput('')
@@ -2011,10 +2026,18 @@ export default function RoomPage() {
       sdk.roomSocket.sendChat(playerId, { text, clientMessageId: randomActionId() })
       return
     }
-    const hostUtterance = hostUtteranceFromActionInput(text)
-    if (hostUtterance) {
+    const singlePlayer = roomInfo?.maxPlayers === 1
+    if (hostRequest || singlePlayer) {
       if (actionSubmissionBlocked) return
-      submitPlayerAction({ clientActionId: randomActionId(), utterance: hostUtterance })
+      submitPlayerAction({
+        clientActionId: randomActionId(),
+        utterance: hostRequest?.utterance ?? text,
+        recipient: {
+          kind: 'keeper',
+          entityId: null,
+          explicit: hostRequest?.explicit ?? false,
+        },
+      })
       return
     }
     sdk.roomSocket.sendActionChat(playerId, { text, clientMessageId: randomActionId() })

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -132,7 +132,9 @@ function checkResultContent(payload: CheckResultPayload): string {
 }
 
 function hostUtteranceFromActionInput(text: string): { utterance: string; explicit: true } | null {
-  const mention = /^\s*@(主持人|守秘人)(?=\s|$)/u.exec(text)
+  // 中文输入习惯会直接在 mention 后接逗号或冒号；这些标点属于分隔符，
+  // 不应让一条明确发给守秘人的消息误落成多人 roleplay。
+  const mention = /^\s*@(主持人|守秘人)(?:\s+|[，。！？；：、,.!?;:]\s*|$)/u.exec(text)
   if (!mention) return null
   const rest = text.slice(mention[0].length).replace(/\s+/g, ' ').trim()
   return { utterance: rest, explicit: true }
@@ -1996,7 +1998,7 @@ export default function RoomPage() {
       const value = current.action
       return {
         ...current,
-        action: value.includes('@主持人')
+        action: hostUtteranceFromActionInput(value) !== null
           ? value
           : value.trim()
             ? `@主持人 ${value.trim()}`

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -45,6 +45,15 @@ export interface ActionPlanCancelPayload {
 }
 
 /**
+ * 玩家输入的结构化接收者；自然语言 mention 只允许在客户端解析一次。
+ */
+export interface ActionRecipientPayload {
+  kind: "keeper" | "npc";
+  entityId?: string | null;
+  explicit: boolean;
+}
+
+/**
  * action.plan.submit 事件 payload。
  *
  * `client_action_id` 是客户端为一次逻辑动作生成的稳定幂等键；网络重试必须
@@ -53,6 +62,7 @@ export interface ActionPlanCancelPayload {
 export interface ActionSubmitPayload {
   clientActionId: string;
   utterance: string;
+  recipient: ActionRecipientPayload;
   summarizedFrom?: string[] | null;
   visibility?: ("public" | "private") | null;
 }
@@ -338,25 +348,31 @@ export interface CharacterUpdateBody {
 }
 
 /**
- * chat.message 讨论区广播 payload。
+ * chat.message 广播 payload；channel 区分玩家讨论和角色扮演。
  */
 export interface ChatMessagePayload {
   messageId: string;
   playerId: string;
   nickname: string;
+  channel: "discussion" | "roleplay";
+  actorId?: string | null;
+  actorName?: string | null;
   text: string;
   sentAt: string;
   clientMessageId: string;
 }
 
 /**
- * 讨论区一条消息。`sent_at` 用 UtcDatetime（对外时间字段的统一约定，
+ * 讨论区分页接口的一条消息。`sent_at` 用 UtcDatetime（对外时间字段的统一约定，
  * 见 app/dto/common.py）。
  */
 export interface ChatMessageRead {
   messageId: string;
   playerId: string;
   nickname: string;
+  channel: "discussion" | "roleplay";
+  actorId?: string | null;
+  actorName?: string | null;
   text: string;
   sentAt: string;
   clientMessageId: string;
@@ -1223,6 +1239,7 @@ export interface RoomActionQueueItemPayload {
   playerId: string;
   actorId: string;
   clientActionId: string;
+  recipient: ActionRecipientPayload;
   position: number;
   utterance: string;
   acceptedAt: string;

--- a/trpg-sdk/src/resources/room-socket.test.ts
+++ b/trpg-sdk/src/resources/room-socket.test.ts
@@ -390,6 +390,7 @@ test('isValidServerEvent：校验可重放的房间行动状态', () => {
             playerId: 'player-2',
             actorId: 'actor-2',
             clientActionId: 'action-2',
+            recipient: { kind: 'keeper', entityId: null, explicit: true },
             position: 1,
             utterance: '我翻书桌',
             acceptedAt: '2026-08-19T10:00:01Z',
@@ -403,6 +404,59 @@ test('isValidServerEvent：校验可重放的房间行动状态', () => {
     isValidServerEvent({
       type: 'room.action.state',
       payload: { status: 'awaiting_player', playerId: 'player-1', revision: '9' },
+    }),
+    false
+  );
+  assert.equal(
+    isValidServerEvent({
+      type: 'room.action.state',
+      payload: {
+        status: 'idle',
+        revision: '9',
+        queued: [
+          {
+            playerId: 'player-2',
+            actorId: 'actor-2',
+            clientActionId: 'action-2',
+            recipient: { kind: 'npc', entityId: 'thomas', explicit: false },
+            position: 1,
+            utterance: '你好',
+            acceptedAt: '2026-08-19T10:00:01Z',
+          },
+        ],
+      },
+    }),
+    false
+  );
+});
+
+test('isValidServerEvent：聊天频道与角色身份必须匹配', () => {
+  const base = {
+    messageId: 'message-1',
+    playerId: 'player-1',
+    nickname: '玩家',
+    text: '晚上好',
+    sentAt: '2026-08-19T10:00:00Z',
+    clientMessageId: 'client-message-1',
+  };
+  assert.equal(
+    isValidServerEvent({
+      type: 'chat.message',
+      payload: { ...base, channel: 'discussion', actorId: null, actorName: null },
+    }),
+    true
+  );
+  assert.equal(
+    isValidServerEvent({
+      type: 'chat.message',
+      payload: { ...base, channel: 'roleplay', actorId: 'actor-1', actorName: '陈探员' },
+    }),
+    true
+  );
+  assert.equal(
+    isValidServerEvent({
+      type: 'chat.message',
+      payload: { ...base, channel: 'roleplay', actorId: null, actorName: null },
     }),
     false
   );
@@ -574,6 +628,7 @@ test('turn.failed reject pending action，view.updated 更新同一份缓存', a
     const pending = socket.submitPlannedAction('player-1', {
       clientActionId: 'failed-action',
       utterance: '调查书架',
+      recipient: { kind: 'keeper', entityId: null, explicit: true },
     });
     transport.emit({
       type: 'turn.failed',
@@ -597,6 +652,7 @@ test('turn.failed reject pending action，view.updated 更新同一份缓存', a
     const rejectedAction = socket.submitPlannedAction('player-1', {
       clientActionId: 'busy-action',
       utterance: '继续调查书架',
+      recipient: { kind: 'keeper', entityId: null, explicit: true },
     });
     transport.emit({
       type: 'error',
@@ -617,6 +673,7 @@ test('turn.failed reject pending action，view.updated 更新同一份缓存', a
     const retriedAction = socket.submitPlannedAction('player-1', {
       clientActionId: 'busy-action',
       utterance: '继续调查书架',
+      recipient: { kind: 'keeper', entityId: null, explicit: true },
     });
     assert.notEqual(retriedAction, rejectedAction);
     transport.emit({
@@ -628,6 +685,7 @@ test('turn.failed reject pending action，view.updated 更新同一份缓存', a
     const interruptedAction = socket.submitPlannedAction('player-1', {
       clientActionId: 'interrupted-action',
       utterance: '查看门外',
+      recipient: { kind: 'keeper', entityId: null, explicit: true },
     });
     transport.emitClose();
     await assert.rejects(
@@ -650,6 +708,7 @@ test('未连接时 submitPlannedAction reject RoomSocketTransportError', async (
     socket.submitPlannedAction('player-1', {
       clientActionId: 'not-connected',
       utterance: '调查书架',
+      recipient: { kind: 'keeper', entityId: null, explicit: true },
     }),
     (error: unknown) =>
       error instanceof RoomSocketTransportError &&

--- a/trpg-sdk/src/resources/room-socket.ts
+++ b/trpg-sdk/src/resources/room-socket.ts
@@ -358,6 +358,14 @@ const PAYLOAD_VALIDATORS: {
           typeof item.playerId !== 'string' ||
           typeof item.actorId !== 'string' ||
           typeof item.clientActionId !== 'string' ||
+          !isRecord(item.recipient) ||
+          (item.recipient.kind !== 'keeper' && item.recipient.kind !== 'npc') ||
+          (item.recipient.kind === 'keeper' && item.recipient.entityId !== null) ||
+          (item.recipient.kind === 'npc' &&
+            (typeof item.recipient.entityId !== 'string' ||
+              !item.recipient.entityId ||
+              item.recipient.explicit !== true)) ||
+          typeof item.recipient.explicit !== 'boolean' ||
           typeof item.position !== 'number' ||
           typeof item.utterance !== 'string' ||
           typeof item.acceptedAt !== 'string'
@@ -462,6 +470,14 @@ const PAYLOAD_VALIDATORS: {
     typeof p.messageId === 'string' &&
     typeof p.playerId === 'string' &&
     typeof p.nickname === 'string' &&
+    (p.channel === 'discussion' || p.channel === 'roleplay') &&
+    (p.channel === 'discussion'
+      ? (p.actorId === null || p.actorId === undefined) &&
+        (p.actorName === null || p.actorName === undefined)
+      : typeof p.actorId === 'string' &&
+        p.actorId.length > 0 &&
+        typeof p.actorName === 'string' &&
+        p.actorName.length > 0) &&
     typeof p.text === 'string' &&
     typeof p.sentAt === 'string' &&
     typeof p.clientMessageId === 'string',


### PR DESCRIPTION
## Summary

- 增加必填的结构化 `recipient`，并在主持行动队列中完整持久化和恢复。
- 单人行动区无 @ 默认提交守秘人；多人无 @ 保存为 roleplay，不调用 Host。
- 讨论区始终保持玩家讨论；开头的 `@主持人` / `@守秘人` 才进入现有 Host 主链。
- 增加 discussion/roleplay 双频道、角色显示名、迁移回填和刷新恢复。
- 预留 NPC recipient 契约，但本 PR 在任何 Turn、PlayerView、队列、Event 或模型副作用前返回 `NOT_IMPLEMENTED`。

设计依据：#407

## Scope

本 PR 只实现输入路由与接收者契约，不实现 NPC 对话、NPC 消息、NPC 记忆或 NPC 模型调用；这些留给 PR2。

## Verification

- Backend: `545 passed, 21 skipped`
- Frontend: `232 passed`，lint/build 通过
- SDK: `31 passed`，typecheck/build 通过
- E2E: `40 passed`
- SQLite 空库迁移、历史数据回填、downgrade/upgrade 通过
- roleplay E2E 断言不产生 Turn、Host 回复、队列、ActionPlan、Event、GameEvent、Memory 或 Summary 痕迹
