### PR TITLE
feat(multiplayer): 确认等待期间允许停止后续行动

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -559,7 +559,11 @@ class ActionPlanOrchestrator:
             return run
         if run.is_terminal and run.status != "stopped":
             return run
-        if run.status == "waiting_for_player":
+        if run.status in {
+            "waiting_for_player",
+            "awaiting_time_consent",
+            "awaiting_scene_consent",
+        }:
             current = run.steps[run.current_step_index]
             status = await self._executor.get_status(
                 GetAdjudicationStatusRequest(
@@ -573,7 +577,12 @@ class ActionPlanOrchestrator:
         if run.current_step_index < len(run.steps):
             current = run.steps[run.current_step_index]
             cancellable_boundary = (
-                current.status == "pending"
+                current.status
+                in {
+                    "pending",
+                    "awaiting_time_consent",
+                    "awaiting_scene_consent",
+                }
                 or (
                     run.status == "needs_clarification"
                     and current.status == "stopped"

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -13,6 +13,7 @@ from collaboration_framework.contracts import (
     ActionPlanPolicyError,
     ActionPlanStep,
     ActionTarget,
+    AdjudicationExecution,
     AdjudicationValidationError,
     AdvanceWorldTimeEffect,
     CancelActionPlanRequest,
@@ -2102,6 +2103,159 @@ async def test_needs_clarification_can_be_cancelled_without_running_later_steps(
 
     assert cancelled.status == "cancelled"
     assert engine_store.inspect_domain_events("room_01") == ()
+
+
+async def _force_consent_status(
+    store,
+    run: ActionPlanRun,
+    *,
+    status: str,
+    execution: AdjudicationExecution,
+    adjudication: ActionAdjudication,
+) -> ActionPlanRun:
+    current = run.steps[run.current_step_index]
+    steps = list(run.steps)
+    steps[run.current_step_index] = current.model_copy(
+        update={
+            "status": status,
+            "source_revision": adjudication.source_revision,
+            "adjudication": adjudication,
+            "adjudication_execution": execution,
+            "pending_action_request_id": current.step_request_id,
+        },
+        deep=True,
+    )
+    updated = run.model_copy(
+        update={
+            "status": status,
+            "steps": tuple(steps),
+            "run_version": run.run_version + 1,
+            "lease_owner": None,
+            "lease_expires_at": None,
+        },
+        deep=True,
+    )
+    return await store.compare_and_swap(
+        expected_run_version=run.run_version,
+        updated_run=updated,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_remaining_at_scene_consent_keeps_completed_steps() -> None:
+    service, _, _, store, engine_store = orchestrator()
+    original = player_input("scene-consent-cancel")
+    checkpointed = await service.start_or_resume(
+        original,
+        plan=plan(4),
+        worker_id="worker-1",
+        auto_continue=False,
+    )
+    assert checkpointed.run.status == "checkpointed"
+    current = checkpointed.run.steps[checkpointed.run.current_step_index]
+    adjudication = ActionAdjudication(
+        request_id=current.step_request_id,
+        source_revision=checkpointed.run.steps[0].source_revision or "0",
+        actor_id="pc_1",
+        summary="前往墓地",
+        target=ActionTarget(kind="location", id="cemetery"),
+        method=ActionMethod(family="travel", description="前往墓地"),
+        check=NoAdjudicationCheck(),
+        success_effects=(EnterLocationEffect(location_id="cemetery"),),
+    )
+    waiting = await _force_consent_status(
+        store,
+        checkpointed.run,
+        status="awaiting_scene_consent",
+        adjudication=adjudication,
+        execution=AdjudicationExecution(
+            request_id=current.step_request_id,
+            action_request_id=current.step_request_id,
+            status="awaiting_scene_consent",
+            view_revision=adjudication.source_revision,
+            outcome="pending",
+            scene_transition_proposal_id="scene_cancel_test",
+        ),
+    )
+
+    cancelled = await service.cancel_remaining(
+        CancelActionPlanRequest(
+            request_id="cancel-scene-consent",
+            room_id=original.room_id,
+            player_id=original.player_id,
+            actor_id=original.actor_id,
+            parent_action_id=original.client_action_id,
+        )
+    )
+    replay = await service.cancel_remaining(
+        CancelActionPlanRequest(
+            request_id="cancel-scene-consent",
+            room_id=original.room_id,
+            player_id=original.player_id,
+            actor_id=original.actor_id,
+            parent_action_id=original.client_action_id,
+        )
+    )
+
+    assert waiting.status == "awaiting_scene_consent"
+    assert cancelled.status == "cancelled"
+    assert replay == cancelled
+    assert cancelled.completed_steps == 3
+    assert cancelled.steps[3].status == "stopped"
+    assert len(engine_store.inspect_domain_events("room_01")) == 3
+
+
+@pytest.mark.asyncio
+async def test_cancel_remaining_at_time_consent_does_not_require_check_boundary() -> (
+    None
+):
+    service, _, _, store, engine_store = orchestrator()
+    original = player_input("time-consent-cancel")
+    checkpointed = await service.start_or_resume(
+        original,
+        plan=plan(4),
+        worker_id="worker-1",
+        auto_continue=False,
+    )
+    current = checkpointed.run.steps[checkpointed.run.current_step_index]
+    adjudication = ActionAdjudication(
+        request_id=current.step_request_id,
+        source_revision=checkpointed.run.steps[0].source_revision or "0",
+        actor_id="pc_1",
+        summary="等到下一个时间点",
+        target=ActionTarget(kind="world", id="coc-7e"),
+        method=ActionMethod(family="wait", description="等待"),
+        check=NoAdjudicationCheck(),
+        success_effects=(AdvanceWorldTimeEffect(),),
+    )
+    await _force_consent_status(
+        store,
+        checkpointed.run,
+        status="awaiting_time_consent",
+        adjudication=adjudication,
+        execution=AdjudicationExecution(
+            request_id=current.step_request_id,
+            action_request_id=current.step_request_id,
+            status="awaiting_time_consent",
+            view_revision=adjudication.source_revision,
+            outcome="pending",
+            time_advance_proposal_id="time_cancel_test",
+        ),
+    )
+
+    cancelled = await service.cancel_remaining(
+        CancelActionPlanRequest(
+            request_id="cancel-time-consent",
+            room_id=original.room_id,
+            player_id=original.player_id,
+            actor_id=original.actor_id,
+            parent_action_id=original.client_action_id,
+        )
+    )
+
+    assert cancelled.status == "cancelled"
+    assert cancelled.completed_steps == 3
+    assert len(engine_store.inspect_domain_events("room_01")) == 3
 
 
 @pytest.mark.asyncio

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -2521,6 +2521,24 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 room_id,
                                 force_processing=True,
                             )
+                            scene_aborted = await scene_transition_service.abort_pending(
+                                db,
+                                engine=adjudication_engine_service,
+                                room_id=room_id,
+                                player_id=bound_player_id,
+                                parent_action_id=cancel.client_action_id,
+                            )
+                            if scene_aborted is not None:
+                                await _broadcast_scene_transition(room_id, scene_aborted)
+                            time_aborted = await time_advance_service.abort_pending(
+                                db,
+                                engine=adjudication_engine_service,
+                                room_id=room_id,
+                                player_id=bound_player_id,
+                                parent_action_id=cancel.client_action_id,
+                            )
+                            if time_aborted is not None:
+                                await _broadcast_time_advance(room_id, time_aborted)
                             result = await action_plan_turn_application.cancel_remaining(
                                 room_id=room_id,
                                 player_id=bound_player_id,

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -1090,6 +1090,25 @@ class ActionPlanTurnApplication:
             existing is not None
             and existing.player_id == player_id
             and existing.actor_id == actor_id
+            and existing.status in {"awaiting_scene_consent", "awaiting_time_consent"}
+        ):
+            abort_consent = getattr(self._adjudication_engine, "abort_consent", None)
+            if abort_consent is not None:
+                current = (
+                    existing.steps[existing.current_step_index]
+                    if existing.current_step_index < len(existing.steps)
+                    else None
+                )
+                await abort_consent(
+                    room_id=room_id,
+                    player_id=player_id,
+                    parent_action_id=parent_action_id,
+                    action_request_id=(current.step_request_id if current is not None else None),
+                )
+        if (
+            existing is not None
+            and existing.player_id == player_id
+            and existing.actor_id == actor_id
             and existing.status == "waiting_for_player"
             and existing.current_step_index < len(existing.steps)
         ):

--- a/trpg-backend/app/service/scene_transition.py
+++ b/trpg-backend/app/service/scene_transition.py
@@ -19,7 +19,7 @@ from collaboration_framework.contracts import (
 from collaboration_framework.contracts.validation import AdjudicationValidationError
 from collaboration_framework.engine import AdjudicationEngineService
 from collaboration_framework.engine.models import GameState
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -299,6 +299,75 @@ async def mark_narration_persisted(
         await db.commit()
 
 
+async def abort_pending(
+    db: AsyncSession,
+    *,
+    engine: AdjudicationEngineService,
+    room_id: str,
+    player_id: str,
+    parent_action_id: str,
+    action_request_id: str | None = None,
+) -> SceneTransitionResolvedPayload | None:
+    """发起者中止剩余计划时作废待确认提案，不能经 respond(False) 撤回已投票。"""
+
+    async with _response_lock(room_id):
+        matchers = [
+            SceneTransitionProposalRecord.parent_action_id == parent_action_id,
+            SceneTransitionProposalRecord.action_request_id == parent_action_id,
+        ]
+        if action_request_id:
+            matchers.extend(
+                (
+                    SceneTransitionProposalRecord.parent_action_id == action_request_id,
+                    SceneTransitionProposalRecord.action_request_id == action_request_id,
+                )
+            )
+        record = await db.scalar(
+            select(SceneTransitionProposalRecord)
+            .where(
+                SceneTransitionProposalRecord.room_id == room_id,
+                SceneTransitionProposalRecord.player_id == player_id,
+                SceneTransitionProposalRecord.status == "pending",
+                or_(*matchers),
+            )
+            .order_by(SceneTransitionProposalRecord.created_at.desc())
+            .limit(1)
+            .with_for_update()
+        )
+        if record is None:
+            return None
+        engine_status = await engine.get_status(
+            GetAdjudicationStatusRequest(
+                room_id=record.room_id,
+                player_id=record.player_id,
+                action_request_id=record.action_request_id,
+            )
+        )
+        if engine_status.status == "resolved" and engine_status.execution is not None:
+            record.status = "approved"
+            record.accepted_player_ids = sorted(record.required_player_ids)
+            record.committed_revision = int(engine_status.execution.view_revision)
+            record.proposal_version += 1
+            record.updated_at = datetime.now(UTC)
+            await db.commit()
+            return _resolved_payload(record)
+        if _aware(record.expires_at) <= datetime.now(UTC):
+            record.status = "expired"
+            record.proposal_version += 1
+            await db.commit()
+            return _resolved_payload(record)
+        if await _is_stale(db, record):
+            record.status = "stale"
+            record.proposal_version += 1
+            await db.commit()
+            return _resolved_payload(record)
+        record.status = "rejected"
+        record.proposal_version += 1
+        record.updated_at = datetime.now(UTC)
+        await db.commit()
+        return _resolved_payload(record)
+
+
 async def respond(
     db: AsyncSession,
     *,
@@ -483,6 +552,7 @@ async def find_active_action_for_player(
 
 __all__ = [
     "SceneTransitionError",
+    "abort_pending",
     "bind_parent_action",
     "create_from_adjudication",
     "find_active_action_for_player",

--- a/trpg-backend/app/service/time_advance.py
+++ b/trpg-backend/app/service/time_advance.py
@@ -26,11 +26,15 @@ from collaboration_framework.contracts.validation import AdjudicationValidationE
 from collaboration_framework.engine import AdjudicationEngineService
 from collaboration_framework.engine.models import GameState
 from collaboration_framework.engine.timeline import advanced_to_next
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.dto.ws import TimeAdvancePendingPayload, TimeAdvanceResolvedPayload
+from app.dto.ws import (
+    SceneTransitionResolvedPayload,
+    TimeAdvancePendingPayload,
+    TimeAdvanceResolvedPayload,
+)
 from app.models.engine import GameSession, ModuleVersion, TimeAdvanceProposalRecord
 from app.models.room import Room
 
@@ -349,6 +353,75 @@ async def mark_narration_persisted(
         await db.commit()
 
 
+async def abort_pending(
+    db: AsyncSession,
+    *,
+    engine: AdjudicationEngineService,
+    room_id: str,
+    player_id: str,
+    parent_action_id: str,
+    action_request_id: str | None = None,
+) -> TimeAdvanceResolvedPayload | None:
+    """发起者中止剩余计划时作废待确认时间提案。"""
+
+    async with _response_lock(room_id):
+        matchers = [
+            TimeAdvanceProposalRecord.parent_action_id == parent_action_id,
+            TimeAdvanceProposalRecord.action_request_id == parent_action_id,
+        ]
+        if action_request_id:
+            matchers.extend(
+                (
+                    TimeAdvanceProposalRecord.parent_action_id == action_request_id,
+                    TimeAdvanceProposalRecord.action_request_id == action_request_id,
+                )
+            )
+        record = await db.scalar(
+            select(TimeAdvanceProposalRecord)
+            .where(
+                TimeAdvanceProposalRecord.room_id == room_id,
+                TimeAdvanceProposalRecord.player_id == player_id,
+                TimeAdvanceProposalRecord.status == "pending",
+                or_(*matchers),
+            )
+            .order_by(TimeAdvanceProposalRecord.created_at.desc())
+            .limit(1)
+            .with_for_update()
+        )
+        if record is None:
+            return None
+        engine_status = await engine.get_status(
+            GetAdjudicationStatusRequest(
+                room_id=record.room_id,
+                player_id=record.player_id,
+                action_request_id=record.action_request_id,
+            )
+        )
+        if engine_status.status == "resolved" and engine_status.execution is not None:
+            record.status = "approved"
+            record.accepted_player_ids = sorted(record.required_player_ids)
+            record.committed_revision = int(engine_status.execution.view_revision)
+            record.proposal_version += 1
+            record.updated_at = datetime.now(UTC)
+            await db.commit()
+            return _resolved_payload(record)
+        if _aware(record.expires_at) <= datetime.now(UTC):
+            record.status = "expired"
+            record.proposal_version += 1
+            await db.commit()
+            return _resolved_payload(record)
+        if await _is_stale(db, record):
+            record.status = "stale"
+            record.proposal_version += 1
+            await db.commit()
+            return _resolved_payload(record)
+        record.status = "rejected"
+        record.proposal_version += 1
+        record.updated_at = datetime.now(UTC)
+        await db.commit()
+        return _resolved_payload(record)
+
+
 async def respond(
     db: AsyncSession,
     *,
@@ -647,10 +720,47 @@ class ConsentAwareAdjudicationEngine:
 
         return await self._engine.decide_post_roll(request)
 
+    async def abort_consent(
+        self,
+        *,
+        room_id: str,
+        player_id: str,
+        parent_action_id: str,
+        action_request_id: str | None = None,
+    ) -> tuple[SceneTransitionResolvedPayload | TimeAdvanceResolvedPayload, ...]:
+        """作废当前计划挂起的场景或时间提案，供取消剩余步骤之前调用。"""
+
+        from app.service import scene_transition
+
+        payloads: list[SceneTransitionResolvedPayload | TimeAdvanceResolvedPayload] = []
+        async with self._session_factory() as db:
+            scene_payload = await scene_transition.abort_pending(
+                db,
+                engine=self._engine,
+                room_id=room_id,
+                player_id=player_id,
+                parent_action_id=parent_action_id,
+                action_request_id=action_request_id,
+            )
+            if scene_payload is not None:
+                payloads.append(scene_payload)
+            time_payload = await abort_pending(
+                db,
+                engine=self._engine,
+                room_id=room_id,
+                player_id=player_id,
+                parent_action_id=parent_action_id,
+                action_request_id=action_request_id,
+            )
+            if time_payload is not None:
+                payloads.append(time_payload)
+        return tuple(payloads)
+
 
 __all__ = [
     "ConsentAwareAdjudicationEngine",
     "TimeAdvanceError",
+    "abort_pending",
     "bind_parent_action",
     "create_from_adjudication",
     "get_pending",

--- a/trpg-backend/tests/test_scene_transition_consent.py
+++ b/trpg-backend/tests/test_scene_transition_consent.py
@@ -426,3 +426,83 @@ async def test_cancel_paths_never_change_shared_scene(
     refreshed = await db_session.get(GameSession, room.id)
     assert refreshed is not None
     assert GameState.model_validate(refreshed.state_json).scene_id == initial_scene
+
+
+@pytest.mark.asyncio
+async def test_initiator_abort_rejects_pending_scene_and_blocks_later_accept(
+    db_session: AsyncSession,
+    engine_store_factory,
+) -> None:
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=4120,
+        player_count=3,
+        prepare_checkpoint=True,
+    )
+    session = await db_session.get(GameSession, room.id)
+    assert session is not None
+    initial_scene = GameState.model_validate(session.state_json).scene_id
+    engine = AdjudicationEngineService(engine_store_factory())
+    request = _request(
+        room_id=room.id,
+        player_id=players[0].id,
+        revision=session.state_version,
+        action_id="scene-abort-412",
+    )
+    await scene_transition.create_from_adjudication(db_session, request)
+    record = await _proposal(db_session, room.id)
+    await scene_transition.bind_parent_action(
+        db_session,
+        room_id=room.id,
+        proposal_id=record.proposal_id,
+        player_id=players[0].id,
+        parent_action_id="scene-parent-412",
+    )
+
+    with pytest.raises(scene_transition.SceneTransitionError, match="不能撤回"):
+        await scene_transition.respond(
+            db_session,
+            engine=engine,
+            room_id=room.id,
+            player_id=players[0].id,
+            proposal_id=record.proposal_id,
+            proposal_version=record.proposal_version,
+            source_revision=str(record.source_revision),
+            accept=False,
+        )
+
+    aborted = await scene_transition.abort_pending(
+        db_session,
+        engine=engine,
+        room_id=room.id,
+        player_id=players[0].id,
+        parent_action_id="scene-parent-412",
+    )
+    replay = await scene_transition.abort_pending(
+        db_session,
+        engine=engine,
+        room_id=room.id,
+        player_id=players[0].id,
+        parent_action_id="scene-parent-412",
+    )
+
+    assert isinstance(aborted, SceneTransitionResolvedPayload)
+    assert aborted.status == "rejected"
+    assert replay is None
+
+    later, resume_player, action_id = await scene_transition.respond(
+        db_session,
+        engine=engine,
+        room_id=room.id,
+        player_id=players[2].id,
+        proposal_id=record.proposal_id,
+        proposal_version=record.proposal_version,
+        source_revision=str(record.source_revision),
+        accept=True,
+    )
+    assert isinstance(later, SceneTransitionResolvedPayload)
+    assert later.status == "rejected"
+    assert resume_player is action_id is None
+    refreshed = await db_session.get(GameSession, room.id)
+    assert refreshed is not None
+    assert GameState.model_validate(refreshed.state_json).scene_id == initial_scene

--- a/trpg-backend/tests/test_time_advance.py
+++ b/trpg-backend/tests/test_time_advance.py
@@ -592,3 +592,73 @@ async def test_wrapper_recovers_pending_and_cancelled_status(
         )
     )
     assert cancelled.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_initiator_abort_rejects_pending_time_and_blocks_later_accept(
+    db_session: AsyncSession,
+    engine_store_factory,
+) -> None:
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=4121,
+        player_count=3,
+        prepare_checkpoint=False,
+    )
+    session = await db_session.get(GameSession, room.id)
+    assert session is not None
+    engine = AdjudicationEngineService(engine_store_factory())
+    request = _request(
+        room_id=room.id,
+        player_id=players[0].id,
+        actor_id="actor_1",
+        revision=session.state_version,
+        action_id="time-abort-412",
+    )
+    await time_advance.create_from_adjudication(db_session, request)
+    record = await _proposal(db_session, room.id)
+    await time_advance.bind_parent_action(
+        db_session,
+        room_id=room.id,
+        proposal_id=record.proposal_id,
+        player_id=players[0].id,
+        parent_action_id="time-parent-412",
+    )
+    initial_time = GameState.model_validate(session.state_json).world_time.current
+
+    aborted = await time_advance.abort_pending(
+        db_session,
+        engine=engine,
+        room_id=room.id,
+        player_id=players[0].id,
+        parent_action_id="time-parent-412",
+    )
+    replay = await time_advance.abort_pending(
+        db_session,
+        engine=engine,
+        room_id=room.id,
+        player_id=players[0].id,
+        parent_action_id="time-parent-412",
+    )
+
+    assert isinstance(aborted, TimeAdvanceResolvedPayload)
+    assert aborted.status == "rejected"
+    assert replay is None
+    assert await _time_event_count(db_session, room.id) == 0
+
+    later, resume_player, action_id = await time_advance.respond(
+        db_session,
+        engine=engine,
+        room_id=room.id,
+        player_id=players[2].id,
+        proposal_id=record.proposal_id,
+        proposal_version=record.proposal_version,
+        source_revision=str(record.source_revision),
+        accept=True,
+    )
+    assert isinstance(later, TimeAdvanceResolvedPayload)
+    assert later.status == "rejected"
+    assert resume_player is action_id is None
+    await db_session.refresh(session)
+    assert GameState.model_validate(session.state_json).world_time.current == initial_time
+    assert await _time_event_count(db_session, room.id) == 0


### PR DESCRIPTION
Closes #412

场景/时间全员确认期间，发起者「停止后续行动」会作废待确认提案并取消剩余计划，已提交步骤保留。

## 改了什么

| 模块 | 改动 |
| --- | --- |
| Orchestrator | `cancel_remaining` 把 `awaiting_scene_consent` / `awaiting_time_consent` 收进可取消边界；若引擎侧已是 `cancelled` 先 reconcile |
| Scene / Time | 新增 `abort_pending`：发起者作废 pending 提案。不能走 `respond(false)`，因为发起者已自动同意 |
| Consent engine | `ConsentAwareAdjudicationEngine.abort_consent` 同时处理场景和时间提案，供取消链恢复 |
| ActionPlan | `cancel_remaining` 在确认态先 abort 提案，再停剩余步骤 |
| WebSocket | 取消前广播 `scene.transition.resolved` / `time.advance.resolved`，确认条从所有客户端消失 |
| Tests | 确认期取消保留已完成步骤；发起者 abort 后他人再点同意不能改世界；abort 幂等 |

## 关键决策

**为什么不让发起者点确认条「拒绝」：**
`respond(accept=False)` 对已投票玩家会报「不能撤回」。发起者创建提案时已经自动同意。取消剩余计划是另一条路，不能放宽投票撤回。

**为什么先作废提案，再取消计划：**
只把 plan 标成 `cancelled`、提案还挂着，别人继续点同意会推进世界。顺序必须是提案关闭 → 停剩余步骤。两条都幂等，中断后重试收束到同一终态。

**为什么引擎已经 resolved 时标 approved 而不是 rejected：**
最后一票与取消并发时，世界可能已经提交。取消不得回滚已提交的场景/时间，只禁止把「还没提交的确认」提交掉。

**为什么不新造第三套取消入口：**
仍然走现有 `action.plan.cancel` → `cancel_remaining`。确认期只是多一个合法边界，和 `pending` 同等对待。

## 验证

- Backend 相关：`test_scene_transition_consent` / `test_time_advance` / `test_action_plan_turn_recovery` 共 41 passed；ruff / format / ty 通过
- Framework：`test_action_plan_orchestrator.py -k cancel` 6 passed
- Frontend / SDK：未改，未跑
- 未跑全量 pytest / 真机三人确认取消

## 已知限制

- 取消与最后一票的并发以 `_response_lock` 串行；若引擎已提交，提案收敛为 approved，不回滚世界。
- 未做三客户端真 WebSocket e2e；确认条消失依赖 `*.resolved` 广播，需真机点一次。

## 不在本 PR 范围

- 带检定的场景切换
- 「移动后等待」等场景确认与时间确认的复合 ActionPlan
- 追书人放到 1–4 人
- 代述、分视角
- 大地点是否必须绑定下一时间块（#387）
