### PR TITLE
ops(preview): 持久预览主持模型改为千问

### DIFF
--- a/.github/workflows/main-preview.yml
+++ b/.github/workflows/main-preview.yml
@@ -80,6 +80,9 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.PREVIEW_DEEPSEEK_API_KEY }}
           DEEPSEEK_BASE_URL: ${{ vars.PREVIEW_DEEPSEEK_BASE_URL }}
           DEEPSEEK_MODEL: ${{ vars.PREVIEW_DEEPSEEK_MODEL }}
+          QWEN_API_KEY: ${{ secrets.PREVIEW_QWEN_API_KEY }}
+          QWEN_BASE_URL: ${{ vars.PREVIEW_QWEN_BASE_URL }}
+          QWEN_MODEL: ${{ vars.PREVIEW_QWEN_MODEL }}
           # 当前凭证同时支持 DeepSeek v4 Pro 和 Sufy Gemini 生图；仍按用途
           # 使用两个 Secret 名称，后续可以独立轮换。不要把图片 key 放进前端。
           SUFY_API_KEY: ${{ secrets.PREVIEW_SUFY_API_KEY }}
@@ -133,6 +136,23 @@ jobs:
             PORTRAIT_PROMPT_PROVIDER=deterministic
             PORTRAIT_IMAGE_PROVIDER=mock
           fi
+          QWEN_BASE_URL="${QWEN_BASE_URL:-https://openai.sufy.com/v1}"
+          QWEN_MODEL="${QWEN_MODEL:-qwen/qwen3.7-plus}"
+          if [ -n "$QWEN_API_KEY" ]; then
+            if [ -z "$QWEN_BASE_URL" ] || [ -z "$QWEN_MODEL" ]; then
+              echo "::error::已配置 PREVIEW_QWEN_API_KEY，但缺少 PREVIEW_QWEN_BASE_URL 或 PREVIEW_QWEN_MODEL"
+              exit 1
+            fi
+            if [[ ! "$QWEN_BASE_URL" =~ ^https?://[^/[:space:]]+(/.*)?$ ]]; then
+              echo "::error::PREVIEW_QWEN_BASE_URL 必须是包含主机名的 HTTP(S) 根地址"
+              exit 1
+            fi
+            if [[ "$QWEN_BASE_URL" == */chat/completions* ]]; then
+              echo "::error::PREVIEW_QWEN_BASE_URL 应填写 API 根地址，不能包含 /chat/completions"
+              exit 1
+            fi
+            HOST_MODEL_PROVIDER=qwen
+          fi
           if [ -n "$DOUBAO_TTS_API_KEY" ] && [ -n "$DOUBAO_TTS_VOICES" ] && [ -n "$DOUBAO_TTS_DEFAULT_VOICE_TYPE" ]; then
             HOST_SPEECH_PROVIDER=doubao
           else
@@ -143,6 +163,12 @@ jobs:
           DEEPSEEK_MODEL_B64=$(printf '%s' "$DEEPSEEK_MODEL" | base64 | tr -d '\n')
           if [ -n "$DEEPSEEK_API_KEY_B64" ]; then
             echo "::add-mask::$DEEPSEEK_API_KEY_B64"
+          fi
+          QWEN_API_KEY_B64=$(printf '%s' "$QWEN_API_KEY" | base64 | tr -d '\n')
+          QWEN_BASE_URL_B64=$(printf '%s' "$QWEN_BASE_URL" | base64 | tr -d '\n')
+          QWEN_MODEL_B64=$(printf '%s' "$QWEN_MODEL" | base64 | tr -d '\n')
+          if [ -n "$QWEN_API_KEY_B64" ]; then
+            echo "::add-mask::$QWEN_API_KEY_B64"
           fi
           SUFY_API_KEY_B64=$(printf '%s' "$SUFY_API_KEY" | base64 | tr -d '\n')
           SUFY_BASE_URL_B64=$(printf '%s' "$SUFY_BASE_URL" | base64 | tr -d '\n')
@@ -170,6 +196,9 @@ jobs:
             export DEEPSEEK_API_KEY="\$(printf '%s' '$DEEPSEEK_API_KEY_B64' | base64 -d)"
             export DEEPSEEK_BASE_URL="\$(printf '%s' '$DEEPSEEK_BASE_URL_B64' | base64 -d)"
             export DEEPSEEK_MODEL="\$(printf '%s' '$DEEPSEEK_MODEL_B64' | base64 -d)"
+            export QWEN_API_KEY="\$(printf '%s' '$QWEN_API_KEY_B64' | base64 -d)"
+            export QWEN_BASE_URL="\$(printf '%s' '$QWEN_BASE_URL_B64' | base64 -d)"
+            export QWEN_MODEL="\$(printf '%s' '$QWEN_MODEL_B64' | base64 -d)"
             export CHARACTER_PORTRAIT_ENABLED=true
             export PORTRAIT_PROMPT_PROVIDER="$PORTRAIT_PROMPT_PROVIDER"
             export PORTRAIT_IMAGE_PROVIDER="$PORTRAIT_IMAGE_PROVIDER"
@@ -187,6 +216,10 @@ jobs:
             CONFIGURED_BACKGROUND_PROVIDER=\$(docker compose config | awk '/CHARACTER_BACKGROUND_PROVIDER:/{print \$2; exit}')
             if [ "\$CONFIGURED_BACKGROUND_PROVIDER" != "$CHARACTER_BACKGROUND_PROVIDER" ]; then
               echo "固定 compose 模板未透传 CHARACTER_BACKGROUND_PROVIDER（期望 $CHARACTER_BACKGROUND_PROVIDER，实际 \${CONFIGURED_BACKGROUND_PROVIDER:-未配置})" >&2
+              exit 1
+            fi
+            if [ "$HOST_MODEL_PROVIDER" = "qwen" ] && ! docker compose config | grep -q 'QWEN_API_KEY:'; then
+              echo "固定 compose 模板未透传 QWEN_API_KEY，无法把主持模型切到千问" >&2
               exit 1
             fi
             docker compose -p main-preview pull

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -157,6 +157,9 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.PREVIEW_DEEPSEEK_API_KEY }}
           DEEPSEEK_BASE_URL: ${{ vars.PREVIEW_DEEPSEEK_BASE_URL }}
           DEEPSEEK_MODEL: ${{ vars.PREVIEW_DEEPSEEK_MODEL }}
+          QWEN_API_KEY: ${{ secrets.PREVIEW_QWEN_API_KEY }}
+          QWEN_BASE_URL: ${{ vars.PREVIEW_QWEN_BASE_URL }}
+          QWEN_MODEL: ${{ vars.PREVIEW_QWEN_MODEL }}
           # 当前凭证同时支持 DeepSeek v4 Pro 和 Sufy Gemini 生图；仍按用途
           # 使用两个 Secret 名称，后续可以独立轮换。不要把图片 key 放进前端。
           SUFY_API_KEY: ${{ secrets.PREVIEW_SUFY_API_KEY }}
@@ -210,6 +213,23 @@ jobs:
             PORTRAIT_PROMPT_PROVIDER=deterministic
             PORTRAIT_IMAGE_PROVIDER=mock
           fi
+          QWEN_BASE_URL="${QWEN_BASE_URL:-https://openai.sufy.com/v1}"
+          QWEN_MODEL="${QWEN_MODEL:-qwen/qwen3.7-plus}"
+          if [ -n "$QWEN_API_KEY" ]; then
+            if [ -z "$QWEN_BASE_URL" ] || [ -z "$QWEN_MODEL" ]; then
+              echo "::error::已配置 PREVIEW_QWEN_API_KEY，但缺少 PREVIEW_QWEN_BASE_URL 或 PREVIEW_QWEN_MODEL"
+              exit 1
+            fi
+            if [[ ! "$QWEN_BASE_URL" =~ ^https?://[^/[:space:]]+(/.*)?$ ]]; then
+              echo "::error::PREVIEW_QWEN_BASE_URL 必须是包含主机名的 HTTP(S) 根地址"
+              exit 1
+            fi
+            if [[ "$QWEN_BASE_URL" == */chat/completions* ]]; then
+              echo "::error::PREVIEW_QWEN_BASE_URL 应填写 API 根地址，不能包含 /chat/completions"
+              exit 1
+            fi
+            HOST_MODEL_PROVIDER=qwen
+          fi
           if [ -n "$DOUBAO_TTS_API_KEY" ] && [ -n "$DOUBAO_TTS_VOICES" ] && [ -n "$DOUBAO_TTS_DEFAULT_VOICE_TYPE" ]; then
             HOST_SPEECH_PROVIDER=doubao
           else
@@ -220,6 +240,12 @@ jobs:
           DEEPSEEK_MODEL_B64=$(printf '%s' "$DEEPSEEK_MODEL" | base64 | tr -d '\n')
           if [ -n "$DEEPSEEK_API_KEY_B64" ]; then
             echo "::add-mask::$DEEPSEEK_API_KEY_B64"
+          fi
+          QWEN_API_KEY_B64=$(printf '%s' "$QWEN_API_KEY" | base64 | tr -d '\n')
+          QWEN_BASE_URL_B64=$(printf '%s' "$QWEN_BASE_URL" | base64 | tr -d '\n')
+          QWEN_MODEL_B64=$(printf '%s' "$QWEN_MODEL" | base64 | tr -d '\n')
+          if [ -n "$QWEN_API_KEY_B64" ]; then
+            echo "::add-mask::$QWEN_API_KEY_B64"
           fi
           SUFY_API_KEY_B64=$(printf '%s' "$SUFY_API_KEY" | base64 | tr -d '\n')
           SUFY_BASE_URL_B64=$(printf '%s' "$SUFY_BASE_URL" | base64 | tr -d '\n')
@@ -272,6 +298,9 @@ jobs:
             export DEEPSEEK_API_KEY="\$(printf '%s' '$DEEPSEEK_API_KEY_B64' | base64 -d)"
             export DEEPSEEK_BASE_URL="\$(printf '%s' '$DEEPSEEK_BASE_URL_B64' | base64 -d)"
             export DEEPSEEK_MODEL="\$(printf '%s' '$DEEPSEEK_MODEL_B64' | base64 -d)"
+            export QWEN_API_KEY="\$(printf '%s' '$QWEN_API_KEY_B64' | base64 -d)"
+            export QWEN_BASE_URL="\$(printf '%s' '$QWEN_BASE_URL_B64' | base64 -d)"
+            export QWEN_MODEL="\$(printf '%s' '$QWEN_MODEL_B64' | base64 -d)"
             export CHARACTER_PORTRAIT_ENABLED=true
             export PORTRAIT_PROMPT_PROVIDER="$PORTRAIT_PROMPT_PROVIDER"
             export PORTRAIT_IMAGE_PROVIDER="$PORTRAIT_IMAGE_PROVIDER"
@@ -289,6 +318,10 @@ jobs:
             CONFIGURED_BACKGROUND_PROVIDER=\$(docker compose config | awk '/CHARACTER_BACKGROUND_PROVIDER:/{print \$2; exit}')
             if [ "\$CONFIGURED_BACKGROUND_PROVIDER" != "$CHARACTER_BACKGROUND_PROVIDER" ]; then
               echo "固定 compose 模板未透传 CHARACTER_BACKGROUND_PROVIDER（期望 $CHARACTER_BACKGROUND_PROVIDER，实际 \${CONFIGURED_BACKGROUND_PROVIDER:-未配置})" >&2
+              exit 1
+            fi
+            if [ "$HOST_MODEL_PROVIDER" = "qwen" ] && ! docker compose config | grep -q 'QWEN_API_KEY:'; then
+              echo "固定 compose 模板未透传 QWEN_API_KEY，无法把主持模型切到千问" >&2
               exit 1
             fi
             docker compose -p pr-$PR pull

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -51,6 +51,10 @@ services:
       # Variables 显式覆盖，通用后端配置不受这里的 Preview 默认值影响。
       DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.qnaigc.com/v1}
       DEEPSEEK_MODEL: ${DEEPSEEK_MODEL:-deepseek/deepseek-v4-pro-202606}
+      QWEN_API_KEY: ${QWEN_API_KEY:-}
+      QWEN_BASE_URL: ${QWEN_BASE_URL:-https://dashscope.aliyuncs.com/compatible-mode/v1}
+      QWEN_MODEL: ${QWEN_MODEL:-qwen3.7-plus}
+      QWEN_TIMEOUT_SECONDS: ${QWEN_TIMEOUT_SECONDS:-30}
       CHARACTER_BACKGROUND_PROVIDER: ${CHARACTER_BACKGROUND_PROVIDER:-deterministic}
       # 角色生图的提示词与图片生成是两段独立链路：DeepSeek 负责提示词，
       # Sufy Gemini 负责图片。CI 在两套 key 都存在时启用真实链路，否则


### PR DESCRIPTION
持久预览的主持/叙事模型改为千问。合进 main 之后，后续任意 PR merge 触发的 Main Preview 都会继续用千问。建卡生图仍走 DeepSeek + Sufy。

## 改了什么

| 模块 | 改动 |
| --- | --- |
| Main / PR Preview workflow | 配置了 `PREVIEW_QWEN_API_KEY` 时 `HOST_MODEL_PROVIDER=qwen`，并把 `QWEN_*` 传进部署 |
| compose | 透传 `QWEN_API_KEY` / `QWEN_BASE_URL` / `QWEN_MODEL` / `QWEN_TIMEOUT_SECONDS` |

## 关键决策

**为什么生图还用 DeepSeek：**
`CHARACTER_BACKGROUND_PROVIDER` / `PORTRAIT_PROMPT_PROVIDER` 目前只有 `deepseek`。主持模型和生图拆开，避免为了换 Narrator 把建卡文案链路一起改掉。

**为什么不在服务器上手改 `.env`：**
Main Preview 每次部署都会用 GitHub Secret 覆盖容器环境。模型选择必须写在 workflow 里，merge 后才稳定。

## 运维

- GitHub Secret：`PREVIEW_QWEN_API_KEY`
- GitHub Variable：`PREVIEW_QWEN_BASE_URL`、`PREVIEW_QWEN_MODEL`
- 服务器固定 compose 模板已加上 `QWEN_*` 透传（只这一次）

## 不在本 PR 范围

- 本地 `.env` 默认 provider
- 把建卡背景/头像提示词也改成千问
