### PR TITLE
feat(dialogue): 增加结构化 NPC 对话垂直链路

### DIFF
--- a/e2e/tests/discussion-chat.e2e.ts
+++ b/e2e/tests/discussion-chat.e2e.ts
@@ -9,7 +9,10 @@
  */
 import assert from 'node:assert/strict'
 import { randomUUID } from 'node:crypto'
+import { dirname, resolve } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
 import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 import { type ServerToClientEvent } from 'trpg-sdk'
 
@@ -20,6 +23,10 @@ const LEGAL_ATTRIBUTES = {
   APP: 50, SIZ: 50, INT: 50, EDU: 50, LUCK: 50,
 }
 const EXPLICIT_KEEPER = { kind: 'keeper', entityId: null, explicit: true } as const
+const DB_FILE = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../trpg-backend/e2e.db'
+)
 
 function waitForEvent(
   socketOwner: { roomSocket: { onMessage: (h: (e: ServerToClientEvent) => void) => () => void } },
@@ -131,6 +138,128 @@ test('🔴 重发相同 clientMessageId 不产生重复记录（重连去重）'
     assert.equal(history.length, 1)
   } finally {
     room.host.sdk.roomSocket.disconnect()
+  }
+})
+
+test('多人 roleplay 不调用主持，也不写入权威事件、记忆或摘要', async () => {
+  const room = await createRoomWithModule('roleplay', 2)
+  const guest = await registerPlayer('roleplayguest')
+  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '扮演访客' }, guest.token)
+  const roleplayId = `roleplay-${randomUUID()}`
+  const roleplayText = `伊莱亚斯敲了两下桌面-${randomUUID()}`
+
+  await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
+  await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken)
+  await buildCharacter(guest.sdk, room.roomId, joined.reconnectToken)
+
+  try {
+    await bindSocket(
+      room.host.sdk, room.roomId, room.host.token, room.hostPlayerId, room.reconnectToken
+    )
+    await bindSocket(guest.sdk, room.roomId, guest.token, joined.playerId, joined.reconnectToken)
+
+    const hostOpening = waitForEvent(room.host.sdk, (e) => e.type === 'narration.push')
+    const guestOpening = waitForEvent(guest.sdk, (e) => e.type === 'narration.push')
+    room.host.sdk.roomSocket.startGame(room.hostPlayerId)
+    await Promise.all([hostOpening, guestOpening])
+
+    const observedTypes: string[] = []
+    const off = guest.sdk.roomSocket.onMessage((event) => observedTypes.push(event.type))
+    const hostHearsRoleplay = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'chat.message' && event.payload.text === roleplayText,
+    )
+    guest.sdk.roomSocket.sendActionChat(joined.playerId, {
+      text: roleplayText,
+      clientMessageId: roleplayId,
+    })
+    const roleplay = await hostHearsRoleplay
+    assert.equal(roleplay.type, 'chat.message')
+    if (roleplay.type === 'chat.message') {
+      assert.equal(roleplay.payload.channel, 'roleplay')
+      assert.ok(roleplay.payload.actorId)
+      assert.equal(roleplay.payload.actorName, 'E2E 调查员')
+    }
+
+    // 用后一条讨论消息作为屏障：收到它时，前一条 roleplay 的服务端处理已完整结束。
+    const barrierText = `处理屏障-${randomUUID()}`
+    const barrier = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'chat.message' && event.payload.text === barrierText,
+    )
+    guest.sdk.roomSocket.sendChat(joined.playerId, {
+      text: barrierText,
+      clientMessageId: randomUUID(),
+    })
+    await barrier
+    off()
+    assert.equal(observedTypes.includes('turn.started'), false)
+    assert.equal(observedTypes.includes('narration.push'), false)
+
+    const conversation = await room.host.sdk.rooms.listConversation(
+      room.roomId,
+      room.reconnectToken,
+    )
+    assert.equal(
+      conversation.some(
+        (event) =>
+          event.type === 'chat.message' &&
+          event.payload.channel === 'roleplay' &&
+          event.payload.text === roleplayText,
+      ),
+      true,
+    )
+
+    const db = new DatabaseSync(DB_FILE, { readOnly: true })
+    try {
+      const marker = `%${roleplayText}%`
+      const traces = [
+        [
+          'events',
+          'SELECT COUNT(*) AS count FROM events WHERE room_id = ? AND (correlation_id = ? OR CAST(payload AS TEXT) LIKE ?)',
+          [room.roomId, roleplayId, marker],
+        ],
+        [
+          'game_events',
+          'SELECT COUNT(*) AS count FROM game_events WHERE room_id = ? AND (client_action_id = ? OR CAST(payload AS TEXT) LIKE ?)',
+          [room.roomId, roleplayId, marker],
+        ],
+        [
+          'action_executions',
+          'SELECT COUNT(*) AS count FROM action_executions WHERE room_id = ? AND request_id = ?',
+          [room.roomId, roleplayId],
+        ],
+        [
+          'action_plan_runs',
+          'SELECT COUNT(*) AS count FROM action_plan_runs WHERE room_id = ? AND parent_action_id = ?',
+          [room.roomId, roleplayId],
+        ],
+        [
+          'host_action_queue',
+          'SELECT COUNT(*) AS count FROM host_action_queue WHERE room_id = ? AND client_action_id = ?',
+          [room.roomId, roleplayId],
+        ],
+        [
+          'memory_entries',
+          'SELECT COUNT(*) AS count FROM memory_entries WHERE room_id = ? AND content LIKE ?',
+          [room.roomId, marker],
+        ],
+        [
+          'conversation_summaries',
+          'SELECT COUNT(*) AS count FROM conversation_summaries WHERE room_id = ? AND CAST(summary_json AS TEXT) LIKE ?',
+          [room.roomId, marker],
+        ],
+      ] as const
+      for (const [table, sql, parameters] of traces) {
+        const row = db.prepare(sql).get(...parameters) as { count: number }
+        assert.equal(row.count, 0, `${table} 不应留下 roleplay 痕迹`)
+      }
+    } finally {
+      db.close()
+    }
+  } finally {
+    room.host.sdk.roomSocket.disconnect()
+    guest.sdk.roomSocket.disconnect()
   }
 })
 

--- a/e2e/tests/discussion-chat.e2e.ts
+++ b/e2e/tests/discussion-chat.e2e.ts
@@ -9,10 +9,7 @@
  */
 import assert from 'node:assert/strict'
 import { randomUUID } from 'node:crypto'
-import { dirname, resolve } from 'node:path'
-import { DatabaseSync } from 'node:sqlite'
 import { test } from 'node:test'
-import { fileURLToPath } from 'node:url'
 
 import { type ServerToClientEvent } from 'trpg-sdk'
 
@@ -23,10 +20,6 @@ const LEGAL_ATTRIBUTES = {
   APP: 50, SIZ: 50, INT: 50, EDU: 50, LUCK: 50,
 }
 const EXPLICIT_KEEPER = { kind: 'keeper', entityId: null, explicit: true } as const
-const DB_FILE = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  '../../trpg-backend/e2e.db'
-)
 
 function waitForEvent(
   socketOwner: { roomSocket: { onMessage: (h: (e: ServerToClientEvent) => void) => () => void } },
@@ -138,128 +131,6 @@ test('🔴 重发相同 clientMessageId 不产生重复记录（重连去重）'
     assert.equal(history.length, 1)
   } finally {
     room.host.sdk.roomSocket.disconnect()
-  }
-})
-
-test('多人 roleplay 不调用主持，也不写入权威事件、记忆或摘要', async () => {
-  const room = await createRoomWithModule('roleplay', 2)
-  const guest = await registerPlayer('roleplayguest')
-  const joined = await guest.sdk.rooms.join(room.roomCode, { nickname: '扮演访客' }, guest.token)
-  const roleplayId = `roleplay-${randomUUID()}`
-  const roleplayText = `伊莱亚斯敲了两下桌面-${randomUUID()}`
-
-  await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
-  await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken)
-  await buildCharacter(guest.sdk, room.roomId, joined.reconnectToken)
-
-  try {
-    await bindSocket(
-      room.host.sdk, room.roomId, room.host.token, room.hostPlayerId, room.reconnectToken
-    )
-    await bindSocket(guest.sdk, room.roomId, guest.token, joined.playerId, joined.reconnectToken)
-
-    const hostOpening = waitForEvent(room.host.sdk, (e) => e.type === 'narration.push')
-    const guestOpening = waitForEvent(guest.sdk, (e) => e.type === 'narration.push')
-    room.host.sdk.roomSocket.startGame(room.hostPlayerId)
-    await Promise.all([hostOpening, guestOpening])
-
-    const observedTypes: string[] = []
-    const off = guest.sdk.roomSocket.onMessage((event) => observedTypes.push(event.type))
-    const hostHearsRoleplay = waitForEvent(
-      room.host.sdk,
-      (event) => event.type === 'chat.message' && event.payload.text === roleplayText,
-    )
-    guest.sdk.roomSocket.sendActionChat(joined.playerId, {
-      text: roleplayText,
-      clientMessageId: roleplayId,
-    })
-    const roleplay = await hostHearsRoleplay
-    assert.equal(roleplay.type, 'chat.message')
-    if (roleplay.type === 'chat.message') {
-      assert.equal(roleplay.payload.channel, 'roleplay')
-      assert.ok(roleplay.payload.actorId)
-      assert.equal(roleplay.payload.actorName, 'E2E 调查员')
-    }
-
-    // 用后一条讨论消息作为屏障：收到它时，前一条 roleplay 的服务端处理已完整结束。
-    const barrierText = `处理屏障-${randomUUID()}`
-    const barrier = waitForEvent(
-      room.host.sdk,
-      (event) => event.type === 'chat.message' && event.payload.text === barrierText,
-    )
-    guest.sdk.roomSocket.sendChat(joined.playerId, {
-      text: barrierText,
-      clientMessageId: randomUUID(),
-    })
-    await barrier
-    off()
-    assert.equal(observedTypes.includes('turn.started'), false)
-    assert.equal(observedTypes.includes('narration.push'), false)
-
-    const conversation = await room.host.sdk.rooms.listConversation(
-      room.roomId,
-      room.reconnectToken,
-    )
-    assert.equal(
-      conversation.some(
-        (event) =>
-          event.type === 'chat.message' &&
-          event.payload.channel === 'roleplay' &&
-          event.payload.text === roleplayText,
-      ),
-      true,
-    )
-
-    const db = new DatabaseSync(DB_FILE, { readOnly: true })
-    try {
-      const marker = `%${roleplayText}%`
-      const traces = [
-        [
-          'events',
-          'SELECT COUNT(*) AS count FROM events WHERE room_id = ? AND (correlation_id = ? OR CAST(payload AS TEXT) LIKE ?)',
-          [room.roomId, roleplayId, marker],
-        ],
-        [
-          'game_events',
-          'SELECT COUNT(*) AS count FROM game_events WHERE room_id = ? AND (client_action_id = ? OR CAST(payload AS TEXT) LIKE ?)',
-          [room.roomId, roleplayId, marker],
-        ],
-        [
-          'action_executions',
-          'SELECT COUNT(*) AS count FROM action_executions WHERE room_id = ? AND request_id = ?',
-          [room.roomId, roleplayId],
-        ],
-        [
-          'action_plan_runs',
-          'SELECT COUNT(*) AS count FROM action_plan_runs WHERE room_id = ? AND parent_action_id = ?',
-          [room.roomId, roleplayId],
-        ],
-        [
-          'host_action_queue',
-          'SELECT COUNT(*) AS count FROM host_action_queue WHERE room_id = ? AND client_action_id = ?',
-          [room.roomId, roleplayId],
-        ],
-        [
-          'memory_entries',
-          'SELECT COUNT(*) AS count FROM memory_entries WHERE room_id = ? AND content LIKE ?',
-          [room.roomId, marker],
-        ],
-        [
-          'conversation_summaries',
-          'SELECT COUNT(*) AS count FROM conversation_summaries WHERE room_id = ? AND CAST(summary_json AS TEXT) LIKE ?',
-          [room.roomId, marker],
-        ],
-      ] as const
-      for (const [table, sql, parameters] of traces) {
-        const row = db.prepare(sql).get(...parameters) as { count: number }
-        assert.equal(row.count, 0, `${table} 不应留下 roleplay 痕迹`)
-      }
-    } finally {
-      db.close()
-    }
-  } finally {
-    room.host.sdk.roomSocket.disconnect()
-    guest.sdk.roomSocket.disconnect()
   }
 })
 

--- a/e2e/tests/discussion-chat.e2e.ts
+++ b/e2e/tests/discussion-chat.e2e.ts
@@ -263,6 +263,93 @@ test('多人 roleplay 不调用主持，也不写入权威事件、记忆或摘�
   }
 })
 
+test('NPC 对话使用结构化接收者、独立气泡事件并可从历史恢复', async () => {
+  const room = await createRoomWithModule('npcdialogue')
+  const actionId = `npc-dialogue-${randomUUID()}`
+  const utterance = `我去地下室并使用侦查，请记住蓝色钟摆-${randomUUID()}`
+
+  await room.host.sdk.rooms.startStory(room.roomId, room.reconnectToken)
+  await buildCharacter(room.host.sdk, room.roomId, room.reconnectToken)
+
+  try {
+    await bindSocket(
+      room.host.sdk,
+      room.roomId,
+      room.host.token,
+      room.hostPlayerId,
+      room.reconnectToken,
+    )
+    const opening = waitForEvent(room.host.sdk, (event) => event.type === 'narration.push')
+    room.host.sdk.roomSocket.startGame(room.hostPlayerId)
+    await opening
+    const view = room.host.sdk.roomSocket.getPlayerView()
+    const npc = view?.scene.visible_entities.find((entity) => entity.kind === 'npc')
+    assert.ok(npc, '开场 PlayerView 应提供可选择的 NPC')
+
+    const playerDialogue = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'dialogue.player' && event.payload.clientActionId === actionId,
+    )
+    const npcDialogue = waitForEvent(
+      room.host.sdk,
+      (event) => event.type === 'dialogue.npc' && event.payload.sourceActionId === actionId,
+    )
+    assert.equal(
+      room.host.sdk.roomSocket.submitNpcDialogue(room.hostPlayerId, {
+        clientActionId: actionId,
+        utterance,
+        recipient: { kind: 'npc', entityId: npc.id, explicit: true },
+      }),
+      true,
+    )
+    const [playerEvent, npcEvent] = await Promise.all([playerDialogue, npcDialogue])
+    assert.equal(playerEvent.type, 'dialogue.player')
+    assert.equal(npcEvent.type, 'dialogue.npc')
+    if (playerEvent.type === 'dialogue.player' && npcEvent.type === 'dialogue.npc') {
+      assert.equal(playerEvent.payload.interlocutorId, npc.id)
+      assert.equal(playerEvent.payload.utterance, utterance)
+      assert.equal(npcEvent.payload.speakerId, npc.id)
+    }
+
+    const conversation = await room.host.sdk.rooms.listConversation(
+      room.roomId,
+      room.reconnectToken,
+    )
+    assert.equal(
+      conversation.some(
+        (event) => event.type === 'dialogue.player' && event.payload.utterance === utterance,
+      ),
+      true,
+    )
+    assert.equal(
+      conversation.some(
+        (event) => event.type === 'dialogue.npc' && event.payload.sourceActionId === actionId,
+      ),
+      true,
+    )
+
+    const db = new DatabaseSync(DB_FILE, { readOnly: true })
+    try {
+      const actionPlan = db.prepare(
+        'SELECT COUNT(*) AS count FROM action_plan_runs WHERE room_id = ? AND parent_action_id = ?',
+      ).get(room.roomId, actionId) as { count: number }
+      const gameEvents = db.prepare(
+        'SELECT COUNT(*) AS count FROM game_events WHERE room_id = ? AND client_action_id = ?',
+      ).get(room.roomId, actionId) as { count: number }
+      const memories = db.prepare(
+        'SELECT COUNT(*) AS count FROM memory_entries WHERE room_id = ? AND content LIKE ?',
+      ).get(room.roomId, `%${utterance}%`) as { count: number }
+      assert.equal(actionPlan.count, 0)
+      assert.equal(gameEvents.count, 0)
+      assert.equal(memories.count, 0)
+    } finally {
+      db.close()
+    }
+  } finally {
+    room.host.sdk.roomSocket.disconnect()
+  }
+})
+
 test('🔴 所有人都能看到发起者的原话 + 守秘人回复（修"聊天像被隔离"bug）', async () => {
   const room = await createRoomWithModule('actbc', 2)
   const guest = await registerPlayer('actbcguest')

--- a/trpg-backend/alembic/versions/d1e2f3a4b5c6_add_npc_dialogue_vertical.py
+++ b/trpg-backend/alembic/versions/d1e2f3a4b5c6_add_npc_dialogue_vertical.py
@@ -1,0 +1,121 @@
+"""为结构化 NPC 对话增加冻结受众、任务恢复字段和 NPC 素材映射。"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d1e2f3a4b5c6"
+down_revision: str | Sequence[str] | None = "c0d1e2f3a4b5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """保守升级既有数据，新增字段均先提供可回填默认值。"""
+
+    with op.batch_alter_table("events") as batch_op:
+        batch_op.drop_constraint("ck_events_visibility", type_="check")
+        batch_op.create_check_constraint(
+            "ck_events_visibility",
+            "visibility IN ('public', 'player_scoped', 'scene_scoped')",
+        )
+
+    op.create_table(
+        "event_audiences",
+        sa.Column("event_id", sa.Uuid(), nullable=False),
+        sa.Column("player_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["player_id"], ["players.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("event_id", "player_id", name="pk_event_audiences"),
+    )
+    op.create_index(
+        "ix_event_audiences_player_event",
+        "event_audiences",
+        ["player_id", "event_id"],
+    )
+
+    with op.batch_alter_table("host_action_queue") as batch_op:
+        batch_op.drop_constraint("ck_host_action_queue_status", type_="check")
+        batch_op.add_column(
+            sa.Column("attempt_count", sa.Integer(), server_default="0", nullable=False)
+        )
+        batch_op.add_column(sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column("lease_owner", sa.String(length=200), nullable=True))
+        batch_op.add_column(
+            sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("result_event_ids", sa.JSON(), server_default="[]", nullable=False)
+        )
+    # 旧 started 只表示已从 FIFO 交给 Keeper，无法恢复，按既有语义视为完成。
+    op.execute("UPDATE host_action_queue SET status = 'completed' WHERE status = 'started'")
+    with op.batch_alter_table("host_action_queue") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_host_action_queue_status",
+            "status IN ('queued', 'processing', 'retryable_failure', 'completed', "
+            "'failed', 'cancelled', 'discarded')",
+        )
+        batch_op.create_check_constraint(
+            "ck_host_action_queue_attempt_count",
+            "attempt_count >= 0",
+        )
+        batch_op.create_check_constraint(
+            "ck_host_action_queue_processing_lease",
+            "(status = 'processing' AND lease_owner IS NOT NULL "
+            "AND lease_expires_at IS NOT NULL) OR "
+            "(status != 'processing' AND lease_owner IS NULL "
+            "AND lease_expires_at IS NULL)",
+        )
+
+    with op.batch_alter_table("module_assets") as batch_op:
+        batch_op.add_column(sa.Column("entity_id", sa.String(length=200), nullable=True))
+        batch_op.create_check_constraint(
+            "ck_module_assets_entity_id_nonempty",
+            "entity_id IS NULL OR length(trim(entity_id)) > 0",
+        )
+        batch_op.create_unique_constraint(
+            "uq_module_assets_entity_type",
+            ["scenario_id", "entity_id", "asset_type"],
+        )
+
+
+def downgrade() -> None:
+    """移除 NPC 对话基础设施；降级不会删除原始 Event。"""
+
+    with op.batch_alter_table("module_assets") as batch_op:
+        batch_op.drop_constraint("uq_module_assets_entity_type", type_="unique")
+        batch_op.drop_constraint("ck_module_assets_entity_id_nonempty", type_="check")
+        batch_op.drop_column("entity_id")
+
+    # 新终态降回旧模型前统一收敛，避免旧状态约束创建失败。
+    op.execute(
+        "UPDATE host_action_queue SET status = 'started', lease_owner = NULL, "
+        "lease_expires_at = NULL, next_attempt_at = NULL "
+        "WHERE status IN ('processing', 'retryable_failure', 'completed', 'failed')"
+    )
+    with op.batch_alter_table("host_action_queue") as batch_op:
+        batch_op.drop_constraint("ck_host_action_queue_processing_lease", type_="check")
+        batch_op.drop_constraint("ck_host_action_queue_attempt_count", type_="check")
+        batch_op.drop_constraint("ck_host_action_queue_status", type_="check")
+        batch_op.drop_column("result_event_ids")
+        batch_op.drop_column("lease_expires_at")
+        batch_op.drop_column("lease_owner")
+        batch_op.drop_column("next_attempt_at")
+        batch_op.drop_column("attempt_count")
+        batch_op.create_check_constraint(
+            "ck_host_action_queue_status",
+            "status IN ('queued', 'started', 'cancelled', 'discarded')",
+        )
+
+    op.drop_index("ix_event_audiences_player_event", table_name="event_audiences")
+    op.drop_table("event_audiences")
+    # 旧版本不认识 scene_scoped；保守退回发起玩家私有，不能改成 public 泄露历史对话。
+    op.execute("UPDATE events SET visibility = 'player_scoped' WHERE visibility = 'scene_scoped'")
+    with op.batch_alter_table("events") as batch_op:
+        batch_op.drop_constraint("ck_events_visibility", type_="check")
+        batch_op.create_check_constraint(
+            "ck_events_visibility",
+            "visibility IN ('public', 'player_scoped')",
+        )

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -35,8 +35,10 @@ WebSocket 可能存活很久，用一个 session 包住整条连接会在这期�
 """
 
 import asyncio
+import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from functools import partial
 from typing import Literal, cast
 
@@ -109,6 +111,8 @@ from app.dto.ws import (
     ChatSendPayload,
     CheckResultPayload,
     ClientEnvelope,
+    DialogueNpcPayload,
+    DialoguePlayerPayload,
     ErrorPayload,
     GameStartPayload,
     NarrationChunkPayload,
@@ -142,6 +146,8 @@ from app.models.engine import (
     SceneTransitionProposalRecord,
     TimeAdvanceProposalRecord,
 )
+from app.models.event import Event
+from app.models.room import Player
 from app.service import auth as auth_service
 from app.service import chat as chat_service
 from app.service import host_action_queue as host_action_queue_service
@@ -150,6 +156,7 @@ from app.service import scene_transition as scene_transition_service
 from app.service import time_advance as time_advance_service
 from app.service.action_lock import action_lock_manager
 from app.service.host_action_queue import HostActionQueueError
+from app.service.npc_dialogue import npc_dialogue_service, require_dialogue_npc
 from app.service.ws_events import broadcast_room_state
 from app.service.ws_manager import manager
 
@@ -408,7 +415,9 @@ async def _enqueue_host_action(
             correlation_id=client_action_id,
         )
         return
-    if created:
+    # NPC 原话必须等出队后二次验证和受众冻结完成再落 dialogue.player；
+    # 不能先写 action.broadcast，否则会误入 Keeper Memory 和摘要。
+    if created and recipient.kind == "keeper":
         await _broadcast_action_utterance(
             db,
             PlayerInput(
@@ -420,7 +429,224 @@ async def _enqueue_host_action(
             ),
             player_view,
         )
+    elif not created and recipient.kind == "npc" and item.status == "completed":
+        correlations = (
+            f"{client_action_id}:player",
+            *(f"{client_action_id}:npc:{ordinal}" for ordinal in range(3)),
+        )
+        events = tuple(
+            await db.scalars(
+                select(Event)
+                .where(
+                    Event.room_id == room_id,
+                    Event.correlation_id.in_(correlations),
+                )
+                .order_by(Event.created_at, Event.id)
+            )
+        )
+        for event in events:
+            audience = tuple(str(value) for value in event.payload.get("audiencePlayerIds", ()))
+            await _broadcast_dialogue_event(db, event, audience)
     await _broadcast_room_action_state(db, room_id)
+
+
+async def _npc_dialogue_audience(
+    db: AsyncSession,
+    *,
+    room_id: str,
+    scene_id: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """投影所有房间成员并冻结同场景玩家和 Actor；任一失败均整体重试。"""
+
+    player_ids = tuple(await db.scalars(select(Player.id).where(Player.room_id == room_id)))
+    audience_players: list[str] = []
+    audience_actors: list[str] = []
+    for player_id in player_ids:
+        view = await session_view_application.current_player_view(
+            room_id=room_id,
+            player_id=player_id,
+        )
+        if view.scene.id == scene_id:
+            audience_players.append(player_id)
+            audience_actors.append(view.self_actor.id)
+    return tuple(audience_players), tuple(audience_actors)
+
+
+async def _broadcast_dialogue_event(
+    db: AsyncSession,
+    event: Event,
+    audience_player_ids: tuple[str, ...],
+) -> None:
+    """提交成功后按冻结受众单播；离线玩家稍后通过 Event 回放恢复。"""
+
+    raw_payload = dict(event.payload)
+    if event.event_type == "dialogue.player":
+        payload = DialoguePlayerPayload.model_validate(raw_payload)
+    else:
+        avatar_url = await npc_dialogue_service.portrait_url(
+            db,
+            room_id=event.room_id,
+            entity_id=str(raw_payload.get("speakerId", "")),
+        )
+        payload = DialogueNpcPayload.model_validate({**raw_payload, "avatarUrl": avatar_url})
+    envelope = ServerEnvelope(
+        type=event.event_type,
+        payload=payload.model_dump(by_alias=True, mode="json"),
+    ).model_dump(by_alias=True)
+    for target_player_id in audience_player_ids:
+        await manager.send_to_player(event.room_id, target_player_id, envelope)
+
+
+async def _persist_npc_unavailable(
+    db: AsyncSession,
+    item,
+    text: str,
+) -> None:
+    """NPC 出队时已失效，只向发起玩家保存并发送安全澄清。"""
+
+    correlation = f"{item.client_action_id}:npc-unavailable"
+    event = await room_service.get_correlated_event(
+        db,
+        item.room_id,
+        "narration.push",
+        correlation,
+    )
+    if event is None:
+        event = Event(
+            id=str(uuid.uuid4()),
+            room_id=item.room_id,
+            player_id=item.player_id,
+            event_type="narration.push",
+            correlation_id=correlation,
+            visibility="player_scoped",
+            actor_id=item.actor_id,
+            payload=NarrationPushPayload(
+                message_id=correlation,
+                text=text,
+            ).model_dump(by_alias=True),
+            created_at=datetime.now(UTC),
+        )
+        db.add(event)
+        await db.commit()
+    envelope = ServerEnvelope(
+        type="narration.push",
+        payload=event.payload,
+    ).model_dump(by_alias=True)
+    await manager.send_to_player(item.room_id, item.player_id, envelope)
+
+
+async def _run_npc_dialogue(
+    db: AsyncSession,
+    item,
+    view: PlayerView,
+) -> None:
+    """执行一项 NPC 对话；玩家发言先落库，回复与队列终态同事务提交。"""
+
+    claimed = await host_action_queue_service.claim_npc(
+        db,
+        item,
+        lease_seconds=npc_dialogue_service.lease_seconds,
+    )
+    if claimed is None:
+        return
+    item = claimed
+    try:
+        require_dialogue_npc(view, item.recipient_entity_id or "")
+        try:
+            audience_player_ids, audience_actor_ids = await _npc_dialogue_audience(
+                db,
+                room_id=item.room_id,
+                scene_id=view.scene.id,
+            )
+        except Exception:
+            # 受众必须完整冻结，任何成员投影失败都不能提交半套 audience。
+            await host_action_queue_service.mark_npc_retryable(db, item)
+            asyncio.get_running_loop().call_later(
+                5,
+                schedule_host_action_drain,
+                item.room_id,
+            )
+            return
+        if item.player_id not in audience_player_ids:
+            raise RuntimeError("NPC 对话发起者不在冻结场景受众中")
+        player = await db.get(Player, item.player_id)
+        if player is None:
+            raise ValueError("玩家已不在房间中")
+        await db.refresh(item)
+        if item.status == "cancelled":
+            # 发言尚未落库时取消，整段对话都不应发生。
+            return
+        player_event = await npc_dialogue_service.persist_player_event(
+            db,
+            item=item,
+            view=view,
+            audience_player_ids=audience_player_ids,
+            nickname=player.nickname,
+        )
+        await _broadcast_dialogue_event(db, player_event, audience_player_ids)
+        existing_replies = tuple(
+            await db.scalars(
+                select(Event)
+                .where(
+                    Event.room_id == item.room_id,
+                    Event.event_type == "dialogue.npc",
+                    Event.correlation_id.in_(
+                        tuple(f"{item.client_action_id}:npc:{ordinal}" for ordinal in range(3))
+                    ),
+                )
+                .order_by(Event.correlation_id)
+            )
+        )
+        if existing_replies:
+            # 回复事务已提交但进程在广播前退出时，按固定 correlation 恢复，
+            # 绝不能再次调用模型生成另一组内容。
+            item.status = "completed"
+            item.result_event_ids = [event.id for event in existing_replies]
+            item.lease_owner = None
+            item.lease_expires_at = None
+            item.updated_at = datetime.now(UTC)
+            await db.commit()
+            for reply in existing_replies:
+                await _broadcast_dialogue_event(db, reply, audience_player_ids)
+            return
+        await db.refresh(item)
+        if item.status == "cancelled":
+            # 玩家原话已经发生并保留；模型尚未开始时取消只阻止 NPC 回复。
+            return
+        output = await npc_dialogue_service.generate(
+            db,
+            view=view,
+            player_id=item.player_id,
+            utterance=item.utterance,
+            interlocutor_id=item.recipient_entity_id or "",
+        )
+        reply_events = await npc_dialogue_service.persist_replies(
+            db,
+            item=item,
+            view=view,
+            player_event=player_event,
+            audience_player_ids=audience_player_ids,
+            output=output,
+            audience_actor_ids=audience_actor_ids,
+        )
+        for reply in reply_events:
+            await _broadcast_dialogue_event(db, reply, audience_player_ids)
+    except ValueError as exc:
+        await host_action_queue_service.mark_npc_failed(db, item)
+        for target_socket in manager.player_connections(item.room_id, item.player_id):
+            await _send_turn_failed(target_socket, item.client_action_id, exc)
+    except Exception as exc:
+        if item.attempt_count < 2 and is_transient_model_error(exc):
+            await host_action_queue_service.mark_npc_retryable(db, item)
+            asyncio.get_running_loop().call_later(
+                5,
+                schedule_host_action_drain,
+                item.room_id,
+            )
+            return
+        await host_action_queue_service.mark_npc_failed(db, item)
+        for target_socket in manager.player_connections(item.room_id, item.player_id):
+            await _send_turn_failed(target_socket, item.client_action_id, exc)
 
 
 async def _drain_host_action_queue(room_id: str) -> None:
@@ -433,16 +659,6 @@ async def _drain_host_action_queue(room_id: str) -> None:
                 item = await host_action_queue_service.peek_next(db, room_id)
                 if item is None:
                     return
-                # PR1 尚未实现 NPC 对话；即使数据库被手工写入也不能误走 Keeper 主链。
-                if item.recipient_kind != "keeper":
-                    logger.error(
-                        "unsupported_host_queue_recipient",
-                        room_id=room_id,
-                        client_action_id=item.client_action_id,
-                        recipient_kind=item.recipient_kind,
-                    )
-                    await host_action_queue_service.discard(db, item)
-                    continue
                 try:
                     view = await session_view_application.current_player_view(
                         room_id=room_id,
@@ -465,6 +681,17 @@ async def _drain_host_action_queue(room_id: str) -> None:
                 if view.self_actor.id != item.actor_id:
                     await host_action_queue_service.discard(db, item)
                     continue
+                if item.recipient_kind == "npc":
+                    try:
+                        require_dialogue_npc(view, item.recipient_entity_id or "")
+                    except ValueError:
+                        await _persist_npc_unavailable(
+                            db,
+                            item,
+                            "你想交谈的 NPC 已不在当前场景，或现在无法回应。",
+                        )
+                        await host_action_queue_service.discard(db, item)
+                        continue
                 lock_token = action_lock_manager.try_acquire(
                     room_id,
                     player_id=item.player_id,
@@ -482,6 +709,9 @@ async def _drain_host_action_queue(room_id: str) -> None:
                         TurnStarted(correlation_id=item.client_action_id),
                     )
                     await _broadcast_room_action_state(db, room_id)
+                    if item.recipient_kind == "npc":
+                        await _run_npc_dialogue(db, item, view)
+                        continue
                     result = await action_plan_turn_application.start(
                         room_id=room_id,
                         player_id=item.player_id,
@@ -2218,16 +2448,6 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 )
                     elif event_type == "action.plan.submit":
                         submit_payload = ActionSubmitPayload.model_validate(raw_payload)
-                        # 接收者决定后续执行边界，必须在恢复旧 Turn、读取 PlayerView、
-                        # 写事件或入队之前完成拒绝，绝不能把 NPC 请求回退到 Keeper。
-                        if submit_payload.recipient.kind == "npc":
-                            await _send_error(
-                                websocket,
-                                "NOT_IMPLEMENTED",
-                                "NPC 对话将在下一阶段开放",
-                                correlation_id=submit_payload.client_action_id,
-                            )
-                            continue
                         room = await room_service.find_room_by_id(db, room_id)
                         if room.max_players > 1 and not submit_payload.recipient.explicit:
                             await _send_error(
@@ -2245,12 +2465,15 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 correlation_id=submit_payload.client_action_id,
                             )
                             continue
-                        if await _recover_persisted_turn_narration(
-                            db,
-                            websocket,
-                            room_id=room_id,
-                            player_id=bound_player_id,
-                            client_action_id=submit_payload.client_action_id,
+                        if (
+                            submit_payload.recipient.kind == "keeper"
+                            and await _recover_persisted_turn_narration(
+                                db,
+                                websocket,
+                                room_id=room_id,
+                                player_id=bound_player_id,
+                                client_action_id=submit_payload.client_action_id,
+                            )
                         ):
                             continue
                         try:
@@ -2266,6 +2489,34 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 submit_payload.client_action_id,
                                 exc,
                             )
+                            continue
+                        if submit_payload.recipient.kind == "npc":
+                            try:
+                                require_dialogue_npc(
+                                    action_view,
+                                    submit_payload.recipient.entity_id or "",
+                                )
+                            except ValueError as exc:
+                                await _send_error(
+                                    websocket,
+                                    "VALIDATION_ERROR",
+                                    str(exc),
+                                    correlation_id=submit_payload.client_action_id,
+                                )
+                                continue
+                            # NPC 对话始终进入房间 FIFO；它不会恢复或占用 Keeper Turn。
+                            await _enqueue_host_action(
+                                db,
+                                websocket,
+                                room_id=room_id,
+                                player_id=bound_player_id,
+                                actor_id=action_view.self_actor.id,
+                                client_action_id=submit_payload.client_action_id,
+                                utterance=submit_payload.utterance,
+                                player_view=action_view,
+                                recipient=submit_payload.recipient,
+                            )
+                            schedule_host_action_drain(room_id)
                             continue
                         occupancy = await _current_room_action_state(db, room_id)
                         decision = await _queue_decision_for_submit(

--- a/trpg-backend/app/dto/replay.py
+++ b/trpg-backend/app/dto/replay.py
@@ -39,7 +39,14 @@ class RoomConversationEventRead(CamelModel):
     """
 
     id: str
-    type: Literal["chat.message", "action.broadcast", "narration.push", "check.result"]
+    type: Literal[
+        "chat.message",
+        "action.broadcast",
+        "narration.push",
+        "check.result",
+        "dialogue.player",
+        "dialogue.npc",
+    ]
     channel: Literal["discussion", "action"]
     payload: dict
     created_at: UtcDatetime

--- a/trpg-backend/app/dto/ws.py
+++ b/trpg-backend/app/dto/ws.py
@@ -351,6 +351,46 @@ class ActionBroadcastPayload(CamelModel):
     participant_ids: tuple[str, ...] = ()
 
 
+class DialoguePlayerPayload(CamelModel):
+    """玩家对场景 NPC 的结构化发言；受众在对话开始时冻结。"""
+
+    message_id: str = Field(..., min_length=1)
+    player_id: str = Field(..., min_length=1)
+    client_action_id: str = Field(..., min_length=1, max_length=200)
+    nickname: str = Field(..., min_length=1)
+    character_name: str = Field(..., min_length=1)
+    speaker_id: str = Field(..., min_length=1)
+    interlocutor_id: str = Field(..., min_length=1)
+    interlocutor_name: str = Field(..., min_length=1)
+    listener_ids: tuple[str, ...] = ()
+    participant_ids: tuple[str, ...] = ()
+    allowed_responder_ids: tuple[str, ...] = ()
+    utterance: str = Field(..., min_length=1, max_length=2000)
+    scene_id: str = Field(..., min_length=1)
+    source_revision: str = Field(..., min_length=1)
+    sent_at: UtcDatetime
+    audience_player_ids: tuple[str, ...] = ()
+
+
+class DialogueNpcPayload(CamelModel):
+    """Host 以 NPC 身份生成的单条回复；头像 URL 仅为展示派生字段。"""
+
+    message_id: str = Field(..., min_length=1)
+    speaker_id: str = Field(..., min_length=1)
+    speaker_name: str = Field(..., min_length=1)
+    avatar_url: str | None = None
+    listener_ids: tuple[str, ...] = ()
+    participant_ids: tuple[str, ...] = ()
+    text: str = Field(..., min_length=1, max_length=1000)
+    scene_id: str = Field(..., min_length=1)
+    source_dialogue_id: str = Field(..., min_length=1)
+    source_action_id: str = Field(..., min_length=1, max_length=200)
+    ordinal: int = Field(..., ge=0, le=2)
+    source_revision: str = Field(..., min_length=1)
+    sent_at: UtcDatetime
+    audience_player_ids: tuple[str, ...] = ()
+
+
 class TurnStartedPayload(CamelModel):
     correlation_id: str
 

--- a/trpg-backend/app/main.py
+++ b/trpg-backend/app/main.py
@@ -6,6 +6,7 @@
 重复写 try/except。
 """
 
+import asyncio
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -72,6 +73,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     portrait_service: PortraitGenerationService = app.state.portrait_generation_service
     await portrait_service.recover_interrupted()
     await app.state.conversation_summary_service.start()
+    # NPC 对话队列是持久化任务；进程重启后恢复到期 lease 和待处理房间。
+    from app.controller.ws import schedule_host_action_drain
+    from app.service.host_action_queue import recovery_schedule
+
+    async with async_session_factory() as db:
+        for room_id, delay_seconds in await recovery_schedule(db):
+            # 按持久化时间精确恢复，不建立通用任务调度平台，也不让后续任务越过队首。
+            asyncio.get_running_loop().call_later(
+                delay_seconds,
+                schedule_host_action_drain,
+                room_id,
+            )
     logger.info("app_started")
     try:
         yield

--- a/trpg-backend/app/models/__init__.py
+++ b/trpg-backend/app/models/__init__.py
@@ -35,7 +35,7 @@ from app.models.engine import (
     TimeAdvanceProposalRecord,
     TurnRunCutoverRecord,
 )
-from app.models.event import CheckResult, Event
+from app.models.event import CheckResult, Event, EventAudience
 from app.models.memory import (
     ConversationSummaryRecord,
     MemoryEntryRecord,
@@ -58,6 +58,7 @@ __all__ = [
     "CharacterPortrait",
     "Entity",
     "Event",
+    "EventAudience",
     "Game",
     "GameEvent",
     "GameSession",

--- a/trpg-backend/app/models/content.py
+++ b/trpg-backend/app/models/content.py
@@ -9,7 +9,17 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import JSON, CheckConstraint, DateTime, ForeignKey, Integer, String, Text, Uuid
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db import Base
@@ -250,6 +260,18 @@ class ModuleAsset(Base):
     """模组素材（地图/立绘等静态资源的引用）。"""
 
     __tablename__ = "module_assets"
+    __table_args__ = (
+        UniqueConstraint(
+            "scenario_id",
+            "entity_id",
+            "asset_type",
+            name="uq_module_assets_entity_type",
+        ),
+        CheckConstraint(
+            "entity_id IS NULL OR length(trim(entity_id)) > 0",
+            name="ck_module_assets_entity_id_nonempty",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(
         Uuid(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
@@ -258,6 +280,8 @@ class ModuleAsset(Base):
         Uuid(as_uuid=False), ForeignKey("scenarios.id"), nullable=False
     )
     asset_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Entity 存在于 ModuleContent JSON，无法建立关系型外键；稳定 ID 仍比名称匹配可靠。
+    entity_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
     name: Mapped[str | None] = mapped_column(String(200), nullable=True)
     url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/trpg-backend/app/models/engine.py
+++ b/trpg-backend/app/models/engine.py
@@ -532,12 +532,21 @@ class HostActionQueueItem(Base):
         ),
         CheckConstraint("position >= 1", name="ck_host_action_queue_position"),
         CheckConstraint(
-            "status IN ('queued', 'started', 'cancelled', 'discarded')",
+            "status IN ('queued', 'processing', 'retryable_failure', 'completed', "
+            "'failed', 'cancelled', 'discarded')",
             name="ck_host_action_queue_status",
         ),
         CheckConstraint(
             "recipient_kind IN ('keeper', 'npc')",
             name="ck_host_action_queue_recipient_kind",
+        ),
+        CheckConstraint("attempt_count >= 0", name="ck_host_action_queue_attempt_count"),
+        CheckConstraint(
+            "(status = 'processing' AND lease_owner IS NOT NULL "
+            "AND lease_expires_at IS NOT NULL) OR "
+            "(status != 'processing' AND lease_owner IS NULL "
+            "AND lease_expires_at IS NULL)",
+            name="ck_host_action_queue_processing_lease",
         ),
         CheckConstraint(
             "(recipient_kind = 'keeper' AND recipient_entity_id IS NULL) OR "
@@ -579,6 +588,17 @@ class HostActionQueueItem(Base):
     )
     position: Mapped[int] = mapped_column(Integer, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
+    attempt_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    lease_owner: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    lease_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    result_event_ids: Mapped[list[str]] = mapped_column(
+        JSON, nullable=False, default=list, server_default="[]"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
     )

--- a/trpg-backend/app/models/event.py
+++ b/trpg-backend/app/models/event.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    PrimaryKeyConstraint,
     String,
     UniqueConstraint,
     Uuid,
@@ -38,7 +39,7 @@ class Event(Base):
             name="uq_events_room_type_correlation",
         ),
         CheckConstraint(
-            "visibility IN ('public', 'player_scoped')",
+            "visibility IN ('public', 'player_scoped', 'scene_scoped')",
             name="ck_events_visibility",
         ),
         CheckConstraint(
@@ -77,6 +78,23 @@ class Event(Base):
     payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+
+
+class EventAudience(Base):
+    """冻结场景事件发生时有权接收和回放该事件的玩家。"""
+
+    __tablename__ = "event_audiences"
+    __table_args__ = (
+        PrimaryKeyConstraint("event_id", "player_id", name="pk_event_audiences"),
+        Index("ix_event_audiences_player_event", "player_id", "event_id"),
+    )
+
+    event_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("events.id", ondelete="CASCADE"), nullable=False
+    )
+    player_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("players.id", ondelete="CASCADE"), nullable=False
     )
 
 

--- a/trpg-backend/app/service/host_action_queue.py
+++ b/trpg-backend/app/service/host_action_queue.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Literal, cast
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -66,7 +66,22 @@ async def get_queued_by_client_action(
         select(HostActionQueueItem).where(
             HostActionQueueItem.room_id == room_id,
             HostActionQueueItem.client_action_id == client_action_id,
-            HostActionQueueItem.status == _QUEUED,
+            HostActionQueueItem.status.in_(("queued", "processing", "retryable_failure")),
+        )
+    )
+
+
+async def get_by_client_action(
+    db: AsyncSession,
+    room_id: str,
+    client_action_id: str,
+) -> HostActionQueueItem | None:
+    """读取任意状态的幂等队列项，终态重复提交也不能触发新任务。"""
+
+    return await db.scalar(
+        select(HostActionQueueItem).where(
+            HostActionQueueItem.room_id == room_id,
+            HostActionQueueItem.client_action_id == client_action_id,
         )
     )
 
@@ -89,7 +104,7 @@ async def enqueue(
     utterance can be published.
     """
 
-    existing_id = await get_queued_by_client_action(db, room_id, client_action_id)
+    existing_id = await get_by_client_action(db, room_id, client_action_id)
     if existing_id is not None:
         return existing_id, False
 
@@ -153,7 +168,7 @@ async def enqueue(
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
-        raced = await get_queued_by_client_action(db, room_id, client_action_id)
+        raced = await get_by_client_action(db, room_id, client_action_id)
         if raced is not None:
             return raced, False
         raise HostActionQueueError(
@@ -175,31 +190,132 @@ async def cancel(
     if item is None or item.player_id != player_id:
         return False
     item.status = "cancelled"
+    item.lease_owner = None
+    item.lease_expires_at = None
+    item.next_attempt_at = None
     item.updated_at = datetime.now(UTC)
     await db.commit()
     return True
 
 
 async def peek_next(db: AsyncSession, room_id: str) -> HostActionQueueItem | None:
-    return await db.scalar(
+    """只检查 FIFO 队首；队首尚在 lease/退避期时禁止后续任务插队。"""
+
+    now = datetime.now(UTC)
+    item = await db.scalar(
         select(HostActionQueueItem)
         .where(
             HostActionQueueItem.room_id == room_id,
-            HostActionQueueItem.status == _QUEUED,
+            HostActionQueueItem.status.in_(("queued", "processing", "retryable_failure")),
         )
         .order_by(HostActionQueueItem.position.asc())
         .limit(1)
     )
+    if item is None:
+        return None
+    if item.status == "retryable_failure" and _utc(item.next_attempt_at) > now:
+        return None
+    if item.status == "processing" and _utc(item.lease_expires_at) > now:
+        return None
+    return item
 
 
 async def mark_started(db: AsyncSession, item: HostActionQueueItem) -> None:
-    item.status = "started"
+    """Keeper 已接管队列项；旧 started 语义在新状态机中对应 completed。"""
+
+    item.status = "completed"
+    item.updated_at = datetime.now(UTC)
+    await db.commit()
+
+
+async def claim_npc(
+    db: AsyncSession,
+    item: HostActionQueueItem,
+    *,
+    lease_seconds: int = 180,
+) -> HostActionQueueItem | None:
+    """用数据库条件更新原子领取 NPC 项，避免并发 drain 重复调用模型。"""
+
+    now = datetime.now(UTC)
+    owner = str(uuid.uuid4())
+    eligible = or_(
+        HostActionQueueItem.status == "queued",
+        and_(
+            HostActionQueueItem.status == "retryable_failure",
+            or_(
+                HostActionQueueItem.next_attempt_at.is_(None),
+                HostActionQueueItem.next_attempt_at <= now,
+            ),
+        ),
+        and_(
+            HostActionQueueItem.status == "processing",
+            HostActionQueueItem.lease_expires_at <= now,
+        ),
+    )
+    result = await db.execute(
+        update(HostActionQueueItem)
+        .where(
+            HostActionQueueItem.room_id == item.room_id,
+            HostActionQueueItem.item_id == item.item_id,
+            HostActionQueueItem.recipient_kind == "npc",
+            eligible,
+        )
+        .values(
+            status="processing",
+            lease_owner=owner,
+            lease_expires_at=now + timedelta(seconds=max(180, lease_seconds)),
+            attempt_count=HostActionQueueItem.attempt_count + 1,
+            next_attempt_at=None,
+            updated_at=now,
+        )
+        .returning(HostActionQueueItem.item_id)
+    )
+    claimed_item_id = result.scalar_one_or_none()
+    await db.commit()
+    if claimed_item_id is None:
+        return None
+    return await db.scalar(
+        select(HostActionQueueItem).where(
+            HostActionQueueItem.room_id == item.room_id,
+            HostActionQueueItem.item_id == item.item_id,
+            HostActionQueueItem.lease_owner == owner,
+        )
+    )
+
+
+async def mark_npc_retryable(
+    db: AsyncSession,
+    item: HostActionQueueItem,
+    *,
+    delay_seconds: int = 5,
+) -> None:
+    """保留已经落库的玩家发言，释放 lease 并安排唯一一次队列级重试。"""
+
+    now = datetime.now(UTC)
+    item.status = "retryable_failure"
+    item.next_attempt_at = now + timedelta(seconds=delay_seconds)
+    item.lease_owner = None
+    item.lease_expires_at = None
+    item.updated_at = now
+    await db.commit()
+
+
+async def mark_npc_failed(db: AsyncSession, item: HostActionQueueItem) -> None:
+    """将不可恢复的 NPC 请求置为终态，并释放房间行动槽。"""
+
+    item.status = "failed"
+    item.next_attempt_at = None
+    item.lease_owner = None
+    item.lease_expires_at = None
     item.updated_at = datetime.now(UTC)
     await db.commit()
 
 
 async def discard(db: AsyncSession, item: HostActionQueueItem) -> None:
     item.status = "discarded"
+    item.lease_owner = None
+    item.lease_expires_at = None
+    item.next_attempt_at = None
     item.updated_at = datetime.now(UTC)
     await db.commit()
 
@@ -226,3 +342,39 @@ async def discard_player(
     if rows:
         await db.commit()
     return len(rows)
+
+
+def _utc(value: datetime | None) -> datetime:
+    """SQLite 可能返回无时区时间；统一为 UTC 后再计算恢复延迟。"""
+
+    if value is None:
+        return datetime.min.replace(tzinfo=UTC)
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+async def recovery_schedule(db: AsyncSession) -> tuple[tuple[str, float], ...]:
+    """按每个房间 FIFO 队首计算启动恢复时间，避免轮询和任务越序。"""
+
+    rows = (
+        await db.scalars(
+            select(HostActionQueueItem)
+            .where(
+                HostActionQueueItem.status.in_(("queued", "processing", "retryable_failure")),
+            )
+            .order_by(HostActionQueueItem.room_id, HostActionQueueItem.position)
+        )
+    ).all()
+    now = datetime.now(UTC)
+    result: list[tuple[str, float]] = []
+    seen_rooms: set[str] = set()
+    for item in rows:
+        if item.room_id in seen_rooms:
+            continue
+        seen_rooms.add(item.room_id)
+        ready_at = now
+        if item.status == "retryable_failure":
+            ready_at = _utc(item.next_attempt_at)
+        elif item.status == "processing":
+            ready_at = _utc(item.lease_expires_at)
+        result.append((item.room_id, max(0.0, (ready_at - now).total_seconds())))
+    return tuple(result)

--- a/trpg-backend/app/service/npc_dialogue.py
+++ b/trpg-backend/app/service/npc_dialogue.py
@@ -1,0 +1,528 @@
+"""NPC 场景对话应用服务：构造玩家安全上下文、调用 Host 并持久化冻结受众事件。"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from math import ceil
+from typing import Protocol
+
+from collaboration_framework.contracts import JsonObject, PlayerView, VisibleEntity
+from pydantic import BaseModel, Field, ValidationError, model_validator
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.adapters.openai_models import StructuredJsonClient
+from app.adapters.structured_http import StructuredOutputError
+from app.core.config import (
+    Settings,
+    get_settings,
+    model_client_retry_policy,
+    secret_value,
+)
+from app.dto.ws import DialogueNpcPayload, DialoguePlayerPayload
+from app.models.content import ModuleAsset
+from app.models.engine import HostActionQueueItem
+from app.models.event import Event, EventAudience
+from app.models.room import Room
+
+_DIALOGUE_INSTRUCTIONS = """你正在扮演当前场景中的 NPC，而不是全知守秘人。
+只能依据输入中的公开场景、NPC 公开描述和最近对话回复，不得读取或编造隐藏模组内容、
+玩家秘密、背包、线索或世界状态。玩家说要移动、检定、攻击或使用物品时，只把它当成
+NPC 听到的一句话；不得裁决行动已经发生。输出 1 至 3 条 NPC 回复，主要 NPC 必须第一条，
+speaker_id 只能从 allowed_responders 逐字复制。只输出符合 JSON schema 的 JSON。"""
+
+
+class NpcDialogueMessage(BaseModel):
+    """结构化模型输出中的单条 NPC 发言。"""
+
+    speaker_id: str = Field(min_length=1)
+    text: str = Field(min_length=1, max_length=1000)
+
+
+class NpcDialogueOutput(BaseModel):
+    """限制模型一次最多生成三名 NPC 的有序回复。"""
+
+    npc_messages: tuple[NpcDialogueMessage, ...] = Field(min_length=1, max_length=3)
+
+    @model_validator(mode="after")
+    def validate_total_budget(self) -> NpcDialogueOutput:
+        if sum(len(item.text) for item in self.npc_messages) > 2400:
+            raise ValueError("NPC 回复总长度不能超过 2400 字")
+        return self
+
+
+class NpcPublicSnapshot(BaseModel):
+    """模型可见的 NPC 公开快照。"""
+
+    id: str
+    name: str
+    aliases: tuple[str, ...] = ()
+    description: str = ""
+    observable_state: tuple[dict[str, object], ...] = ()
+
+
+class RecentDialogueItem(BaseModel):
+    """当前 viewer 有权读取且涉及主要 NPC 的近期对话。"""
+
+    speaker_id: str
+    speaker_name: str
+    text: str
+
+
+class NpcDialogueContext(BaseModel):
+    """严格的玩家安全 NPC 模型输入，不包含 Keeper 能力或 Engine 写能力。"""
+
+    room_id: str
+    player_id: str
+    actor_id: str
+    actor_name: str
+    actor_public_status: str = ""
+    scene_id: str
+    scene_name: str
+    scene_description: str
+    interlocutor_id: str
+    allowed_responders: tuple[NpcPublicSnapshot, ...]
+    recent_dialogue: tuple[RecentDialogueItem, ...] = ()
+    utterance: str
+
+
+class NpcDialogueModel(Protocol):
+    async def generate(self, context: NpcDialogueContext) -> NpcDialogueOutput: ...
+
+
+class FakeNpcDialogueModel:
+    """测试和本地试玩使用的确定性 Host 替身。"""
+
+    async def generate(self, context: NpcDialogueContext) -> NpcDialogueOutput:
+        primary = next(
+            item for item in context.allowed_responders if item.id == context.interlocutor_id
+        )
+        return NpcDialogueOutput(
+            npc_messages=(
+                NpcDialogueMessage(
+                    speaker_id=primary.id,
+                    text=f"{context.actor_name}，我听见了：{context.utterance}",
+                ),
+            )
+        )
+
+
+class PromptNpcDialogueModel:
+    """复用现有 StructuredJsonClient 的真实 NPC 对话模型适配器。"""
+
+    def __init__(self, client: StructuredJsonClient) -> None:
+        self._client = client
+
+    async def generate(self, context: NpcDialogueContext) -> NpcDialogueOutput:
+        payload: JsonObject = context.model_dump(mode="json")
+        error_feedback: str | None = None
+        for attempt in range(2):
+            try:
+                raw = await self._client.generate(
+                    schema_name="trpg_npc_dialogue",
+                    schema=NpcDialogueOutput.model_json_schema(mode="serialization"),
+                    instructions=_DIALOGUE_INSTRUCTIONS,
+                    input_payload=(
+                        payload
+                        if error_feedback is None
+                        else {**payload, "validation_feedback": error_feedback}
+                    ),
+                )
+            except StructuredOutputError as exc:
+                if attempt == 1:
+                    raise ValueError("NPC 模型连续返回非法 JSON") from exc
+                error_feedback = "上次响应不是合法 JSON，请只输出符合 schema 的 JSON 对象。"
+                continue
+            try:
+                output = NpcDialogueOutput.model_validate(raw)
+                allowed_ids = {item.id for item in context.allowed_responders}
+                if output.npc_messages[0].speaker_id != context.interlocutor_id:
+                    raise ValueError("主要 NPC 必须第一条回复")
+                if any(item.speaker_id not in allowed_ids for item in output.npc_messages):
+                    raise ValueError("speaker_id 不在 allowed_responders 中")
+                return output
+            except (ValidationError, ValueError) as exc:
+                if attempt == 1:
+                    raise ValueError("NPC 模型输出不符合契约") from exc
+                # 只反馈契约错误，不回显私密数据或扩大模型权限。
+                error_feedback = (
+                    "上次输出未满足消息数量、顺序、speaker_id 或长度约束，请仅修复 JSON。"
+                )
+        raise AssertionError("unreachable")
+
+
+def _is_available_npc(entity: VisibleEntity) -> bool:
+    """NPC 必须可见且有意识；未知状态按可对话处理。"""
+
+    if entity.kind != "npc":
+        return False
+    consciousness = next(
+        (state.value for state in entity.observable_state if state.key == "consciousness"),
+        None,
+    )
+    return consciousness not in {"dead", "unconscious"}
+
+
+def visible_dialogue_npcs(view: PlayerView) -> tuple[VisibleEntity, ...]:
+    """返回服务端允许绑定为结构化接收者的当前 NPC。"""
+
+    return tuple(entity for entity in view.scene.visible_entities if _is_available_npc(entity))
+
+
+def require_dialogue_npc(view: PlayerView, entity_id: str) -> VisibleEntity:
+    """按稳定 ID 验证 NPC，绝不根据自然语言名称猜测。"""
+
+    npc = next((item for item in visible_dialogue_npcs(view) if item.id == entity_id), None)
+    if npc is None:
+        raise ValueError("该 NPC 当前不可见、已失去意识或无法对话")
+    return npc
+
+
+class NpcDialogueService:
+    """协调近期窗口、模型生成与 Event/Audience 原子写入。"""
+
+    def __init__(self, model: NpcDialogueModel, *, lease_seconds: int = 180) -> None:
+        self._model = model
+        self.lease_seconds = max(180, lease_seconds)
+
+    async def recent_dialogue(
+        self,
+        db: AsyncSession,
+        *,
+        room_id: str,
+        player_id: str,
+        npc_id: str,
+    ) -> tuple[RecentDialogueItem, ...]:
+        """只读取冻结受众内涉及指定 NPC 的最近八条对话。"""
+
+        rows = (
+            await db.scalars(
+                select(Event)
+                .outerjoin(EventAudience, EventAudience.event_id == Event.id)
+                .where(
+                    Event.room_id == room_id,
+                    Event.event_type.in_(("dialogue.player", "dialogue.npc")),
+                    or_(
+                        Event.visibility == "public",
+                        and_(
+                            Event.visibility == "player_scoped",
+                            Event.player_id == player_id,
+                        ),
+                        and_(
+                            Event.visibility == "scene_scoped",
+                            EventAudience.player_id == player_id,
+                        ),
+                    ),
+                )
+                .order_by(Event.created_at.desc(), Event.id.desc())
+                .limit(64)
+            )
+        ).all()
+        result: list[RecentDialogueItem] = []
+        for event in rows:
+            participant_ids = event.payload.get("participantIds", ())
+            if npc_id not in participant_ids:
+                continue
+            result.append(
+                RecentDialogueItem(
+                    speaker_id=str(event.payload.get("speakerId", "unknown")),
+                    speaker_name=str(
+                        event.payload.get("speakerName")
+                        or event.payload.get("characterName")
+                        or "玩家"
+                    ),
+                    text=str(event.payload.get("text") or event.payload.get("utterance") or ""),
+                )
+            )
+            if len(result) == 8:
+                break
+        return tuple(reversed(result))
+
+    async def generate(
+        self,
+        db: AsyncSession,
+        *,
+        view: PlayerView,
+        player_id: str,
+        utterance: str,
+        interlocutor_id: str,
+    ) -> NpcDialogueOutput:
+        """构造最小玩家安全上下文，并校验模型不能越权添加说话者。"""
+
+        responders = visible_dialogue_npcs(view)
+        require_dialogue_npc(view, interlocutor_id)
+        context = NpcDialogueContext(
+            room_id=view.room_id,
+            player_id=player_id,
+            actor_id=view.self_actor.id,
+            actor_name=view.self_actor.name,
+            actor_public_status=view.self_actor.public_status_summary,
+            scene_id=view.scene.id,
+            scene_name=view.scene.name,
+            scene_description=view.scene.description,
+            interlocutor_id=interlocutor_id,
+            allowed_responders=tuple(
+                NpcPublicSnapshot(
+                    id=item.id,
+                    name=item.name,
+                    aliases=item.aliases,
+                    description=item.description,
+                    observable_state=tuple(
+                        state.model_dump(mode="json") for state in item.observable_state
+                    ),
+                )
+                for item in responders
+            ),
+            recent_dialogue=await self.recent_dialogue(
+                db,
+                room_id=view.room_id,
+                player_id=player_id,
+                npc_id=interlocutor_id,
+            ),
+            utterance=utterance,
+        )
+        output = await self._model.generate(context)
+        allowed_ids = {item.id for item in responders}
+        if output.npc_messages[0].speaker_id != interlocutor_id:
+            raise ValueError("主要 NPC 必须第一条回复")
+        if any(item.speaker_id not in allowed_ids for item in output.npc_messages):
+            raise ValueError("NPC 模型返回了场景外说话者")
+        return output
+
+    async def portrait_url(
+        self,
+        db: AsyncSession,
+        *,
+        room_id: str,
+        entity_id: str,
+    ) -> str | None:
+        """按稳定实体 ID 查 NPC 头像；未映射时由前端使用默认头像。"""
+
+        scenario_id = await db.scalar(select(Room.scenario_id).where(Room.id == room_id))
+        if scenario_id is None:
+            return None
+        return await db.scalar(
+            select(ModuleAsset.url).where(
+                ModuleAsset.scenario_id == scenario_id,
+                ModuleAsset.entity_id == entity_id,
+                ModuleAsset.asset_type == "npc_portrait",
+            )
+        )
+
+    async def persist_player_event(
+        self,
+        db: AsyncSession,
+        *,
+        item: HostActionQueueItem,
+        view: PlayerView,
+        audience_player_ids: tuple[str, ...],
+        nickname: str,
+    ) -> Event:
+        """幂等保存玩家原话和冻结受众；已有 correlation 直接复用。"""
+
+        correlation = f"{item.client_action_id}:player"
+        existing = await db.scalar(
+            select(Event).where(
+                Event.room_id == item.room_id,
+                Event.event_type == "dialogue.player",
+                Event.correlation_id == correlation,
+            )
+        )
+        if existing is not None:
+            return existing
+        primary = require_dialogue_npc(view, item.recipient_entity_id or "")
+        responders = visible_dialogue_npcs(view)
+        now = datetime.now(UTC)
+        event = Event(
+            id=str(uuid.uuid4()),
+            room_id=item.room_id,
+            player_id=item.player_id,
+            event_type="dialogue.player",
+            correlation_id=correlation,
+            visibility="scene_scoped",
+            actor_id=item.actor_id,
+            scene_id=view.scene.id,
+            view_revision=view.revision,
+            created_at=now,
+            payload={},
+        )
+        payload = DialoguePlayerPayload(
+            message_id=event.id,
+            player_id=item.player_id,
+            client_action_id=item.client_action_id,
+            nickname=nickname,
+            character_name=view.self_actor.name,
+            speaker_id=item.actor_id,
+            interlocutor_id=primary.id,
+            interlocutor_name=primary.name,
+            listener_ids=tuple(npc.id for npc in responders),
+            participant_ids=(item.actor_id, *(npc.id for npc in responders)),
+            allowed_responder_ids=tuple(npc.id for npc in responders),
+            utterance=item.utterance,
+            scene_id=view.scene.id,
+            source_revision=view.revision,
+            sent_at=now,
+            audience_player_ids=audience_player_ids,
+        )
+        event.payload = payload.model_dump(by_alias=True, mode="json")
+        db.add(event)
+        db.add_all(
+            EventAudience(event_id=event.id, player_id=target_id)
+            for target_id in audience_player_ids
+        )
+        await db.commit()
+        await db.refresh(event)
+        return event
+
+    async def persist_replies(
+        self,
+        db: AsyncSession,
+        *,
+        item: HostActionQueueItem,
+        view: PlayerView,
+        player_event: Event,
+        audience_player_ids: tuple[str, ...],
+        output: NpcDialogueOutput,
+        audience_actor_ids: tuple[str, ...],
+    ) -> tuple[Event, ...]:
+        """在一个事务中保存全部回复、受众和队列完成状态。"""
+
+        names = {npc.id: npc.name for npc in visible_dialogue_npcs(view)}
+        responders = tuple(names)
+        events: list[Event] = []
+        now = datetime.now(UTC)
+        for ordinal, message in enumerate(output.npc_messages):
+            correlation = f"{item.client_action_id}:npc:{ordinal}"
+            existing = await db.scalar(
+                select(Event).where(
+                    Event.room_id == item.room_id,
+                    Event.event_type == "dialogue.npc",
+                    Event.correlation_id == correlation,
+                )
+            )
+            if existing is not None:
+                events.append(existing)
+                continue
+            event = Event(
+                id=str(uuid.uuid4()),
+                room_id=item.room_id,
+                player_id=item.player_id,
+                event_type="dialogue.npc",
+                correlation_id=correlation,
+                visibility="scene_scoped",
+                actor_id=message.speaker_id,
+                scene_id=view.scene.id,
+                view_revision=view.revision,
+                created_at=now,
+                payload={},
+            )
+            listeners = (
+                *audience_actor_ids,
+                *(npc for npc in responders if npc != message.speaker_id),
+            )
+            payload = DialogueNpcPayload(
+                message_id=event.id,
+                speaker_id=message.speaker_id,
+                speaker_name=names[message.speaker_id],
+                listener_ids=listeners,
+                participant_ids=(message.speaker_id, *listeners),
+                text=message.text,
+                scene_id=view.scene.id,
+                source_dialogue_id=player_event.id,
+                source_action_id=item.client_action_id,
+                ordinal=ordinal,
+                source_revision=view.revision,
+                sent_at=now,
+                audience_player_ids=audience_player_ids,
+            )
+            event.payload = payload.model_dump(by_alias=True, mode="json", exclude={"avatar_url"})
+            db.add(event)
+            db.add_all(
+                EventAudience(event_id=event.id, player_id=target_id)
+                for target_id in audience_player_ids
+            )
+            events.append(event)
+        await db.flush()
+        item.status = "completed"
+        item.result_event_ids = [event.id for event in events]
+        item.lease_owner = None
+        item.lease_expires_at = None
+        item.next_attempt_at = None
+        item.updated_at = now
+        await db.commit()
+        return tuple(events)
+
+
+def build_npc_dialogue_service(settings: Settings | None = None) -> NpcDialogueService:
+    """按当前 Host provider 构造 NPC 对话服务，不增加独立 provider 配置。"""
+
+    resolved = settings or get_settings()
+    if resolved.host_model_provider == "fake":
+        return NpcDialogueService(FakeNpcDialogueModel())
+
+    from app.adapters import (
+        DeepSeekChatCompletionsJsonClient,
+        OpenAIResponsesJsonClient,
+        QwenChatCompletionsJsonClient,
+    )
+
+    if resolved.host_model_provider == "deepseek":
+        client_type = DeepSeekChatCompletionsJsonClient
+        api_key, base_url, model, timeout = (
+            resolved.deepseek_api_key,
+            resolved.deepseek_base_url,
+            resolved.deepseek_model,
+            resolved.deepseek_timeout_seconds,
+        )
+    elif resolved.host_model_provider == "qwen":
+        client_type = QwenChatCompletionsJsonClient
+        api_key, base_url, model, timeout = (
+            resolved.qwen_api_key,
+            resolved.qwen_base_url,
+            resolved.qwen_model,
+            resolved.qwen_timeout_seconds,
+        )
+    else:
+        client_type = OpenAIResponsesJsonClient
+        api_key, base_url, model, timeout = (
+            resolved.openai_api_key,
+            resolved.openai_base_url,
+            resolved.openai_model,
+            resolved.openai_timeout_seconds,
+        )
+    if api_key is None:
+        raise ValueError("NPC 对话模型缺少 Host provider API key")
+    retry_policy = model_client_retry_policy(resolved)
+    client = client_type(
+        api_key=secret_value(api_key),
+        base_url=base_url,
+        model=model,
+        timeout_seconds=timeout,
+        retry_policy=retry_policy,
+    )
+    # 一次生成最多包含“原请求 + 一次结构修复”；lease 必须覆盖两次请求各自的
+    # 传输重试和指数退避，避免慢模型尚未返回就被其他 worker 重复领取。
+    request_window = timeout * retry_policy.max_attempts + sum(
+        retry_policy.delay_before(attempt) for attempt in range(1, retry_policy.max_attempts)
+    )
+    lease_seconds = ceil(request_window * 2 + 5)
+    return NpcDialogueService(
+        PromptNpcDialogueModel(client),
+        lease_seconds=lease_seconds,
+    )
+
+
+npc_dialogue_service = build_npc_dialogue_service()
+
+
+__all__ = [
+    "FakeNpcDialogueModel",
+    "NpcDialogueContext",
+    "NpcDialogueOutput",
+    "NpcDialogueService",
+    "build_npc_dialogue_service",
+    "npc_dialogue_service",
+    "require_dialogue_npc",
+    "visible_dialogue_npcs",
+]

--- a/trpg-backend/app/service/room.py
+++ b/trpg-backend/app/service/room.py
@@ -10,6 +10,7 @@ import secrets
 import string
 from copy import deepcopy
 from datetime import UTC, datetime
+from typing import Literal, cast
 
 from collaboration_framework.contracts import (
     ContractError,
@@ -45,7 +46,7 @@ from app.dto.room import (
 from app.models.chat import ChatMessage
 from app.models.content import Game, GameSystem, Scenario, World
 from app.models.engine import GameSession, ModuleVersion
-from app.models.event import Event
+from app.models.event import Event, EventAudience
 from app.models.room import Character, CharacterPortrait, Player, Room
 from app.models.user import User
 from app.service import chat as chat_service
@@ -1062,6 +1063,7 @@ async def get_replay(
     player = await require_room_member(db, room_id, reconnect_token)
     result = await db.scalars(
         select(Event)
+        .outerjoin(EventAudience, EventAudience.event_id == Event.id)
         .where(
             Event.room_id == room_id,
             or_(
@@ -1070,8 +1072,13 @@ async def get_replay(
                     Event.visibility == "player_scoped",
                     Event.player_id == player.id,
                 ),
+                and_(
+                    Event.visibility == "scene_scoped",
+                    EventAudience.player_id == player.id,
+                ),
             ),
         )
+        .distinct()
         .order_by(Event.created_at)
     )
     replay: list[ReplayEventRead] = []
@@ -1149,15 +1156,29 @@ async def list_conversation_events(
             select(Event)
             .where(
                 Event.room_id == room_id,
-                Event.event_type.in_(["action.broadcast", "narration.push", "check.result"]),
+                Event.event_type.in_(
+                    [
+                        "action.broadcast",
+                        "narration.push",
+                        "check.result",
+                        "dialogue.player",
+                        "dialogue.npc",
+                    ]
+                ),
                 or_(
                     Event.visibility == "public",
                     and_(
                         Event.visibility == "player_scoped",
                         Event.player_id == player.id,
                     ),
+                    and_(
+                        Event.visibility == "scene_scoped",
+                        EventAudience.player_id == player.id,
+                    ),
                 ),
             )
+            .outerjoin(EventAudience, EventAudience.event_id == Event.id)
+            .distinct()
             .order_by(Event.created_at, Event.id)
         )
     ).scalars()
@@ -1189,6 +1210,29 @@ async def list_conversation_events(
                     type="check.result",
                     channel="action",
                     payload=event.payload,
+                    created_at=event.created_at,
+                )
+            )
+        elif event.event_type in {"dialogue.player", "dialogue.npc"}:
+            payload = dict(event.payload)
+            if event.event_type == "dialogue.npc":
+                # Event 中只保存稳定 speaker ID；URL 是可替换的展示资产。
+                from app.service.npc_dialogue import npc_dialogue_service
+
+                payload["avatarUrl"] = await npc_dialogue_service.portrait_url(
+                    db,
+                    room_id=room_id,
+                    entity_id=str(payload.get("speakerId", "")),
+                )
+            conversation.append(
+                RoomConversationEventRead(
+                    id=event.id,
+                    type=cast(
+                        Literal["dialogue.player", "dialogue.npc"],
+                        event.event_type,
+                    ),
+                    channel="action",
+                    payload=payload,
                     created_at=event.created_at,
                 )
             )

--- a/trpg-backend/scripts/export_schema.py
+++ b/trpg-backend/scripts/export_schema.py
@@ -171,6 +171,8 @@ _MODELS: list[type[BaseModel]] = [
     ws.ChatSendPayload,
     ws.ChatMessagePayload,
     ws.ActionBroadcastPayload,
+    ws.DialoguePlayerPayload,
+    ws.DialogueNpcPayload,
     # 多人共享时间推进确认（issue #349）
     ws.TimeAdvanceRespondPayload,
     ws.TimeAdvancePendingPayload,

--- a/trpg-backend/tests/conftest.py
+++ b/trpg-backend/tests/conftest.py
@@ -37,6 +37,7 @@ from app.service.conversation_summary import (
     ConversationSummaryService,
     DeterministicConversationSummaryModel,
 )
+from app.service.npc_dialogue import build_npc_dialogue_service
 from tests.content_fixtures import publish_multiplayer_module
 
 # 用临时文件 SQLite，不用 ":memory:"+StaticPool。关键原因是并发模型：异步 HTTP
@@ -103,6 +104,9 @@ ws_controller.action_plan_turn_application = build_action_plan_turn_application(
     time_consent_session_factory=TestSessionLocal,
 )
 ws_controller.adjudication_engine_service = AdjudicationEngineService(_test_turn_store)
+ws_controller.npc_dialogue_service = build_npc_dialogue_service(  # type: ignore[assignment]
+    Settings(host_model_provider="fake")
+)
 
 
 @pytest.fixture(autouse=True)

--- a/trpg-backend/tests/test_chat_ws.py
+++ b/trpg-backend/tests/test_chat_ws.py
@@ -256,8 +256,8 @@ def test_single_player_action_chat_is_rejected(sync_client: TestClient) -> None:
     assert error["payload"]["code"] == "BAD_REQUEST"
 
 
-def test_npc_recipient_is_rejected_before_host_processing(sync_client: TestClient) -> None:
-    """PR1 只预留 NPC recipient，不能误入 Keeper 主链。"""
+def test_npc_recipient_bypasses_keeper_processing(sync_client: TestClient) -> None:
+    """PR2 开放 NPC recipient，但仍不能误入 Keeper ActionPlan 主链。"""
 
     token = register_and_login(sync_client, "npc_recipient_reject")
     room = create_room(sync_client, token, max_players=1)
@@ -278,9 +278,15 @@ def test_npc_recipient_is_rejected_before_host_processing(sync_client: TestClien
                 },
             }
         )
-        error = receive_until(ws, lambda item: item.get("type") == "error")[0]
+        reply, seen = receive_until(ws, lambda item: item.get("type") == "dialogue.npc")
 
-    assert error["payload"]["code"] == "NOT_IMPLEMENTED"
+    assert reply["payload"]["speakerId"] == "thomas"
+    assert any(item.get("type") == "dialogue.player" for item in seen)
+    assert not any(
+        item.get("type") in {"action.broadcast", "check.request", "check.result"}
+        or item.get("message_type") == "turn.completed"
+        for item in seen
+    )
 
 
 def test_single_player_accepts_implicit_keeper_recipient(sync_client: TestClient) -> None:

--- a/trpg-backend/tests/test_host_action_queue.py
+++ b/trpg-backend/tests/test_host_action_queue.py
@@ -2,20 +2,26 @@
 
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
 from collaboration_framework.contracts import ContractError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.controller import ws as ws_controller
 from app.core.turn import ActorResolutionError
 from app.dto.ws import ActionRecipientPayload
+from app.models.event import Event
 from app.service import host_action_queue
 from app.service.host_action_queue import HostActionQueueError
 from tests.test_engine_runtime import _start_room
+from tests.test_npc_dialogue import _view
 
 _KEEPER_RECIPIENT = ActionRecipientPayload(kind="keeper", entity_id=None, explicit=True)
+_NPC_RECIPIENT = ActionRecipientPayload(kind="npc", entity_id="caretaker", explicit=True)
 
 
 @pytest.mark.asyncio
@@ -284,3 +290,157 @@ async def test_drain_discards_queued_item_when_actor_id_changed(
     await ws_controller._drain_host_action_queue(room_id)
 
     assert await host_action_queue.peek_next(db_session, room_id) is None
+
+
+@pytest.mark.asyncio
+async def test_npc_queue_claim_is_atomic_and_expired_lease_recovers(
+    db_session: AsyncSession,
+) -> None:
+    """两个 drain 竞争时只允许一个领取；lease 过期后同一项可以再次领取。"""
+
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=3978,
+        player_count=1,
+        prepare_checkpoint=False,
+    )
+    await host_action_queue.enqueue(
+        db_session,
+        room_id=room.id,
+        player_id=players[0].id,
+        actor_id="actor-a",
+        client_action_id="npc-action",
+        utterance="请记住蓝色钟摆",
+        recipient=_NPC_RECIPIENT,
+    )
+    sessions = async_sessionmaker(db_session.bind, expire_on_commit=False)
+
+    async def compete():
+        async with sessions() as session:
+            candidate = await host_action_queue.peek_next(session, room.id)
+            assert candidate is not None
+            return await host_action_queue.claim_npc(session, candidate)
+
+    winners = await asyncio.gather(compete(), compete())
+    claimed = [item for item in winners if item is not None]
+    assert len(claimed) == 1
+    assert claimed[0].attempt_count == 1
+
+    async with sessions() as session:
+        expired = await host_action_queue.get_by_client_action(session, room.id, "npc-action")
+        assert expired is not None
+        expired.lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        await session.commit()
+        candidate = await host_action_queue.peek_next(session, room.id)
+        assert candidate is not None
+        recovered = await host_action_queue.claim_npc(session, candidate)
+        assert recovered is not None
+        assert recovered.attempt_count == 2
+
+
+@pytest.mark.asyncio
+async def test_npc_queue_waiting_head_blocks_later_items_and_schedules_recovery(
+    db_session: AsyncSession,
+) -> None:
+    """未过期 lease 必须保留 FIFO 位置，重启恢复时间取自持久化 lease。"""
+
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=3979,
+        player_count=2,
+        prepare_checkpoint=False,
+    )
+    first, _ = await host_action_queue.enqueue(
+        db_session,
+        room_id=room.id,
+        player_id=players[0].id,
+        actor_id="actor-a",
+        client_action_id="npc-first",
+        utterance="先和守墓人说话",
+        recipient=_NPC_RECIPIENT,
+    )
+    await host_action_queue.enqueue(
+        db_session,
+        room_id=room.id,
+        player_id=players[1].id,
+        actor_id="actor-b",
+        client_action_id="keeper-second",
+        utterance="随后调查书架",
+        recipient=_KEEPER_RECIPIENT,
+    )
+    claimed = await host_action_queue.claim_npc(db_session, first)
+    assert claimed is not None
+
+    # 队首仍由旧 worker 的 lease 持有时，第二项不能绕过它执行。
+    assert await host_action_queue.peek_next(db_session, room.id) is None
+    schedule = await host_action_queue.recovery_schedule(db_session)
+    room_delay = dict(schedule)[room.id]
+    assert 170 <= room_delay <= 180
+
+    claimed.lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    await db_session.commit()
+    recovered_head = await host_action_queue.peek_next(db_session, room.id)
+    assert recovered_head is not None
+    assert recovered_head.client_action_id == "npc-first"
+
+
+@pytest.mark.asyncio
+async def test_npc_cancel_before_player_event_persists_nothing(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """受众冻结期间收到取消时，玩家原话和 NPC 回复都不能落库。"""
+
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=3980,
+        player_count=1,
+        prepare_checkpoint=False,
+    )
+    item, _ = await host_action_queue.enqueue(
+        db_session,
+        room_id=room.id,
+        player_id=players[0].id,
+        actor_id="actor-a",
+        client_action_id="npc-cancel-before-event",
+        utterance="这句话不应发生",
+        recipient=_NPC_RECIPIENT,
+    )
+    base_view = _view()
+    view = base_view.model_copy(
+        update={
+            "room_id": room.id,
+            "player_id": players[0].id,
+            "actor_id": "actor-a",
+            "self_actor": base_view.self_actor.model_copy(update={"id": "actor-a"}),
+        }
+    )
+
+    async def cancel_while_freezing(db: AsyncSession, **kwargs):  # noqa: ANN003, ARG001
+        await host_action_queue.cancel(
+            db,
+            room_id=room.id,
+            player_id=players[0].id,
+            client_action_id=item.client_action_id,
+        )
+        return (players[0].id,), ("actor-a",)
+
+    monkeypatch.setattr(ws_controller, "_npc_dialogue_audience", cancel_while_freezing)
+    await ws_controller._run_npc_dialogue(db_session, item, view)
+
+    persisted = await db_session.scalar(
+        select(func.count())
+        .select_from(Event)
+        .where(
+            Event.room_id == room.id,
+            Event.event_type.in_(("dialogue.player", "dialogue.npc")),
+        )
+    )
+    cancelled = await host_action_queue.get_by_client_action(
+        db_session,
+        room.id,
+        item.client_action_id,
+    )
+    assert persisted == 0
+    assert cancelled is not None
+    assert cancelled.status == "cancelled"

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -9,8 +9,8 @@ from pathlib import Path
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 PREVIOUS_REVISION = "1a02058345ee"
 ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
-# 记忆链 head 是 a7b8c9d0e1f2；主持队列接在它后面。
-HEAD_REVISION = "c0d1e2f3a4b5"
+# PR2 NPC 对话迁移直接接在 PR1 输入路由 head 后面。
+HEAD_REVISION = "d1e2f3a4b5c6"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -94,6 +94,7 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "turn_run_cutover",
         "scene_transition_proposals",
         "host_action_queue",
+        "event_audiences",
     }.issubset(tables)
     assert "decision_schema_version" in _column_names(
         database,
@@ -118,7 +119,13 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
         "recipient_kind",
         "recipient_entity_id",
         "recipient_explicit",
+        "attempt_count",
+        "next_attempt_at",
+        "lease_owner",
+        "lease_expires_at",
+        "result_event_ids",
     }.issubset(_column_names(database, "host_action_queue"))
+    assert "entity_id" in _column_names(database, "module_assets")
     assert {"channel", "actor_id"}.issubset(_column_names(database, "chat_messages"))
     assert "room_sessions" not in tables
     assert {"status", "name_en", "story_label", "subtitle", "story_pages"}.issubset(
@@ -307,6 +314,65 @@ def test_message_channel_and_recipient_migration_backfills_old_rows(tmp_path: Pa
 
     assert chat == ("discussion", None)
     assert recipient == ("keeper", None, 1)
+
+
+def test_npc_dialogue_migration_backfills_started_queue(tmp_path: Path) -> None:
+    """PR2 把旧 started 收敛为不可重复执行的 completed，并初始化恢复字段。"""
+
+    database = tmp_path / "npc-dialogue-backfill.db"
+    _upgrade_or_fail(database, "c0d1e2f3a4b5")
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """
+            INSERT INTO host_action_queue (
+                room_id, item_id, client_action_id, player_id, actor_id,
+                utterance, recipient_kind, recipient_entity_id,
+                recipient_explicit, position, status, created_at, updated_at
+            ) VALUES (
+                'room-1', 'old-started', 'old-started-action', 'player-1', 'actor-1',
+                '已经由旧服务接管', 'keeper', NULL, 1, 1, 'started',
+                '2026-08-23 00:00:00', '2026-08-23 00:00:00'
+            )
+            """
+        )
+
+    _upgrade_or_fail(database, "head")
+    with sqlite3.connect(database) as connection:
+        row = connection.execute(
+            """
+            SELECT status, attempt_count, result_event_ids
+            FROM host_action_queue WHERE item_id = 'old-started'
+            """
+        ).fetchone()
+
+    assert row == ("completed", 0, "[]")
+
+
+def test_npc_dialogue_downgrade_keeps_scene_events_private(tmp_path: Path) -> None:
+    """旧版本不支持冻结受众时，降级只能收窄到发起玩家，不能扩大为公开事件。"""
+
+    database = tmp_path / "npc-dialogue-downgrade.db"
+    _upgrade_or_fail(database, "head")
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """
+            INSERT INTO events (
+                id, room_id, player_id, event_type, payload, visibility, created_at
+            ) VALUES (
+                '90000000-0000-0000-0000-000000000001',
+                'room-1', 'player-1', 'dialogue.player', '{}', 'scene_scoped',
+                '2026-08-24 00:00:00'
+            )
+            """
+        )
+
+    result = _run_alembic(database, "downgrade", "c0d1e2f3a4b5")
+    assert result.returncode == 0, result.stdout + result.stderr
+    with sqlite3.connect(database) as connection:
+        visibility = connection.execute(
+            "SELECT visibility FROM events WHERE event_type = 'dialogue.player'",
+        ).fetchone()
+    assert visibility == ("player_scoped",)
 
 
 def test_migration_rejects_duplicate_characters_before_ddl(tmp_path: Path) -> None:

--- a/trpg-backend/tests/test_npc_dialogue.py
+++ b/trpg-backend/tests/test_npc_dialogue.py
@@ -1,0 +1,280 @@
+"""验证 NPC 对话的接收者边界、结构化输出和动作隔离。"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from collaboration_framework.contracts import (
+    ObservableStateView,
+    PlayerView,
+    SceneView,
+    SelfActorView,
+    VisibleEntity,
+)
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.adapters.structured_http import StructuredOutputError
+from app.core.config import Settings
+from app.models.event import Event, EventAudience
+from app.service import room as room_service
+from app.service.npc_dialogue import (
+    FakeNpcDialogueModel,
+    NpcDialogueContext,
+    NpcDialogueMessage,
+    NpcDialogueOutput,
+    NpcPublicSnapshot,
+    PromptNpcDialogueModel,
+    build_npc_dialogue_service,
+    require_dialogue_npc,
+    visible_dialogue_npcs,
+)
+from tests.test_engine_runtime import _start_room
+
+
+def _view() -> PlayerView:
+    """构造只含公开身份和三名可见实体的玩家视图。"""
+
+    return PlayerView(
+        room_id="room-1",
+        player_id="player-1",
+        actor_id="actor-1",
+        background="测试场景",
+        scene_id="cemetery",
+        phase="playing",
+        revision="revision-9",
+        self_actor=SelfActorView(
+            id="actor-1",
+            name="林岚",
+            public_status_summary="站在墓园入口。",
+        ),
+        scene=SceneView(
+            id="cemetery",
+            name="旧墓园",
+            description="石碑间雾气低垂。",
+            visible_entities=(
+                VisibleEntity(
+                    id="caretaker",
+                    kind="npc",
+                    name="守墓人",
+                    aliases=("老人",),
+                    description="沉默寡言的守墓人。",
+                ),
+                VisibleEntity(
+                    id="sleeping-witness",
+                    kind="npc",
+                    name="昏迷的目击者",
+                    description="倒在长椅上。",
+                    observable_state=(
+                        ObservableStateView(
+                            key="consciousness",
+                            label="意识",
+                            value="unconscious",
+                        ),
+                    ),
+                ),
+                VisibleEntity(
+                    id="gate",
+                    kind="object",
+                    name="铁门",
+                    description="生锈的铁门。",
+                ),
+            ),
+        ),
+    )
+
+
+def test_visible_dialogue_npcs_rejects_non_npc_and_unconscious() -> None:
+    view = _view()
+
+    assert [item.id for item in visible_dialogue_npcs(view)] == ["caretaker"]
+    assert require_dialogue_npc(view, "caretaker").name == "守墓人"
+    with pytest.raises(ValueError, match="无法对话"):
+        require_dialogue_npc(view, "sleeping-witness")
+    with pytest.raises(ValueError, match="无法对话"):
+        require_dialogue_npc(view, "gate")
+
+
+def test_npc_output_enforces_message_and_character_budgets() -> None:
+    with pytest.raises(ValidationError):
+        NpcDialogueOutput(npc_messages=())
+    with pytest.raises(ValidationError):
+        NpcDialogueOutput(
+            npc_messages=tuple(
+                NpcDialogueMessage(speaker_id=f"npc-{index}", text="回复") for index in range(4)
+            )
+        )
+    with pytest.raises(ValidationError):
+        NpcDialogueMessage(speaker_id="caretaker", text="字" * 1001)
+
+
+def test_real_provider_lease_covers_timeout_retries_and_repair() -> None:
+    """lease 按 Host provider 最坏调用窗口计算，不能固定早于模型超时。"""
+
+    service = build_npc_dialogue_service(
+        Settings(
+            host_model_provider="qwen",
+            qwen_api_key="test-key",
+            qwen_timeout_seconds=120,
+            model_client_max_attempts=5,
+            model_client_retry_backoff_seconds=10,
+        )
+    )
+
+    assert service.lease_seconds >= 1505
+
+
+@pytest.mark.asyncio
+async def test_fake_npc_treats_action_words_as_dialogue_only() -> None:
+    """Fake 只生成一句 NPC 发言，不返回任何 Engine 效果或技能裁决。"""
+
+    context = NpcDialogueContext(
+        room_id="room-1",
+        player_id="player-1",
+        actor_id="actor-1",
+        actor_name="林岚",
+        scene_id="cemetery",
+        scene_name="旧墓园",
+        scene_description="石碑间雾气低垂。",
+        interlocutor_id="caretaker",
+        allowed_responders=(
+            NpcPublicSnapshot(
+                id="caretaker",
+                name="守墓人",
+                description="沉默寡言的守墓人。",
+            ),
+        ),
+        utterance="我去地下室并使用侦查检查门。",
+    )
+
+    output = await FakeNpcDialogueModel().generate(context)
+
+    assert output.npc_messages[0].speaker_id == "caretaker"
+    assert "我去地下室并使用侦查检查门" in output.npc_messages[0].text
+    assert set(output.model_dump()) == {"npc_messages"}
+
+
+@pytest.mark.asyncio
+async def test_prompt_model_repairs_illegal_speaker_once() -> None:
+    """模型第一次添加场景外 NPC 时收到安全反馈，第二次只允许合法说话者。"""
+
+    class RepairingClient:
+        def __init__(self) -> None:
+            self.payloads: list[dict] = []
+
+        async def generate(self, **kwargs):
+            self.payloads.append(kwargs["input_payload"])
+            speaker = "offscene-npc" if len(self.payloads) == 1 else "caretaker"
+            return {"npc_messages": [{"speaker_id": speaker, "text": "收到。"}]}
+
+    context = NpcDialogueContext(
+        room_id="room-1",
+        player_id="player-1",
+        actor_id="actor-1",
+        actor_name="林岚",
+        scene_id="cemetery",
+        scene_name="旧墓园",
+        scene_description="石碑间雾气低垂。",
+        interlocutor_id="caretaker",
+        allowed_responders=(NpcPublicSnapshot(id="caretaker", name="守墓人"),),
+        utterance="请记住蓝色钟摆。",
+    )
+    client = RepairingClient()
+
+    output = await PromptNpcDialogueModel(client).generate(context)  # type: ignore[arg-type]
+
+    assert output.npc_messages[0].speaker_id == "caretaker"
+    assert "validation_feedback" in client.payloads[1]
+
+
+@pytest.mark.asyncio
+async def test_prompt_model_repairs_invalid_json_once() -> None:
+    """结构化 client 解码失败时立即进行一次受限修复，不进入 Engine。"""
+
+    class InvalidOnceClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def generate(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise StructuredOutputError("invalid json")
+            assert "validation_feedback" in kwargs["input_payload"]
+            return {"npc_messages": [{"speaker_id": "caretaker", "text": "收到。"}]}
+
+    context = NpcDialogueContext(
+        room_id="room-1",
+        player_id="player-1",
+        actor_id="actor-1",
+        actor_name="林岚",
+        scene_id="cemetery",
+        scene_name="旧墓园",
+        scene_description="石碑间雾气低垂。",
+        interlocutor_id="caretaker",
+        allowed_responders=(NpcPublicSnapshot(id="caretaker", name="守墓人"),),
+        utterance="请记住蓝色钟摆。",
+    )
+    client = InvalidOnceClient()
+
+    output = await PromptNpcDialogueModel(client).generate(context)  # type: ignore[arg-type]
+
+    assert client.calls == 2
+    assert output.npc_messages[0].speaker_id == "caretaker"
+
+
+@pytest.mark.asyncio
+async def test_scene_dialogue_replay_uses_frozen_audience(db_session: AsyncSession) -> None:
+    """未在事件受众中的房间成员后来进入场景，也不能补看旧 NPC 对话。"""
+
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=4072,
+        player_count=2,
+        prepare_checkpoint=False,
+    )
+    event = Event(
+        id=str(uuid.uuid4()),
+        room_id=room.id,
+        player_id=players[0].id,
+        event_type="dialogue.npc",
+        correlation_id="frozen-audience:npc:0",
+        visibility="scene_scoped",
+        actor_id="caretaker",
+        scene_id="cemetery",
+        view_revision="revision-1",
+        payload={
+            "messageId": "npc-message-1",
+            "speakerId": "caretaker",
+            "speakerName": "守墓人",
+            "listenerIds": ["actor-1"],
+            "participantIds": ["caretaker", "actor-1"],
+            "text": "只让当时在场的人听见。",
+            "sceneId": "cemetery",
+            "sourceDialogueId": "player-message-1",
+            "sourceActionId": "action-1",
+            "ordinal": 0,
+            "sourceRevision": "revision-1",
+            "sentAt": datetime.now(UTC).isoformat(),
+            "audiencePlayerIds": [players[0].id],
+        },
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(event)
+    db_session.add(EventAudience(event_id=event.id, player_id=players[0].id))
+    await db_session.commit()
+
+    visible = await room_service.list_conversation_events(
+        db_session,
+        room.id,
+        players[0].reconnect_token,
+    )
+    hidden = await room_service.list_conversation_events(
+        db_session,
+        room.id,
+        players[1].reconnect_token,
+    )
+
+    assert [item.type for item in visible] == ["dialogue.npc"]
+    assert hidden == []

--- a/trpg-backend/tests/test_ws.py
+++ b/trpg-backend/tests/test_ws.py
@@ -301,6 +301,78 @@ def receive_replayed_opening(ws) -> dict:
     return opening
 
 
+def test_npc_recipient_uses_dialogue_path_without_engine_action(sync_client: TestClient) -> None:
+    """NPC 收到动作措辞也只回复对话，不进入 Keeper 的行动与检定链路。"""
+
+    token = register_and_login(sync_client, "npc-dialogue-host")
+    room = create_room(sync_client, token)
+    advance_to_building(sync_client, room)
+    complete_character(sync_client, room["roomId"], room["reconnectToken"])
+    start_game(sync_client, room, token)
+
+    with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as websocket:
+        websocket.send_json(
+            {
+                "type": "room.join",
+                "playerId": room["playerId"],
+                "payload": {"reconnectToken": room["reconnectToken"]},
+            }
+        )
+        websocket.receive_json()  # session.bound
+        view_event = websocket.receive_json()
+        assert view_event["type"] == "view.updated"
+        visible_npcs = [
+            entity
+            for entity in view_event["payload"]["playerView"]["scene"]["visible_entities"]
+            if entity["kind"] == "npc"
+        ]
+        assert visible_npcs, "内置模组开场必须至少有一名可见 NPC"
+        target = visible_npcs[0]
+        receive_replayed_opening(websocket)
+
+        websocket.send_json(
+            {
+                "type": "action.plan.submit",
+                "playerId": room["playerId"],
+                "payload": {
+                    "clientActionId": "npc-dialogue-action-1",
+                    "utterance": "我去地下室并使用侦查检查门，请你记住这句话。",
+                    "recipient": {
+                        "kind": "npc",
+                        "entityId": target["id"],
+                        "explicit": True,
+                    },
+                },
+            }
+        )
+        npc_reply, preceding = receive_until(
+            websocket,
+            lambda message: message.get("type") == "dialogue.npc",
+        )
+
+    player_dialogue = next(
+        message for message in preceding if message.get("type") == "dialogue.player"
+    )
+    assert player_dialogue["payload"]["interlocutorId"] == target["id"]
+    assert npc_reply["payload"]["speakerId"] == target["id"]
+    assert not any(
+        message.get("type") in {"action.broadcast", "check.request", "check.result"}
+        or message.get("message_type") == "turn.completed"
+        for message in preceding
+    )
+
+    conversation = sync_client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/conversation",
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    )
+    assert conversation.status_code == 200
+    event_types = [item["type"] for item in conversation.json()["data"]]
+    assert "dialogue.player" in event_types
+    assert "dialogue.npc" in event_types
+    assert "action.broadcast" not in event_types
+    assert "check.result" not in event_types
+
+
 def receive_narration_stream(ws, *, limit: int = 60) -> tuple[dict, list[dict]]:
     """Receive up to the authoritative `narration.push`, returning it with its chunks."""
 

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.css
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.css
@@ -290,6 +290,22 @@
   -webkit-touch-callout: none;
 }
 
+.room-play__avatar--npc {
+  width: 2.75rem;
+  height: 2.75rem;
+  flex-basis: 2.75rem;
+  border: 1px solid rgb(150 105 53 / 45%);
+  color: #6f4c25;
+  background: #ecd5a8;
+  font-size: 0.62rem;
+  font-weight: 800;
+}
+
+.room-play__npc-card {
+  border-color: rgb(117 137 106 / 38%);
+  background: #edf0df;
+}
+
 .room-play__avatar--dice {
   color: #79552d;
   background: #e6d6ad;
@@ -687,9 +703,9 @@
 
 .room-play__composer-button {
   display: grid;
-  width: 2.4rem;
-  height: 2.4rem;
-  flex: 0 0 2.4rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  flex: 0 0 2.75rem;
   place-items: center;
   border: 1.5px solid rgb(245 222 178 / 68%);
   border-radius: 999px;
@@ -700,6 +716,41 @@
     inset 0 0 0 2px rgb(132 84 35 / 10%);
   cursor: pointer;
   transition: filter 160ms ease, transform 160ms ease;
+}
+
+.room-play__recipient-menu {
+  display: grid;
+  max-height: 14rem;
+  margin: 0 0 0.45rem 3.1rem;
+  border: 1px solid rgb(139 91 38 / 35%);
+  border-radius: 0.4rem;
+  overflow-y: auto;
+  background: #f7e7c7;
+  box-shadow: 0 0.35rem 0.8rem rgb(42 24 10 / 18%);
+}
+
+.room-play__recipient-menu button {
+  display: flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.5rem 0.75rem;
+  color: #4b321b;
+  text-align: left;
+}
+
+.room-play__recipient-menu button.is-active,
+.room-play__recipient-menu button:focus-visible {
+  outline: 2px solid #9b6428;
+  outline-offset: -2px;
+  background: rgb(213 170 104 / 24%);
+}
+
+.room-play__recipient-menu button span {
+  min-width: 2rem;
+  color: #806126;
+  font-size: 0.62rem;
+  font-weight: 800;
 }
 
 .room-play__composer-button svg {
@@ -1110,10 +1161,10 @@
   }
 
   .room-play__composer-button {
-    width: 2.25rem;
-    height: 2.25rem;
-    min-height: 2.25rem;
-    flex-basis: 2.25rem;
+    width: 2.75rem;
+    height: 2.75rem;
+    min-height: 2.75rem;
+    flex-basis: 2.75rem;
   }
 }
 

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -806,6 +806,25 @@ describe('RoomPage conversation history', () => {
     ))
   })
 
+  it('accepts Chinese punctuation after a leading keeper mention', async () => {
+    mockSubmitPlannedAction.mockReturnValue(new Promise(() => undefined))
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    const actionField = screen.getByPlaceholderText('输入消息…')
+    fireEvent.change(actionField, { target: { value: '@守秘人：我查看窗外' } })
+    fireEvent.submit(actionField.closest('form')!)
+
+    await waitFor(() => expect(mockSubmitPlannedAction).toHaveBeenCalledWith(
+      'player-1',
+      expect.objectContaining({
+        utterance: '我查看窗外',
+        recipient: { kind: 'keeper', entityId: null, explicit: true },
+      }),
+    ))
+    expect(mockSendActionChat).not.toHaveBeenCalled()
+  })
+
   it('disables action submission until room mode is known but keeps discussion available', async () => {
     roomInfoState.maxPlayers = null
     renderRoomPage()
@@ -834,6 +853,20 @@ describe('RoomPage conversation history', () => {
     expect(mockSubmitPlannedAction.mock.calls[0][1]).toEqual(
       expect.objectContaining({ utterance: '我搜查书桌' }),
     )
+  })
+
+  it('action channel @ button moves a mid-text mention to the routing position', async () => {
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    const actionField = screen.getByPlaceholderText('输入消息…')
+    fireEvent.change(actionField, { target: { value: '我稍后再问@主持人' } })
+    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
+    expect(actionField).toHaveValue('@主持人 我稍后再问@主持人')
+
+    fireEvent.change(actionField, { target: { value: '@守秘人 我查看窗外' } })
+    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
+    expect(actionField).toHaveValue('@守秘人 我查看窗外')
   })
 
   it('long-pressing the keeper avatar inserts @主持人', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -105,6 +105,7 @@ const {
   mockSendActionChat,
   mockSubmitAction,
   mockSubmitPlannedAction,
+  mockSubmitNpcDialogue,
   mockSelectAdjudication,
   mockDecidePostRoll,
   mockCancelActionPlan,
@@ -146,6 +147,7 @@ const {
     }),
     mockSubmitAction: vi.fn(),
     mockSubmitPlannedAction: vi.fn(),
+    mockSubmitNpcDialogue: vi.fn(),
     mockSelectAdjudication: vi.fn(),
     mockDecidePostRoll: vi.fn(),
     mockCancelActionPlan: vi.fn(),
@@ -181,6 +183,7 @@ vi.mock('@/services/api-client', () => ({
       sendActionChat: mockSendActionChat,
       submitAction: mockSubmitAction,
       submitPlannedAction: mockSubmitPlannedAction,
+      submitNpcDialogue: mockSubmitNpcDialogue,
       selectAdjudication: mockSelectAdjudication,
       decidePostRoll: mockDecidePostRoll,
       cancelActionPlan: mockCancelActionPlan,
@@ -465,6 +468,7 @@ describe('RoomPage conversation history', () => {
     })
     mockSubmitAction.mockReturnValue(new Promise(() => undefined))
     mockSubmitPlannedAction.mockReturnValue(new Promise(() => undefined))
+    mockSubmitNpcDialogue.mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -840,13 +844,14 @@ describe('RoomPage conversation history', () => {
     expect(mockSubmitPlannedAction).not.toHaveBeenCalled()
   })
 
-  it('action channel @ button inserts a host mention', async () => {
+  it('action channel @ menu inserts a host mention', async () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
 
     const actionField = screen.getByPlaceholderText('输入消息…')
     fireEvent.change(actionField, { target: { value: '我搜查书桌' } })
-    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择消息接收者' }))
+    fireEvent.click(screen.getByRole('option', { name: /主持人/ }))
     expect(actionField).toHaveValue('@主持人 我搜查书桌')
     fireEvent.submit(actionField.closest('form')!)
     await waitFor(() => expect(mockSubmitPlannedAction).toHaveBeenCalled())
@@ -855,18 +860,120 @@ describe('RoomPage conversation history', () => {
     )
   })
 
-  it('action channel @ button moves a mid-text mention to the routing position', async () => {
+  it('action channel @ menu moves a mid-text mention to the routing position', async () => {
     renderRoomPage()
     await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
 
     const actionField = screen.getByPlaceholderText('输入消息…')
     fireEvent.change(actionField, { target: { value: '我稍后再问@主持人' } })
-    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择消息接收者' }))
+    fireEvent.click(screen.getByRole('option', { name: /主持人/ }))
     expect(actionField).toHaveValue('@主持人 我稍后再问@主持人')
 
     fireEvent.change(actionField, { target: { value: '@守秘人 我查看窗外' } })
-    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
-    expect(actionField).toHaveValue('@守秘人 我查看窗外')
+    fireEvent.click(screen.getByRole('button', { name: '选择消息接收者' }))
+    fireEvent.click(screen.getByRole('option', { name: /主持人/ }))
+    expect(actionField).toHaveValue('@主持人 我查看窗外')
+  })
+
+  it('selects a visible NPC by stable id and renders independent dialogue bubbles', async () => {
+    const view = playerViewFixture()
+    mockGetPlayerView.mockReturnValue({
+      ...view,
+      scene: {
+        ...view.scene,
+        visible_entities: [{
+          id: 'caretaker',
+          kind: 'npc',
+          name: '守墓人',
+          aliases: ['老人'],
+          description: '沉默寡言的守墓人。',
+          narrative_details: [],
+          observable_state: [],
+        }],
+      },
+    })
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: '选择消息接收者' }))
+    fireEvent.click(screen.getByRole('option', { name: /守墓人/ }))
+    const actionField = screen.getByPlaceholderText('输入消息…')
+    fireEvent.change(actionField, { target: { value: '@守墓人 请记住蓝色钟摆。' } })
+    fireEvent.submit(actionField.closest('form')!)
+
+    expect(mockSubmitNpcDialogue).toHaveBeenCalledWith('player-1', expect.objectContaining({
+      utterance: '请记住蓝色钟摆。',
+      recipient: { kind: 'npc', entityId: 'caretaker', explicit: true },
+    }))
+    act(() => emitWsMessage({
+      type: 'dialogue.player',
+      payload: {
+        messageId: 'dialogue-player-1',
+        playerId: 'player-1',
+        clientActionId: 'action-dialogue-1',
+        nickname: '陈探员',
+        characterName: '杜调查员',
+        speakerId: 'actor-1',
+        interlocutorId: 'caretaker',
+        interlocutorName: '守墓人',
+        listenerIds: ['caretaker'],
+        participantIds: ['actor-1', 'caretaker'],
+        allowedResponderIds: ['caretaker'],
+        utterance: '请记住蓝色钟摆。',
+        sceneId: 'scene-1',
+        sourceRevision: 'revision-1',
+        sentAt: '2026-08-24T12:00:00Z',
+        audiencePlayerIds: ['player-1'],
+      },
+    }))
+    act(() => emitWsMessage({
+      type: 'dialogue.npc',
+      payload: {
+        messageId: 'dialogue-npc-1',
+        speakerId: 'caretaker',
+        speakerName: '守墓人',
+        avatarUrl: null,
+        listenerIds: ['actor-1'],
+        participantIds: ['caretaker', 'actor-1'],
+        text: '我记住了。',
+        sceneId: 'scene-1',
+        sourceDialogueId: 'dialogue-player-1',
+        sourceActionId: 'action-dialogue-1',
+        ordinal: 0,
+        sourceRevision: 'revision-1',
+        sentAt: '2026-08-24T12:00:01Z',
+        audiencePlayerIds: ['player-1'],
+      },
+    }))
+
+    expect(screen.getByText('@守墓人 请记住蓝色钟摆。')).toBeInTheDocument()
+    expect(screen.getByText('我记住了。')).toBeInTheDocument()
+    vi.useFakeTimers()
+    fireEvent.pointerDown(screen.getByRole('button', { name: '长按 @守墓人' }))
+    act(() => vi.advanceTimersByTime(450))
+    expect(actionField).toHaveValue('@守墓人 ')
+  })
+
+  it('supports keyboard selection in the recipient list', async () => {
+    const view = playerViewFixture()
+    mockGetPlayerView.mockReturnValue({
+      ...view,
+      scene: {
+        ...view.scene,
+        visible_entities: [{
+          id: 'thomas', kind: 'npc', name: '托马斯', aliases: [],
+          description: '戴眼镜的学者。', narrative_details: [], observable_state: [],
+        }],
+      },
+    })
+    renderRoomPage()
+    const actionField = await screen.findByPlaceholderText('输入消息…')
+    fireEvent.change(actionField, { target: { value: '@' } })
+    fireEvent.keyDown(actionField, { key: 'ArrowDown' })
+    fireEvent.keyDown(actionField, { key: 'Enter' })
+
+    expect(actionField).toHaveValue('@托马斯 ')
   })
 
   it('long-pressing the keeper avatar inserts @主持人', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -806,25 +806,6 @@ describe('RoomPage conversation history', () => {
     ))
   })
 
-  it('accepts Chinese punctuation after a leading keeper mention', async () => {
-    mockSubmitPlannedAction.mockReturnValue(new Promise(() => undefined))
-    renderRoomPage()
-    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
-
-    const actionField = screen.getByPlaceholderText('输入消息…')
-    fireEvent.change(actionField, { target: { value: '@守秘人：我查看窗外' } })
-    fireEvent.submit(actionField.closest('form')!)
-
-    await waitFor(() => expect(mockSubmitPlannedAction).toHaveBeenCalledWith(
-      'player-1',
-      expect.objectContaining({
-        utterance: '我查看窗外',
-        recipient: { kind: 'keeper', entityId: null, explicit: true },
-      }),
-    ))
-    expect(mockSendActionChat).not.toHaveBeenCalled()
-  })
-
   it('disables action submission until room mode is known but keeps discussion available', async () => {
     roomInfoState.maxPlayers = null
     renderRoomPage()
@@ -853,20 +834,6 @@ describe('RoomPage conversation history', () => {
     expect(mockSubmitPlannedAction.mock.calls[0][1]).toEqual(
       expect.objectContaining({ utterance: '我搜查书桌' }),
     )
-  })
-
-  it('action channel @ button moves a mid-text mention to the routing position', async () => {
-    renderRoomPage()
-    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
-
-    const actionField = screen.getByPlaceholderText('输入消息…')
-    fireEvent.change(actionField, { target: { value: '我稍后再问@主持人' } })
-    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
-    expect(actionField).toHaveValue('@主持人 我稍后再问@主持人')
-
-    fireEvent.change(actionField, { target: { value: '@守秘人 我查看窗外' } })
-    fireEvent.click(screen.getByRole('button', { name: '插入 @主持人' }))
-    expect(actionField).toHaveValue('@守秘人 我查看窗外')
   })
 
   it('long-pressing the keeper avatar inserts @主持人', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.test.tsx
@@ -829,6 +829,25 @@ describe('RoomPage conversation history', () => {
     expect(mockSendActionChat).not.toHaveBeenCalled()
   })
 
+  it('accepts a leading keeper mention even when the正文紧跟在 mention 后面', async () => {
+    mockSubmitPlannedAction.mockReturnValue(new Promise(() => undefined))
+    renderRoomPage()
+    await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+    const actionField = screen.getByPlaceholderText('输入消息…')
+    fireEvent.change(actionField, { target: { value: '@主持人我去图书馆' } })
+    fireEvent.submit(actionField.closest('form')!)
+
+    await waitFor(() => expect(mockSubmitPlannedAction).toHaveBeenCalledWith(
+      'player-1',
+      expect.objectContaining({
+        utterance: '我去图书馆',
+        recipient: { kind: 'keeper', entityId: null, explicit: true },
+      }),
+    ))
+    expect(mockSendActionChat).not.toHaveBeenCalled()
+  })
+
   it('disables action submission until room mode is known but keeps discussion available', async () => {
     roomInfoState.maxPlayers = null
     renderRoomPage()
@@ -1179,7 +1198,7 @@ describe('RoomPage conversation history', () => {
     // 输入框在两个频道复用过，草稿会跟着频道一起漂移：在讨论区打了一半、
     // 检定到达把频道切回行动区，那段本来要说给队友听的话再一按发送就提交给
     // 引擎了（#306 review 指出）。草稿必须按频道各存各的。
-    it('keeps each channel draft to itself when a check pulls the player back', async () => {
+  it('keeps each channel draft to itself when a check pulls the player back', async () => {
       renderRoomPage()
       await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
 
@@ -1215,6 +1234,64 @@ describe('RoomPage conversation history', () => {
       // 讨论区那句原样还在，没被顺手清掉也没被提交。
       switchToDiscussion()
       expect(discussionField()).toHaveValue('我们先商量一下路线')
+    })
+
+    it('keeps the action draft when a pending adjudication blocks new keeper submissions', async () => {
+      renderRoomPage()
+      await waitFor(() => expect(mockOnWsMessage).toHaveBeenCalled())
+
+      const actionField = () => screen.getByPlaceholderText('输入消息…')
+      fireEvent.change(actionField(), { target: { value: '@主持人 这是等待中的草稿' } })
+
+      await act(async () => {
+        emitWsMessage({
+          type: 'room.action.state',
+          payload: {
+            status: 'awaiting_player',
+            playerId: 'player-1',
+            actorId: 'actor-1',
+            clientActionId: 'pending-action',
+            startedAt: '2026-08-24T10:01:00Z',
+            revision: '8',
+          },
+        })
+        emitWsMessage({
+          type: 'adjudication.pending',
+          payload: {
+            correlationId: 'pending-action',
+            planId: 'plan-pending',
+            sourceRevision: '8',
+            status: 'awaiting_skill_choice',
+            pendingDecision: {
+              decision_id: 'decision-pending',
+              action_request_id: 'pending-action',
+              source_revision: '8',
+              decision_version: 1,
+              actor_id: 'actor-1',
+              summary: '调查书房',
+              options: [
+                {
+                  candidate_id: 'library',
+                  skill_id: 'library-use',
+                  display_name: '图书馆使用',
+                  target_value: 50,
+                  difficulty: 'regular',
+                  method_summary: '检查书架',
+                  player_safe_reason: '现场可见的调查方式',
+                },
+              ],
+              allow_cancel: true,
+            },
+          },
+        })
+      })
+
+      fireEvent.submit(actionField().closest('form')!)
+
+      expect(actionField()).toHaveValue('@主持人 这是等待中的草稿')
+      expect(mockSubmitPlannedAction).not.toHaveBeenCalled()
+      expect(mockSendActionChat).not.toHaveBeenCalled()
+      expect(mockSendChat).not.toHaveBeenCalled()
     })
 
     it('switches back to the action channel when a check arrives during discussion', async () => {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -2171,6 +2171,7 @@ export default function RoomPage() {
     e?.preventDefault()
     const text = input.trim()
     if (!text || !playerId || suspended) return
+    if (channel === 'action' && actionSubmissionBlocked) return
     const hostRequest = channel === 'action' ? hostUtteranceFromActionInput(text) : null
     // 只有 mention 没有正文时保留草稿，避免在多人房间误发成 roleplay。
     if (hostRequest && !hostRequest.utterance) return
@@ -2217,7 +2218,6 @@ export default function RoomPage() {
     }
     const singlePlayer = roomInfo?.maxPlayers === 1
     if (hostRequest || singlePlayer) {
-      if (actionSubmissionBlocked) return
       submitPlayerAction({
         clientActionId: randomActionId(),
         utterance: hostRequest?.utterance ?? text,

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -180,9 +180,44 @@ function KeeperAvatar({ onLongPress }: { onLongPress: () => void }) {
   )
 }
 
+function NpcAvatar({
+  name,
+  url,
+  onLongPress,
+}: {
+  name: string
+  url?: string
+  onLongPress?: () => void
+}) {
+  const timerRef = useRef<number | null>(null)
+  const clearTimer = () => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+    timerRef.current = null
+  }
+  useEffect(() => clearTimer, [])
+  return (
+    <button
+      type="button"
+      aria-label={onLongPress ? `长按 @${name}` : `${name}的头像`}
+      className="room-play__avatar room-play__avatar--npc"
+      onPointerDown={() => {
+        if (!onLongPress) return
+        clearTimer()
+        timerRef.current = window.setTimeout(onLongPress, HOST_MENTION_LONG_PRESS_MS)
+      }}
+      onPointerUp={clearTimer}
+      onPointerCancel={clearTimer}
+      onPointerLeave={clearTimer}
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      {url ? <img src={url} alt="" aria-hidden="true" /> : <span aria-hidden="true">NPC</span>}
+    </button>
+  )
+}
+
 // ─── Types ───────────────────────────────────────────
 interface Message {
-  type: 'system' | 'narr' | 'player' | 'dice'
+  type: 'system' | 'narr' | 'player' | 'npc' | 'dice'
   channel?: 'action' | 'discussion'
   messageId?: string
   narrationId?: string
@@ -191,6 +226,14 @@ interface Message {
   time: string
   isSelf?: boolean
   playerId?: string
+  speakerId?: string
+  avatarUrl?: string
+}
+
+interface SelectedRecipient {
+  kind: 'keeper' | 'npc'
+  entityId: string | null
+  name: string
 }
 
 const EMPTY_ROOM_PLAYERS: RoomPlayerSummary[] = []
@@ -529,6 +572,46 @@ function conversationEventToMessage(
       content: checkResultContent(payload),
       time: formatRoomTime(event.createdAt),
       isSelf: payload.playerId === selfPlayerId,
+    }
+  }
+  if (event.type === 'dialogue.player') {
+    const payload = event.payload as {
+      messageId: string
+      playerId: string
+      characterName: string
+      interlocutorName: string
+      utterance: string
+      sentAt: string
+    }
+    return {
+      type: 'player',
+      channel: 'action',
+      messageId: conversationMessageId(event.type, payload.messageId),
+      sender: payload.characterName,
+      content: `@${payload.interlocutorName} ${payload.utterance}`,
+      time: formatRoomTime(payload.sentAt),
+      isSelf: payload.playerId === selfPlayerId,
+      playerId: payload.playerId,
+    }
+  }
+  if (event.type === 'dialogue.npc') {
+    const payload = event.payload as {
+      messageId: string
+      speakerId: string
+      speakerName: string
+      avatarUrl?: string | null
+      text: string
+      sentAt: string
+    }
+    return {
+      type: 'npc',
+      channel: 'action',
+      messageId: conversationMessageId(event.type, payload.messageId),
+      sender: payload.speakerName,
+      speakerId: payload.speakerId,
+      avatarUrl: payload.avatarUrl ?? undefined,
+      content: payload.text,
+      time: formatRoomTime(payload.sentAt),
     }
   }
   return null
@@ -1333,6 +1416,9 @@ export default function RoomPage() {
   const [showPortraitGenerator, setShowPortraitGenerator] = useState(false)
   const [messages, setMessages] = useState<Message[]>([])
   const [channel, setChannel] = useState<'action' | 'discussion'>('action')
+  const [selectedRecipient, setSelectedRecipient] = useState<SelectedRecipient | null>(null)
+  const [recipientMenuOpen, setRecipientMenuOpen] = useState(false)
+  const [recipientMenuIndex, setRecipientMenuIndex] = useState(0)
   const isActionChannel = channel === 'action'
   /**
    * 草稿按频道各存各的（issue #304）。
@@ -1482,6 +1568,23 @@ export default function RoomPage() {
         '其他调查员',
       )
   const mapLocations = mapLocationsFromPlayerView(playerView)
+  const visibleNpcs = useMemo(
+    () => (playerView?.scene.visible_entities ?? []).filter((entity) => {
+      if (entity.kind !== 'npc') return false
+      const consciousness = entity.observable_state.find(
+        (state) => state.key === 'consciousness',
+      )?.value
+      return consciousness !== 'dead' && consciousness !== 'unconscious'
+    }),
+    [playerView],
+  )
+  const recipientOptions = useMemo(
+    () => [
+      { kind: 'keeper' as const, entityId: null, name: '主持人' },
+      ...visibleNpcs.map((npc) => ({ kind: 'npc' as const, entityId: npc.id, name: npc.name })),
+    ],
+    [visibleNpcs],
+  )
   const sceneTransitionTargetName = pendingSceneTransition
     ? mapLocations.find((location) => location.id === pendingSceneTransition.targetSceneId)?.name
       ?? pendingSceneTransition.targetSceneId
@@ -1542,7 +1645,22 @@ export default function RoomPage() {
   useEffect(() => {
     // 输入框在行动和讨论区复用；切换频道时丢弃尚未完成的识别，避免结果进入新频道。
     cancelSpeechInput()
+    if (channel === 'discussion') {
+      setSelectedRecipient(null)
+      setRecipientMenuOpen(false)
+    }
   }, [cancelSpeechInput, channel])
+
+  useEffect(() => {
+    if (
+      selectedRecipient?.kind === 'npc' &&
+      !visibleNpcs.some((npc) => npc.id === selectedRecipient.entityId)
+    ) {
+      // PlayerView 是权威候选源；NPC 离场后旧选择立即失效。
+      setSelectedRecipient(null)
+      setRecipientMenuOpen(false)
+    }
+  }, [selectedRecipient, visibleNpcs])
 
   useEffect(() => {
     if (suspended) cancelSpeechInput()
@@ -1753,6 +1871,30 @@ export default function RoomPage() {
           time: formatRoomTime(new Date()),
           isSelf: envelope.payload.playerId === playerId,
           playerId: envelope.payload.playerId,
+        }))
+      } else if (envelope.type === 'dialogue.player') {
+        setMessages((prev) => appendLiveMessage(prev, {
+          type: 'player',
+          channel: 'action',
+          messageId: conversationMessageId('dialogue.player', envelope.payload.messageId),
+          sender: envelope.payload.characterName,
+          content: `@${envelope.payload.interlocutorName} ${envelope.payload.utterance}`,
+          time: formatRoomTime(envelope.payload.sentAt),
+          isSelf: envelope.payload.playerId === playerId,
+          playerId: envelope.payload.playerId,
+        }))
+      } else if (envelope.type === 'dialogue.npc') {
+        setTyping(false)
+        clearBackendProgress()
+        setMessages((prev) => appendLiveMessage(prev, {
+          type: 'npc',
+          channel: 'action',
+          messageId: conversationMessageId('dialogue.npc', envelope.payload.messageId),
+          sender: envelope.payload.speakerName,
+          speakerId: envelope.payload.speakerId,
+          avatarUrl: envelope.payload.avatarUrl ?? undefined,
+          content: envelope.payload.text,
+          time: formatRoomTime(envelope.payload.sentAt),
         }))
       } else if (envelope.type === 'check.request') {
         setTyping(false)
@@ -1995,18 +2137,21 @@ export default function RoomPage() {
       })
   }
 
-  const insertHostMention = () => {
+  const selectRecipient = (recipient: SelectedRecipient) => {
     if (suspended) return
     setChannel('action')
+    setSelectedRecipient(recipient)
+    setRecipientMenuOpen(false)
     setDrafts((current) => {
       const value = current.action
+      const withoutMention = value.trim() === '@'
+        ? ''
+        : value.replace(/^\s*@[^\s，。！？；：、,.!?;:]+[\s，。！？；：、,.!?;:]*/u, '')
       return {
         ...current,
-        action: hostUtteranceFromActionInput(value) !== null
-          ? value
-          : value.trim()
-            ? `@主持人 ${value.trim()}`
-            : '@主持人 ',
+        action: withoutMention.trim()
+          ? `@${recipient.name} ${withoutMention.trim()}`
+          : `@${recipient.name} `,
       }
     })
     requestAnimationFrame(() => {
@@ -2016,6 +2161,10 @@ export default function RoomPage() {
       const cursor = field.value.length
       field.setSelectionRange(cursor, cursor)
     })
+  }
+
+  const insertHostMention = () => {
+    selectRecipient({ kind: 'keeper', entityId: null, name: '主持人' })
   }
 
   const sendMessage = (e?: FormEvent) => {
@@ -2030,6 +2179,40 @@ export default function RoomPage() {
     setInput('')
     if (channel === 'discussion') {
       sdk.roomSocket.sendChat(playerId, { text, clientMessageId: randomActionId() })
+      return
+    }
+    if (selectedRecipient?.kind === 'npc') {
+      const prefix = `@${selectedRecipient.name}`
+      if (!text.startsWith(prefix)) {
+        setInput(text)
+        setActionError('NPC 接收者已失效，请从 @ 菜单重新选择')
+        return
+      }
+      const utterance = text.slice(prefix.length).replace(/^[\s，。！？；：、,.!?;:]+/u, '').trim()
+      if (!utterance || !selectedRecipient.entityId) return
+      const clientActionId = randomActionId()
+      setTyping(true)
+      setActionError('')
+      const sent = sdk.roomSocket.submitNpcDialogue(playerId, {
+        clientActionId,
+        utterance,
+        recipient: {
+          kind: 'npc',
+          entityId: selectedRecipient.entityId,
+          explicit: true,
+        },
+      })
+      if (!sent) {
+        setTyping(false)
+        setActionError('NPC 对话发送失败，请检查连接后重试')
+      }
+      setSelectedRecipient(null)
+      setRecipientMenuOpen(false)
+      return
+    }
+    if (/^\s*@/u.test(text) && !hostRequest) {
+      setInput(text)
+      setActionError('请从 @ 菜单选择当前场景中的守秘人或 NPC')
       return
     }
     const singlePlayer = roomInfo?.maxPlayers === 1
@@ -2250,12 +2433,25 @@ export default function RoomPage() {
 
           const isPlayer = msg.type === 'player' && msg.isSelf
           const isNarr = msg.type === 'narr'
+          const isNpc = msg.type === 'npc'
           const portraitUrl = msg.playerId ? portraitUrls[msg.playerId] : undefined
 
           return (
             <div key={i} className={`room-play__message ${isPlayer ? 'room-play__message--self' : ''} ${isNarr ? 'room-play__message--narration' : ''} animate-[msgIn_0.3s_ease]`}>
               {isNarr ? (
                 <KeeperAvatar onLongPress={insertHostMention} />
+              ) : isNpc ? (
+                <NpcAvatar
+                  name={msg.sender ?? 'NPC'}
+                  url={msg.avatarUrl}
+                  onLongPress={msg.speakerId && visibleNpcs.some((npc) => npc.id === msg.speakerId)
+                    ? () => selectRecipient({
+                        kind: 'npc',
+                        entityId: msg.speakerId ?? null,
+                        name: msg.sender ?? 'NPC',
+                      })
+                    : undefined}
+                />
               ) : (
                 <div className="room-play__avatar">
                   {msg.type === 'player' && portraitUrl ? (
@@ -2271,7 +2467,7 @@ export default function RoomPage() {
                 <div className="room-play__sender">
                   {msg.sender}
                 </div>
-                <div className={`room-play__message-card ${isNarr ? 'room-play__narration-card' : ''}`}>
+                <div className={`room-play__message-card ${isNarr ? 'room-play__narration-card' : ''} ${isNpc ? 'room-play__npc-card' : ''}`}>
                   <div className="room-play__narration-text whitespace-pre-wrap">
                     {isNarr && msg.narrationId === hostSpeech.currentMessageId && hostSpeech.currentSentences.length > 0
                       ? hostSpeech.currentSentences.map((sentence) => (
@@ -2586,7 +2782,7 @@ export default function RoomPage() {
         {isActionChannel && actionError && !suspended && (
           <div className="pb-1.5 px-1">
             <div className="flex items-center justify-between gap-2">
-              <p className={`text-[11px] ${actionErrorIsGuidance ? 'text-[#8a642d]' : 'text-[#c04040]'}`}>
+              <p role="alert" className={`text-[11px] ${actionErrorIsGuidance ? 'text-[#8a642d]' : 'text-[#c04040]'}`}>
                 {actionErrorIsGuidance ? `守秘人提示：${actionError}` : actionError}
               </p>
               {pendingAction && actionErrorRetryable && (
@@ -2634,6 +2830,29 @@ export default function RoomPage() {
                     : speechInput.error}
           </p>
         )}
+        {isActionChannel && recipientMenuOpen && (
+          <div
+            id="dialogue-recipient-list"
+            role="listbox"
+            aria-label="选择消息接收者"
+            className="room-play__recipient-menu"
+          >
+            {recipientOptions.map((option, index) => (
+              <button
+                key={`${option.kind}:${option.entityId ?? 'keeper'}`}
+                type="button"
+                role="option"
+                aria-selected={recipientMenuIndex === index}
+                className={recipientMenuIndex === index ? 'is-active' : ''}
+                onMouseEnter={() => setRecipientMenuIndex(index)}
+                onClick={() => selectRecipient(option)}
+              >
+                <span aria-hidden="true">{option.kind === 'keeper' ? 'KP' : 'NPC'}</span>
+                {option.name}
+              </button>
+            ))}
+          </div>
+        )}
         <form data-onboarding-target="action-input" onSubmit={sendMessage} className="room-play__composer-form">
           {/* 讨论区只承载玩家之间的讨论，不提供掷骰入口（issue #304）。 */}
           {isActionChannel && (
@@ -2651,11 +2870,16 @@ export default function RoomPage() {
           {isActionChannel && (
             <button
               type="button"
-              aria-label="插入 @主持人"
-              title="@主持人"
-              onClick={insertHostMention}
+              aria-label="选择消息接收者"
+              title="选择守秘人或 NPC"
+              aria-expanded={recipientMenuOpen}
+              aria-controls="dialogue-recipient-list"
+              onClick={() => {
+                setRecipientMenuIndex(0)
+                setRecipientMenuOpen((open) => !open)
+              }}
               disabled={composerDisabled}
-              className={`room-play__composer-button room-play__host-mention-button${input.includes('@主持人') ? ' is-active' : ''}`}
+              className={`room-play__composer-button room-play__host-mention-button${selectedRecipient ? ' is-active' : ''}`}
             >
               <span aria-hidden="true">@</span>
             </button>
@@ -2665,8 +2889,46 @@ export default function RoomPage() {
             rows={1}
             wrap="soft"
             value={input}
-            onChange={(e) => setInput(e.target.value)}
+            role={isActionChannel ? 'combobox' : undefined}
+            aria-autocomplete={isActionChannel ? 'list' : undefined}
+            aria-expanded={isActionChannel ? recipientMenuOpen : undefined}
+            aria-controls={isActionChannel ? 'dialogue-recipient-list' : undefined}
+            onChange={(e) => {
+              const value = e.target.value
+              setInput(value)
+              if (
+                selectedRecipient &&
+                !value.trimStart().startsWith(`@${selectedRecipient.name}`)
+              ) {
+                setSelectedRecipient(null)
+              }
+              if (isActionChannel && /^\s*@[^\s]*$/u.test(value) && !selectedRecipient) {
+                setRecipientMenuIndex(0)
+                setRecipientMenuOpen(true)
+              }
+            }}
             onKeyDown={(e) => {
+              if (recipientMenuOpen) {
+                if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+                  e.preventDefault()
+                  const delta = e.key === 'ArrowDown' ? 1 : -1
+                  setRecipientMenuIndex((current) =>
+                    (current + delta + recipientOptions.length) % recipientOptions.length
+                  )
+                  return
+                }
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  setRecipientMenuOpen(false)
+                  return
+                }
+                if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+                  e.preventDefault()
+                  const option = recipientOptions[recipientMenuIndex]
+                  if (option) selectRecipient(option)
+                  return
+                }
+              }
               if (e.key !== 'Enter' || e.shiftKey || e.nativeEvent.isComposing) return
               e.preventDefault()
               sendMessage()

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -132,11 +132,15 @@ function checkResultContent(payload: CheckResultPayload): string {
 }
 
 function hostUtteranceFromActionInput(text: string): { utterance: string; explicit: true } | null {
-  // 中文输入习惯会直接在 mention 后接逗号或冒号；这些标点属于分隔符，
-  // 不应让一条明确发给守秘人的消息误落成多人 roleplay。
-  const mention = /^\s*@(主持人|守秘人)(?:\s+|[，。！？；：、,.!?;:]\s*|$)/u.exec(text)
+  // 中文输入习惯会直接在 mention 后接正文；这里把行首 @主持人/@守秘人 视为
+  // 显式主持路由，后面的空白或标点只是分隔符，不影响路由判定。
+  const mention = /^\s*@(主持人|守秘人)(?=(?:\s|[，。！？；：、,.!?;:]|$|[^A-Za-z0-9_]))/u.exec(text)
   if (!mention) return null
-  const rest = text.slice(mention[0].length).replace(/\s+/g, ' ').trim()
+  const rest = text
+    .slice(mention[0].length)
+    .replace(/^[\s，。！？；：、,.!?;:]+/u, '')
+    .replace(/\s+/g, ' ')
+    .trim()
   return { utterance: rest, explicit: true }
 }
 

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -521,6 +521,48 @@ export interface CreateInventoryImportDraftRequest {
   claims: ItemClaim[];
 }
 
+/**
+ * Host 以 NPC 身份生成的单条回复；头像 URL 仅为展示派生字段。
+ */
+export interface DialogueNpcPayload {
+  messageId: string;
+  speakerId: string;
+  speakerName: string;
+  avatarUrl?: string | null;
+  listenerIds?: string[];
+  participantIds?: string[];
+  text: string;
+  sceneId: string;
+  sourceDialogueId: string;
+  sourceActionId: string;
+  ordinal: number;
+  sourceRevision: string;
+  sentAt: string;
+  audiencePlayerIds?: string[];
+}
+
+/**
+ * 玩家对场景 NPC 的结构化发言；受众在对话开始时冻结。
+ */
+export interface DialoguePlayerPayload {
+  messageId: string;
+  playerId: string;
+  clientActionId: string;
+  nickname: string;
+  characterName: string;
+  speakerId: string;
+  interlocutorId: string;
+  interlocutorName: string;
+  listenerIds?: string[];
+  participantIds?: string[];
+  allowedResponderIds?: string[];
+  utterance: string;
+  sceneId: string;
+  sourceRevision: string;
+  sentAt: string;
+  audiencePlayerIds?: string[];
+}
+
 export interface EndingDraft {
   draft_id: string;
   request_id: string;
@@ -1267,7 +1309,7 @@ export interface RoomActionStatePayload {
  */
 export interface RoomConversationEventRead {
   id: string;
-  type: "chat.message" | "action.broadcast" | "narration.push" | "check.result";
+  type: "chat.message" | "action.broadcast" | "narration.push" | "check.result" | "dialogue.player" | "dialogue.npc";
   channel: "discussion" | "action";
   payload: {
     [k: string]: unknown;

--- a/trpg-sdk/src/resources/room-socket.test.ts
+++ b/trpg-sdk/src/resources/room-socket.test.ts
@@ -274,6 +274,48 @@ test('isValidServerEvent：拒绝 payload 字段缺失或类型不对', () => {
   );
 });
 
+test('isValidServerEvent：校验结构化 NPC 对话事件', () => {
+  const player = {
+    type: 'dialogue.player',
+    payload: {
+      messageId: 'dialogue-player-1',
+      playerId: 'player-1',
+      clientActionId: 'action-1',
+      speakerId: 'actor-1',
+      interlocutorId: 'caretaker',
+      interlocutorName: '守墓人',
+      utterance: '请记住蓝色钟摆。',
+      sceneId: 'cemetery',
+      audiencePlayerIds: ['player-1'],
+    },
+  };
+  const npc = {
+    type: 'dialogue.npc',
+    payload: {
+      messageId: 'dialogue-npc-1',
+      speakerId: 'caretaker',
+      speakerName: '守墓人',
+      text: '我记住了。',
+      sceneId: 'cemetery',
+      sourceDialogueId: 'dialogue-player-1',
+      sourceActionId: 'action-1',
+      ordinal: 0,
+      audiencePlayerIds: ['player-1'],
+    },
+  };
+
+  assert.equal(isValidServerEvent(player), true);
+  assert.equal(isValidServerEvent(npc), true);
+  assert.equal(
+    isValidServerEvent({ ...npc, payload: { ...npc.payload, ordinal: 0.5 } }),
+    false
+  );
+  assert.equal(
+    isValidServerEvent({ ...player, payload: { ...player.payload, audiencePlayerIds: 'all' } }),
+    false
+  );
+});
+
 test('isValidServerEvent：校验共享时间提案与终态', () => {
   assert.equal(
     isValidServerEvent({

--- a/trpg-sdk/src/resources/room-socket.ts
+++ b/trpg-sdk/src/resources/room-socket.ts
@@ -489,6 +489,27 @@ const PAYLOAD_VALIDATORS: {
       p.characterName === null ||
       p.characterName === undefined) &&
     typeof p.utterance === 'string',
+  'dialogue.player': (p) =>
+    typeof p.messageId === 'string' &&
+    typeof p.playerId === 'string' &&
+    typeof p.clientActionId === 'string' &&
+    typeof p.speakerId === 'string' &&
+    typeof p.interlocutorId === 'string' &&
+    typeof p.interlocutorName === 'string' &&
+    typeof p.utterance === 'string' &&
+    typeof p.sceneId === 'string' &&
+    isStringArray(p.audiencePlayerIds),
+  'dialogue.npc': (p) =>
+    typeof p.messageId === 'string' &&
+    typeof p.speakerId === 'string' &&
+    typeof p.speakerName === 'string' &&
+    typeof p.text === 'string' &&
+    typeof p.sceneId === 'string' &&
+    typeof p.sourceDialogueId === 'string' &&
+    typeof p.sourceActionId === 'string' &&
+    typeof p.ordinal === 'number' &&
+    Number.isInteger(p.ordinal) &&
+    isStringArray(p.audiencePlayerIds),
   'san.check.request': (p) => typeof p.playerId === 'string',
   'san.check.result': (p) =>
     typeof p.playerId === 'string' &&
@@ -714,6 +735,12 @@ export class RoomSocket {
       reject(new RoomSocketTransportError('WebSocket is not connected'));
     }
     return promise;
+  }
+
+  /** NPC 对话不产生 Agent turn.completed；回复通过 dialogue.* 事件到达。 */
+  submitNpcDialogue(playerId: string, payload: ActionSubmitPayload): boolean {
+    if (payload.recipient.kind !== 'npc') return false;
+    return this.send('action.plan.submit', playerId, payload);
   }
 
   selectAdjudication(playerId: string, payload: AdjudicationChoicePayload): void {

--- a/trpg-sdk/src/types.ts
+++ b/trpg-sdk/src/types.ts
@@ -82,6 +82,8 @@ export type {
   AdjudicationPendingPayload,
   AdjudicationPostRollPayload,
   ActionBroadcastPayload,
+  DialoguePlayerPayload,
+  DialogueNpcPayload,
   GameStartPayload,
   SessionBoundPayload,
   NarrationPushPayload,
@@ -164,6 +166,8 @@ import type {
   CheckRequestPayload,
   CheckResultPayload,
   ClueGrantedPayload,
+  DialogueNpcPayload,
+  DialoguePlayerPayload,
   ErrorPayload,
   GameEndedPayload,
   NarrationChunkPayload,
@@ -222,6 +226,8 @@ export type ServerToClientEvent =
   | { type: 'check.result'; payload: CheckResultPayload }
   | { type: 'chat.message'; payload: ChatMessagePayload }
   | { type: 'action.broadcast'; payload: ActionBroadcastPayload }
+  | { type: 'dialogue.player'; payload: DialoguePlayerPayload }
+  | { type: 'dialogue.npc'; payload: DialogueNpcPayload }
   | { type: 'host_speech.settings_updated'; payload: HostSpeechSettingsUpdatedPayload }
   | { type: 'san.check.request'; payload: SanCheckRequestPayload }
   | { type: 'san.check.result'; payload: SanCheckResultPayload }


### PR DESCRIPTION
## 关联 Issue

Refs #406

> 说明：本 PR 叠加在 #413 之上。当前对 `main` 的 diff 会暂时包含 PR1 的改动，建议先合并 #413，再按本 PR 的增量提交继续 Review。

## 主要改动

- 在现有结构化 `recipient` 路由之上，正式打通 `recipient.kind=npc` 的可执行链路；
- 新增 `dialogue.player` / `dialogue.npc` 事件、DTO、回放 DTO 与 SDK 类型；
- 为 NPC 对话增加冻结受众、`scene_scoped` 可见性、可恢复队列状态和结果事件持久化；
- 新增 `NpcDialogueService`，复用当前 Host provider 生成 NPC 回复，但不进入 Keeper Planner、ActionPlan、技能检定或 Engine；
- `@NPC` 路径只保存玩家发言与 NPC 回复，不会因为“去地下室”“侦查一下”之类措辞直接触发地点改变、检定或世界状态变化；
- 前端增加 NPC 选择、独立 NPC 气泡、历史恢复与默认头像映射；
- 增加后端、SDK、前端与 E2E 测试，覆盖权限、恢复、幂等和完整试玩链路。

## 采用该方案的原因

- 先把 `@NPC -> 结构化对话 -> 独立气泡 -> 刷新恢复` 这条垂直链路打通，避免继续把 NPC 台词埋在守秘人 narration 中；
- 继续复用现有房间行动队列和 Host provider，减少新基础设施，便于后续在此之上继续做“同回合守秘人/NPC 双回复编排”；
- 明确把 NPC 对话与 Keeper 行动主链隔离，先保证权限、受众和持久化边界稳定，再在后续 PR 中接入长期记忆与摘要。

## 测试与验证

已实际运行：

- Backend：`uv run pytest tests/test_action_routing_contract.py tests/test_chat_ws.py tests/test_host_action_queue.py tests/test_migrations.py tests/test_npc_dialogue.py tests/test_ws.py tests/test_ws_engine_capabilities.py`
  - 结果：`73 passed, 1 warning`
- SDK：`npm test -- --runInBand src/resources/room-socket.test.ts`
  - 结果：`32 passed`
- Frontend：`npm test -- src/routes/games/trpg/RoomPage.test.tsx`
  - 结果：`69 passed`
- E2E：`npm run test:e2e -- tests/discussion-chat.e2e.ts tests/multiplayer-ws.e2e.ts tests/action-plan-acceptance.e2e.ts`
  - 结果：`7 passed`

未在本次发 PR 前运行：

- 全量 monorepo 测试
- 前端 lint / build
- SDK typecheck / build
- 真实模型 provider 试玩

## 风险与回滚

- 当前 PR 依赖 #413 的输入路由与结构化接收者契约，合并顺序必须是 `#413 -> 本 PR`；
- 因为复用房间 FIFO 队列，NPC 对话仍会受当前房间主持行动串行化约束；
- 如需回滚，可整体回退本 PR；新增迁移只涉及 NPC 对话事件受众、队列恢复字段和 NPC 素材映射，不修改既有 Engine 权威边界。

## UI 证据

- 本 PR 包含前端展示改动；当前先以 `RoomPage.test.tsx` 和 E2E 覆盖作为验证依据；
- 若进入正式合并阶段，我可以再补一组截图或录屏到评论区。

## AI 使用情况

本 PR 的实现与自检由 AI 辅助完成，重点覆盖了接收者路由、冻结受众、队列恢复、DTO/SDK 一致性和前端独立气泡展示。合并前仍需要人工 Review 重点确认：权限边界、迁移兼容、前端交互和实际游玩体验。

## 自检

- [x] 改动范围符合 Issue #406 的实现子集
- [x] 不包含无关改动
- [x] 已包含必要的测试
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查
- [ ] 已完成人工 Review
