### PR TITLE
fix(ci): inject planner config into preview compose

### DIFF
--- a/.github/workflows/main-preview.yml
+++ b/.github/workflows/main-preview.yml
@@ -195,6 +195,23 @@ jobs:
             mkdir -p ~/trpg-previews/main
             cp ~/trpg-previews/compose-template/docker-compose.yml ~/trpg-previews/main/docker-compose.yml
             cd ~/trpg-previews/main
+
+            # 固定模板继续控制权限、挂载、端口和健康检查；版本化工作流只补充
+            # 允许注入的 Planner 环境变量，避免新增配置依赖人工同步服务器模板。
+            cat > docker-compose.override.yml <<'COMPOSE'
+          services:
+            backend:
+              environment:
+                TURN_PLANNER_PROVIDER: \${TURN_PLANNER_PROVIDER:-fake}
+                TURN_PLANNER_API_KEY: \${TURN_PLANNER_API_KEY:-}
+                TURN_PLANNER_BASE_URL: \${TURN_PLANNER_BASE_URL:-https://api.qnaigc.com/v1}
+                TURN_PLANNER_MODEL: \${TURN_PLANNER_MODEL:-deepseek/deepseek-v4-flash}
+                TURN_PLANNER_TIMEOUT_SECONDS: \${TURN_PLANNER_TIMEOUT_SECONDS:-5}
+                TURN_PLANNER_MAX_ATTEMPTS: \${TURN_PLANNER_MAX_ATTEMPTS:-2}
+                TURN_PLANNER_RETRY_BACKOFF_SECONDS: \${TURN_PLANNER_RETRY_BACKOFF_SECONDS:-0.25}
+                TURN_PLANNER_ROLLOUT_PERCENT: \${TURN_PLANNER_ROLLOUT_PERCENT:-0}
+          COMPOSE
+
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
             export BACKEND_IMAGE="$BACKEND_IMAGE"
             export FRONTEND_IMAGE="$FRONTEND_IMAGE"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -297,6 +297,23 @@ jobs:
 
             cp ~/trpg-previews/compose-template/docker-compose.yml ~/trpg-previews/pr-$PR/docker-compose.yml
             cd ~/trpg-previews/pr-$PR
+
+            # 不执行 PR 自带的 compose；只由基准工作流生成 Planner 配置白名单
+            # override，因此新增环境变量不再依赖人工同步服务器固定模板。
+            cat > docker-compose.override.yml <<'COMPOSE'
+          services:
+            backend:
+              environment:
+                TURN_PLANNER_PROVIDER: \${TURN_PLANNER_PROVIDER:-fake}
+                TURN_PLANNER_API_KEY: \${TURN_PLANNER_API_KEY:-}
+                TURN_PLANNER_BASE_URL: \${TURN_PLANNER_BASE_URL:-https://api.qnaigc.com/v1}
+                TURN_PLANNER_MODEL: \${TURN_PLANNER_MODEL:-deepseek/deepseek-v4-flash}
+                TURN_PLANNER_TIMEOUT_SECONDS: \${TURN_PLANNER_TIMEOUT_SECONDS:-5}
+                TURN_PLANNER_MAX_ATTEMPTS: \${TURN_PLANNER_MAX_ATTEMPTS:-2}
+                TURN_PLANNER_RETRY_BACKOFF_SECONDS: \${TURN_PLANNER_RETRY_BACKOFF_SECONDS:-0.25}
+                TURN_PLANNER_ROLLOUT_PERCENT: \${TURN_PLANNER_ROLLOUT_PERCENT:-0}
+          COMPOSE
+
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
             export BACKEND_IMAGE="$BACKEND_IMAGE"
             export FRONTEND_IMAGE="$FRONTEND_IMAGE"


### PR DESCRIPTION
## Problem
Main Preview deploy fails before `docker compose pull` because the server-managed compose template does not expose the new `TURN_PLANNER_*` variables.

## Fix
Keep the server-managed compose template as the security boundary, and generate a controlled `docker-compose.override.yml` during Main Preview and PR Preview deployment. The override adds only the approved `TURN_PLANNER_*` environment variables, so the workflow no longer depends on manually synchronized server templates.

## Verification
- YAML parsing passed for both workflows.
- Extracted deployment scripts passed `bash -n`.
- Generated override heredoc was verified as valid YAML.
- `git diff --check` passed.

The actual Docker deployment will be verified by the GitHub Actions run for this PR.