### PR TITLE
feat(multiplayer): 带检定的场景切换先完成检定再全员确认

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -23,6 +23,7 @@ from collaboration_framework.contracts import (
     AdjudicationRecovery,
     AdjudicationStatusView,
     AdvanceWorldTimeEffect,
+    EnterLocationEffect,
     CheckDecisionRequest,
     CheckRunView,
     CheckStep,
@@ -466,6 +467,27 @@ class AdjudicationEngineService:
         async with self._store.transaction(room_id) as transaction:
             return await transaction.find_active_action_for_player(player_id)
 
+    async def load_action_adjudication(
+        self,
+        *,
+        room_id: str,
+        action_request_id: str,
+    ) -> ActionAdjudication | None:
+        """Return the frozen ActionAdjudication for one action, if it still exists."""
+
+        async with self._store.transaction(room_id) as transaction:
+            pending = await transaction.find_pending_check_by_action(action_request_id)
+            if pending is not None:
+                return pending.adjudication
+            command = await transaction.find_latest_adjudication_command_by_action(
+                action_request_id
+            )
+            if command is None:
+                return None
+            if isinstance(command.request, SubmitAdjudicationRequest):
+                return command.request.adjudication
+            return None
+
     async def recover_action(
         self,
         request: GetAdjudicationStatusRequest,
@@ -622,7 +644,11 @@ class AdjudicationEngineService:
                 runtime,
                 request.adjudication,
                 allow_party_time_advance=allow_party_time_advance,
-                allow_party_scene_transition=allow_party_scene_transition,
+                # 带检定的 EnterLocation 此时还不会落世界：先过检定，再由应用层开确认。
+                allow_party_scene_transition=(
+                    allow_party_scene_transition
+                    or request.adjudication.check.mode != "none"
+                ),
             )
             proposal_validation, proposal_committed_level = (
                 self._build_submission_validation(
@@ -639,6 +665,7 @@ class AdjudicationEngineService:
                     passed=True,
                     player_id=request.player_id,
                     prefix_events=(),
+                    allow_party_scene_transition=allow_party_scene_transition,
                 )
                 new_state, events = final.state, final.events
                 execution = self._execution_for(
@@ -1767,6 +1794,7 @@ class AdjudicationEngineService:
         player_id: str,
         prefix_events: tuple[DomainEvent, ...],
         check_run: CheckRun | None = None,
+        allow_party_scene_transition: bool = False,
     ) -> ActionFinalization:
         """Commit this action's effects and settle the Rules they triggered.
 
@@ -1797,6 +1825,12 @@ class AdjudicationEngineService:
             passed=passed,
             check_run=check_run,
         )
+        if not allow_party_scene_transition and len(runtime.game_state.actors) > 1:
+            selected_effects = tuple(
+                effect
+                for effect in selected_effects
+                if not isinstance(effect, EnterLocationEffect)
+            )
         settlement = self._new_settlement(
             runtime, request_id=request_id, actor_id=adjudication.actor_id
         )

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -164,6 +164,7 @@ from app.service.npc_dialogue import (
     require_dialogue_npc,
     visible_dialogue_npcs,
 )
+from app.service.time_advance import ConsentAwareAdjudicationEngine
 from app.service.ws_events import broadcast_room_state
 from app.service.ws_manager import manager
 
@@ -1134,6 +1135,15 @@ async def _resume_after_authoritative_decision(
         player_id=player_id,
         on_phase=on_phase,
     )
+
+
+def _check_decision_engine() -> ConsentAwareAdjudicationEngine:
+    """检定结算必须经过确认装饰器，才能在成功的换场景效果上开全员确认。"""
+
+    engine = adjudication_engine_service
+    if isinstance(engine, ConsentAwareAdjudicationEngine):
+        return engine
+    return ConsentAwareAdjudicationEngine(engine, async_session_factory)
 
 
 def _require_pending_adjudication_status(
@@ -2835,7 +2845,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 room_id,
                                 force_processing=True,
                             )
-                            execution = await adjudication_engine_service.decide(
+                            execution = await _check_decision_engine().decide(
                                 CheckDecisionRequest(
                                     request_id=choice.request_id,
                                     room_id=room_id,
@@ -2906,7 +2916,7 @@ async def room_socket(websocket: WebSocket, room_id: str, token: str | None = No
                                 room_id,
                                 force_processing=True,
                             )
-                            execution = await adjudication_engine_service.decide_post_roll(
+                            execution = await _check_decision_engine().decide_post_roll(
                                 PostRollDecisionRequest(
                                     request_id=choice.request_id,
                                     room_id=room_id,

--- a/trpg-backend/app/core/engine.py
+++ b/trpg-backend/app/core/engine.py
@@ -10,6 +10,7 @@ from app.adapters import SqlAlchemyActionPlanRunStore, SqlAlchemyEngineStore
 from app.core.config import get_settings
 from app.core.db import async_session_factory
 from app.core.legacy_turn_run import LegacySingleActionRecoveryAdapter
+from app.service.time_advance import ConsentAwareAdjudicationEngine
 
 
 class _FixedDiceSource:
@@ -30,10 +31,14 @@ _dice = (
     if _settings.app_env == "test" and _settings.test_fixed_dice_roll is not None
     else None
 )
-adjudication_engine_service = AdjudicationEngineService(engine_store, dice=_dice)
+_raw_adjudication_engine = AdjudicationEngineService(engine_store, dice=_dice)
+adjudication_engine_service = ConsentAwareAdjudicationEngine(
+    _raw_adjudication_engine,
+    async_session_factory,
+)
 rule_engine_service = RuleEngineService(engine_store)
 legacy_single_action_recovery = LegacySingleActionRecoveryAdapter(
-    engine=adjudication_engine_service,
+    engine=_raw_adjudication_engine,
     session_factory=async_session_factory,
 )
 

--- a/trpg-backend/app/core/engine.py
+++ b/trpg-backend/app/core/engine.py
@@ -10,7 +10,6 @@ from app.adapters import SqlAlchemyActionPlanRunStore, SqlAlchemyEngineStore
 from app.core.config import get_settings
 from app.core.db import async_session_factory
 from app.core.legacy_turn_run import LegacySingleActionRecoveryAdapter
-from app.service.time_advance import ConsentAwareAdjudicationEngine
 
 
 class _FixedDiceSource:
@@ -31,14 +30,10 @@ _dice = (
     if _settings.app_env == "test" and _settings.test_fixed_dice_roll is not None
     else None
 )
-_raw_adjudication_engine = AdjudicationEngineService(engine_store, dice=_dice)
-adjudication_engine_service = ConsentAwareAdjudicationEngine(
-    _raw_adjudication_engine,
-    async_session_factory,
-)
+adjudication_engine_service = AdjudicationEngineService(engine_store, dice=_dice)
 rule_engine_service = RuleEngineService(engine_store)
 legacy_single_action_recovery = LegacySingleActionRecoveryAdapter(
-    engine=_raw_adjudication_engine,
+    engine=adjudication_engine_service,
     session_factory=async_session_factory,
 )
 

--- a/trpg-backend/app/service/scene_transition.py
+++ b/trpg-backend/app/service/scene_transition.py
@@ -15,6 +15,7 @@ from collaboration_framework.contracts import (
     AdjudicationStatusView,
     EnterLocationEffect,
     GetAdjudicationStatusRequest,
+    NoAdjudicationCheck,
     SubmitAdjudicationRequest,
 )
 from collaboration_framework.contracts.validation import AdjudicationValidationError
@@ -187,11 +188,10 @@ async def create_from_adjudication(
     db: AsyncSession,
     request: SubmitAdjudicationRequest,
 ) -> AdjudicationExecution:
-    adjudication = request.adjudication
-    if adjudication.check.mode != "none":
-        raise SceneTransitionError("带检定的场景切换必须先完成检定")
+    original = request.adjudication
+    original_action_id = original.request_id
     effects = tuple(
-        effect for effect in adjudication.success_effects if isinstance(effect, EnterLocationEffect)
+        effect for effect in original.success_effects if isinstance(effect, EnterLocationEffect)
     )
     if not effects:
         raise SceneTransitionError("裁决中没有可确认的场景切换效果")
@@ -200,8 +200,22 @@ async def create_from_adjudication(
     if session is None:
         raise SceneTransitionError("游戏尚未开始")
     source_revision = session.state_version
-    if adjudication.source_revision != str(source_revision):
+    if original.check.mode == "none" and original.source_revision != str(source_revision):
         raise SceneTransitionError("房间状态已变化，请刷新后重试")
+    adjudication = original
+    if original.check.mode != "none":
+        # 检定已经提交；提案只冻结剩余的 EnterLocation，避免同意后再次开检定。
+        adjudication = original.model_copy(
+            update={
+                "request_id": f"{original_action_id}:scene-consent",
+                "source_revision": str(source_revision),
+                "check": NoAdjudicationCheck(),
+                "success_effects": effects,
+                "failure_effects": (),
+                "persistence_intent": "location",
+            },
+            deep=True,
+        )
     state = GameState.model_validate(session.state_json)
     player_by_actor = {actor_id: actor.player_id for actor_id, actor in state.actors.items()}
     if player_by_actor.get(adjudication.actor_id) != request.player_id:
@@ -211,17 +225,17 @@ async def create_from_adjudication(
         raise SceneTransitionError("单人房间不需要全员确认")
     existing = await _active_record(db, request.room_id)
     if existing is not None:
-        if existing.action_request_id == adjudication.request_id:
+        if existing.action_request_id == original_action_id:
             return _execution(existing)
         raise SceneTransitionError("房间已有待确认的场景提案")
 
     now = datetime.now(UTC)
     proposal_id = f"scene_{uuid4().hex}"
     execution = AdjudicationExecution(
-        request_id=adjudication.request_id,
-        action_request_id=adjudication.request_id,
+        request_id=original_action_id,
+        action_request_id=original_action_id,
         status="awaiting_scene_consent",
-        view_revision=adjudication.source_revision,
+        view_revision=str(source_revision),
         outcome="pending",
         scene_transition_proposal_id=proposal_id,
     )
@@ -232,8 +246,8 @@ async def create_from_adjudication(
         proposal_version=1,
         status="pending",
         player_id=request.player_id,
-        action_request_id=adjudication.request_id,
-        parent_action_id=adjudication.request_id,
+        action_request_id=original_action_id,
+        parent_action_id=original_action_id,
         requester_player_id=request.player_id,
         source_scene_id=state.scene_id,
         target_scene_id=target_scene_id,
@@ -256,7 +270,7 @@ async def create_from_adjudication(
         winner = await _record_for_action(
             db,
             room_id=request.room_id,
-            action_request_id=adjudication.request_id,
+            action_request_id=original_action_id,
         )
         if winner is not None:
             return _execution(winner)
@@ -468,6 +482,13 @@ async def respond(
         await db.refresh(record)
         record.status = "approved"
         record.committed_revision = int(execution.view_revision)
+        record.execution_json = execution.model_copy(
+            update={
+                "request_id": record.action_request_id,
+                "action_request_id": record.action_request_id,
+            },
+            deep=True,
+        ).model_dump(mode="json")
         record.proposal_version += 1
         record.updated_at = datetime.now(UTC)
         await db.commit()
@@ -512,6 +533,12 @@ async def get_status(
         return AdjudicationStatusView(
             action_request_id=action_request_id,
             status="cancelled",
+            execution=execution,
+        )
+    if record.status == "approved":
+        return AdjudicationStatusView(
+            action_request_id=action_request_id,
+            status=execution.status,
             execution=execution,
         )
     return None

--- a/trpg-backend/app/service/time_advance.py
+++ b/trpg-backend/app/service/time_advance.py
@@ -736,6 +736,17 @@ class ConsentAwareAdjudicationEngine:
             consent_player_ids=consent_player_ids,
         )
 
+    async def submit_with_time_consent(
+        self,
+        request: SubmitAdjudicationRequest,
+        *,
+        consent_player_ids: tuple[str, ...],
+    ) -> AdjudicationExecution:
+        return await self._engine.submit_with_time_consent(
+            request,
+            consent_player_ids=consent_player_ids,
+        )
+
     async def decide(self, request):  # noqa: ANN001, ANN201
         """检定结算后，若成功效果含未提交的场景切换，再开全员确认。"""
 

--- a/trpg-backend/app/service/time_advance.py
+++ b/trpg-backend/app/service/time_advance.py
@@ -19,6 +19,7 @@ from collaboration_framework.contracts import (
     AdjudicationRecovery,
     AdjudicationStatusView,
     AdvanceWorldTimeEffect,
+    EnterLocationEffect,
     GetAdjudicationStatusRequest,
     ModuleContentV3,
     SubmitAdjudicationRequest,
@@ -736,14 +737,73 @@ class ConsentAwareAdjudicationEngine:
         )
 
     async def decide(self, request):  # noqa: ANN001, ANN201
-        """检定决策不属于时间确认，原样交给 Engine。"""
+        """检定结算后，若成功效果含未提交的场景切换，再开全员确认。"""
 
-        return await self._engine.decide(request)
+        execution = await self._engine.decide(request)
+        return await self._open_scene_consent_after_check(
+            execution,
+            room_id=request.room_id,
+            player_id=request.player_id,
+        )
 
     async def decide_post_roll(self, request):  # noqa: ANN001, ANN201
-        """检定后决策不属于时间确认，原样交给 Engine。"""
+        """奖惩骰结算后同样检查是否还需要场景确认。"""
 
-        return await self._engine.decide_post_roll(request)
+        execution = await self._engine.decide_post_roll(request)
+        return await self._open_scene_consent_after_check(
+            execution,
+            room_id=request.room_id,
+            player_id=request.player_id,
+        )
+
+    async def load_action_adjudication(
+        self,
+        *,
+        room_id: str,
+        action_request_id: str,
+    ) -> ActionAdjudication | None:
+        return await self._engine.load_action_adjudication(
+            room_id=room_id,
+            action_request_id=action_request_id,
+        )
+
+    async def _open_scene_consent_after_check(
+        self,
+        execution: AdjudicationExecution,
+        *,
+        room_id: str,
+        player_id: str,
+    ) -> AdjudicationExecution:
+        if execution.outcome != "success" or execution.status != "resolved":
+            return execution
+        adjudication = await self._engine.load_action_adjudication(
+            room_id=room_id,
+            action_request_id=execution.action_request_id,
+        )
+        if adjudication is None or not any(
+            isinstance(effect, EnterLocationEffect) for effect in adjudication.success_effects
+        ):
+            return execution
+        from app.service import scene_transition
+
+        async with self._session_factory() as db:
+            try:
+                waiting = await scene_transition.create_from_adjudication(
+                    db,
+                    SubmitAdjudicationRequest(
+                        room_id=room_id,
+                        player_id=player_id,
+                        adjudication=adjudication,
+                    ),
+                )
+            except scene_transition.SceneTransitionError:
+                return execution
+        if waiting.check_run is None and execution.check_run is not None:
+            waiting = waiting.model_copy(
+                update={"check_run": execution.check_run},
+                deep=True,
+            )
+        return waiting
 
     async def abort_consent(
         self,

--- a/trpg-backend/tests/test_scene_transition_consent.py
+++ b/trpg-backend/tests/test_scene_transition_consent.py
@@ -10,12 +10,22 @@ from collaboration_framework.contracts import (
     ActionAdjudication,
     ActionMethod,
     ActionTarget,
+    CheckDecisionRequest,
     EnterLocationEffect,
     NoAdjudicationCheck,
+    PostRollDecisionRequest,
+    RequiredAdjudicationCheck,
+    SelectCheckChoice,
+    SkillCheckCandidate,
     SubmitAdjudicationRequest,
 )
 from collaboration_framework.contracts.validation import AdjudicationValidationError
-from collaboration_framework.engine import AdjudicationEngineService, GameState
+from collaboration_framework.engine import (
+    AdjudicationEngineService,
+    DiceRoller,
+    GameState,
+    SequenceDiceSource,
+)
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,6 +33,7 @@ from app.dto.ws import SceneTransitionPendingPayload, SceneTransitionResolvedPay
 from app.main import app
 from app.models.engine import GameSession, SceneTransitionProposalRecord
 from app.service import scene_transition
+from app.service.time_advance import ConsentAwareAdjudicationEngine
 from tests.test_engine_runtime import _start_room
 
 
@@ -506,3 +517,272 @@ async def test_initiator_abort_rejects_pending_scene_and_blocks_later_accept(
     refreshed = await db_session.get(GameSession, room.id)
     assert refreshed is not None
     assert GameState.model_validate(refreshed.state_json).scene_id == initial_scene
+
+
+def _checked_request(
+    *,
+    room_id: str,
+    player_id: str,
+    revision: int,
+    action_id: str,
+) -> SubmitAdjudicationRequest:
+    return SubmitAdjudicationRequest(
+        room_id=room_id,
+        player_id=player_id,
+        adjudication=ActionAdjudication(
+            request_id=action_id,
+            source_revision=str(revision),
+            actor_id="actor_1",
+            summary="撬开门锁进入公共墓地",
+            target=ActionTarget(kind="location", id="cemetery"),
+            method=ActionMethod(family="travel", description="撬开门锁进入公共墓地"),
+            check=RequiredAdjudicationCheck(
+                candidates=(
+                    SkillCheckCandidate(
+                        candidate_id="brawl",
+                        skill_id="fighting-brawl",
+                        difficulty="regular",
+                        method_summary="撬开门锁",
+                        player_safe_reason="进入前需要通过检定",
+                    ),
+                )
+            ),
+            success_effects=(EnterLocationEffect(location_id="cemetery"),),
+        ),
+    )
+
+
+async def _roll_checked_transition(
+    *,
+    db_session: AsyncSession,
+    engine_store_factory,
+    dice: int,
+    room_number: int,
+    action_id: str,
+):
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=room_number,
+        player_count=2,
+        prepare_checkpoint=False,
+    )
+    session = await db_session.get(GameSession, room.id)
+    assert session is not None
+    wrapper = ConsentAwareAdjudicationEngine(
+        AdjudicationEngineService(
+            engine_store_factory(),
+            dice=DiceRoller(SequenceDiceSource([dice])),
+        ),
+        app.state.test_session_factory,
+    )
+    request = _checked_request(
+        room_id=room.id,
+        player_id=players[0].id,
+        revision=session.state_version,
+        action_id=action_id,
+    )
+    initial_scene = GameState.model_validate(session.state_json).scene_id
+    pending = await wrapper.submit(request)
+    assert pending.status == "awaiting_skill_choice"
+    assert pending.pending_decision is not None
+    await db_session.refresh(session)
+    assert GameState.model_validate(session.state_json).scene_id == initial_scene
+    execution = await wrapper.decide(
+        CheckDecisionRequest(
+            request_id=f"{action_id}-choice",
+            room_id=room.id,
+            player_id=players[0].id,
+            source_revision=pending.view_revision,
+            decision_id=pending.pending_decision.decision_id,
+            decision_version=pending.pending_decision.decision_version,
+            choice=SelectCheckChoice(candidate_id="brawl"),
+        )
+    )
+    if execution.status == "awaiting_post_roll_decision":
+        assert execution.check_run is not None
+        execution = await wrapper.decide_post_roll(
+            PostRollDecisionRequest(
+                request_id=f"{action_id}-accept",
+                room_id=room.id,
+                player_id=players[0].id,
+                source_revision=execution.view_revision,
+                check_id=execution.check_run.check_id,
+                check_version=execution.check_run.version,
+                option_id="accept-current",
+            )
+        )
+    await db_session.refresh(session)
+    return room, players, session, wrapper, execution, initial_scene
+
+
+@pytest.mark.asyncio
+async def test_checked_scene_transition_waits_for_roll_not_consent(
+    db_session: AsyncSession,
+    engine_store_factory,
+) -> None:
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=4391,
+        player_count=2,
+        prepare_checkpoint=False,
+    )
+    session = await db_session.get(GameSession, room.id)
+    assert session is not None
+    engine = AdjudicationEngineService(engine_store_factory())
+    request = _checked_request(
+        room_id=room.id,
+        player_id=players[0].id,
+        revision=session.state_version,
+        action_id="scene-check-submit-439",
+    )
+
+    initial_scene = GameState.model_validate(session.state_json).scene_id
+    pending = await engine.submit(request)
+    assert pending.status == "awaiting_skill_choice"
+    assert await scene_transition.get_pending(db_session, room.id) is None
+    await db_session.refresh(session)
+    assert GameState.model_validate(session.state_json).scene_id == initial_scene
+
+
+@pytest.mark.asyncio
+async def test_checked_scene_transition_failure_skips_consent(
+    db_session: AsyncSession,
+    engine_store_factory,
+) -> None:
+    room, players, session, _, execution, initial_scene = await _roll_checked_transition(
+        db_session=db_session,
+        engine_store_factory=engine_store_factory,
+        dice=100,
+        room_number=4392,
+        action_id="scene-check-fail-439",
+    )
+    assert execution.status == "resolved"
+    assert execution.outcome == "failure"
+    assert await scene_transition.get_pending(db_session, room.id) is None
+    assert GameState.model_validate(session.state_json).scene_id == initial_scene
+
+
+@pytest.mark.asyncio
+async def test_checked_scene_transition_success_opens_consent_then_commits(
+    db_session: AsyncSession,
+    engine_store_factory,
+) -> None:
+    room, players, session, wrapper, execution, initial_scene = await _roll_checked_transition(
+        db_session=db_session,
+        engine_store_factory=engine_store_factory,
+        dice=1,
+        room_number=4393,
+        action_id="scene-check-pass-439",
+    )
+    assert execution.status == "awaiting_scene_consent"
+    assert execution.check_run is not None
+    pending = await scene_transition.get_pending(db_session, room.id)
+    assert isinstance(pending, SceneTransitionPendingPayload)
+    assert GameState.model_validate(session.state_json).scene_id == initial_scene
+
+    resolved, resume_player, action_id = await scene_transition.respond(
+        db_session,
+        engine=wrapper,
+        room_id=room.id,
+        player_id=players[1].id,
+        proposal_id=pending.proposal_id,
+        proposal_version=pending.proposal_version,
+        source_revision=pending.source_revision,
+        accept=True,
+    )
+    assert isinstance(resolved, SceneTransitionResolvedPayload)
+    assert resolved.status == "approved"
+    assert resume_player == players[0].id
+    assert action_id == "scene-check-pass-439"
+    await db_session.refresh(session)
+    assert GameState.model_validate(session.state_json).scene_id == "cemetery"
+
+
+@pytest.mark.asyncio
+async def test_checked_scene_transition_reject_keeps_check_without_moving(
+    db_session: AsyncSession,
+    engine_store_factory,
+) -> None:
+    room, players, session, wrapper, execution, initial_scene = await _roll_checked_transition(
+        db_session=db_session,
+        engine_store_factory=engine_store_factory,
+        dice=1,
+        room_number=4394,
+        action_id="scene-check-reject-439",
+    )
+    pending = await scene_transition.get_pending(db_session, room.id)
+    assert isinstance(pending, SceneTransitionPendingPayload)
+    resolved, _, _ = await scene_transition.respond(
+        db_session,
+        engine=wrapper,
+        room_id=room.id,
+        player_id=players[1].id,
+        proposal_id=pending.proposal_id,
+        proposal_version=pending.proposal_version,
+        source_revision=pending.source_revision,
+        accept=False,
+    )
+    assert isinstance(resolved, SceneTransitionResolvedPayload)
+    assert resolved.status == "rejected"
+    await db_session.refresh(session)
+    assert GameState.model_validate(session.state_json).scene_id == initial_scene
+    assert execution.check_run is not None
+
+
+@pytest.mark.asyncio
+async def test_single_player_checked_scene_transition_commits_without_consent(
+    db_session: AsyncSession,
+    engine_store_factory,
+) -> None:
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=4395,
+        player_count=1,
+        prepare_checkpoint=False,
+    )
+    session = await db_session.get(GameSession, room.id)
+    assert session is not None
+    wrapper = ConsentAwareAdjudicationEngine(
+        AdjudicationEngineService(
+            engine_store_factory(),
+            dice=DiceRoller(SequenceDiceSource([1])),
+        ),
+        app.state.test_session_factory,
+    )
+    request = _checked_request(
+        room_id=room.id,
+        player_id=players[0].id,
+        revision=session.state_version,
+        action_id="scene-check-solo-439",
+    )
+    pending = await wrapper.submit(request)
+    assert pending.pending_decision is not None
+    execution = await wrapper.decide(
+        CheckDecisionRequest(
+            request_id="scene-check-solo-439-choice",
+            room_id=room.id,
+            player_id=players[0].id,
+            source_revision=pending.view_revision,
+            decision_id=pending.pending_decision.decision_id,
+            decision_version=pending.pending_decision.decision_version,
+            choice=SelectCheckChoice(candidate_id="brawl"),
+        )
+    )
+    if execution.status == "awaiting_post_roll_decision":
+        assert execution.check_run is not None
+        execution = await wrapper.decide_post_roll(
+            PostRollDecisionRequest(
+                request_id="scene-check-solo-439-accept",
+                room_id=room.id,
+                player_id=players[0].id,
+                source_revision=execution.view_revision,
+                check_id=execution.check_run.check_id,
+                check_version=execution.check_run.version,
+                option_id="accept-current",
+            )
+        )
+    assert execution.status == "resolved"
+    assert execution.outcome == "success"
+    assert await scene_transition.get_pending(db_session, room.id) is None
+    await db_session.refresh(session)
+    assert GameState.model_validate(session.state_json).scene_id == "cemetery"


### PR DESCRIPTION
Closes #439

带检定的换场景不再一提交就拒绝：先走完两阶段检定，成功后再弹全员确认，地点在同意前不变。

## 改了什么

| 模块 | 改动 |
| --- | --- |
| `engine/adjudication.py` | 检定提交不再触发 `SCENE_TRANSITION_BLOCKED`；结算时多人房先不提交 `EnterLocation` |
| `scene_transition.py` | 检定成功后开确认；提案只冻结剩余换场景效果（`check=none`），避免同意后再掷一次骰 |
| `time_advance.py` / `engine.py` | `decide` / `decide_post_roll` 走 `ConsentAware`，检定成功后接到场景确认 |
| `test_scene_transition_consent.py` | 覆盖提交等待掷骰、失败不弹确认、成功后确认再提交、拒绝保留检定结果、单人直接换场景 |

## 关键决策

**为什么不在检定成功时先把人送进目标场景：**
确认条的意义是世界还没改。先移动再补确认，拒绝/取消时还得回滚已经提交的地点。

**为什么同意后的引擎请求改用新的 `request_id`：**
原 `request_id` 已经留给检定命令。复用会撞上 replay，变成「再走一遍选技能」而不是提交 `EnterLocation`。

**为什么单人仍直接换场景：**
单人没有全员确认。`create_from_adjudication` 对单人房继续拒绝开提案，检定成功后的 `EnterLocation` 按原路径提交。

## 验证

- `tests/test_scene_transition_consent.py` + `tests/test_time_advance.py`：32 passed
- ruff / ty：改动文件通过

## 不在本 PR 范围

- 带检定的时间推进
- 「移动后等待」等场景确认 + 时间确认的复合 ActionPlan
- 大地点是否绑定下一时间块（#387）