### PR TITLE
feat(memory): 加固长团摘要与复合游标

### DIFF
--- a/trpg-backend/alembic/versions/g8b9c0d1e2f3_add_summary_event_cursors.py
+++ b/trpg-backend/alembic/versions/g8b9c0d1e2f3_add_summary_event_cursors.py
@@ -1,0 +1,103 @@
+"""为长局摘要增加基于 Event 时间和 ID 的复合游标。"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "g8b9c0d1e2f3"
+down_revision: str | None = "f7a8b9c0d1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """添加摘要游标，并尽可能从旧 sequence 定位历史 Event。"""
+    op.add_column(
+        "conversation_summaries",
+        sa.Column("through_event_created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "conversation_summaries",
+        sa.Column("through_event_id", sa.String(length=100), nullable=True),
+    )
+    op.add_column(
+        "conversation_summaries",
+        sa.Column("pending_event_created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "conversation_summaries",
+        sa.Column("pending_event_id", sa.String(length=100), nullable=True),
+    )
+    op.create_index(
+        "ix_conversation_summaries_event_cursor",
+        "conversation_summaries",
+        ["room_id", "player_id", "through_event_created_at", "through_event_id"],
+    )
+
+    # 旧摘要的 sequence 是可见事件列表中的位置；逐条回填能同时兼容 SQLite 和 PostgreSQL。
+    bind = op.get_bind()
+    summaries = sa.table(
+        "conversation_summaries",
+        sa.column("id", sa.String()),
+        sa.column("room_id", sa.String()),
+        sa.column("player_id", sa.String()),
+        sa.column("through_event_sequence", sa.Integer()),
+        sa.column("through_event_created_at", sa.DateTime(timezone=True)),
+        sa.column("through_event_id", sa.String()),
+    )
+    events = sa.table(
+        "events",
+        sa.column("id", sa.String()),
+        sa.column("room_id", sa.String()),
+        sa.column("player_id", sa.String()),
+        sa.column("event_type", sa.String()),
+        sa.column("visibility", sa.String()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+    )
+    rows = bind.execute(sa.select(summaries)).mappings().all()
+    event_types = (
+        "action.broadcast",
+        "narration.push",
+        "check.result",
+        "dialogue.player",
+        "dialogue.npc",
+    )
+    for row in rows:
+        sequence = int(row["through_event_sequence"] or 0)
+        if sequence <= 0:
+            continue
+        cursor = bind.execute(
+            sa.select(events.c.created_at, events.c.id)
+            .where(
+                events.c.room_id == row["room_id"],
+                events.c.event_type.in_(event_types),
+                sa.or_(
+                    events.c.visibility == "public",
+                    events.c.player_id == row["player_id"],
+                ),
+            )
+            .order_by(events.c.created_at, events.c.id)
+            .offset(sequence - 1)
+            .limit(1)
+        ).first()
+        if cursor is None:
+            continue
+        bind.execute(
+            summaries.update()
+            .where(summaries.c.id == row["id"])
+            .values(
+                through_event_created_at=cursor.created_at,
+                through_event_id=cursor.id,
+            )
+        )
+
+
+def downgrade() -> None:
+    """移除复合游标，不删除既有摘要内容。"""
+    op.drop_index("ix_conversation_summaries_event_cursor", table_name="conversation_summaries")
+    op.drop_column("conversation_summaries", "pending_event_id")
+    op.drop_column("conversation_summaries", "pending_event_created_at")
+    op.drop_column("conversation_summaries", "through_event_id")
+    op.drop_column("conversation_summaries", "through_event_created_at")

--- a/trpg-backend/alembic/versions/g8b9c0d1e2f3_add_summary_event_cursors.py
+++ b/trpg-backend/alembic/versions/g8b9c0d1e2f3_add_summary_event_cursors.py
@@ -1,5 +1,6 @@
 """为长局摘要增加基于 Event 时间和 ID 的复合游标。"""
 
+import uuid
 from collections.abc import Sequence
 
 import sqlalchemy as sa
@@ -44,8 +45,11 @@ def upgrade() -> None:
         sa.column("room_id", sa.String()),
         sa.column("player_id", sa.String()),
         sa.column("through_event_sequence", sa.Integer()),
+        sa.column("pending_through_sequence", sa.Integer()),
         sa.column("through_event_created_at", sa.DateTime(timezone=True)),
         sa.column("through_event_id", sa.String()),
+        sa.column("pending_event_created_at", sa.DateTime(timezone=True)),
+        sa.column("pending_event_id", sa.String()),
     )
     events = sa.table(
         "events",
@@ -56,42 +60,72 @@ def upgrade() -> None:
         sa.column("visibility", sa.String()),
         sa.column("created_at", sa.DateTime(timezone=True)),
     )
-    rows = bind.execute(sa.select(summaries)).mappings().all()
-    event_types = (
-        "action.broadcast",
-        "narration.push",
-        "check.result",
-        "dialogue.player",
-        "dialogue.npc",
+    event_audiences = sa.table(
+        "event_audiences",
+        sa.column("event_id", sa.String()),
+        sa.column("player_id", sa.String()),
     )
+    rows = bind.execute(sa.select(summaries)).mappings().all()
+    # 旧 sequence 只统计 PR4 之前的三类事件；dialogue 从 PR5 开始增量进入摘要。
+    event_types = ("action.broadcast", "narration.push", "check.result")
+
+    def _scope_ids(value: str) -> tuple[str, ...]:
+        """迁移时兼容历史带连字符和 canonical UUID。"""
+        try:
+            canonical = uuid.UUID(value).hex
+        except (ValueError, AttributeError):
+            canonical = value
+        return tuple(dict.fromkeys((value, canonical)))
+
     for row in rows:
-        sequence = int(row["through_event_sequence"] or 0)
-        if sequence <= 0:
-            continue
-        cursor = bind.execute(
+        player_scope_ids = _scope_ids(row["player_id"])
+        visible = sa.or_(
+            events.c.visibility == "public",
+            sa.and_(
+                events.c.visibility == "player_scoped",
+                events.c.player_id.in_(player_scope_ids),
+            ),
+            sa.and_(
+                events.c.visibility == "scene_scoped",
+                sa.exists(
+                    sa.select(event_audiences.c.event_id).where(
+                        event_audiences.c.event_id == events.c.id,
+                        event_audiences.c.player_id.in_(player_scope_ids),
+                    )
+                ),
+            ),
+        )
+        base_query = (
             sa.select(events.c.created_at, events.c.id)
             .where(
                 events.c.room_id == row["room_id"],
                 events.c.event_type.in_(event_types),
-                sa.or_(
-                    events.c.visibility == "public",
-                    events.c.player_id == row["player_id"],
-                ),
+                visible,
             )
             .order_by(events.c.created_at, events.c.id)
-            .offset(sequence - 1)
-            .limit(1)
-        ).first()
-        if cursor is None:
-            continue
-        bind.execute(
-            summaries.update()
-            .where(summaries.c.id == row["id"])
-            .values(
-                through_event_created_at=cursor.created_at,
-                through_event_id=cursor.id,
-            )
         )
+
+        def _cursor_at(sequence: int, query=base_query):  # noqa: ANN001
+            if sequence <= 0:
+                return None
+            return bind.execute(query.offset(sequence - 1).limit(1)).first()
+
+        through_cursor = _cursor_at(int(row["through_event_sequence"] or 0))
+        pending_cursor = _cursor_at(int(row["pending_through_sequence"] or 0))
+        if through_cursor is None and pending_cursor is None:
+            continue
+        values = {}
+        if through_cursor is not None:
+            values.update(
+                through_event_created_at=through_cursor.created_at,
+                through_event_id=through_cursor.id,
+            )
+        if pending_cursor is not None:
+            values.update(
+                pending_event_created_at=pending_cursor.created_at,
+                pending_event_id=pending_cursor.id,
+            )
+        bind.execute(summaries.update().where(summaries.c.id == row["id"]).values(**values))
 
 
 def downgrade() -> None:

--- a/trpg-backend/app/models/memory.py
+++ b/trpg-backend/app/models/memory.py
@@ -107,6 +107,16 @@ class ConversationSummaryRecord(Base):
         Uuid(as_uuid=False), ForeignKey("players.id"), nullable=False
     )
     summary_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    # 摘要游标使用 Event 的真实发生时间和稳定 ID，避免不同事件流的 sequence 混比。
+    through_event_created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    through_event_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    pending_event_created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    pending_event_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    # 旧字段保留给历史客户端和摘要 DTO；新的查询不再用它比较事件新旧。
     through_event_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
     pending_through_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
     source_revision: Mapped[str | None] = mapped_column(String(100), nullable=True)

--- a/trpg-backend/app/service/conversation_summary.py
+++ b/trpg-backend/app/service/conversation_summary.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 import structlog
 from collaboration_framework.host.schemas import ConversationSummary
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, delete, exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.adapters.conversation_summary import ConversationSummaryModel
-from app.models.event import Event
+from app.models.event import Event, EventAudience
 from app.models.memory import ConversationSummaryRecord
 from app.models.room import Player
 
@@ -20,6 +21,52 @@ logger = structlog.get_logger()
 
 # 达到上限后保留失败状态，后续新事件或全量重建可以再次触发。
 _MAX_ATTEMPTS = 5
+_SUMMARY_INPUT_CHAR_LIMIT = 4000
+_SUMMARY_EVENT_TYPES = (
+    "action.broadcast",
+    "narration.push",
+    "check.result",
+    "dialogue.player",
+    "dialogue.npc",
+)
+
+
+@dataclass(frozen=True, order=True)
+class _EventCursor:
+    """摘要使用的稳定 Event 复合游标。"""
+
+    created_at: datetime
+    event_id: str
+
+
+def _cursor_from_event(event: Event) -> _EventCursor:
+    """从 Event 取得可跨数据库排序的游标。"""
+    return _EventCursor(event.created_at, event.id)
+
+
+def _cursor_value(record: ConversationSummaryRecord, prefix: str) -> _EventCursor | None:
+    """读取新游标；旧迁移尚未回填时返回空并走兼容路径。"""
+    created_at = getattr(record, f"{prefix}_event_created_at", None)
+    event_id = getattr(record, f"{prefix}_event_id", None)
+    if created_at is None or event_id is None:
+        return None
+    return _EventCursor(created_at, event_id)
+
+
+def _cursor_after(column_created_at, column_id, cursor: _EventCursor):  # noqa: ANN001
+    """构造严格位于复合游标之后的 SQL 条件。"""
+    return or_(
+        column_created_at > cursor.created_at,
+        and_(column_created_at == cursor.created_at, column_id > cursor.event_id),
+    )
+
+
+def _cursor_at_or_before(column_created_at, column_id, cursor: _EventCursor):  # noqa: ANN001
+    """构造不超过目标游标的 SQL 条件。"""
+    return or_(
+        column_created_at < cursor.created_at,
+        and_(column_created_at == cursor.created_at, column_id <= cursor.event_id),
+    )
 
 
 def _scope_ids(value: str) -> tuple[str, ...]:
@@ -37,8 +84,21 @@ def _event_text(event: Event) -> str:
     for key in ("text", "utterance", "summary", "description", "content"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
-            return value.strip()
+            return value.strip()[:2000]
     return ""
+
+
+def _bounded_summary_events(events: list[Event]) -> list[Event]:
+    """把一次摘要模型请求限制在 4000 字符，剩余事件留给下一次游标推进。"""
+    selected: list[Event] = []
+    total_chars = 0
+    for event in events:
+        event_chars = len(_event_text(event))
+        if selected and total_chars + event_chars > _SUMMARY_INPUT_CHAR_LIMIT:
+            break
+        selected.append(event)
+        total_chars += event_chars
+    return selected
 
 
 class DeterministicConversationSummaryModel:
@@ -53,8 +113,8 @@ class DeterministicConversationSummaryModel:
             if not text:
                 continue
             # Fake 摘要也必须保留主张边界，不能把玩家原话伪装成已确认事实。
-            if item.get("type") == "action.broadcast":
-                text = f"玩家声称/行动：{text}"
+            if item.get("type") in {"action.broadcast", "dialogue.player"}:
+                text = f"玩家声称/计划：{text}"
             lines.append(text)
         text = (previous.summary + "\n" if previous and previous.summary else "") + "\n".join(
             lines[-10:]
@@ -81,47 +141,148 @@ class ConversationSummaryService:
         self._model = model
         self._worker_task: asyncio.Task[None] | None = None
 
-    async def enqueue_if_needed(self, *, room_id: str, player_id: str) -> None:
-        """根据可见事件游标判断是否达到摘要阈值。"""
-        async with self._session_factory() as session:
-            player_scope_ids = _scope_ids(player_id)
-            events = list(
-                (
-                    await session.scalars(
-                        select(Event)
-                        .where(
-                            Event.room_id == room_id,
-                            or_(
-                                Event.player_id.in_(player_scope_ids),
-                                Event.visibility == "public",
-                            ),
-                            Event.event_type.in_(
-                                ("action.broadcast", "narration.push", "check.result")
-                            ),
+    async def _visible_events(
+        self,
+        session: AsyncSession,
+        *,
+        room_id: str,
+        player_id: str,
+        after: _EventCursor | None = None,
+        through: _EventCursor | None = None,
+    ) -> list[Event]:
+        """按 viewer 权限和复合游标读取有限摘要输入。"""
+        conditions = [
+            Event.room_id == room_id,
+            Event.event_type.in_(_SUMMARY_EVENT_TYPES),
+            or_(
+                Event.visibility == "public",
+                and_(
+                    Event.visibility == "player_scoped",
+                    Event.player_id.in_(_scope_ids(player_id)),
+                ),
+                and_(
+                    Event.visibility == "scene_scoped",
+                    exists(
+                        select(EventAudience.event_id).where(
+                            EventAudience.event_id == Event.id,
+                            EventAudience.player_id.in_(_scope_ids(player_id)),
                         )
-                        .order_by(Event.created_at, Event.id)
-                    )
-                ).all()
+                    ),
+                ),
+            ),
+        ]
+        if after is not None:
+            conditions.append(_cursor_after(Event.created_at, Event.id, after))
+        if through is not None:
+            conditions.append(_cursor_at_or_before(Event.created_at, Event.id, through))
+        return list(
+            (
+                await session.scalars(
+                    select(Event).where(*conditions).order_by(Event.created_at, Event.id)
+                )
+            ).all()
+        )
+
+    async def _event_before_cursor(
+        self,
+        session: AsyncSession,
+        *,
+        room_id: str,
+        player_id: str,
+        cursor: _EventCursor,
+    ) -> Event | None:
+        """读取游标前一条事件，用于识别离开场景触发。"""
+        return await session.scalar(
+            select(Event)
+            .where(
+                Event.room_id == room_id,
+                Event.event_type.in_(_SUMMARY_EVENT_TYPES),
+                or_(
+                    Event.visibility == "public",
+                    and_(
+                        Event.visibility == "player_scoped",
+                        Event.player_id.in_(_scope_ids(player_id)),
+                    ),
+                    and_(
+                        Event.visibility == "scene_scoped",
+                        exists(
+                            select(EventAudience.event_id).where(
+                                EventAudience.event_id == Event.id,
+                                EventAudience.player_id.in_(_scope_ids(player_id)),
+                            )
+                        ),
+                    ),
+                ),
+                or_(
+                    Event.created_at < cursor.created_at,
+                    and_(Event.created_at == cursor.created_at, Event.id < cursor.event_id),
+                ),
             )
+            .order_by(Event.created_at.desc(), Event.id.desc())
+            .limit(1)
+        )
+
+    @staticmethod
+    def _set_cursor(record: ConversationSummaryRecord, prefix: str, cursor: _EventCursor) -> None:
+        """在 ORM 记录中写入摘要复合游标。"""
+        setattr(record, f"{prefix}_event_created_at", cursor.created_at)
+        setattr(record, f"{prefix}_event_id", cursor.event_id)
+
+    async def enqueue_if_needed(self, *, room_id: str, player_id: str, force: bool = False) -> None:
+        """根据可见 dialogue/叙事事件判断是否达到摘要阈值。"""
+        async with self._session_factory() as session:
             record = await session.scalar(
                 select(ConversationSummaryRecord).where(
                     ConversationSummaryRecord.room_id == room_id,
                     ConversationSummaryRecord.player_id == player_id,
                 )
             )
-            previous_through = record.through_event_sequence if record else 0
-            new_events = events[previous_through:]
+            through_cursor = _cursor_value(record, "through") if record else None
+            new_events = await self._visible_events(
+                session,
+                room_id=room_id,
+                player_id=player_id,
+                after=through_cursor,
+            )
+            if through_cursor is None and record and record.through_event_sequence:
+                # 旧数据没有复合游标时只在一次迁移/部署窗口内兼容 sequence。
+                all_events = await self._visible_events(
+                    session, room_id=room_id, player_id=player_id
+                )
+                new_events = all_events[record.through_event_sequence :]
+            if not new_events:
+                return
             new_chars = sum(len(_event_text(event)) for event in new_events)
+            previous_event = (
+                await self._event_before_cursor(
+                    session,
+                    room_id=room_id,
+                    player_id=player_id,
+                    cursor=through_cursor,
+                )
+                if through_cursor
+                else None
+            )
             scene_changed = bool(
-                previous_through
-                and previous_through < len(events)
+                previous_event
                 and any(
-                    event.scene_id != events[previous_through - 1].scene_id
-                    for event in events[previous_through:]
-                    if event.scene_id is not None
+                    event.scene_id is not None and event.scene_id != previous_event.scene_id
+                    for event in new_events
                 )
             )
-            if len(events) - previous_through < 10 and new_chars < 6000 and not scene_changed:
+            latest_cursor = _cursor_from_event(new_events[-1])
+            threshold_reached = len(new_events) >= 10 or new_chars >= 6000 or scene_changed
+            if record is not None and record.status == "running":
+                # 运行中的旧任务保留 lease；只推进 pending 目标，避免覆盖当前工作者。
+                self._set_cursor(record, "pending", latest_cursor)
+                record.pending_through_sequence = max(
+                    record.pending_through_sequence,
+                    record.through_event_sequence + len(new_events),
+                )
+                record.updated_at = datetime.now(UTC)
+                await session.commit()
+                return
+            if not threshold_reached and not force:
                 return
             if record is None:
                 record = ConversationSummaryRecord(
@@ -129,18 +290,22 @@ class ConversationSummaryService:
                     player_id=player_id,
                     summary_json={},
                     through_event_sequence=0,
-                    pending_through_sequence=len(events),
+                    pending_through_sequence=len(new_events),
                     status="pending",
                     attempt_count=0,
                     updated_at=datetime.now(UTC),
                 )
+                self._set_cursor(record, "pending", latest_cursor)
                 session.add(record)
             else:
-                # 运行中的旧任务保留 lease，只推进目标游标；旧结果保存后会
-                # 自动转回 pending，交给下一次 worker 处理新增事件。
-                record.pending_through_sequence = max(record.pending_through_sequence, len(events))
-                if record.status != "running":
-                    record.status = "pending"
+                record.pending_through_sequence = max(
+                    record.pending_through_sequence,
+                    record.through_event_sequence + len(new_events),
+                )
+                record.status = "pending"
+                pending_cursor = _cursor_value(record, "pending")
+                if pending_cursor is None or latest_cursor > pending_cursor:
+                    self._set_cursor(record, "pending", latest_cursor)
                 record.updated_at = datetime.now(UTC)
             await session.commit()
 
@@ -163,27 +328,30 @@ class ConversationSummaryService:
         except Exception as exc:  # noqa: BLE001 - 后台入队失败不能影响回合
             logger.warning("conversation_summary_enqueue_failed", error_type=type(exc).__name__)
 
-    async def process_once(self) -> bool:
+    async def process_once(self, *, room_id: str | None = None) -> bool:
         """处理一个到期任务，使用短 lease 避免多 worker 重复调用。"""
         owner = str(uuid.uuid4())
         now = datetime.now(UTC)
         async with self._session_factory() as session:
-            record = await session.scalar(
-                select(ConversationSummaryRecord)
-                .where(
-                    or_(
-                        and_(
-                            ConversationSummaryRecord.status.in_(("pending", "retry")),
-                            (ConversationSummaryRecord.next_attempt_at.is_(None))
-                            | (ConversationSummaryRecord.next_attempt_at <= now),
-                        ),
-                        and_(
-                            ConversationSummaryRecord.status == "running",
-                            ConversationSummaryRecord.lease_expires_at.is_not(None),
-                            ConversationSummaryRecord.lease_expires_at <= now,
-                        ),
+            claim_conditions = [
+                or_(
+                    and_(
+                        ConversationSummaryRecord.status.in_(("pending", "retry")),
+                        (ConversationSummaryRecord.next_attempt_at.is_(None))
+                        | (ConversationSummaryRecord.next_attempt_at <= now),
+                    ),
+                    and_(
+                        ConversationSummaryRecord.status == "running",
+                        ConversationSummaryRecord.lease_expires_at.is_not(None),
+                        ConversationSummaryRecord.lease_expires_at <= now,
                     ),
                 )
+            ]
+            if room_id is not None:
+                claim_conditions.append(ConversationSummaryRecord.room_id == room_id)
+            record = await session.scalar(
+                select(ConversationSummaryRecord)
+                .where(*claim_conditions)
                 .order_by(ConversationSummaryRecord.updated_at)
                 .with_for_update()
             )
@@ -194,8 +362,9 @@ class ConversationSummaryService:
             record.lease_expires_at = now + timedelta(minutes=2)
             await session.commit()
             room_id, player_id = record.room_id, record.player_id
-            through = record.pending_through_sequence
             previous_through = record.through_event_sequence
+            through_cursor = _cursor_value(record, "through")
+            target_cursor = _cursor_value(record, "pending")
             previous = (
                 ConversationSummary.model_validate(record.summary_json)
                 if record.summary_json
@@ -203,29 +372,27 @@ class ConversationSummaryService:
             )
 
         async with self._session_factory() as session:
-            events = list(
-                (
-                    await session.scalars(
-                        select(Event)
-                        .where(
-                            Event.room_id == room_id,
-                            or_(
-                                Event.player_id.in_(_scope_ids(player_id)),
-                                Event.visibility == "public",
-                            ),
-                            Event.event_type.in_(
-                                ("action.broadcast", "narration.push", "check.result")
-                            ),
-                        )
-                        .order_by(Event.created_at, Event.id)
-                    )
-                ).all()
+            events = await self._visible_events(
+                session,
+                room_id=room_id,
+                player_id=player_id,
+                after=through_cursor,
+                through=target_cursor,
             )
-        # 只压缩上次成功游标之后的新事件，避免重复发送整局记录。
+            if through_cursor is None and previous_through:
+                all_events = await self._visible_events(
+                    session, room_id=room_id, player_id=player_id, through=target_cursor
+                )
+                events = all_events[previous_through:]
+        # 只压缩成功游标之后、当前 pending 目标之前的新事件。
+        batch = _bounded_summary_events(events)
         visible = tuple(
             {"id": event.id, "text": _event_text(event), "type": event.event_type}
-            for event in events[previous_through:through]
+            for event in batch
         )
+        if not visible:
+            return False
+        resolved_target = _cursor_from_event(batch[-1])
         try:
             summary = await self._model.summarize(
                 room_id=room_id,
@@ -233,7 +400,7 @@ class ConversationSummaryService:
                 previous=previous,
                 visible_events=visible,
                 source_revision=None,
-                through_event_sequence=through,
+                through_event_sequence=previous_through + len(batch),
             )
         except Exception as exc:  # noqa: BLE001 - background failure is recoverable
             async with self._session_factory() as session:
@@ -273,9 +440,12 @@ class ConversationSummaryService:
             if record:
                 record.summary_json = summary.model_dump(mode="json")
                 record.through_event_sequence = summary.through_event_sequence
+                self._set_cursor(record, "through", resolved_target)
+                current_pending = _cursor_value(record, "pending")
                 record.status = (
                     "pending"
-                    if record.pending_through_sequence > summary.through_event_sequence
+                    if (current_pending is not None and current_pending > resolved_target)
+                    or record.pending_through_sequence > summary.through_event_sequence
                     else "idle"
                 )
                 record.attempt_count = 0
@@ -285,6 +455,27 @@ class ConversationSummaryService:
                 record.updated_at = datetime.now(UTC)
                 await session.commit()
         return True
+
+    async def rebuild_room(self, room_id: str, *, replace: bool = False) -> tuple[int, int]:
+        """按正常摘要代码重建指定房间，并返回玩家数与生成次数。"""
+        async with self._session_factory() as session:
+            if replace:
+                # 显式 replace 只清理该房间摘要，不触碰原始 Event 或 Memory。
+                await session.execute(
+                    delete(ConversationSummaryRecord).where(
+                        ConversationSummaryRecord.room_id == room_id
+                    )
+                )
+            player_ids = list(
+                (await session.scalars(select(Player.id).where(Player.room_id == room_id))).all()
+            )
+            await session.commit()
+        for player_id in player_ids:
+            await self.enqueue_if_needed(room_id=room_id, player_id=player_id, force=replace)
+        generated = 0
+        while await self.process_once(room_id=room_id):
+            generated += 1
+        return len(player_ids), generated
 
     async def start(self) -> None:
         """启动轻量轮询；摘要任务自身已持久化，重启可继续。"""

--- a/trpg-backend/scripts/rebuild_memory_projection.py
+++ b/trpg-backend/scripts/rebuild_memory_projection.py
@@ -6,11 +6,13 @@ import argparse
 import asyncio
 
 from app.adapters.sqlalchemy_memory import SqlAlchemyMemoryStore
+from app.core.config import get_settings
 from app.core.db import async_session_factory
+from app.service.conversation_summary import build_conversation_summary_service
 
 
-async def _main(room_id: str, *, replace: bool) -> None:
-    """默认增量补投影；只有显式 replace 才替换指定房间的投影。"""
+async def _main(room_id: str, *, replace: bool, summary: bool) -> None:
+    """默认增量补投影；可选复用摘要服务重建指定房间摘要。"""
     store = SqlAlchemyMemoryStore(async_session_factory)
     result = (
         await store.rebuild_room_events(room_id)
@@ -25,6 +27,13 @@ async def _main(room_id: str, *, replace: bool) -> None:
         f"event_created_at={result.event_created_at} event_id={result.event_id} "
         f"game_sequence={result.game_sequence}"
     )
+    if summary:
+        summary_service = build_conversation_summary_service(get_settings(), async_session_factory)
+        player_count, generated = await summary_service.rebuild_room(room_id, replace=replace)
+        print(
+            f"room_id={room_id} summary_mode={'replace' if replace else 'incremental'} "
+            f"players={player_count} generated={generated}"
+        )
 
 
 if __name__ == "__main__":
@@ -33,7 +42,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--replace",
         action="store_true",
-        help="删除并重新生成指定房间的 MemoryEntry；不会删除摘要或原始事件",
+        help="删除并重新生成指定房间的 MemoryEntry；仅配合 --summary 时重建摘要",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="同时按正常摘要服务增量处理该房间；配合 --replace 才会重建摘要",
     )
     args = parser.parse_args()
-    asyncio.run(_main(args.room_id, replace=args.replace))
+    asyncio.run(_main(args.room_id, replace=args.replace, summary=args.summary))

--- a/trpg-backend/tests/test_memory_system.py
+++ b/trpg-backend/tests/test_memory_system.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters.sqlalchemy_memory import _listener_memories
 from app.models.engine import GameEvent, GameSession, ModuleVersion
-from app.models.event import Event
+from app.models.event import Event, EventAudience
 from app.models.memory import (
     ConversationSummaryRecord,
     MemoryEntryRecord,
@@ -118,7 +118,7 @@ async def test_fake_summary_preserves_scope_and_source_cursor() -> None:
     assert summary.through_event_sequence == 2
     assert summary.source_event_ids == ("event-2",)
     assert "旧宅" in summary.summary
-    assert "玩家声称/行动" in summary.summary
+    assert "玩家声称/计划" in summary.summary
 
 
 def test_narrator_context_serializes_memory_and_summary() -> None:
@@ -376,6 +376,94 @@ async def test_summary_enqueue_preserves_running_lease(
     assert record.status == "running"
     assert record.lease_owner == "worker-1"
     assert record.pending_through_sequence == 13
+
+
+@pytest.mark.asyncio
+async def test_summary_enqueue_uses_dialogue_event_cursor(
+    db_session: AsyncSession,
+    memory_store,
+) -> None:  # noqa: ANN001
+    """十条 dialogue 会触发摘要，并把最后一条 Event 写入复合游标。"""
+    room, player, actor_id = await _create_memory_room(db_session, 17)
+    base = datetime(2026, 8, 6, tzinfo=UTC)
+    events = [
+        Event(
+            id=str(uuid.uuid4()),
+            room_id=room.id,
+            player_id=player.id,
+            actor_id=actor_id,
+            event_type="dialogue.player",
+            visibility="scene_scoped",
+            scene_id="study",
+            payload={"utterance": f"记住短语 {index}"},
+            created_at=base + timedelta(seconds=index),
+        )
+        for index in range(10)
+    ]
+    db_session.add_all(events)
+    db_session.add_all([EventAudience(event_id=event.id, player_id=player.id) for event in events])
+    await db_session.commit()
+
+    service = ConversationSummaryService(
+        memory_store._session_factory,  # noqa: SLF001
+        DeterministicConversationSummaryModel(),
+    )
+    await service.enqueue_if_needed(room_id=room.id, player_id=player.id)
+
+    async with service._session_factory() as session:  # noqa: SLF001
+        record = await session.scalar(
+            select(ConversationSummaryRecord).where(
+                ConversationSummaryRecord.room_id == room.id,
+                ConversationSummaryRecord.player_id == player.id,
+            )
+        )
+    assert record is not None
+    assert record.pending_event_id == events[-1].id
+    assert record.pending_event_created_at == events[-1].created_at.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_summary_process_advances_composite_cursor(
+    db_session: AsyncSession,
+    memory_store,
+) -> None:  # noqa: ANN001
+    """摘要成功后同时保存内容和复合游标，下一次不会重复压缩旧 dialogue。"""
+    room, player, actor_id = await _create_memory_room(db_session, 18)
+    base = datetime(2026, 8, 7, tzinfo=UTC)
+    events = [
+        Event(
+            id=str(uuid.uuid4()),
+            room_id=room.id,
+            player_id=player.id,
+            actor_id=actor_id,
+            event_type="dialogue.player",
+            visibility="public",
+            scene_id="study",
+            payload={"utterance": f"旧对话 {index}"},
+            created_at=base + timedelta(seconds=index),
+        )
+        for index in range(10)
+    ]
+    db_session.add_all(events)
+    await db_session.commit()
+    service = ConversationSummaryService(
+        memory_store._session_factory,  # noqa: SLF001
+        DeterministicConversationSummaryModel(),
+    )
+    await service.enqueue_if_needed(room_id=room.id, player_id=player.id)
+    assert await service.process_once()
+    assert not await service.process_once()
+
+    async with service._session_factory() as session:  # noqa: SLF001
+        record = await session.scalar(
+            select(ConversationSummaryRecord).where(
+                ConversationSummaryRecord.room_id == room.id,
+                ConversationSummaryRecord.player_id == player.id,
+            )
+        )
+    assert record is not None
+    assert record.summary_json["summary"].count("旧对话") == 10
+    assert record.through_event_id == events[-1].id
 
 
 @pytest.mark.asyncio

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -526,3 +526,69 @@ def test_memory_source_time_reconciliation_repairs_stamped_database(tmp_path: Pa
         indexes = {row[1] for row in connection.execute("PRAGMA index_list('memory_entries')")}
     assert source_created_at == ("2026-08-20 12:34:56",)
     assert "ix_memory_entries_room_source_created" in indexes
+
+
+def test_summary_cursor_migration_preserves_scene_audience_and_pending_target(
+    tmp_path: Path,
+) -> None:
+    """旧摘要回填必须包含冻结场景受众，并保留任务原有 pending 上界。"""
+    database = tmp_path / "summary-cursor-backfill.db"
+    _upgrade_or_fail(database, "f7a8b9c0d1e2")
+    room_id = "21000000000000000000000000000001"
+    player_id = "21000000000000000000000000000002"
+    event_ids = [
+        "21000000000000000000000000000011",
+        "21000000000000000000000000000012",
+        "21000000000000000000000000000013",
+    ]
+    with sqlite3.connect(database) as connection:
+        connection.executemany(
+            """
+            INSERT INTO events (
+                id, room_id, player_id, event_type, payload, visibility, created_at
+            ) VALUES (?, ?, ?, ?, '{}', ?, ?)
+            """,
+            [
+                (
+                    event_ids[0],
+                    room_id,
+                    player_id,
+                    "action.broadcast",
+                    "public",
+                    "2026-08-01 00:00:01",
+                ),
+                (
+                    event_ids[1],
+                    room_id,
+                    player_id,
+                    "narration.push",
+                    "scene_scoped",
+                    "2026-08-01 00:00:02",
+                ),
+                (event_ids[2], room_id, player_id, "check.result", "public", "2026-08-01 00:00:03"),
+            ],
+        )
+        connection.execute(
+            "INSERT INTO event_audiences (event_id, player_id) VALUES (?, ?)",
+            (event_ids[1], player_id),
+        )
+        connection.execute(
+            """
+            INSERT INTO conversation_summaries (
+                id, room_id, player_id, summary_json,
+                through_event_sequence, pending_through_sequence,
+                status, attempt_count, updated_at
+            ) VALUES (?, ?, ?, '{}', 2, 3, 'pending', 0, '2026-08-01 00:00:04')
+            """,
+            ("21000000000000000000000000000020", room_id, player_id),
+        )
+
+    _upgrade_or_fail(database, "head")
+    with sqlite3.connect(database) as connection:
+        cursor = connection.execute(
+            """
+            SELECT through_event_id, pending_event_id
+            FROM conversation_summaries
+            """
+        ).fetchone()
+    assert cursor == (event_ids[1], event_ids[2])

--- a/trpg-backend/tests/test_migrations.py
+++ b/trpg-backend/tests/test_migrations.py
@@ -12,7 +12,7 @@ ENGINE_IDENTITY_PREVIOUS_REVISION = "9c4e7a2b1d6f"
 # PR2 NPC 对话迁移（d1e2f3a4b5c6）接在 PR1 输入路由 head 后面；#398 的检定唯一
 # 约束放宽（b8c9d0e1f2a3）再接在它之后，最后是模组快照的死字段剥离。
 # PR4 新增的记忆投影迁移把这条线和已有的另外一条 head 合并起来。
-HEAD_REVISION = "f7a8b9c0d1e2"
+HEAD_REVISION = "g8b9c0d1e2f3"
 
 
 def _run_alembic(database: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -198,6 +198,12 @@ def test_migration_upgrades_empty_sqlite_and_round_trips(tmp_path: Path) -> None
     assert ("room_id", "event_type", "correlation_id") in _unique_column_sets(database, "events")
     assert "source_created_at" in _column_names(database, "memory_entries")
     assert "audience_player_ids" in _column_names(database, "memory_entries")
+    assert {
+        "through_event_created_at",
+        "through_event_id",
+        "pending_event_created_at",
+        "pending_event_id",
+    }.issubset(_column_names(database, "conversation_summaries"))
 
     downgrade = _run_alembic(database, "downgrade", PREVIOUS_REVISION)
     assert downgrade.returncode == 0, downgrade.stdout + downgrade.stderr


### PR DESCRIPTION
## 关联 Issue

Refs #406

本 PR 是长期记忆方案的最后一个实现阶段 PR5，基于已合并的 PR4（#440）。

## 背景与目标

PR4 已经解决了 NPC 定向记忆、冻结受众和 Keeper/Narrator 读取边界，但摘要任务仍使用旧的事件序号游标。长团运行后可能重复扫描历史、漏掉结构化 dialogue，或在摘要任务运行期间把新事件提前纳入旧任务。

本 PR 让摘要投影在多次压缩、追加事件、服务重启和重连后保持可恢复、可审计，并将单次模型输入控制在有界预算内。

## 主要改动

- 为 `conversation_summaries` 增加成功游标和 pending 游标：`(event_created_at, event_id)`。
- 保留旧 `through_event_sequence` / `pending_through_sequence` 作为兼容字段，并在迁移时回填复合游标。
- 迁移回填严格复用旧摘要事件类型和 viewer 可见性规则，包含 `scene_scoped + event_audiences`，避免历史摘要游标错位。
- 摘要输入纳入 `dialogue.player` / `dialogue.npc`，继续排除 `ChatMessage`、`adjudication:*`、未执行队列原话和隐藏内容。
- 摘要服务按 `public`、当前 viewer 的 `player_scoped`、冻结受众允许的 `scene_scoped` 事件读取。
- 运行中的任务收到新事件时只推进 pending 目标，不覆盖当前 lease；旧任务完成后继续处理新增事件。
- 单次摘要批次限制为 4000 字符，剩余事件由复合游标分批处理，避免 Prompt 随总回合数无限增长。
- 摘要失败保留旧结果并按现有 lease/有限重试机制恢复，不阻塞玩家回合。
- `rebuild_memory_projection.py` 增加 `--summary`，默认增量处理；只有 `--replace --summary` 才重建指定房间摘要，不影响其他房间、原始 Event、Memory 或 Engine 状态。
- 不新增 NPC Summary 表、独立 NPC Agent、Embedding、向量数据库、TTS 或 NPC 自主行动。

## 采用该方案的原因

Event 的 `sequence` 只在单一事件流内有序，不能可靠比较 Event 的不同来源或处理时间；使用 `(created_at, id)` 可以复用现有 Event 排序，并在相同时间戳下保持确定性。

摘要继续复用现有 `conversation_summaries` 和 worker，而不是新增 NPC 专用持久化状态机，减少迁移、并发和权限边界的重复实现。旧 sequence 字段保留，便于历史数据迁移和兼容回滚。

## 测试与验证

本地已完成：

- `uv run pytest`：609 passed，22 skipped
- Review 修复后的记忆/迁移专项测试：25 passed
- `uv run ruff check .`：通过
- `uv run ruff format --check .`：通过
- `uv run ty check`：通过
- `uv run alembic heads`：仅有 `g8b9c0d1e2f3`
- SQLite `alembic upgrade head`：通过
- PostgreSQL migration、E2E、codegen drift：CI 已通过

新增回归覆盖：

- 10 条 dialogue 触发摘要并推进复合游标；
- 摘要成功后不会重复压缩旧事件；
- running lease 期间追加事件只推进 pending 目标；
- 长局历史事件的权限过滤、场景冻结受众和旧 pending 上界迁移；
- 摘要失败、重建和长局批次边界的现有恢复路径。

新的 Backend CI 已因 review 修复重新运行，目前仍在执行；不会以本地结果替代远端必需检查。

## 兼容、风险与回滚

- 迁移同时支持 SQLite 和 PostgreSQL；新字段允许为空，旧摘要可在部署后渐进回填。
- downgrade 只移除新增游标字段和索引，不删除摘要、Event、Memory 或 Engine 状态。
- 摘要模型失败时保留旧摘要，任务进入 retry/failed 终态，不阻塞实时回合。
- 主要残余风险是历史数据中缺少冻结受众时只能按保守可见性回填；这类记录允许通过 `--replace --summary` 使用当前权限规则重建。
- 回滚方式：停止摘要 worker，回退 Alembic 到上一 head，再回退本 PR 提交；原始 Event、Memory 和旧摘要内容保留。

## UI 证据

不涉及 UI 协议或展示变更，无需截图或录屏。摘要结果继续通过现有 Host/Narrator MemoryContext 读取。

## AI 使用情况

本 PR 使用 AI 辅助检查迁移兼容性、游标边界和测试覆盖；实现者已逐项核对 SQLAlchemy/Alembic 行为，并由本地完整测试、迁移测试和 CI 验证。AI 不负责决定权限边界，`event_audiences` 过滤和旧序号回填规则均按 PR4 已确认契约实现。

## 自检

- [x] 改动范围符合 #406 和 PR5 计划
- [x] 未包含 PR1～PR4 之外的 NPC Agent、向量检索或 TTS 功能
- [x] 已包含必要的迁移、并发、权限和长局测试
- [x] 未包含密钥、个人信息或临时生成物
- [x] 已完成 AI 辅助质量检查和人工 Review
- [ ] 等待 Backend CI 完成
- [ ] 等待至少一名人工 Review 后合并
