### PR TITLE
feat(character): 支持建卡时手动掷幸运骰

### DIFF
--- a/trpg-backend/app/controller/v1/rooms.py
+++ b/trpg-backend/app/controller/v1/rooms.py
@@ -23,6 +23,7 @@ from app.dto.character import (
     QuickGenerateRequest,
     QuickGenerateResult,
     RollAttributesResult,
+    RollLuckResult,
 )
 from app.dto.chat import ChatMessageRead
 from app.dto.common import ApiResponse
@@ -453,6 +454,30 @@ async def roll_attributes(
     """
     try:
         result = await character_service.roll_attributes(db, room_id, character_id, reconnect_token)
+    except (
+        character_service.CharacterNotFoundError,
+        room_service.RoomAuthenticationError,
+        room_service.RoomAuthorizationError,
+        room_service.RoomConflictError,
+    ) as exc:
+        _raise_service_error(exc)
+    return ApiResponse.ok(result)
+
+
+@router.post(
+    "/{room_id}/characters/{character_id}/roll-luck",
+    response_model=ApiResponse[RollLuckResult],
+    tags=["characters"],
+)
+async def roll_luck(
+    room_id: str,
+    character_id: str,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[RollLuckResult]:
+    """POST /api/v1/rooms/{roomId}/characters/{characterId}/roll-luck —— 单独确定本局幸运值。"""
+    try:
+        result = await character_service.roll_luck(db, room_id, character_id, reconnect_token)
     except (
         character_service.CharacterNotFoundError,
         room_service.RoomAuthenticationError,

--- a/trpg-backend/app/dto/character.py
+++ b/trpg-backend/app/dto/character.py
@@ -116,6 +116,16 @@ class RollAttributesResult(CamelModel):
     derived_stats: dict[str, int]
 
 
+class RollLuckResult(CamelModel):
+    """POST /api/v1/rooms/{roomId}/characters/{characterId}/roll-luck 返回。
+
+    服务端返回三颗 d6 的明细和最终幸运值，客户端只负责展示动画，不参与结果计算。
+    """
+
+    dice: list[int] = Field(..., min_length=3, max_length=3)
+    luck: int
+
+
 # 卡库卡的 `data` 是 JSON 列，写入方是客户端。不设上限的话一次 PATCH 就能往
 # 单行里塞进任意大小的内容（实测 2MB 直接 201）。建卡态数据满打满算也就几 KB。
 CHARACTER_TEMPLATE_DATA_MAX_BYTES = 64 * 1024

--- a/trpg-backend/app/service/character.py
+++ b/trpg-backend/app/service/character.py
@@ -10,8 +10,9 @@ import hashlib
 import json
 import random
 from dataclasses import asdict, replace
+from typing import cast
 
-from sqlalchemy import select, update
+from sqlalchemy import CursorResult, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -180,8 +181,10 @@ def _seed_character_from_template(character: Character, template: UserCharacterT
     character.gender = data.get("gender")
     character.residence = data.get("residence") or ""
     character.birthplace = data.get("birthplace") or ""
-    character.attributes = dict(data.get("attributes") or {})
-    character.attributes.pop("LUCK", None)
+    attributes = dict(data.get("attributes") or {})
+    # 卡库中的幸运值属于旧游戏；复制到新房间后必须等待本局重新掷骰。
+    attributes.pop("LUCK", None)
+    character.attributes = attributes
     character.skills = dict(data.get("skills") or {})
     character.occupation_choice_skill_ids = data.get("occupation_choice_skill_ids")
     character.equipment = list(data.get("equipment") or [])
@@ -517,11 +520,11 @@ async def roll_luck(
     attributes = dict(character.attributes or {})
     attributes["LUCK"] = luck
     # 用版本条件完成原子写入：两个并发请求最多一个成功，后到者不能覆盖先到结果。
-    result = await db.execute(
+    result = cast(CursorResult[tuple[()],], await db.execute(
         update(Character)
         .where(Character.id == character.id, Character.version == character.version)
         .values(attributes=attributes, version=character.version + 1)
-    )
+    ))
     if result.rowcount != 1:
         await db.rollback()
         raise RoomConflictError("幸运值已经掷出，不能重复掷骰")

--- a/trpg-backend/app/service/character.py
+++ b/trpg-backend/app/service/character.py
@@ -39,6 +39,7 @@ from app.dto.character import (
     QuickGenerateRequest,
     QuickGenerateResult,
     RollAttributesResult,
+    RollLuckResult,
     SystemQuickGenerateResult,
 )
 from app.dto.character_background import CharacterBackgroundContext, CharacterBackgroundSkill
@@ -180,6 +181,7 @@ def _seed_character_from_template(character: Character, template: UserCharacterT
     character.residence = data.get("residence") or ""
     character.birthplace = data.get("birthplace") or ""
     character.attributes = dict(data.get("attributes") or {})
+    character.attributes.pop("LUCK", None)
     character.skills = dict(data.get("skills") or {})
     character.occupation_choice_skill_ids = data.get("occupation_choice_skill_ids")
     character.equipment = list(data.get("equipment") or [])
@@ -493,6 +495,38 @@ async def roll_attributes(
     character.version += 1
     await db.commit()
     return RollAttributesResult(attributes=attributes, derived_stats=derived_stats)
+
+
+async def roll_luck(
+    db: AsyncSession, room_id: str, character_id: str, reconnect_token: str | None
+) -> RollLuckResult:
+    """为房间角色草稿单独掷一次幸运值，并把结果写入服务端。
+
+    幸运值是每局角色的初始状态：已有合法结果时拒绝再次掷骰，避免重复点击覆盖
+    玩家已经确认的结果；其他属性和属性点购买来源保持不变。
+    """
+    character = await _get_own_character(db, room_id, character_id, reconnect_token)
+    room = await find_room_by_id(db, room_id)
+    _require_character_editable(room)
+    current_luck = (character.attributes or {}).get("LUCK")
+    if isinstance(current_luck, int) and 1 <= current_luck <= 99:
+        raise RoomConflictError("幸运值已经掷出，不能重复掷骰")
+
+    dice = [random.randint(1, 6) for _ in range(3)]
+    luck = sum(dice) * 5
+    attributes = dict(character.attributes or {})
+    attributes["LUCK"] = luck
+    # 用版本条件完成原子写入：两个并发请求最多一个成功，后到者不能覆盖先到结果。
+    result = await db.execute(
+        update(Character)
+        .where(Character.id == character.id, Character.version == character.version)
+        .values(attributes=attributes, version=character.version + 1)
+    )
+    if result.rowcount != 1:
+        await db.rollback()
+        raise RoomConflictError("幸运值已经掷出，不能重复掷骰")
+    await db.commit()
+    return RollLuckResult(dice=dice, luck=luck)
 
 
 async def quick_generate_character(

--- a/trpg-backend/app/service/character.py
+++ b/trpg-backend/app/service/character.py
@@ -520,11 +520,14 @@ async def roll_luck(
     attributes = dict(character.attributes or {})
     attributes["LUCK"] = luck
     # 用版本条件完成原子写入：两个并发请求最多一个成功，后到者不能覆盖先到结果。
-    result = cast(CursorResult[tuple[()],], await db.execute(
-        update(Character)
-        .where(Character.id == character.id, Character.version == character.version)
-        .values(attributes=attributes, version=character.version + 1)
-    ))
+    result = cast(
+        CursorResult[tuple[()],],
+        await db.execute(
+            update(Character)
+            .where(Character.id == character.id, Character.version == character.version)
+            .values(attributes=attributes, version=character.version + 1)
+        ),
+    )
     if result.rowcount != 1:
         await db.rollback()
         raise RoomConflictError("幸运值已经掷出，不能重复掷骰")

--- a/trpg-backend/scripts/export_schema.py
+++ b/trpg-backend/scripts/export_schema.py
@@ -92,6 +92,7 @@ _MODELS: list[type[BaseModel]] = [
     character.CharacterDraftResult,
     character.CharacterRead,
     character.RollAttributesResult,
+    character.RollLuckResult,
     character.QuickGenerateRequest,
     character.QuickGenerateResult,
     character.CharacterTemplateCreateBody,

--- a/trpg-backend/tests/test_character_templates.py
+++ b/trpg-backend/tests/test_character_templates.py
@@ -244,7 +244,9 @@ async def test_seeding_a_room_draft_copies_the_card_and_then_stands_alone(
     )
     body = read.json()["data"]
     assert body["name"] == "陈探员"
-    assert body["attributes"] == TEMPLATE_ATTRIBUTES
+    assert body["attributes"] == {
+        key: value for key, value in TEMPLATE_ATTRIBUTES.items() if key != "LUCK"
+    }
     assert body["skills"] == TEMPLATE_DATA["skills"]
     assert body["occupation"] == "私家侦探"
     # 局内状态不跟着卡库走：衍生值等 complete 时服务端按属性权威重算。
@@ -341,7 +343,9 @@ async def test_deleting_a_referenced_card_clears_provenance_instead_of_failing(
     assert stored.based_on_template_id is None
     # 房间卡自己的数据一点没少。
     assert stored.name == "陈探员"
-    assert stored.attributes == TEMPLATE_ATTRIBUTES
+    assert stored.attributes == {
+        key: value for key, value in TEMPLATE_ATTRIBUTES.items() if key != "LUCK"
+    }
 
 
 async def test_seeding_refuses_a_card_from_another_rule_system(
@@ -456,6 +460,12 @@ async def test_a_client_cannot_claim_its_attributes_were_rolled(client: AsyncCli
         json={"basedOnTemplateId": template_id},
         headers={"X-Reconnect-Token": room["reconnectToken"]},
     )
+    room_character = await client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{draft.json()['data']['characterId']}",
+        headers={"X-Reconnect-Token": room["reconnectToken"]},
+    )
+    assert "LUCK" not in room_character.json()["data"]["attributes"]
+    assert created.json()["data"]["data"]["attributes"]["LUCK"] == 90
     completed = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{draft.json()['data']['characterId']}/complete",
         headers={"X-Reconnect-Token": room["reconnectToken"]},

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import cast
 
 from httpx import AsyncClient
 from sqlalchemy import func, select
@@ -389,7 +390,9 @@ async def test_complete_character_without_luck_roll_is_rejected(client: AsyncCli
     without_luck = {
         **BUILT_CHARACTER,
         "attributes": {
-            key: value for key, value in BUILT_CHARACTER["attributes"].items() if key != "LUCK"
+            key: value
+            for key, value in cast(dict[str, int], BUILT_CHARACTER["attributes"]).items()
+            if key != "LUCK"
         },
     }
     await client.patch(

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from httpx import AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -347,6 +349,77 @@ async def test_roll_attributes_marks_card_as_rolled(client: AsyncClient) -> None
         headers=reconnect(room["reconnectToken"]),
     )
     assert read_back.json()["data"]["generationMethod"] == "roll"
+
+
+async def test_roll_luck_persists_one_server_authoritative_result(client: AsyncClient) -> None:
+    """幸运值只掷一次，服务端保存三颗 d6 明细并拒绝覆盖既有结果。"""
+    room = await create_room(client)
+    headers = reconnect(room["reconnectToken"])
+    draft = await client.post(f"{ROOMS_BASE}/{room['roomId']}/characters", headers=headers)
+    character_id = draft.json()["data"]["characterId"]
+
+    rolled = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-luck",
+        headers=headers,
+    )
+
+    assert rolled.status_code == 200, rolled.text
+    result = rolled.json()["data"]
+    assert len(result["dice"]) == 3
+    assert all(1 <= die <= 6 for die in result["dice"])
+    assert result["luck"] == sum(result["dice"]) * 5
+    reread = await client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}", headers=headers
+    )
+    assert reread.json()["data"]["attributes"]["LUCK"] == result["luck"]
+
+    duplicate = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-luck",
+        headers=headers,
+    )
+    assert duplicate.status_code == 409
+
+
+async def test_complete_character_without_luck_roll_is_rejected(client: AsyncClient) -> None:
+    """没有幸运值时，完成接口不能把默认值或缺失值当成已掷结果。"""
+    room = await create_room(client)
+    headers = reconnect(room["reconnectToken"])
+    draft = await client.post(f"{ROOMS_BASE}/{room['roomId']}/characters", headers=headers)
+    character_id = draft.json()["data"]["characterId"]
+    without_luck = {
+        **BUILT_CHARACTER,
+        "attributes": {
+            key: value for key, value in BUILT_CHARACTER["attributes"].items() if key != "LUCK"
+        },
+    }
+    await client.patch(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
+        json=without_luck,
+        headers=headers,
+    )
+
+    completed = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/complete",
+        headers=headers,
+    )
+    assert completed.status_code == 422
+    assert completed.json()["error"]["code"] == "CHARACTER_INVALID"
+
+
+async def test_concurrent_luck_rolls_only_persist_one_result(client: AsyncClient) -> None:
+    """并发双击也只能有一次成功，后到请求不能覆盖已经落库的幸运值。"""
+    room = await create_room(client)
+    headers = reconnect(room["reconnectToken"])
+    draft = await client.post(f"{ROOMS_BASE}/{room['roomId']}/characters", headers=headers)
+    character_id = draft.json()["data"]["characterId"]
+    path = f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-luck"
+
+    first, second = await asyncio.gather(
+        client.post(path, headers=headers),
+        client.post(path, headers=headers),
+    )
+
+    assert sorted((first.status_code, second.status_code)) == [200, 409]
 
 
 async def test_quick_generate_saves_a_complete_rule_valid_draft(client: AsyncClient) -> None:

--- a/trpg-backend/tests/test_portrait_generation.py
+++ b/trpg-backend/tests/test_portrait_generation.py
@@ -520,6 +520,15 @@ async def test_template_derived_generation_updates_library_and_next_room(
     )
     assert draft.status_code == 201, draft.text
     character_id = draft.json()["data"]["characterId"]
+    # 卡库副本会清除旧幸运值，新房间必须按本局流程重新掷骰。
+    rolled = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-luck",
+        headers=reconnect(room["reconnectToken"]),
+    )
+    assert rolled.status_code == 200, rolled.text
+    roll_data = rolled.json()["data"]
+    assert len(roll_data["dice"]) == 3
+    assert roll_data["luck"] == sum(roll_data["dice"]) * 5
     completed = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/complete",
         headers=reconnect(room["reconnectToken"]),

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -122,6 +122,7 @@ const { mockRuleset, mockPreviewCharacter, mockCharacterApi } = vi.hoisted(() =>
     quickGenerateCharacter: vi.fn(),
     saveCharacter: vi.fn().mockResolvedValue(undefined),
     completeCharacter: vi.fn().mockResolvedValue(undefined),
+    rollLuckCharacter: vi.fn().mockResolvedValue({ dice: [3, 4, 5], luck: 60 }),
     fetchCharacter: vi.fn().mockResolvedValue({ attributes: {}, skills: {} }),
   }
 
@@ -229,6 +230,14 @@ describe('CharacterPage', () => {
       fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
       expect(screen.getByText('属性分配')).toBeInTheDocument()
     })
+    const luckButton = screen.queryByRole('button', { name: '掷幸运骰' })
+    if (luckButton) {
+      const previewCalls = mockPreviewCharacter.mock.calls.length
+      fireEvent.click(luckButton)
+      await waitFor(() => expect(mockCharacterApi.rollLuckCharacter).toHaveBeenCalledWith('room-1', 'draft-1'))
+      // 幸运回填会触发一次新的规则预览，等它完成后再继续后续页面操作。
+      await waitFor(() => expect(mockPreviewCharacter.mock.calls.length).toBeGreaterThan(previewCalls))
+    }
   }
 
   async function advanceToBackgroundStep() {
@@ -254,8 +263,12 @@ describe('CharacterPage', () => {
       fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
       expect(screen.getByText('属性分配')).toBeInTheDocument()
     })
-    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
-    expect(await screen.findByTestId('occupation-choice-panel')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '掷幸运骰' }))
+    await waitFor(() => expect(mockCharacterApi.rollLuckCharacter).toHaveBeenCalledWith('room-1', 'draft-1'))
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+      expect(screen.getByTestId('occupation-choice-panel')).toBeInTheDocument()
+    })
   }
 
   it('switches directly between the four book tabs without requiring sequential progress', () => {

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -222,6 +222,15 @@ describe('CharacterPage', () => {
     })
   }
 
+  async function confirmLuckDicePanel() {
+    for (let index = 0; index < 3; index += 1) {
+      fireEvent.click(await screen.findByRole('button', { name: '掷骰' }))
+      fireEvent.click(await screen.findByRole('button', {
+        name: index === 2 ? '确认幸运值' : '继续投骰',
+      }))
+    }
+  }
+
   async function advanceToAttributesAfterOccupationPreview() {
     await waitFor(() => {
       expect(mockPreviewCharacter).toHaveBeenCalledWith(expect.objectContaining({ occupationId: 1 }))
@@ -235,8 +244,14 @@ describe('CharacterPage', () => {
       const previewCalls = mockPreviewCharacter.mock.calls.length
       fireEvent.click(luckButton)
       await waitFor(() => expect(mockCharacterApi.rollLuckCharacter).toHaveBeenCalledWith('room-1', 'draft-1'))
+      await confirmLuckDicePanel()
       // 幸运回填会触发一次新的规则预览，等它完成后再继续后续页面操作。
-      await waitFor(() => expect(mockPreviewCharacter.mock.calls.length).toBeGreaterThan(previewCalls))
+      await waitFor(() => {
+        expect(mockPreviewCharacter.mock.calls.length).toBeGreaterThan(previewCalls)
+        expect(mockPreviewCharacter).toHaveBeenLastCalledWith(
+          expect.objectContaining({ attributes: expect.objectContaining({ LUCK: 60 }) })
+        )
+      })
     }
   }
 
@@ -265,6 +280,12 @@ describe('CharacterPage', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: '掷幸运骰' }))
     await waitFor(() => expect(mockCharacterApi.rollLuckCharacter).toHaveBeenCalledWith('room-1', 'draft-1'))
+    await confirmLuckDicePanel()
+    await waitFor(() => {
+      expect(mockPreviewCharacter).toHaveBeenLastCalledWith(
+        expect.objectContaining({ attributes: expect.objectContaining({ LUCK: 60 }) })
+      )
+    })
     await waitFor(() => {
       fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
       expect(screen.getByTestId('occupation-choice-panel')).toBeInTheDocument()

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -1893,7 +1893,8 @@ export default function CharacterPage() {
                     同样由 ruleset 驱动，不写死是哪一项——换个规则系统这里自然跟着变。 */}
                 {(ruleset?.attributes ?? []).filter(a => !a.pointBuy).map(attribute => {
                   const helpOpen = attributeHelpKey === attribute.key
-                  const luckReady = typeof attr[attribute.key] === 'number'
+                  // 中途累计值也会写入 attr，但只有三颗骰子都确认后才算完成。
+                  const luckReady = luckRollComplete && typeof attr[attribute.key] === 'number'
                   return (
                     <div key={attribute.key} className="character-create__attribute-row character-create__attribute-row--standalone px-3 py-2.5 bg-panel rounded-md">
                       <div className="character-create__attribute-row-main flex items-center gap-3">
@@ -1935,6 +1936,9 @@ export default function CharacterPage() {
                       </div>
                       {!isTemplateHost && luckRolling && (
                         <p className="mt-2 text-center text-[11px] text-text-muted">请完成幸运骰后继续</p>
+                      )}
+                      {!isTemplateHost && luckDice && !luckRollComplete && (
+                        <p className="mt-2 text-center text-[11px] text-text-muted">已投 {luckDiceIndex}/3 颗 · 当前幸运值：{luckAccumulated * 5}</p>
                       )}
                       {!isTemplateHost && luckRollComplete && (
                         <p className="mt-2 text-center text-[11px] text-text-muted">本局幸运值已确定：{attr[attribute.key] ?? luckAccumulated * 5}</p>

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -258,6 +258,7 @@ export default function CharacterPage() {
     typeof existingCharacter?.attr.LUCK === 'number'
   )
   const [luckAccumulated, setLuckAccumulated] = useState(0)
+  const [luckDiceIndex, setLuckDiceIndex] = useState(0)
 
   // 职业自选技能按槽位分组保存在表单中；提交时再按槽位顺序压平成 API 的
   // occupationChoiceSkillIds。occupationId 跟选择放在同一份状态里，避免异步
@@ -914,7 +915,12 @@ export default function CharacterPage() {
 
   /** 首次点击时创建房间草稿，再请求服务端确定本局唯一的幸运值。 */
   const handleLuckRoll = async () => {
-    if (!roomId || luckRolling || typeof attr.LUCK === 'number') return
+    if (!roomId || luckRolling || luckRollComplete) return
+    if (luckDice) {
+      setLuckRolling(true)
+      setLuckDiceOpen(true)
+      return
+    }
     setLuckRolling(true)
     setLuckError('')
     try {
@@ -927,6 +933,7 @@ export default function CharacterPage() {
       // 服务端只先返回目标点数；每颗骰子由玩家确认后才把当前累计值写回草稿。
       setLuckDice(result.dice)
       setLuckAccumulated(0)
+      setLuckDiceIndex(0)
       setLuckRollComplete(false)
       setLuckDiceOpen(true)
     } catch (error) {
@@ -1917,12 +1924,12 @@ export default function CharacterPage() {
                             type="button"
                             onClick={handleLuckRoll}
                             disabled={luckRolling || luckDiceOpen || luckReady}
-                            aria-label={luckReady ? '幸运值已确定' : '掷幸运骰'}
-                            title={luckReady ? '幸运值已确定' : '掷幸运骰'}
+                            aria-label={luckReady ? '幸运值已确定' : luckDice ? '继续投幸运骰' : '掷幸运骰'}
+                            title={luckReady ? '幸运值已确定' : luckDice ? '继续投幸运骰' : '掷幸运骰'}
                             className="flex min-h-8 items-center gap-1 rounded-sm border border-brass px-2 text-[11px] font-semibold text-brass-dark transition-colors active:bg-brass/10 disabled:cursor-not-allowed disabled:opacity-50"
                           >
                             <Dices className="h-3.5 w-3.5" />
-                            {luckRolling ? '掷骰中' : luckReady ? '已确定' : '掷骰'}
+                            {luckRolling ? '掷骰中' : luckReady ? '已确定' : luckDice ? '继续投骰' : '掷骰'}
                           </button>
                         )}
                       </div>
@@ -1949,17 +1956,21 @@ export default function CharacterPage() {
                 <DiceModal
                   open={luckDiceOpen}
                   onClose={() => {
-                    // 连续幸运骰必须由玩家逐颗确认，未完成前不允许关闭面板跳过。
-                    if (luckRollComplete) setLuckDiceOpen(false)
+                    // 关闭只收起面板，已确认的点数和当前进度保留，之后可继续。
+                    setLuckDiceOpen(false)
+                    setLuckRolling(false)
                   }}
                   onResult={() => undefined}
                   checkRequest={null}
                   checkDiceState={null}
                   setCheckDiceState={() => undefined}
                   sequentialTargets={luckDice}
+                  sequentialStartIndex={luckDiceIndex}
+                  sequentialAccumulated={luckAccumulated}
                   onSequentialRoll={(value, index) => {
                     const next = luckAccumulated + value
                     setLuckAccumulated(next)
+                    setLuckDiceIndex(index + 1)
                     setAttr(previous => ({ ...previous, LUCK: next * 5 }))
                     if (index === luckDice.length - 1) {
                       setLuckRollComplete(true)

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -78,22 +78,37 @@ const EMPTY_CHOICE_SELECTIONS: string[][] = []
 function LuckDiceAnimation({ dice, onDone }: { dice: [number, number, number]; onDone: () => void }) {
   const stageRef = useRef<Dice3DHandle>(null)
   const [index, setIndex] = useState(0)
+  const [displayValue, setDisplayValue] = useState(1)
   const [use3D, setUse3D] = useState(() => supports3DDice())
   const token = `luck-${index}`
 
   useEffect(() => {
+    if (use3D) {
+      // 和游戏内骰盘一样，目标点数只交给 3D 舞台用于定格，不直接显示结果。
+      const timer = window.setTimeout(() => {
+        if (!stageRef.current?.roll(token, dice[index])) setUse3D(false)
+      }, 0)
+      return () => window.clearTimeout(timer)
+    }
+
+    // 无 WebGL 时复用游戏骰盘的 700ms 2D 掷骰节奏，最后才定格到服务端点数。
+    const interval = window.setInterval(() => {
+      setDisplayValue(Math.floor(Math.random() * 6) + 1)
+    }, 80)
     const timer = window.setTimeout(() => {
-      if (!use3D) {
-        if (index >= dice.length - 1) onDone()
-        else setIndex(current => current + 1)
-        return
-      }
-      if (!stageRef.current?.roll(token, dice[index])) setUse3D(false)
-    }, use3D ? 0 : 350)
-    return () => window.clearTimeout(timer)
+      window.clearInterval(interval)
+      setDisplayValue(dice[index])
+      if (index >= dice.length - 1) onDone()
+      else setIndex(current => current + 1)
+    }, 700)
+    return () => {
+      window.clearInterval(interval)
+      window.clearTimeout(timer)
+    }
   }, [dice, index, onDone, token, use3D])
 
   const settle = () => {
+    setDisplayValue(dice[index])
     if (index >= dice.length - 1) onDone()
     else setIndex(current => current + 1)
   }
@@ -111,7 +126,7 @@ function LuckDiceAnimation({ dice, onDone }: { dice: [number, number, number]; o
         />
       ) : (
         <span className="flex h-14 w-14 items-center justify-center rounded-md border border-[#c9a86a] bg-[#f8e7c2] text-2xl font-bold text-[#4a3520]">
-          {dice[index]}
+          {displayValue}
         </span>
       )}
       <span className="ml-2 text-xs text-[#f8e7c2]">第 {index + 1}/3 颗</span>
@@ -959,6 +974,7 @@ export default function CharacterPage() {
         setCharacterId(characterId)
       }
       const result = await rollLuckCharacter(roomId, characterId)
+      // 服务端结果先写入草稿供规则预览使用；幸运行在动画结束前仍显示“掷骰中”。
       setAttr(previous => ({ ...previous, LUCK: result.luck }))
       setLuckDice(result.dice)
     } catch (error) {
@@ -1940,7 +1956,7 @@ export default function CharacterPage() {
                           </div>
                           <div className="character-create__attribute-note text-[10px] mt-0.5">不占属性点数（规则为独立掷 <span className="character-create__number">{attribute.generation}</span>，由当前生成方式决定）</div>
                         </div>
-                        <span className="character-create__attribute-static-value character-create__attribute-static-value--plain text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{luckReady ? attr[attribute.key] : '待掷'}</span>
+                        <span className="character-create__attribute-static-value character-create__attribute-static-value--plain text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{luckRolling ? '掷骰中' : luckReady ? attr[attribute.key] : '待掷'}</span>
                         {!isTemplateHost && (
                           <button
                             type="button"

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -6,7 +6,7 @@ import type { Attributes, InvestigatorInfo } from '@/data/character-model'
 import { useCharacterStore } from '@/stores/character-store'
 import { useRoomStore } from '@/stores/room-store'
 import { createCharacterDraft, saveCharacter, completeCharacter, fetchCharacter, quickGenerateCharacter, rollLuckCharacter, type BuiltCharacter } from '@/services/character/character-api'
-import { Dice3DStage, supports3DDice, type Dice3DHandle } from '@/features/dice3d'
+import { DiceModal } from './RoomPage'
 import type { CharacterTemplate } from '@/services/character/template-api'
 import {
   characterReadFromTemplate,
@@ -73,66 +73,6 @@ const BACKGROUND_PLACEHOLDERS: Record<BackgroundSectionKey, string> = {
 }
 
 const EMPTY_CHOICE_SELECTIONS: string[][] = []
-
-/** 播放服务端已经确定的三颗 d6；3D 不可用时由现有骰子组件通知降级完成。 */
-function LuckDiceAnimation({ dice, onDone }: { dice: [number, number, number]; onDone: () => void }) {
-  const stageRef = useRef<Dice3DHandle>(null)
-  const [index, setIndex] = useState(0)
-  const [displayValue, setDisplayValue] = useState(1)
-  const [use3D, setUse3D] = useState(() => supports3DDice())
-  const token = `luck-${index}`
-
-  useEffect(() => {
-    if (use3D) {
-      // 和游戏内骰盘一样，目标点数只交给 3D 舞台用于定格，不直接显示结果。
-      const timer = window.setTimeout(() => {
-        if (!stageRef.current?.roll(token, dice[index])) setUse3D(false)
-      }, 0)
-      return () => window.clearTimeout(timer)
-    }
-
-    // 无 WebGL 时复用游戏骰盘的 700ms 2D 掷骰节奏，最后才定格到服务端点数。
-    const interval = window.setInterval(() => {
-      setDisplayValue(Math.floor(Math.random() * 6) + 1)
-    }, 80)
-    const timer = window.setTimeout(() => {
-      window.clearInterval(interval)
-      setDisplayValue(dice[index])
-      if (index >= dice.length - 1) onDone()
-      else setIndex(current => current + 1)
-    }, 700)
-    return () => {
-      window.clearInterval(interval)
-      window.clearTimeout(timer)
-    }
-  }, [dice, index, onDone, token, use3D])
-
-  const settle = () => {
-    setDisplayValue(dice[index])
-    if (index >= dice.length - 1) onDone()
-    else setIndex(current => current + 1)
-  }
-
-  return (
-    <div className="mt-2 flex h-20 items-center justify-center rounded-md bg-[#2d241b]" aria-label="幸运骰子动画">
-      {use3D ? (
-        <Dice3DStage
-          ref={stageRef}
-          kind="d6"
-          className="h-20 w-24"
-          onSettled={settle}
-          onUnsupported={() => setUse3D(false)}
-          onRollAbandoned={() => setUse3D(false)}
-        />
-      ) : (
-        <span className="flex h-14 w-14 items-center justify-center rounded-md border border-[#c9a86a] bg-[#f8e7c2] text-2xl font-bold text-[#4a3520]">
-          {displayValue}
-        </span>
-      )}
-      <span className="ml-2 text-xs text-[#f8e7c2]">第 {index + 1}/3 颗</span>
-    </div>
-  )
-}
 
 function occupationIcon(occupation: Pick<OccupationSpec, 'icon'>): string {
   return occupation.icon ?? '·'
@@ -313,6 +253,11 @@ export default function CharacterPage() {
   const [luckRolling, setLuckRolling] = useState(false)
   const [luckError, setLuckError] = useState('')
   const [luckDice, setLuckDice] = useState<[number, number, number] | null>(null)
+  const [luckDiceOpen, setLuckDiceOpen] = useState(false)
+  const [luckRollComplete, setLuckRollComplete] = useState(
+    typeof existingCharacter?.attr.LUCK === 'number'
+  )
+  const [luckAccumulated, setLuckAccumulated] = useState(0)
 
   // 职业自选技能按槽位分组保存在表单中；提交时再按槽位顺序压平成 API 的
   // occupationChoiceSkillIds。occupationId 跟选择放在同一份状态里，避免异步
@@ -412,6 +357,7 @@ export default function CharacterPage() {
         }
 
         setAttr({ ...savedAttrs })
+        setLuckRollComplete(typeof savedAttrs.LUCK === 'number')
         setGenerationMethod(savedGenerationMethod)
         // 输入框的字符串镜像必须一起重建。它平时只在「属性项集合变化」时同步
         // 一次（见下面 attrInputs 那个 effect：跟着 attr 走的话，每敲一个字都会
@@ -726,6 +672,10 @@ export default function CharacterPage() {
   const interestPointsTotal = preview?.interestSkillPoints.budget ?? 0
 
   const previewValidationIssues = preview?.validation ?? []
+  // 幸运值允许在属性页之后才掷；缺少 LUCK 不能提前污染属性/技能页提示。
+  const visibleRuleIssues = previewValidationIssues.filter(
+    issue => !(issue.field === 'attributes' && issue.message.includes('缺少 LUCK'))
+  )
 
   // 兴趣技能的局部分配量需要单独保存；职业技能可以先吃职业池，再按 COC7
   // 规则使用剩余兴趣点，因此它们只保存在总分配 skillAlloc 中。
@@ -974,9 +924,11 @@ export default function CharacterPage() {
         setCharacterId(characterId)
       }
       const result = await rollLuckCharacter(roomId, characterId)
-      // 服务端结果先写入草稿供规则预览使用；幸运行在动画结束前仍显示“掷骰中”。
-      setAttr(previous => ({ ...previous, LUCK: result.luck }))
+      // 服务端只先返回目标点数；每颗骰子由玩家确认后才把当前累计值写回草稿。
       setLuckDice(result.dice)
+      setLuckAccumulated(0)
+      setLuckRollComplete(false)
+      setLuckDiceOpen(true)
     } catch (error) {
       setLuckRolling(false)
       setLuckError(friendlyErrorMessage(error, '幸运掷骰失败，请重试'))
@@ -1223,9 +1175,6 @@ export default function CharacterPage() {
       )
       issues.push(missingSlot ? `请完成职业自选技能：${missingSlot.label}` : '请完成职业自选技能')
     }
-    if (!isTemplateHost && targetStep >= 4 && typeof attr.LUCK !== 'number') {
-      issues.push('请先掷出幸运值')
-    }
     if (targetStep >= 4 && serializedBackground.length > CHARACTER_BACKGROUND_MAX_LENGTH) {
       issues.push(`背景故事不能超过 ${CHARACTER_BACKGROUND_MAX_LENGTH} 个字符`)
     }
@@ -1238,7 +1187,7 @@ export default function CharacterPage() {
       } else if (previewStatus !== 'ready') {
         issues.push('规则预览尚未准备好，请稍后')
       } else {
-        issues.push(...previewValidationIssues
+        issues.push(...visibleRuleIssues
           .filter(issue => issue.code !== 'OCCUPATION_CHOICES_INCOMPLETE')
           .map(issue => issue.message))
       }
@@ -1304,6 +1253,12 @@ export default function CharacterPage() {
       return
     }
     if (!ruleset) return
+    if (!isTemplateHost && (!luckRollComplete || typeof attr.LUCK !== 'number')) {
+      setValidationAttempted(true)
+      setSubmitError('请先完成幸运值掷骰，再完成建卡')
+      setStep(1)
+      return
+    }
     const issues = getBlockingIssues(4)
     if (issues.length > 0) {
       setValidationAttempted(true)
@@ -1391,7 +1346,7 @@ export default function CharacterPage() {
   }
 
   const currentNavigationIssues = validationAttempted ? getBlockingIssues(step < 3 ? step + 1 : 4) : []
-  const visiblePreviewIssues = previewValidationIssues.filter(
+  const visiblePreviewIssues = visibleRuleIssues.filter(
     issue => issue.code !== 'OCCUPATION_CHOICES_INCOMPLETE'
   )
 
@@ -1956,12 +1911,12 @@ export default function CharacterPage() {
                           </div>
                           <div className="character-create__attribute-note text-[10px] mt-0.5">不占属性点数（规则为独立掷 <span className="character-create__number">{attribute.generation}</span>，由当前生成方式决定）</div>
                         </div>
-                        <span className="character-create__attribute-static-value character-create__attribute-static-value--plain text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{luckRolling ? '掷骰中' : luckReady ? attr[attribute.key] : '待掷'}</span>
+                        <span className="character-create__attribute-static-value character-create__attribute-static-value--plain text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{luckReady ? attr[attribute.key] : luckAccumulated > 0 ? luckAccumulated * 5 : '待掷'}</span>
                         {!isTemplateHost && (
                           <button
                             type="button"
                             onClick={handleLuckRoll}
-                            disabled={luckRolling || luckReady}
+                            disabled={luckRolling || luckDiceOpen || luckReady}
                             aria-label={luckReady ? '幸运值已确定' : '掷幸运骰'}
                             title={luckReady ? '幸运值已确定' : '掷幸运骰'}
                             className="flex min-h-8 items-center gap-1 rounded-sm border border-brass px-2 text-[11px] font-semibold text-brass-dark transition-colors active:bg-brass/10 disabled:cursor-not-allowed disabled:opacity-50"
@@ -1971,11 +1926,11 @@ export default function CharacterPage() {
                           </button>
                         )}
                       </div>
-                      {!isTemplateHost && luckRolling && luckDice && (
-                        <LuckDiceAnimation
-                          dice={luckDice}
-                          onDone={() => setLuckRolling(false)}
-                        />
+                      {!isTemplateHost && luckRolling && (
+                        <p className="mt-2 text-center text-[11px] text-text-muted">请完成幸运骰后继续</p>
+                      )}
+                      {!isTemplateHost && luckRollComplete && (
+                        <p className="mt-2 text-center text-[11px] text-text-muted">本局幸运值已确定：{attr[attribute.key] ?? luckAccumulated * 5}</p>
                       )}
                       {!isTemplateHost && luckError && (
                         <p className="mt-2 text-[11px] text-[#c04040]">{luckError}</p>
@@ -1989,6 +1944,31 @@ export default function CharacterPage() {
                   )
                 })}
               </div>
+
+              {!isTemplateHost && luckDice && (
+                <DiceModal
+                  open={luckDiceOpen}
+                  onClose={() => {
+                    // 连续幸运骰必须由玩家逐颗确认，未完成前不允许关闭面板跳过。
+                    if (luckRollComplete) setLuckDiceOpen(false)
+                  }}
+                  onResult={() => undefined}
+                  checkRequest={null}
+                  checkDiceState={null}
+                  setCheckDiceState={() => undefined}
+                  sequentialTargets={luckDice}
+                  onSequentialRoll={(value, index) => {
+                    const next = luckAccumulated + value
+                    setLuckAccumulated(next)
+                    setAttr(previous => ({ ...previous, LUCK: next * 5 }))
+                    if (index === luckDice.length - 1) {
+                      setLuckRollComplete(true)
+                      setLuckDiceOpen(false)
+                      setLuckRolling(false)
+                    }
+                  }}
+                />
+              )}
 
               {/* Derived Stats */}
               <div className="character-create__derived mt-3">

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -1,11 +1,12 @@
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useState, useMemo, useEffect, useRef } from 'react'
-import { Plus, Minus, Search, Shield, Heart, Brain, Zap, Eye, Maximize2, Lightbulb, BookOpen, ChevronDown, ChevronUp, X, Info, Clover, Sparkles } from 'lucide-react'
+import { Plus, Minus, Search, Shield, Heart, Brain, Zap, Eye, Maximize2, Lightbulb, BookOpen, ChevronDown, ChevronUp, X, Info, Clover, Sparkles, Dices } from 'lucide-react'
 import type { CharacterComputeResult, SkillComputeView } from 'trpg-sdk'
 import type { Attributes, InvestigatorInfo } from '@/data/character-model'
 import { useCharacterStore } from '@/stores/character-store'
 import { useRoomStore } from '@/stores/room-store'
-import { createCharacterDraft, saveCharacter, completeCharacter, fetchCharacter, quickGenerateCharacter, type BuiltCharacter } from '@/services/character/character-api'
+import { createCharacterDraft, saveCharacter, completeCharacter, fetchCharacter, quickGenerateCharacter, rollLuckCharacter, type BuiltCharacter } from '@/services/character/character-api'
+import { Dice3DStage, supports3DDice, type Dice3DHandle } from '@/features/dice3d'
 import type { CharacterTemplate } from '@/services/character/template-api'
 import {
   characterReadFromTemplate,
@@ -72,6 +73,51 @@ const BACKGROUND_PLACEHOLDERS: Record<BackgroundSectionKey, string> = {
 }
 
 const EMPTY_CHOICE_SELECTIONS: string[][] = []
+
+/** 播放服务端已经确定的三颗 d6；3D 不可用时由现有骰子组件通知降级完成。 */
+function LuckDiceAnimation({ dice, onDone }: { dice: [number, number, number]; onDone: () => void }) {
+  const stageRef = useRef<Dice3DHandle>(null)
+  const [index, setIndex] = useState(0)
+  const [use3D, setUse3D] = useState(() => supports3DDice())
+  const token = `luck-${index}`
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      if (!use3D) {
+        if (index >= dice.length - 1) onDone()
+        else setIndex(current => current + 1)
+        return
+      }
+      if (!stageRef.current?.roll(token, dice[index])) setUse3D(false)
+    }, use3D ? 0 : 350)
+    return () => window.clearTimeout(timer)
+  }, [dice, index, onDone, token, use3D])
+
+  const settle = () => {
+    if (index >= dice.length - 1) onDone()
+    else setIndex(current => current + 1)
+  }
+
+  return (
+    <div className="mt-2 flex h-20 items-center justify-center rounded-md bg-[#2d241b]" aria-label="幸运骰子动画">
+      {use3D ? (
+        <Dice3DStage
+          ref={stageRef}
+          kind="d6"
+          className="h-20 w-24"
+          onSettled={settle}
+          onUnsupported={() => setUse3D(false)}
+          onRollAbandoned={() => setUse3D(false)}
+        />
+      ) : (
+        <span className="flex h-14 w-14 items-center justify-center rounded-md border border-[#c9a86a] bg-[#f8e7c2] text-2xl font-bold text-[#4a3520]">
+          {dice[index]}
+        </span>
+      )}
+      <span className="ml-2 text-xs text-[#f8e7c2]">第 {index + 1}/3 颗</span>
+    </div>
+  )
+}
 
 function occupationIcon(occupation: Pick<OccupationSpec, 'icon'>): string {
   return occupation.icon ?? '·'
@@ -249,6 +295,9 @@ export default function CharacterPage() {
   // Attributes
   const [attr, setAttr] = useState<Attributes>(() => ({ ...existingCharacter?.attr }))
   const [attributeHelpKey, setAttributeHelpKey] = useState<string | null>(null)
+  const [luckRolling, setLuckRolling] = useState(false)
+  const [luckError, setLuckError] = useState('')
+  const [luckDice, setLuckDice] = useState<[number, number, number] | null>(null)
 
   // 职业自选技能按槽位分组保存在表单中；提交时再按槽位顺序压平成 API 的
   // occupationChoiceSkillIds。occupationId 跟选择放在同一份状态里，避免异步
@@ -405,6 +454,8 @@ export default function CharacterPage() {
       const filled = { ...prev }
       let changed = false
       for (const attribute of ruleset.attributes) {
+        // 幸运必须由玩家主动掷骰，不能沿用点数购买法的默认值 50。
+        if (!attribute.pointBuy) continue
         if (typeof filled[attribute.key] !== 'number') {
           filled[attribute.key] = pointBuyRules.defaultValue
           changed = true
@@ -896,6 +947,26 @@ export default function CharacterPage() {
     setAttr(prev => ({ ...prev, [key]: newVal }))
   }
 
+  /** 首次点击时创建房间草稿，再请求服务端确定本局唯一的幸运值。 */
+  const handleLuckRoll = async () => {
+    if (!roomId || luckRolling || typeof attr.LUCK === 'number') return
+    setLuckRolling(true)
+    setLuckError('')
+    try {
+      let characterId = useRoomStore.getState().characterId
+      if (!characterId) {
+        characterId = await createCharacterDraft(roomId)
+        setCharacterId(characterId)
+      }
+      const result = await rollLuckCharacter(roomId, characterId)
+      setAttr(previous => ({ ...previous, LUCK: result.luck }))
+      setLuckDice(result.dice)
+    } catch (error) {
+      setLuckRolling(false)
+      setLuckError(friendlyErrorMessage(error, '幸运掷骰失败，请重试'))
+    }
+  }
+
   // 手动输入属性值——允许先清空再打字（不在每次按键就夹值，否则没法删了重打），
   // 只在失焦时校验：范围和总预算都取自后端 ruleset。超出总预算时按"其余属性
   // 还剩多少点"封顶，而不是直接拒绝，体验上比"打了数字却没反应"更清楚。
@@ -1136,6 +1207,9 @@ export default function CharacterPage() {
       )
       issues.push(missingSlot ? `请完成职业自选技能：${missingSlot.label}` : '请完成职业自选技能')
     }
+    if (!isTemplateHost && targetStep >= 4 && typeof attr.LUCK !== 'number') {
+      issues.push('请先掷出幸运值')
+    }
     if (targetStep >= 4 && serializedBackground.length > CHARACTER_BACKGROUND_MAX_LENGTH) {
       issues.push(`背景故事不能超过 ${CHARACTER_BACKGROUND_MAX_LENGTH} 个字符`)
     }
@@ -1195,21 +1269,8 @@ export default function CharacterPage() {
       const characterId = await createCharacterDraft(roomId, templateId)
       setCharacterId(characterId)
       setLibraryOpen(false)
-      // 卡库卡通常已经是捏好的，没道理再让玩家把四步向导点一遍。直接完成建卡进
-      // 准备页——准备页本来就自己从后端拉角色卡，不需要这里再拼一份 store 数据。
-      //
-      // 完不成的情况是真实存在的（例如玩家刚在卡库里新建了一张空白卡就拿来用），
-      // 后端会用 422 明确拒绝。那时候退回向导让玩家补完，而不是卡在一个说不清
-      // 为什么失败的准备页。
-      try {
-        await completeCharacter(roomId, characterId)
-        navigate('/room/ready')
-      } catch {
-        setLibraryError('这张卡还没建完，先在这里补完剩下的部分。')
-        // 草稿已经带着卡库卡的数据落库了，重新进这个页面让既有的水合逻辑把它读
-        // 回表单——不在这里再抄一遍字段映射。
-        navigate(0)
-      }
+      // 房间副本的幸运值已由服务端清除，必须回到向导让玩家手动掷本局幸运骰。
+      navigate(0)
     } catch (err) {
       setLibraryError(
         err instanceof ApiError && err.status === 409
@@ -1854,6 +1915,7 @@ export default function CharacterPage() {
                     同样由 ruleset 驱动，不写死是哪一项——换个规则系统这里自然跟着变。 */}
                 {(ruleset?.attributes ?? []).filter(a => !a.pointBuy).map(attribute => {
                   const helpOpen = attributeHelpKey === attribute.key
+                  const luckReady = typeof attr[attribute.key] === 'number'
                   return (
                     <div key={attribute.key} className="character-create__attribute-row character-create__attribute-row--standalone px-3 py-2.5 bg-panel rounded-md">
                       <div className="character-create__attribute-row-main flex items-center gap-3">
@@ -1878,8 +1940,30 @@ export default function CharacterPage() {
                           </div>
                           <div className="character-create__attribute-note text-[10px] mt-0.5">不占属性点数（规则为独立掷 <span className="character-create__number">{attribute.generation}</span>，由当前生成方式决定）</div>
                         </div>
-                        <span className="character-create__attribute-static-value character-create__attribute-static-value--plain text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{attr[attribute.key] ?? '—'}</span>
+                        <span className="character-create__attribute-static-value character-create__attribute-static-value--plain text-[17px] font-bold font-mono text-text-primary min-w-[36px] text-center">{luckReady ? attr[attribute.key] : '待掷'}</span>
+                        {!isTemplateHost && (
+                          <button
+                            type="button"
+                            onClick={handleLuckRoll}
+                            disabled={luckRolling || luckReady}
+                            aria-label={luckReady ? '幸运值已确定' : '掷幸运骰'}
+                            title={luckReady ? '幸运值已确定' : '掷幸运骰'}
+                            className="flex min-h-8 items-center gap-1 rounded-sm border border-brass px-2 text-[11px] font-semibold text-brass-dark transition-colors active:bg-brass/10 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            <Dices className="h-3.5 w-3.5" />
+                            {luckRolling ? '掷骰中' : luckReady ? '已确定' : '掷骰'}
+                          </button>
+                        )}
                       </div>
+                      {!isTemplateHost && luckRolling && luckDice && (
+                        <LuckDiceAnimation
+                          dice={luckDice}
+                          onDone={() => setLuckRolling(false)}
+                        />
+                      )}
+                      {!isTemplateHost && luckError && (
+                        <p className="mt-2 text-[11px] text-[#c04040]">{luckError}</p>
+                      )}
                       {helpOpen && (
                         <p id={`attribute-help-${attribute.key}`} className="mt-2 border-t border-border-light pt-2 text-[11px] leading-relaxed text-text-muted">
                           {ATTRIBUTE_HELP[attribute.key] ?? `${attribute.label}是当前规则系统定义的基础属性。`}

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.css
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.css
@@ -822,6 +822,16 @@
   overscroll-behavior: contain;
 }
 
+/* 连续幸运骰使用紧凑固定高度，避免移动端被普通骰子面板撑出大块留白。 */
+.room-play__bottom-panel--sequential-dice {
+  height: 64vh !important;
+  max-height: 64vh !important;
+}
+
+.room-play__bottom-panel--sequential-dice > .room-play__bottom-panel-content {
+  max-height: calc(64vh - 60px) !important;
+}
+
 .room-play__bottom-panel--character-sheet > .room-play__bottom-panel-content {
   max-height: calc(70vh - 7.25rem) !important;
   overscroll-behavior: contain;
@@ -1063,6 +1073,15 @@
   .room-play__bottom-panel--dice > .room-play__bottom-panel-content {
     max-height: calc(76vh - 60px) !important;
     max-height: calc(76dvh - 60px) !important;
+  }
+
+  .room-play__bottom-panel--sequential-dice {
+    height: 64dvh !important;
+    max-height: 64dvh !important;
+  }
+
+  .room-play__bottom-panel--sequential-dice > .room-play__bottom-panel-content {
+    max-height: calc(64dvh - 60px) !important;
   }
 
   .room-play__header {

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1095,8 +1095,8 @@ export function DiceModal({
       open={open}
       onClose={onClose}
       title={isSequentialMode ? '幸运值投掷' : '骰子检定'}
-      className="room-play__bottom-panel--dice"
-      heightVh={isSequentialMode ? 68 : undefined}
+      className={`room-play__bottom-panel--dice ${isSequentialMode ? 'room-play__bottom-panel--sequential-dice' : ''}`}
+      heightVh={isSequentialMode ? 64 : undefined}
     >
       {!isCheckMode && !isSequentialMode && (
         <div className="flex gap-1.5 mb-3.5">

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -634,6 +634,8 @@ export function DiceModal({
   onPostRollOption,
   sequentialTargets,
   onSequentialRoll,
+  sequentialStartIndex = 0,
+  sequentialAccumulated = 0,
 }: {
   open: boolean
   onClose: () => void
@@ -650,6 +652,10 @@ export function DiceModal({
   /** 连续骰模式：复用同一骰盘逐颗展示服务端已经确定的目标点数。 */
   sequentialTargets?: number[]
   onSequentialRoll?: (value: number, index: number) => void
+  /** 关闭后重新打开时，从当前未完成的骰子继续。 */
+  sequentialStartIndex?: number
+  /** 连续骰模式中已经确认的 d6 点数总和。 */
+  sequentialAccumulated?: number
 }) {
   const [freeDiceType, setFreeDiceType] = useState<DiceType>('d100')
   const [freeResult, setFreeResult] = useState<number | null>(null)
@@ -687,10 +693,10 @@ export function DiceModal({
       setFreeShowResult(false)
       setFreeTens(0)
       setFreeOnes(0)
-      setSequentialIndex(0)
+      setSequentialIndex(sequentialStartIndex)
       submitLockRef.current = false
     }
-  }, [open, checkRequest])
+  }, [open, checkRequest, sequentialStartIndex])
 
   const isCheckMode = Boolean(checkRequest)
   const isSequentialMode = Boolean(sequentialTargets?.length)
@@ -1088,8 +1094,9 @@ export function DiceModal({
     <BottomPanel
       open={open}
       onClose={onClose}
-      title="骰子检定"
+      title={isSequentialMode ? '幸运值投掷' : '骰子检定'}
       className="room-play__bottom-panel--dice"
+      heightVh={isSequentialMode ? 68 : undefined}
     >
       {!isCheckMode && !isSequentialMode && (
         <div className="flex gap-1.5 mb-3.5">
@@ -1152,10 +1159,12 @@ export function DiceModal({
 
       <div className="text-center mb-3">
         <span className="text-xs text-brass-dark font-semibold bg-brass/10 px-4 py-1 rounded-full inline-block">
-          {selectedSkill?.name ?? '自由掷骰'}
+          {isSequentialMode ? `幸运值 · 第 ${sequentialIndex + 1}/3 颗` : selectedSkill?.name ?? '自由掷骰'}
         </span>
         <div className="font-mono text-xs text-text-muted mt-1">
-          {activeDiceType === 'd100'
+          {isSequentialMode
+            ? `已投点数：${sequentialAccumulated} · 当前幸运值：${sequentialAccumulated * 5}`
+            : activeDiceType === 'd100'
             ? `目标: ${targetValue} · D% = 十位 + 个位`
             : '自由检定'}
         </div>
@@ -1163,7 +1172,7 @@ export function DiceModal({
 
       <div
         data-testid="dice-table"
-        className="rounded-md px-4 pt-5 pb-4 flex flex-col items-center relative overflow-hidden"
+        className={`rounded-md px-4 pt-4 pb-3 flex flex-col items-center relative overflow-hidden ${isSequentialMode ? 'min-h-36' : ''}`}
         style={{
           // 暖调骰盘而不是冷近黑：骰子是亮面树脂材质，深底才有对比；
           // 中心略亮、边缘压暗，配合内阴影读起来像一个打着光的托盘。
@@ -1192,7 +1201,7 @@ export function DiceModal({
       </div>
 
       {activeShowResult && activeResult !== null && (
-        <div className="flex flex-col items-center pt-4 gap-3 animate-[fadeIn_0.3s_ease]">
+        <div className="flex flex-col items-center pt-3 gap-2 animate-[fadeIn_0.3s_ease]">
           <div className="text-center">
             {activeDiceType === 'd100' ? (
               <>
@@ -1209,11 +1218,13 @@ export function DiceModal({
             ) : (
               <div className="text-[44px] font-bold font-mono text-text-primary">{activeResult}</div>
             )}
-            {verdict && (
+            {!isSequentialMode && verdict && (
               <div className="text-base font-bold mt-1" style={{ color: verdict.color }}>{verdict.label}</div>
             )}
             <div className="text-xs text-text-dim mt-1 font-mono">
-              {activeDiceType === 'd100'
+              {isSequentialMode
+                ? `本次点数：${activeResult} · 确认后累计：${sequentialAccumulated + activeResult}`
+                : activeDiceType === 'd100'
                 ? `${selectedSkill?.name ?? '自由检定'} ${targetValue}% · 需求 ≤${targetValue}`
                 : `${activeDiceType.toUpperCase()} · 自由检定`}
             </div>

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -619,7 +619,7 @@ function BottomPanel({ open, onClose, title, children, heightVh, className = '' 
 // 不再是独立的全屏深色页面。面板现在跟其他面板一样常驻挂载、靠 open 控制
 // 滑入滑出，所以每次重新打开都要把上一次投骰的结果清空，不然会看到上一轮
 // 的结果还留着。
-function DiceModal({
+export function DiceModal({
   open,
   onClose,
   onResult,
@@ -632,6 +632,8 @@ function DiceModal({
   postRollOptions = [],
   luckValue = null,
   onPostRollOption,
+  sequentialTargets,
+  onSequentialRoll,
 }: {
   open: boolean
   onClose: () => void
@@ -645,6 +647,9 @@ function DiceModal({
   postRollOptions?: UiCheckRunView['post_roll_options']
   luckValue?: number | null
   onPostRollOption?: (optionId: string, revisedMethod?: string) => void
+  /** 连续骰模式：复用同一骰盘逐颗展示服务端已经确定的目标点数。 */
+  sequentialTargets?: number[]
+  onSequentialRoll?: (value: number, index: number) => void
 }) {
   const [freeDiceType, setFreeDiceType] = useState<DiceType>('d100')
   const [freeResult, setFreeResult] = useState<number | null>(null)
@@ -653,6 +658,7 @@ function DiceModal({
   const [freeTens, setFreeTens] = useState(0)
   const [freeOnes, setFreeOnes] = useState(0)
   const [revisedMethod, setRevisedMethod] = useState('')
+  const [sequentialIndex, setSequentialIndex] = useState(0)
   const submitLockRef = useRef(false)
   const dice3dRef = useRef<Dice3DHandle>(null)
   const rollGenerationRef = useRef(0)
@@ -681,13 +687,17 @@ function DiceModal({
       setFreeShowResult(false)
       setFreeTens(0)
       setFreeOnes(0)
+      setSequentialIndex(0)
       submitLockRef.current = false
     }
   }, [open, checkRequest])
 
   const isCheckMode = Boolean(checkRequest)
+  const isSequentialMode = Boolean(sequentialTargets?.length)
+  const sequentialTarget = isSequentialMode ? sequentialTargets?.[sequentialIndex] ?? null : null
+  const activePresetResult = isSequentialMode ? sequentialTarget : presetResult
   const activeCheckDice = checkRequest ? checkDiceState : null
-  const activeDiceType: DiceType = isCheckMode ? 'd100' : freeDiceType
+  const activeDiceType: DiceType = isCheckMode ? 'd100' : isSequentialMode ? 'd6' : freeDiceType
   const activeResult = isCheckMode ? activeCheckDice?.result ?? null : freeResult
   const activeRolling = isCheckMode ? activeCheckDice?.rolling ?? false : freeRolling
   const activeShowResult = isCheckMode ? activeCheckDice?.showResult ?? false : freeShowResult
@@ -740,7 +750,7 @@ function DiceModal({
   const settle = (value: number, requestId: string | null) => {
     clear3DWatchdog()
     inFlight3DRollRef.current = null
-    const settledValue = presetResult ?? value
+    const settledValue = activePresetResult ?? value
     const { tens, ones } = activeDiceType === 'd100' ? splitD100(settledValue) : { tens: 0, ones: 0 }
     if (requestId !== null) {
       setCheckDiceState((current) => {
@@ -772,8 +782,8 @@ function DiceModal({
   /** 2D 回退掷骰：本地随机 + 固定时长的假动画，与改造前一致。 */
   const roll2D = (requestId: string | null) => {
     let finalResult: number
-    if (presetResult !== null) {
-      finalResult = presetResult
+    if (activePresetResult !== null) {
+      finalResult = activePresetResult
     } else if (activeDiceType === 'd100') {
       const tens = Math.floor(Math.random() * 10)
       const ones = Math.floor(Math.random() * 10)
@@ -840,7 +850,7 @@ function DiceModal({
         roll2D(requestId)
         return
       }
-      if (!stage.roll(token, presetResult ?? undefined)) {
+      if (!stage.roll(token, activePresetResult ?? undefined)) {
         // 舞台在，只是还占着上一次掷骰。掷骰现在一律由玩家点击触发，所以清掉
         // rolling 让按钮重新可用就够了——不要退回 2D，那会把玩家想看的动画
         // 悄悄换成一个直接蹦出来的数字。
@@ -908,6 +918,19 @@ function DiceModal({
   const canRoll = !activeRolling && !activeShowResult && activeResult === null && !activeCheckDice?.submitted
 
   const confirmResult = () => {
+    if (isSequentialMode) {
+      if (activeResult === null) return
+      onSequentialRoll?.(activeResult, sequentialIndex)
+      if (sequentialIndex >= (sequentialTargets?.length ?? 1) - 1) {
+        onClose()
+      } else {
+        setSequentialIndex(index => index + 1)
+        setFreeResult(null)
+        setFreeShowResult(false)
+        setFreeRolling(false)
+      }
+      return
+    }
     if (isCheckMode) {
       if (!checkRequest || !activeCheckDice || activeResult === null || !activeSelectedSkillId) return
       if (submitLockRef.current || activeCheckDice.submitted) return
@@ -1068,7 +1091,7 @@ function DiceModal({
       title="骰子检定"
       className="room-play__bottom-panel--dice"
     >
-      {!isCheckMode && (
+      {!isCheckMode && !isSequentialMode && (
         <div className="flex gap-1.5 mb-3.5">
           {DICE_OPTIONS.map((opt) => (
             <button
@@ -1194,14 +1217,14 @@ function DiceModal({
                 ? `${selectedSkill?.name ?? '自由检定'} ${targetValue}% · 需求 ≤${targetValue}`
                 : `${activeDiceType.toUpperCase()} · 自由检定`}
             </div>
-            {presetResult !== null && (
+            {!isSequentialMode && presetResult !== null && (
               <p className="mt-1 text-[11px] text-text-muted">
                 骰点已保存；刷新或重试不会重新投掷
               </p>
             )}
           </div>
 
-          {presetResult !== null && acceptOption ? (
+          {!isSequentialMode && presetResult !== null && acceptOption ? (
             <div className="w-full space-y-2">
               <button
                 type="button"
@@ -1270,7 +1293,9 @@ function DiceModal({
               disabled={isCheckMode && !!activeCheckDice?.submitted}
               className="w-full py-3 rounded-sm bg-brass text-white text-sm font-semibold active:bg-brass-dark active:scale-[0.97] transition-all disabled:opacity-60"
             >
-              确认并发送
+              {isSequentialMode
+                ? sequentialIndex >= (sequentialTargets?.length ?? 1) - 1 ? '确认幸运值' : '继续投骰'
+                : '确认并发送'}
             </button>
           )}
         </div>

--- a/trpg-frontend/src/services/character/character-api.ts
+++ b/trpg-frontend/src/services/character/character-api.ts
@@ -95,6 +95,11 @@ export async function fetchCharacter(roomId: string, characterId: string) {
   return sdk.characters.get(roomId, characterId, requireReconnectToken());
 }
 
+/** 为当前房间角色草稿掷一次幸运值；最终结果由后端权威返回。 */
+export async function rollLuckCharacter(roomId: string, characterId: string) {
+  return sdk.characters.rollLuck(roomId, characterId, requireReconnectToken());
+}
+
 export async function quickGenerateCharacter(
   roomId: string,
   characterId: string,

--- a/trpg-sdk/src/generated/dto.ts
+++ b/trpg-sdk/src/generated/dto.ts
@@ -1217,6 +1217,20 @@ export interface RollAttributesResult {
 }
 
 /**
+ * POST /api/v1/rooms/{roomId}/characters/{characterId}/roll-luck 返回。
+ *
+ * 服务端返回三颗 d6 的明细和最终幸运值，客户端只负责展示动画，不参与结果计算。
+ */
+export interface RollLuckResult {
+  /**
+   * @minItems 3
+   * @maxItems 3
+   */
+  dice: [number, number, number];
+  luck: number;
+}
+
+/**
  * 已接受、尚未开始的主持行动。
  */
 export interface RoomActionQueueItemPayload {

--- a/trpg-sdk/src/resources/characters.ts
+++ b/trpg-sdk/src/resources/characters.ts
@@ -7,6 +7,7 @@ import type {
   QuickGenerateInput,
   QuickGenerateResult,
   RollAttributesResult,
+  RollLuckResult,
   UpdateCharacterInput,
 } from '../types';
 
@@ -181,6 +182,19 @@ export class CharactersResource {
   ): Promise<RollAttributesResult> {
     return this.client.post<RollAttributesResult>(
       `/rooms/${roomId}/characters/${characterId}/roll-attributes`,
+      null,
+      this.authenticated(reconnectToken)
+    );
+  }
+
+  /** POST /api/v1/rooms/{roomId}/characters/{characterId}/roll-luck — 单独掷本局幸运值。 */
+  rollLuck(
+    roomId: string,
+    characterId: string,
+    reconnectToken: string
+  ): Promise<RollLuckResult> {
+    return this.client.post<RollLuckResult>(
+      `/rooms/${roomId}/characters/${characterId}/roll-luck`,
       null,
       this.authenticated(reconnectToken)
     );

--- a/trpg-sdk/src/types.ts
+++ b/trpg-sdk/src/types.ts
@@ -46,6 +46,7 @@ export type {
   QuickGenerateRequest as QuickGenerateInput,
   QuickGenerateResult,
   RollAttributesResult,
+  RollLuckResult,
   // 我的卡库（issue #77 决策 5）—— 对应后端 dto/character.py
   CharacterTemplateCreateBody as SaveCharacterTemplateInput,
   CharacterTemplateRead as CharacterTemplate,


### PR DESCRIPTION
## 关联 Issue

Closes #448

## 主要改动

- 新增房间角色 `roll-luck` 接口，服务端按 `3d6*5` 生成并持久化幸运值。
- 每张房间角色卡只允许成功掷骰一次，并用版本条件防止并发覆盖。
- 从角色卡库套用到新房间时清除旧幸运值，卡库模板保持不变。
- 建卡页面增加手动掷幸运骰按钮，复用现有 `Dice3DStage`，无 WebGL 时使用数字降级动画。
- 未完成幸运掷骰时禁止完成建卡。
- 同步 SDK DTO、接口封装和相关测试。

## 采用该方案的原因

幸运值属于每局角色的随机初始状态，不能继续使用固定 50，也不能复用会同时重掷全部属性的 `roll-attributes` 接口。最终结果由后端生成，前端只展示动画和状态，保证规则权威性与可恢复性。

## 测试与验证

- [x] 后端角色与卡库测试：47 passed
- [x] 后端规则测试：80 passed
- [x] 前端完整测试：227 passed
- [x] 前端建卡与骰子测试：25 passed
- [x] 前端生产构建通过
- [x] SDK codegen、typecheck、build 通过
- [x] Ruff 检查通过
- [x] `git diff --check` 通过

## 风险与回滚

- 历史草稿若没有幸运值，需要玩家重新掷骰后才能完成。
- 无 WebGL 时使用数字降级动画，不影响服务端结果生成和建卡流程。
- 回滚本 PR 即可恢复原有建卡幸运值流程，不涉及数据库迁移。

## UI 证据

建卡页面幸运值区域新增“掷骰”按钮、掷骰中状态、最终结果和降级显示。
<img width="460" height="78" alt="image" src="https://github.com/user-attachments/assets/f1c5f879-0493-4097-887b-2da3ee2dab63" />
<img width="254" height="498" alt="image" src="https://github.com/user-attachments/assets/1247910a-1377-499b-9758-d8c5f7d4576c" />
<img width="462" height="112" alt="image" src="https://github.com/user-attachments/assets/1c7c7cb8-c14f-477e-9acd-a4f8e70fa77e" />


## AI 使用情况

本次使用 AI 辅助完成代码检索、实现和测试编排。已运行自动化测试、类型检查、构建和静态检查；提交前已人工检查改动范围、接口边界、并发保护和卡库兼容逻辑。

## 自检

- [x] 改动范围符合 Issue #448
- [x] 不包含无关改动
- [x] 已包含必要测试
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查
- [ ] 等待至少一名人工 Review

请人工 Review，本 PR 不自动合并。