### PR TITLE
fix(character): 修复本地幸运掷骰调用失败

### DIFF
--- a/trpg-frontend/package.json
+++ b/trpg-frontend/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "predev": "npm --prefix ../trpg-sdk run build",
     "dev": "vite",
+    "prebuild": "npm --prefix ../trpg-sdk run build",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint . --max-warnings 0",

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -915,7 +915,11 @@ export default function CharacterPage() {
 
   /** 首次点击时创建房间草稿，再请求服务端确定本局唯一的幸运值。 */
   const handleLuckRoll = async () => {
-    if (!roomId || luckRolling || luckRollComplete) return
+    if (!roomId) {
+      setLuckError('当前页面没有绑定有效房间，请返回大厅后重新进入角色卡')
+      return
+    }
+    if (luckRolling || luckRollComplete) return
     if (luckDice) {
       setLuckRolling(true)
       setLuckDiceOpen(true)
@@ -938,6 +942,12 @@ export default function CharacterPage() {
       setLuckDiceOpen(true)
     } catch (error) {
       setLuckRolling(false)
+      // 请求失败时清掉所有临时骰子状态，避免 luckDiceOpen 残留导致按钮
+      // 看似可点击但实际一直被 disabled，后续点击也不会重新发请求。
+      setLuckDiceOpen(false)
+      setLuckDice(null)
+      setLuckDiceIndex(0)
+      setLuckAccumulated(0)
       setLuckError(friendlyErrorMessage(error, '幸运掷骰失败，请重试'))
     }
   }


### PR DESCRIPTION
## 主要改动

- 前端开发和构建前自动重新构建本地 `trpg-sdk`，确保加载包含 `rollLuck` 的产物。
- 幸运掷骰请求失败时清理临时状态，允许用户重新尝试。
- 缺少房间信息时显示明确提示。

## 采用该方案的原因

本地 SDK 的 `dist` 目录被忽略，直接同步仓库后可能继续使用缺少 `rollLuck` 的旧构建产物。将 SDK 构建接入前端 `predev`/`prebuild` 生命周期可以消除该环境差异；状态清理只影响失败分支，不改变幸运值规则。

## 测试与验证

- [x] `trpg-frontend/npm run build`：通过，包含 SDK 构建和 Vite 生产构建。
- [x] `trpg-frontend/npm run lint`：通过。
- [x] 后端健康检查：`GET /api/v1/health` 返回成功。
- [x] 已确认构建后的 SDK 暴露 `rollLuck` 方法。
- [ ] 自动化 CharacterPage 测试：未完成，现有测试运行时卡在 Canvas 环境警告。

## 风险与回滚

改动仅增加本地 SDK 构建步骤，可能让 `npm run dev`/`npm run build` 多花几秒；不涉及生产后端、数据库或接口协议。回滚该提交即可恢复原有脚本和状态处理。

## UI 证据

无视觉改动；修复后“掷骰”按钮会正常发起 `roll-luck` 请求。

## AI 使用情况

本 PR 使用 AI 辅助定位本地 SDK 构建产物过期问题并整理改动；提交内容已完成代码检查和人工确认。

## 自检

- [x] 改动范围符合 Issue
- [x] 不包含无关改动
- [x] 已完成构建和静态检查
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查和人工 Review
