### PR TITLE
fix(rule-engine): 将 agent_match 动作族降为语义参考 (#453)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -1436,7 +1436,8 @@ class AdjudicationEngineService:
             )
             # 存在性不等于「此时此地可用」。候选菜单是按当前场景发布的，提交时
             # 必须用同一个谓词重新绑定：否则模型可以点名另一个地点的规则，把它
-            # 的后果带到这里来 —— 范围校验等于交给了模型自觉。
+            # 的后果带到这里来。action_family 是开放词表，仅作语义参考，不参与
+            # 这里的硬拒绝；地点、目标类型、目标 ID 和 when 才是权威范围。
             if not agent_match_admits(
                 rule,
                 state=state,
@@ -1446,13 +1447,9 @@ class AdjudicationEngineService:
                 target_kind=adjudication.target.kind,
                 target_id=adjudication.target.id,
             ):
-                # 可自动修复，不是死路。菜单是按「玩家站在哪」发布的，这里才
-                # 第一次用上 method.family 和 target —— 也就是说模型看得到的
-                # 候选，提交时完全可能不适用（#313：在 neighborhood 说「跟邻居
-                # 打个招呼」，菜单里有 question_neighbors，但它只认
-                # family=interview + target=lyla）。这是 fault="agent" 的错，
-                # 而放弃 rule_decision 就能变回一次普通叙事裁决，没有任何理由
-                # 让玩家的回合直接死在这里。
+                # 可自动修复，不是死路。target 或结构范围不匹配时，
+                # 放弃 rule_decision 就能变回一次普通叙事裁决；单纯的 family
+                # 词汇差异不会进入此分支（#453）。
                 self._reject_validation(
                     "RULE_OUT_OF_SCOPE",
                     repairability="auto_repairable",

--- a/agent-collaboration-framework/collaboration_framework/engine/persistent_results.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/persistent_results.py
@@ -7,6 +7,7 @@ COC7 战斗算法；模型必须通过受控的 ``method.family`` 和 ``persiste
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Literal
 
@@ -27,6 +28,8 @@ from collaboration_framework.contracts import (
 )
 
 from .models import DomainEvent
+
+logger = logging.getLogger(__name__)
 
 
 # 标准键和值是玩家可见状态的唯一白名单，任意模组私有键不会因此被公开。
@@ -99,7 +102,19 @@ def validate_persistent_effects(
     """检查自由裁决成功分支是否完整表达声明的持久结果。"""
 
     intent = effective_persistence_intent(adjudication)
-    policy = _FAMILY_POLICIES.get(adjudication.method.family.strip().lower())
+    family = adjudication.method.family.strip().lower()
+    policy = _FAMILY_POLICIES.get(family)
+    if policy is None:
+        # 动作族是开放字符串；记录未覆盖值，便于发现模型或模组的新词，
+        # 但不把观测升级成新的拒绝条件，保持既有兼容行为。
+        logger.info(
+            "persistent_family_policy_missing",
+            extra={
+                "family": family,
+                "persistence_intent": adjudication.persistence_intent,
+                "persistence_intent_explicit": adjudication.persistence_intent_explicit,
+            },
+        )
     # 新模型显式写 none 不能把明显持久动作降级成普通叙事；旧存量裁决没有
     # explicit 标记，继续按兼容语义读取 none。
     if adjudication.persistence_intent_explicit and policy is not None:

--- a/agent-collaboration-framework/collaboration_framework/engine/rules_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/rules_v3.py
@@ -430,6 +430,11 @@ def agent_match_scope_admits(
 
     The arguments narrow as the caller knows more: publishing knows only where
     the actor stands, submitting also knows what was aimed at and how.
+
+    ``action_family`` is deliberately advisory. It is an open, model-produced
+    string and therefore cannot safely veto a rule whose structural location and
+    target scope already match.
+    动作族只帮助模型选择候选，地点、目标和状态条件才决定规则能否提交。
     """
 
     trigger = rule.trigger
@@ -437,12 +442,6 @@ def agent_match_scope_admits(
         return False
     scope = trigger.scope
     if scope.location_ids and location_id not in scope.location_ids:
-        return False
-    if (
-        action_family is not None
-        and scope.action_families
-        and action_family not in scope.action_families
-    ):
         return False
     if (
         target_kind is not None

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -76,11 +76,11 @@ _REPAIR_HINTS: dict[str, str] = {
         "kind=location + player_view.scene.id 为目标返回 narrative_only。"
     ),
     "RULE_OUT_OF_SCOPE": (
-        "所选 rule_decision 与本次 method.family 或 target 不匹配。"
-        "keeper_capabilities.rule_candidates 里一条候选的 action_families、"
+        "所选 rule_decision 的地点、目标类型、目标 ID 或 when 条件不匹配。"
+        "action_families 是开放的语义参考，不要求与 method.family 逐字相等；"
+        "不能仅因动作族词汇不同就去掉一个结构性范围仍然匹配的 rule_decision。"
         "target_kinds、target_ids 为空即表示该维度不设限，非空才要求本次裁决落在"
-        "其中——逐个字段判断，非空的都命中才能保留 rule_decision；一条都对不上就"
-        "去掉 rule_decision，按普通裁决重新给出这一步。"
+        "其中。确认硬约束不匹配后，才去掉 rule_decision，按普通裁决重新给出这一步。"
     ),
     "INVENTORY_TARGET_NOT_PORTABLE": (
         "holder_actor_id 只接受 player_view.scene.loose_items、player_view.inventory，"

--- a/agent-collaboration-framework/collaboration_framework/host/prompts/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/prompts/action_plan.py
@@ -2,7 +2,7 @@
 
 from collaboration_framework.contracts import ActionPlanPolicy
 
-PROMPT_VERSION = "trpg-host-intent-v5"
+PROMPT_VERSION = "trpg-host-intent-v6"
 TURN_PLANNER_PROMPT_VERSION = "trpg-turn-planner-v2"
 
 
@@ -131,9 +131,11 @@ player_view.self_actor.id（玩家自己）或 scene.visible_actors[].id（同�
 keeper_capabilities.world_id，或 kind=location + player_view.scene.id；world 只认
 world_id 这一个值，不要自己拼一个像 "world" 的 id。
 
-rule_decision 是可选的。keeper_capabilities.rule_candidates 是按玩家当前所在地发布的，
-一条候选还可能声明 action_families、target_kinds、target_ids 作为额外约束：**这三个字段
-为空表示该维度不设限，非空才要求本次裁决落在其中**。逐个字段判断，非空的都命中才能选它。
+rule_decision 是可选的。keeper_capabilities.rule_candidates 是按玩家当前所在地发布的。
+target_kinds、target_ids 是规则的结构性范围约束：为空表示该维度不设限，非空才要求本次
+裁决落在其中。action_families 是开放的语义参考词，不要求与 method.family 逐字相等，
+不能仅因动作族词汇不同就放弃一个地点、目标和 when 都匹配的候选。逐个检查结构性范围，
+只有这些硬约束不满足时才移除 rule_decision。
 玩家的话对不上任何一条候选（例如只是打个招呼）时，不要硬套一条规则，直接不带
 rule_decision 按普通裁决给出这一步。
 

--- a/agent-collaboration-framework/collaboration_framework/module/validation_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/module/validation_v3.py
@@ -356,6 +356,7 @@ def _rule_issues(
     elif isinstance(rule.trigger, AgentMatchTriggerSpec):
         if rule.trigger.when is not None:
             issues.extend(_condition_issues(rule.trigger.when, f"{path}.trigger.when"))
+        issues.extend(_agent_match_hint_issues(rule.trigger, f"{path}.trigger"))
         for index, location_id in enumerate(rule.trigger.scope.location_ids):
             require(
                 location_id,
@@ -401,6 +402,62 @@ def _rule_issues(
     # 声明过的片段。随 `RulePresentationSpec` 一起删除（#288 结案、#398 执行）：
     # 被引用的一侧不存在了，这条检查也就无从谈起。`PresentationStep` 仍在 union
     # 里但依旧不接通，两个已发布模组都没有用过它。
+    return issues
+
+
+def _agent_match_hint_issues(
+    trigger: AgentMatchTriggerSpec,
+    path: str,
+) -> list[ValidationIssue]:
+    """Reject machine identifiers masquerading as semantic Match hints.
+
+    该函数只校验模型看到的规则问题提示词，不改变 action_family 的运行时开放性。
+    ``semantic_hints`` is the model-facing natural-language vocabulary. Family
+    names and option ids remain valid contract fields, but copying them into the
+    hint list makes the published vocabulary less useful and can hide duplicate
+    entries. Comparisons are normalized only for validation; diagnostics retain
+    the authored array index.
+    """
+
+    def normalize(value: str) -> str:
+        return value.strip().casefold()
+
+    families = {normalize(value) for value in trigger.scope.action_families}
+    option_ids = {normalize(option.id) for option in trigger.options}
+    issues: list[ValidationIssue] = []
+    seen: dict[str, int] = {}
+    for index, hint in enumerate(trigger.question.semantic_hints):
+        hint_path = f"{path}.question.semantic_hints.{index}"
+        normalized = normalize(hint)
+        if normalized in families:
+            issues.append(
+                ValidationIssue(
+                    severity="error",
+                    code="MODULE_V3_AGENT_MATCH_HINT_EQUALS_ACTION_FAMILY",
+                    path=hint_path,
+                    message="semantic_hint 不能直接等于 action_family",
+                )
+            )
+        if normalized in option_ids:
+            issues.append(
+                ValidationIssue(
+                    severity="error",
+                    code="MODULE_V3_AGENT_MATCH_HINT_EQUALS_OPTION_ID",
+                    path=hint_path,
+                    message="semantic_hint 不能直接等于 option id",
+                )
+            )
+        if normalized in seen:
+            issues.append(
+                ValidationIssue(
+                    severity="error",
+                    code="MODULE_V3_AGENT_MATCH_HINT_DUPLICATE",
+                    path=hint_path,
+                    message=f"semantic_hint 与第 {seen[normalized]} 项重复",
+                )
+            )
+        else:
+            seen[normalized] = index
     return issues
 
 

--- a/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json
+++ b/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json
@@ -970,7 +970,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "interview",
+            "询问莱拉近况",
             "莱拉·奥戴尔"
           ]
         },
@@ -1126,7 +1126,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "social",
+            "给守墓人留下好印象",
             "梅洛迪亚斯·杰弗逊"
           ]
         },
@@ -1219,7 +1219,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "observe",
+            "仔细观察守墓人",
             "梅洛迪亚斯·杰弗逊"
           ]
         },
@@ -1321,7 +1321,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "intimidate",
+            "威吓守墓人",
             "梅洛迪亚斯·杰弗逊"
           ]
         },
@@ -1424,7 +1424,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "bribe",
+            "贿赂守墓人",
             "梅洛迪亚斯·杰弗逊"
           ]
         },
@@ -1602,7 +1602,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "research",
+            "查阅当地旧报档案",
             "当地旧报档案"
           ]
         },
@@ -1694,7 +1694,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "request_access",
+            "请求查阅当地旧报档案",
             "当地旧报档案"
           ]
         },
@@ -1893,7 +1893,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "search",
+            "搜索当地旧报档案",
             "当地旧报档案"
           ]
         },
@@ -2007,7 +2007,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "search",
+            "向镇民打听消息",
             "打听地下酒吧的位置"
           ]
         },
@@ -2121,7 +2121,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "search",
+            "寻找一品脱酒",
             "一品脱酒"
           ]
         },
@@ -2203,7 +2203,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "search",
+            "搜索道格拉斯的书房",
             "道格拉斯的书房"
           ]
         },
@@ -2285,7 +2285,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "read",
+            "阅读道格拉斯的旧日记",
             "道格拉斯的旧日记"
           ]
         },
@@ -2377,7 +2377,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "surveil",
+            "监视夜间区域",
             "夜间监视区域"
           ]
         },
@@ -2470,7 +2470,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "call_name",
+            "呼唤墓地中的人影",
             "墓地中的人影"
           ]
         },
@@ -2542,7 +2542,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "track",
+            "追踪道格拉斯常坐的墓碑",
             "道格拉斯常坐的墓碑"
           ]
         },
@@ -2635,7 +2635,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "move",
+            "搬开石板",
             "石板下的地穴入口"
           ]
         },
@@ -2717,7 +2717,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "enter",
+            "进入地穴",
             "石板下的地穴入口"
           ]
         },
@@ -2811,7 +2811,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "talk",
+            "与墓地中的人影交谈",
             "墓地中的人影"
           ]
         },
@@ -2909,7 +2909,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "let_leave",
+            "让墓地中的人影离开",
             "墓地中的人影"
           ]
         },
@@ -2970,7 +2970,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "follow",
+            "跟随墓地中的人影",
             "墓地中的人影"
           ]
         },
@@ -3031,7 +3031,7 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "flee",
+            "逃离食尸鬼群",
             "食尸鬼群"
           ]
         },

--- a/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/银之锁/module-content-v3.json
+++ b/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/银之锁/module-content-v3.json
@@ -1238,16 +1238,16 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "spot-hidden",
-            "spot-hidden"
+            "仔细搜索床铺",
+            "寻找床铺中的隐藏物品"
           ]
         },
         "options": [
           {
             "id": "spot-hidden",
             "semantic_hints": [
-              "spot-hidden",
-              "spot-hidden"
+              "仔细搜索床铺",
+              "寻找床铺中的隐藏物品"
             ]
           }
         ]
@@ -1340,16 +1340,16 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "STR",
-            "STR"
+            "移动床铺",
+            "挪开床铺"
           ]
         },
         "options": [
           {
             "id": "STR",
             "semantic_hints": [
-              "STR",
-              "STR"
+              "移动床铺",
+              "挪开床铺"
             ]
           }
         ]
@@ -2265,16 +2265,16 @@
         "question": {
           "kind": "method",
           "semantic_hints": [
-            "listen",
-            "listen"
+            "倾听衣柜",
+            "仔细听衣柜里的动静"
           ]
         },
         "options": [
           {
             "id": "listen",
             "semantic_hints": [
-              "listen",
-              "listen"
+              "倾听衣柜",
+              "仔细听衣柜里的动静"
             ]
           }
         ]

--- a/agent-collaboration-framework/scripts/build_silver_lock_module.py
+++ b/agent-collaboration-framework/scripts/build_silver_lock_module.py
@@ -177,8 +177,12 @@ def check_rule(
     success_effects: list[dict[str, Any]],
     failure_effects: list[dict[str, Any]],
     difficulty: str = "regular",
+    hints: list[str] | None = None,
 ) -> dict[str, Any]:
-    """构造失败后仍可重试的正式 COC7 检定规则。"""
+    """构造失败后仍可重试的正式 COC7 检定规则。
+
+    hint 必须描述玩家实际动作；未传入时才回退到技能/选项的兼容默认值。
+    """
 
     steps: list[dict[str, Any]] = [
         {
@@ -214,7 +218,7 @@ def check_rule(
             target_kind,
             target_id,
             option_id,
-            [skill_id, option_id],
+            hints if hints is not None else [skill_id, option_id],
         ),
         "execution": {
             "branches": [{"id": option_id, "entry_step_id": "check"}],
@@ -329,8 +333,8 @@ def build_module() -> dict[str, Any]:
         [
             effect_rule("cut_restraints_with_knife", families=["cut", "use"], location_ids=["sealed_room"], target_kind="entity", target_id="restraint_rope", option_id="pencil-knife", hints=["铅笔刀", "割断绳索"], effects=[{"type": "change_entity_state", "entity_id": "restraint_rope", "key": "cut", "value": True}, {"type": "reveal_information", "information_id": "restraints_removed", "scope": "party"}]),
             effect_rule("cut_restraints_on_bed_corner", families=["cut", "rub"], location_ids=["sealed_room"], target_kind="entity", target_id="sharp_bed_corner", option_id="sharp-corner", hints=["锋利铁皮", "磨断绳索"], effects=[{"type": "change_entity_state", "entity_id": "sharp_bed_corner", "key": "noticed", "value": True}, {"type": "change_entity_state", "entity_id": "restraint_rope", "key": "cut", "value": True}, {"type": "reveal_information", "information_id": "restraints_removed", "scope": "party"}]),
-            check_rule("search_bed", families=["search", "observe"], target_kind="entity", target_id="bed", option_id="spot-hidden", skill_id="spot-hidden", success_effects=[{"type": "change_entity_state", "entity_id": "bed_key", "key": "found", "value": True}, {"type": "reveal_information", "information_id": "bed_key_found", "scope": "party"}], failure_effects=[{"type": "reveal_information", "information_id": "bed_search_hint", "scope": "party"}]),
-            check_rule("move_bed", families=["move"], target_kind="entity", target_id="bed", option_id="STR", skill_id="STR", success_effects=[{"type": "change_entity_state", "entity_id": "bed", "key": "moved", "value": True}, {"type": "change_entity_state", "entity_id": "bed_key", "key": "found", "value": True}, {"type": "reveal_information", "information_id": "bed_key_found", "scope": "party"}], failure_effects=[{"type": "reveal_information", "information_id": "bed_move_hint", "scope": "party"}]),
+            check_rule("search_bed", families=["search", "observe"], target_kind="entity", target_id="bed", option_id="spot-hidden", skill_id="spot-hidden", hints=["仔细搜索床铺", "寻找床铺中的隐藏物品"], success_effects=[{"type": "change_entity_state", "entity_id": "bed_key", "key": "found", "value": True}, {"type": "reveal_information", "information_id": "bed_key_found", "scope": "party"}], failure_effects=[{"type": "reveal_information", "information_id": "bed_search_hint", "scope": "party"}]),
+            check_rule("move_bed", families=["move"], target_kind="entity", target_id="bed", option_id="STR", skill_id="STR", hints=["移动床铺", "挪开床铺"], success_effects=[{"type": "change_entity_state", "entity_id": "bed", "key": "moved", "value": True}, {"type": "change_entity_state", "entity_id": "bed_key", "key": "found", "value": True}, {"type": "reveal_information", "information_id": "bed_key_found", "scope": "party"}], failure_effects=[{"type": "reveal_information", "information_id": "bed_move_hint", "scope": "party"}]),
             effect_rule("inspect_wall_painting", families=["inspect", "search"], location_ids=["sealed_room"], target_kind="entity", target_id="wall_painting", option_id="lift-painting", hints=["掀开挂画", "检查暗格"], effects=[{"type": "change_entity_state", "entity_id": "wall_painting", "key": "inspected", "value": True}, {"type": "change_entity_state", "entity_id": "wall_key", "key": "found", "value": True}, {"type": "reveal_information", "information_id": "wall_key_found", "scope": "party"}]),
             effect_rule("open_top_drawer", families=["unlock", "open"], location_ids=["sealed_room"], target_kind="entity", target_id="top_drawer", option_id="wall-key", hints=["暗格钥匙", "上层抽屉"], effects=[{"type": "change_entity_state", "entity_id": "top_drawer", "key": "open", "value": True}, {"type": "change_entity_state", "entity_id": "sketchbook", "key": "discovered", "value": True}, {"type": "reveal_information", "information_id": "sketchbook_found", "scope": "party"}]),
             effect_rule("open_middle_drawer", families=["unlock", "open"], location_ids=["sealed_room"], target_kind="entity", target_id="middle_drawer", option_id="bed-key", hints=["床下钥匙", "中层抽屉"], effects=[{"type": "change_entity_state", "entity_id": "middle_drawer", "key": "opened", "value": True}, {"type": "change_entity_state", "entity_id": "white_paper", "key": "found", "value": True}, {"type": "reveal_information", "information_id": "danger_note_read", "scope": "party"}]),
@@ -341,7 +345,7 @@ def build_module() -> dict[str, Any]:
             effect_rule("open_bottom_drawer", families=["unlock", "open"], location_ids=["sealed_room"], target_kind="entity", target_id="bottom_drawer", option_id="vent-key", hints=["通风管钥匙", "下层抽屉"], effects=[{"type": "change_entity_state", "entity_id": "bottom_drawer", "key": "opened", "value": True}]),
             effect_rule("contact_bast_with_white_paper", families=["write", "communicate"], location_ids=["sealed_room"], target_kind="entity", target_id="white_paper", option_id="use-white-paper", hints=["把白纸放进下层抽屉"], effects=[{"type": "consume_entity", "entity_id": "white_paper"}, {"type": "change_entity_state", "entity_id": "bast", "key": "contacted", "value": True}, {"type": "reveal_information", "information_id": "bast_contacted", "scope": "party"}]),
             effect_rule("contact_bast_with_last_page", families=["write", "communicate"], location_ids=["sealed_room"], target_kind="entity", target_id="communication_page", option_id="use-last-page", hints=["用最后一页替代白纸"], effects=[{"type": "consume_entity", "entity_id": "communication_page"}, {"type": "change_entity_state", "entity_id": "bast", "key": "contacted", "value": True}, {"type": "reveal_information", "information_id": "bast_contacted", "scope": "party"}]),
-            check_rule("listen_to_wardrobe", families=["listen"], target_kind="entity", target_id="wardrobe", option_id="listen", skill_id="listen", success_effects=[{"type": "reveal_information", "information_id": "wardrobe_sound", "scope": "party"}], failure_effects=[{"type": "reveal_information", "information_id": "wardrobe_sound", "scope": "party"}]),
+            check_rule("listen_to_wardrobe", families=["listen"], target_kind="entity", target_id="wardrobe", option_id="listen", skill_id="listen", hints=["倾听衣柜", "仔细听衣柜里的动静"], success_effects=[{"type": "reveal_information", "information_id": "wardrobe_sound", "scope": "party"}], failure_effects=[{"type": "reveal_information", "information_id": "wardrobe_sound", "scope": "party"}]),
             effect_rule("cut_wardrobe_chain", families=["cut", "open"], location_ids=["sealed_room"], target_kind="entity", target_id="wardrobe", option_id="bolt-cutters", hints=["用钢钳剪开锁链"], effects=[{"type": "change_entity_state", "entity_id": "wardrobe", "key": "opened", "value": True}, {"type": "change_entity_state", "entity_id": "bast", "key": "freed", "value": True}, {"type": "reveal_information", "information_id": "bast_rescued", "scope": "party"}]),
             effect_rule("feed_bast", families=["feed", "offer"], location_ids=["sealed_room"], target_kind="entity", target_id="bast", option_id="osmanthus-porridge", hints=["喂桂花糯米糖粥"], effects=[{"type": "consume_entity", "entity_id": "osmanthus_porridge"}, {"type": "change_entity_state", "entity_id": "bast", "key": "trusted", "value": True}, {"type": "change_entity_state", "entity_id": "bast", "key": "following", "value": True}, {"type": "reveal_information", "information_id": "bast_trusted", "scope": "party"}]),
             effect_rule("inspect_door_monitor", families=["inspect", "observe"], location_ids=["sealed_room"], target_kind="entity", target_id="door_monitor", option_id="watch-monitor", hints=["查看门外显示器"], effects=[{"type": "change_entity_state", "entity_id": "door_monitor", "key": "ghost_seen", "value": True}, {"type": "reveal_information", "information_id": "door_ghost_seen", "scope": "party"}]),

--- a/agent-collaboration-framework/tests/test_architecture.py
+++ b/agent-collaboration-framework/tests/test_architecture.py
@@ -138,7 +138,7 @@ class ArchitectureTests(unittest.TestCase):
         )
         self.assertTrue(HostAgentContext.model_fields)
         self.assertTrue(Intent.model_fields)
-        self.assertEqual(PROMPT_VERSION, "trpg-host-intent-v5")
+        self.assertEqual(PROMPT_VERSION, "trpg-host-intent-v6")
         self.assertEqual(TURN_PLANNER_PROMPT_VERSION, "trpg-turn-planner-v2")
         planning = turn_planning_instructions(ActionPlanPolicy())
         self.assertIn("公开地点、人物、物件名称或别名", planning)

--- a/agent-collaboration-framework/tests/test_module_content_v3.py
+++ b/agent-collaboration-framework/tests/test_module_content_v3.py
@@ -14,9 +14,10 @@ import copy
 import unittest
 from typing import Any
 
+from pydantic import ValidationError
+
 from collaboration_framework.contracts import ModuleContentV3
 from collaboration_framework.module import validate_module_v3, validate_module_v3_json
-from pydantic import ValidationError
 
 
 def module_payload() -> dict[str, Any]:
@@ -316,6 +317,44 @@ class ReferenceIntegrityTests(unittest.TestCase):
 
 
 class RuleGraphTests(unittest.TestCase):
+    def test_agent_match_hint_equal_to_family_is_rejected(self) -> None:
+        payload = mutate()
+        payload["rules"][0]["trigger"]["question"]["semantic_hints"] = [
+            " Research "
+        ]
+        report = validate_module_v3(payload)
+        self.assertEqual(
+            [issue.code for issue in report.errors],
+            ["MODULE_V3_AGENT_MATCH_HINT_EQUALS_ACTION_FAMILY"],
+        )
+        self.assertEqual(
+            report.errors[0].path,
+            "rules.0.trigger.question.semantic_hints.0",
+        )
+
+    def test_agent_match_hint_equal_to_option_id_is_rejected(self) -> None:
+        payload = mutate()
+        payload["rules"][0]["trigger"]["question"]["semantic_hints"] = [
+            " by_date "
+        ]
+        report = validate_module_v3(payload)
+        self.assertEqual(
+            [issue.code for issue in report.errors],
+            ["MODULE_V3_AGENT_MATCH_HINT_EQUALS_OPTION_ID"],
+        )
+
+    def test_agent_match_duplicate_hints_are_rejected_after_normalization(self) -> None:
+        payload = mutate()
+        payload["rules"][0]["trigger"]["question"]["semantic_hints"] = [
+            "查阅旧报",
+            " 查阅旧报 ",
+        ]
+        report = validate_module_v3(payload)
+        self.assertEqual(
+            [issue.code for issue in report.errors],
+            ["MODULE_V3_AGENT_MATCH_HINT_DUPLICATE"],
+        )
+
     def test_agent_match_option_without_a_branch_is_rejected(self) -> None:
         payload = mutate()
         payload["rules"][0]["trigger"]["options"].append(

--- a/agent-collaboration-framework/tests/test_persistent_results.py
+++ b/agent-collaboration-framework/tests/test_persistent_results.py
@@ -1,0 +1,37 @@
+"""持久化动作族覆盖观测测试。
+
+本文件确保开放动作族未命中策略表时只产生诊断，不改变既有裁决结果。
+"""
+
+import logging
+
+from collaboration_framework.contracts import (
+    ActionAdjudication,
+    ActionMethod,
+    ActionTarget,
+    NoAdjudicationCheck,
+)
+from collaboration_framework.engine.persistent_results import (
+    validate_persistent_effects,
+)
+
+
+def test_unknown_family_is_observable_without_changing_validation(caplog) -> None:
+    adjudication = ActionAdjudication(
+        request_id="unknown-family-observation",
+        source_revision="revision-1",
+        actor_id="actor-1",
+        summary="观察周围",
+        target=ActionTarget(kind="location", id="library"),
+        method=ActionMethod(family="  观察  ", description="观察周围"),
+        check=NoAdjudicationCheck(),
+    )
+
+    with caplog.at_level(logging.INFO):
+        result = validate_persistent_effects(adjudication)
+
+    assert result is None
+    assert "persistent_family_policy_missing" in caplog.text
+    record = next(item for item in caplog.records if item.message == "persistent_family_policy_missing")
+    assert record.family == "观察"
+    assert record.persistence_intent == "none"

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -855,12 +855,11 @@ class AdjudicationAgainstV3Tests(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_greeting_a_neighbour_is_repairable_not_a_dead_turn(self) -> None:
-        """#313 复现：在 neighborhood 说「跟邻居打个招呼」被直接判死。
+        """#313 回归：动作族不同也不能阻断结构范围匹配的规则。
 
         菜单是按「玩家站在哪」发布的，所以 `question_neighbors` 会出现在候选里；
-        但它另外要求 `family=interview` 且 `target=lyla`，提交时才第一次校验这两
-        项。模型把打招呼归成 `social` 是它自己的错（`fault="agent"`），而放弃
-        rule_decision 就能退回一次普通叙事裁决——没有任何理由让玩家的回合死在这。
+        `target=lyla` 仍需在提交时复查，但模型把打招呼归成 `social` 不再导致
+        `RULE_OUT_OF_SCOPE`。
         """
 
         store, engine, rules = self.build(scene_id="neighborhood")
@@ -885,31 +884,13 @@ class AdjudicationAgainstV3Tests(unittest.IsolatedAsyncioTestCase):
                 rule_id="question_neighbors", option_id="fast-talk"
             ),
         )
-        with self.assertRaises(AdjudicationValidationError) as rejected:
-            await engine.submit(
-                SubmitAdjudicationRequest(
-                    room_id=ROOM, player_id=PLAYER, adjudication=greeting
-                )
-            )
-
-        result = rejected.exception.result
-        self.assertEqual(result.code, "RULE_OUT_OF_SCOPE")
-        self.assertEqual(result.fault, "agent")
-        # 关键断言：修复循环只认 auto_repairable / retry_with_latest_revision，
-        # hard_reject 会被直接抛出去变成 turn.failed。
-        self.assertEqual(result.repairability, "auto_repairable")
-        self.assertEqual(self.store_events(store), 0)
-
-        # 放弃这条规则之后，同一句话应当照常裁决完成。
-        repaired = greeting.model_copy(
-            update={"request_id": "greet-neighbour-313-repaired", "rule_decision": None},
-            deep=True,
-        )
-        await engine.submit(
+        execution = await engine.submit(
             SubmitAdjudicationRequest(
-                room_id=ROOM, player_id=PLAYER, adjudication=repaired
+                room_id=ROOM, player_id=PLAYER, adjudication=greeting
             )
         )
+        self.assertEqual(execution.status, "resolved")
+        self.assertGreater(self.store_events(store), 0)
 
     @staticmethod
     def store_events(store: InMemoryEngineStore) -> int:
@@ -1847,15 +1828,27 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
                 family="research",
             )
 
-    async def test_rule_decision_with_a_foreign_action_family_is_refused(self) -> None:
-        """scope.action_families 声明了 research，用恐吓去触发它不成立。"""
+    async def test_rule_decision_with_a_foreign_action_family_is_admitted(self) -> None:
+        """开放动作族只作参考，结构范围匹配时不能阻断规则。"""
+
+        execution = await self._submit_rule_decision(
+            scene_id="crypt",
+            rule_id="enter_crypt",
+            option_id="proceed",
+            target=ActionTarget(kind="entity", id="crypt_entrance"),
+            family="travel",
+        )
+        self.assertIn(execution.status, {"resolved", "awaiting_skill_choice"})
+
+    async def test_rule_decision_with_a_foreign_family_keeps_target_scope_hard(self) -> None:
+        """放宽 family 不得放宽规则声明的目标范围。"""
 
         with self.assertRaises(ContractError):
             await self._submit_rule_decision(
                 scene_id="library",
                 rule_id="research_library_archive",
                 option_id="library-use",
-                target=ActionTarget(kind="entity", id="newspaper_archive"),
+                target=ActionTarget(kind="entity", id="melodias"),
                 family="intimidate",
             )
 

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -248,7 +248,8 @@ change_entity_state）；但不要为了内部写入次数把一个意图拆成�
 不要自己拼效果。判断依据是候选上的这几个字段：
 
 - `semantic_hints`：这条规则想捕捉的说法（例如"观察""用侦查"）；
-- `action_families`：动作大类（observe / search / talk …）；
+- `action_families`：动作大类参考（observe / search / talk …），是开放语义词表，
+  不要求与最终 `method.family` 逐字相等；不能仅因动作族不同就放弃其他范围都匹配的规则；
 - `target_kinds` 与 `target_ids`：这条规则针对的对象，`target_ids` 里的 id 通常就是
   玩家话里指的那个实体；
 - `options[]`：这条规则给出的**候选做法**，每项有一个不透明的 `id`、它的

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -3086,11 +3086,14 @@ def _match_rule_candidate(capabilities, text: str, target_id: str | None):
     return candidate, candidate.options[0] if candidate.options else None
 
 
-# Match View action families are stable contract identifiers. These localized
-# words merely recognize the player's explicit verb; they do not add a rule or
-# reveal module-only facts. Ties still yield no match below.
+# Match View action families are stable contract identifiers. This small local
+# vocabulary is intentionally not exhaustive: these words only recognize a
+# player's explicit verb and never act as a rule admission gate. Ties still
+# yield no match below.
+# 这里的词汇只是离线测试/兜底提示，不是模组动作族的完整注册表。
 _ACTION_FAMILY_HINTS: dict[str, tuple[str, ...]] = {
     "observe": ("仔细观察", "观察", "察看", "查看"),
+    "surveil": ("监视", "观察周围", "留意动静", "观察"),
     "search": ("搜索", "搜查", "查找", "找线索", "寻找"),
     "research": ("研究", "查阅", "检索", "翻阅", "查旧报"),
     "social": ("留下好印象", "博取信任", "说服"),

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -3093,7 +3093,7 @@ def _match_rule_candidate(capabilities, text: str, target_id: str | None):
 # 这里的词汇只是离线测试/兜底提示，不是模组动作族的完整注册表。
 _ACTION_FAMILY_HINTS: dict[str, tuple[str, ...]] = {
     "observe": ("仔细观察", "观察", "察看", "查看"),
-    "surveil": ("监视", "观察周围", "留意动静", "观察"),
+    "surveil": ("监视", "观察周围", "留意动静"),
     "search": ("搜索", "搜查", "查找", "找线索", "寻找"),
     "research": ("研究", "查阅", "检索", "翻阅", "查旧报"),
     "social": ("留下好印象", "博取信任", "说服"),

--- a/trpg-backend/tests/test_rule_match_adjudication.py
+++ b/trpg-backend/tests/test_rule_match_adjudication.py
@@ -196,6 +196,22 @@ def test_prompt_teaches_the_model_to_use_rule_candidates() -> None:
     assert "option_id" in _SAFE_ADJUDICATION_INSTRUCTIONS
 
 
+def test_prompt_treats_action_families_as_advisory() -> None:
+    """提示词不能把开放动作族重新描述成逐字硬闸。"""
+
+    assert "不要求与最终 `method.family` 逐字相等" in _SAFE_ADJUDICATION_INSTRUCTIONS
+    instructions = current_step_adjudication_instructions()
+    assert "不能仅因动作族词汇不同就放弃" in instructions
+
+
+def test_offline_match_recognizes_surveillance_wording() -> None:
+    """离线兜底至少覆盖 #453 的自然中文观察说法。"""
+
+    from app.core.action_plan_turn import _ACTION_FAMILY_HINTS
+
+    assert "观察周围" in _ACTION_FAMILY_HINTS["surveil"]
+
+
 async def test_matched_rule_hands_ownership_to_the_rule() -> None:
     """命中规则时：交出 rule_decision 与检定，且不自带任何效果（#226 §5）。
 

--- a/trpg-backend/tests/test_rule_match_adjudication.py
+++ b/trpg-backend/tests/test_rule_match_adjudication.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import pathlib
+from types import SimpleNamespace
 from typing import Literal
 
 import pytest
@@ -65,6 +66,7 @@ from app.core.action_plan_turn import (
     _deterministic_adjudication_miss_reason,
     _deterministic_step_adjudication,
     _DeterministicStepAdjudicator,
+    _match_rule_candidate,
     _match_travel_target,
     _normalize_single_travel_decision,
     _project_plan_prerequisite_facts,
@@ -210,6 +212,32 @@ def test_offline_match_recognizes_surveillance_wording() -> None:
     from app.core.action_plan_turn import _ACTION_FAMILY_HINTS
 
     assert "观察周围" in _ACTION_FAMILY_HINTS["surveil"]
+
+
+def test_offline_generic_observe_does_not_tie_with_surveillance() -> None:
+    """通用“观察”不能因 surveil 词表过宽而把两个候选判成歧义。"""
+
+    from app.core.action_plan_turn import _ACTION_FAMILY_HINTS
+
+    # 用最小候选替身覆盖离线匹配器的真实评分路径，避免依赖具体模组夹具。
+    def candidate(rule_id: str, family: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            rule_id=rule_id,
+            action_families=[family],
+            semantic_hints=[],
+            target_kinds=[],
+            target_ids=[],
+            options=[],
+        )
+
+    capabilities = SimpleNamespace(
+        rule_candidates=[candidate("observe_rule", "observe"), candidate("watch_rule", "surveil")]
+    )
+    matched, _ = _match_rule_candidate(capabilities, "观察", None)
+
+    assert matched is not None
+    assert matched.rule_id == "observe_rule"
+    assert "观察" not in _ACTION_FAMILY_HINTS["surveil"]
 
 
 async def test_matched_rule_hands_ownership_to_the_rule() -> None:


### PR DESCRIPTION
## 关联 Issue

Closes #453

## 主要改动

- 移除 `agent_match` 提交侧对 `action_families` 的硬拒绝，保留地点、目标类型、目标 ID 和 `when` 约束。
- 增加 `semantic_hints` 等于动作族、等于 option ID、重复值的发布期错误校验，并清理《追书人》《银之锁》内置夹具。
- 为未知持久化动作族增加 `persistent_family_policy_missing` INFO 观测。
- 更新主持提示词、`RULE_OUT_OF_SCOPE` 修复提示和离线 `surveil` 词汇映射。
- 补充规则准入、发布校验、日志和自然语言回归测试。

## 采用该方案的原因

`action_families` 是模型生成的开放字符串，线上语义判断已经由主持模型完成，用它作为提交硬闸会把合理的自然表达误判为越界。地点、目标和状态条件仍由引擎确定性校验，继续承担规则边界保护。未引入动作族枚举、模组专用分支或数据库迁移。

本 PR 不包含 #426 的 Keeper 信息边界修复，也不包含地穴入口 travel 分发、`surveillance_arranged` 状态或夜间自动事件。

## 测试与验证

- [x] 框架完整测试：425 passed。
- [x] 后端完整测试：623 passed，23 skipped，1 个既有 httpx/Starlette 弃用警告。
- [x] 框架定向测试：97 passed。
- [x] 后端规则匹配定向测试：43 passed，1 skipped。
- [x] 本次改动相关 Ruff 检查通过。
- [x] `git diff --check` 通过。
- [ ] 真实模型 smoke：仓库现有测试因缺少外部模型凭据跳过，未伪造结果。

## 风险与回滚

放宽动作族准入后，规则区分主要依赖地点、目标、`when` 和候选语义；这些硬约束未改变。若线上观察到误命中，可回滚提交 `115d20e`，不涉及数据迁移。

## UI 证据

不适用，本 PR 不修改 UI。

## AI 使用情况

本 PR 使用 AI 辅助完成代码检索、实现和测试编排；变更已逐项审阅，新增逻辑均有对应回归测试。合并前仍需要至少一名人工 Reviewer 审核。

## 自检

- [x] 改动范围符合 #453。
- [x] 不包含 #426、#451 等其他 Issue 的实现。
- [x] 已包含必要的测试和生成夹具同步。
- [x] 不包含密钥、个人信息或非预期生成物。
- [x] 已完成 AI 辅助质量检查，等待人工 Review。