### PR TITLE
fix(host): 冻结后的主持队列失败可恢复，不阻塞后续行动

### DIFF
--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -875,6 +875,7 @@ async def _run_direct_host_action(
 ) -> None:
     """Persist and deliver a frozen A1 response without entering ActionPlan."""
 
+    await db.refresh(item)
     text = (item.direct_response_text or "").strip()
     if not text:
         raise RuntimeError("direct_response 队列项缺少已校验文本")
@@ -959,6 +960,78 @@ async def _run_direct_host_action(
         )
     if broadcast_state:
         await _broadcast_room_action_state_fresh(item.room_id)
+
+
+async def _recover_keeper_queue_failure(
+    db: AsyncSession,
+    item,
+    websocket: WebSocket | None,
+    exc: Exception,
+    *,
+    room_id: str,
+) -> None:
+    """Keep frozen keeper work retryable; only fail closed after the last attempt.
+
+    Discarding a processing item made the same client_action_id unrecoverable and
+    could drop a route that had already been frozen.  Delivery errors after the
+    event+queue commit must leave the item completed so reconnect can replay.
+    """
+
+    client_action_id = item.client_action_id
+    try:
+        await db.rollback()
+    except SQLAlchemyError:
+        logger.warning(
+            "host_queue_rollback_after_failure",
+            room_id=room_id,
+            client_action_id=client_action_id,
+            error_type=type(exc).__name__,
+            error_reason=_turn_error_reason(exc),
+        )
+    persisted = await host_action_queue_service.get_by_client_action(db, room_id, client_action_id)
+    if persisted is not None:
+        item = persisted
+    route = host_action_queue_service.effective_execution_route(item)
+    if (
+        item.recipient_kind == "keeper"
+        and route == "direct_response"
+        and item.status == "completed"
+    ):
+        logger.warning(
+            "host_direct_response_delivery_failed_after_commit",
+            room_id=room_id,
+            client_action_id=client_action_id,
+            error_type=type(exc).__name__,
+            error_reason=_turn_error_reason(exc),
+        )
+        return
+    if item.recipient_kind == "keeper" and item.status == "processing":
+        if item.attempt_count < 2:
+            await host_action_queue_service.mark_npc_retryable(db, item, delay_seconds=0)
+            return
+        await host_action_queue_service.mark_npc_failed(db, item)
+        log_turn_failed(
+            room_id=room_id,
+            stage="队列出队",
+            code=_map_turn_error(exc)[0],
+            correlation_id=client_action_id,
+            error_type=type(exc).__name__,
+            error_reason=_turn_error_reason(exc),
+            exc=exc,
+        )
+        await _send_turn_failed(websocket, client_action_id, exc)
+        return
+    await host_action_queue_service.discard(db, item)
+    log_turn_failed(
+        room_id=room_id,
+        stage="队列出队",
+        code=_map_turn_error(exc)[0],
+        correlation_id=client_action_id,
+        error_type=type(exc).__name__,
+        error_reason=_turn_error_reason(exc),
+        exc=exc,
+    )
+    await _send_turn_failed(websocket, client_action_id, exc)
 
 
 async def _drain_host_action_queue(room_id: str) -> None:
@@ -1097,34 +1170,13 @@ async def _drain_host_action_queue(room_id: str) -> None:
                     if result.waiting_for_player:
                         return
                 except Exception as exc:
-                    # A direct response commits its Event and queue completion before
-                    # any socket/broadcast work.  Delivery failures must therefore
-                    # leave the durable result completed so reconnect can replay it.
-                    if (
-                        item.recipient_kind == "keeper"
-                        and host_action_queue_service.effective_execution_route(item)
-                        == "direct_response"
-                        and item.status == "completed"
-                    ):
-                        logger.warning(
-                            "host_direct_response_delivery_failed_after_commit",
-                            room_id=room_id,
-                            client_action_id=item.client_action_id,
-                            error_type=type(exc).__name__,
-                            error_reason=_turn_error_reason(exc),
-                        )
-                        continue
-                    await host_action_queue_service.discard(db, item)
-                    log_turn_failed(
+                    await _recover_keeper_queue_failure(
+                        db,
+                        item,
+                        websocket,
+                        exc,
                         room_id=room_id,
-                        stage="队列出队",
-                        code=_map_turn_error(exc)[0],
-                        correlation_id=item.client_action_id,
-                        error_type=type(exc).__name__,
-                        error_reason=_turn_error_reason(exc),
-                        exc=exc,
                     )
-                    await _send_turn_failed(websocket, item.client_action_id, exc)
                 finally:
                     with anyio.CancelScope(shield=True):
                         action_lock_manager.release(room_id, lock_token)

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -198,6 +198,7 @@ def _listener_ids_for_utterance(utterance: str, player_view: PlayerView) -> tupl
 _UNAUTHORIZED_CLOSE_CODE = 4401
 _NOT_FOUND_CLOSE_CODE = 4404
 _OPENING_MESSAGE_ID = "game-opening"
+_HOST_QUEUE_TERMINAL = frozenset({"failed", "cancelled", "discarded"})
 
 _host_entry_router: HostEntryRouter | None = None
 
@@ -876,6 +877,8 @@ async def _run_direct_host_action(
     """Persist and deliver a frozen A1 response without entering ActionPlan."""
 
     await db.refresh(item)
+    if item.status in _HOST_QUEUE_TERMINAL:
+        return
     text = (item.direct_response_text or "").strip()
     if not text:
         raise RuntimeError("direct_response 队列项缺少已校验文本")
@@ -1728,7 +1731,7 @@ async def _send_completed_turn_message(
 
 async def _recover_persisted_turn_narration(
     db: AsyncSession,
-    websocket: WebSocket,
+    websocket: WebSocket | None,
     *,
     room_id: str,
     player_id: str,
@@ -1745,6 +1748,17 @@ async def _recover_persisted_turn_narration(
     ):
         if queued_item.player_id != player_id:
             raise ContractError("持久化 direct response 不属于当前玩家")
+        if queued_item.status in _HOST_QUEUE_TERMINAL:
+            await _send_turn_failed(
+                websocket,
+                client_action_id,
+                TurnExecutionError(
+                    "TURN_INTERNAL_ERROR",
+                    "本次动作处理失败，请稍后重试",
+                    retryable=False,
+                ),
+            )
+            return True
         view = await session_view_application.current_player_view(
             room_id=room_id,
             player_id=player_id,
@@ -1842,7 +1856,7 @@ async def _recover_persisted_turn_narration(
             payload=persisted.model_dump(by_alias=True),
         ).model_dump(by_alias=True),
     )
-    if raw_completion is not None and completion.npc_replies:
+    if websocket is not None and raw_completion is not None and completion.npc_replies:
         await _recover_persisted_turn_followup_dialogue(
             db,
             websocket,

--- a/trpg-backend/app/service/host_action_queue.py
+++ b/trpg-backend/app/service/host_action_queue.py
@@ -310,6 +310,8 @@ async def claim(
 
     now = datetime.now(UTC)
     owner = str(uuid.uuid4())
+    room_id = item.room_id
+    item_id = item.item_id
     eligible = or_(
         HostActionQueueItem.status == "queued",
         and_(
@@ -327,8 +329,8 @@ async def claim(
     result = await db.execute(
         update(HostActionQueueItem)
         .where(
-            HostActionQueueItem.room_id == item.room_id,
-            HostActionQueueItem.item_id == item.item_id,
+            HostActionQueueItem.room_id == room_id,
+            HostActionQueueItem.item_id == item_id,
             *([HostActionQueueItem.recipient_kind == recipient_kind] if recipient_kind else []),
             eligible,
         )
@@ -341,15 +343,20 @@ async def claim(
             updated_at=now,
         )
         .returning(HostActionQueueItem.item_id)
+        # SQLite round-trips timezone-aware columns as naive UTC.  Evaluating the
+        # WHERE in Python then TypeErrors (aware vs naive) and aborts a valid SQL
+        # claim.  Expire the local row and reload it after commit instead.
+        .execution_options(synchronize_session=False)
     )
     claimed_item_id = result.scalar_one_or_none()
+    db.expire(item)
     await db.commit()
     if claimed_item_id is None:
         return None
     return await db.scalar(
         select(HostActionQueueItem).where(
-            HostActionQueueItem.room_id == item.room_id,
-            HostActionQueueItem.item_id == item.item_id,
+            HostActionQueueItem.room_id == room_id,
+            HostActionQueueItem.item_id == item_id,
             HostActionQueueItem.lease_owner == owner,
         )
     )

--- a/trpg-backend/tests/test_host_action_queue.py
+++ b/trpg-backend/tests/test_host_action_queue.py
@@ -385,6 +385,44 @@ async def test_npc_queue_waiting_head_blocks_later_items_and_schedules_recovery(
 
 
 @pytest.mark.asyncio
+async def test_claim_retryable_failure_after_sqlite_reload(
+    db_session: AsyncSession,
+) -> None:
+    """SQLite 读出的 naive datetime 不能让二次领取在 Python 侧比较崩溃。"""
+
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=3981,
+        player_count=1,
+        prepare_checkpoint=False,
+    )
+    item, _ = await host_action_queue.enqueue(
+        db_session,
+        room_id=room.id,
+        player_id=players[0].id,
+        actor_id="actor-a",
+        client_action_id="retry-reload",
+        utterance="跟邻居打个招呼",
+        recipient=_KEEPER_RECIPIENT,
+    )
+    claimed = await host_action_queue.claim(
+        db_session, item, recipient_kind="keeper", lease_seconds=180
+    )
+    assert claimed is not None
+    await host_action_queue.mark_npc_retryable(db_session, claimed, delay_seconds=0)
+    room_id = room.id
+    db_session.expire_all()
+    head = await host_action_queue.peek_next(db_session, room_id)
+    assert head is not None
+    recovered = await host_action_queue.claim(
+        db_session, head, recipient_kind="keeper", lease_seconds=180
+    )
+    assert recovered is not None
+    assert recovered.status == "processing"
+    assert recovered.attempt_count == 2
+
+
+@pytest.mark.asyncio
 async def test_npc_cancel_before_player_event_persists_nothing(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,

--- a/trpg-backend/tests/test_host_entry_recovery.py
+++ b/trpg-backend/tests/test_host_entry_recovery.py
@@ -365,6 +365,97 @@ async def test_failed_direct_response_unblocks_following_queue_item(
 
 
 @pytest.mark.asyncio
+async def test_recover_failed_direct_response_stays_failed_and_writes_no_event(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4649)
+    player_id = players[0].id
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=player_id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-dead",
+        utterance="跟邻居打个招呼",
+    )
+
+    async def poison(db, item, view, websocket, **kwargs):  # noqa: ANN001
+        raise RuntimeError("poisoned head")
+
+    failures: list[tuple[str, bool | None]] = []
+    original_failed = ws_controller._send_turn_failed
+
+    async def record_failed(websocket, correlation_id, exc):  # noqa: ANN001
+        failures.append((correlation_id, getattr(exc, "retryable", None)))
+        return await original_failed(websocket, correlation_id, exc)
+
+    monkeypatch.setattr(ws_controller, "_run_direct_host_action", poison)
+    monkeypatch.setattr(ws_controller, "_send_turn_failed", record_failed)
+    await ws_controller._drain_host_action_queue(room_id)
+    db_session.expire_all()
+
+    recovered = await ws_controller._recover_persisted_turn_narration(
+        db_session,
+        None,
+        room_id=room_id,
+        player_id=player_id,
+        client_action_id="greet-dead",
+    )
+    db_session.expire_all()
+    item = await host_action_queue.get_by_client_action(db_session, room_id, "greet-dead")
+    events = await _narration_events(db_session, room_id)
+    assert recovered is True
+    assert item is not None
+    assert item.status == "failed"
+    assert events == []
+    assert ("greet-dead", False) in failures
+
+
+@pytest.mark.asyncio
+async def test_recover_discarded_direct_response_does_not_complete(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4650)
+    player_id = players[0].id
+    item, _ = await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=player_id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-discarded",
+        utterance="跟邻居打个招呼",
+    )
+    await host_action_queue.save_execution_route(
+        db_session,
+        item,
+        route="direct_response",
+        text="对方礼貌地点了点头。",
+        provenance="model_direct",
+    )
+    await host_action_queue.discard(db_session, item)
+    db_session.expire_all()
+
+    recovered = await ws_controller._recover_persisted_turn_narration(
+        db_session,
+        None,
+        room_id=room_id,
+        player_id=player_id,
+        client_action_id="greet-discarded",
+    )
+    db_session.expire_all()
+    again = await host_action_queue.get_by_client_action(db_session, room_id, "greet-discarded")
+    events = await _narration_events(db_session, room_id)
+    assert recovered is True
+    assert again is not None
+    assert again.status == "discarded"
+    assert events == []
+
+
+@pytest.mark.asyncio
 async def test_later_direct_response_sees_previous_public_narration(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,

--- a/trpg-backend/tests/test_host_entry_recovery.py
+++ b/trpg-backend/tests/test_host_entry_recovery.py
@@ -1,0 +1,434 @@
+"""#421-E 前置：主持入口与房间 FIFO 的排队、失败和恢复。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from collaboration_framework.contracts import PlayerView
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.controller import ws as ws_controller
+from app.core.host_entry import (
+    DeterministicHostEntryModel,
+    HostEntryRouter,
+    HostPublicContext,
+)
+from app.dto.ws import ActionRecipientPayload
+from app.models.event import Event
+from app.models.room import Player
+from app.service import host_action_queue
+from app.service.action_lock import action_lock_manager
+from tests.test_engine_runtime import _start_room
+
+_KEEPER = ActionRecipientPayload(kind="keeper", entity_id=None, explicit=True)
+
+
+class _RecordingHostEntryModel:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.contexts: list[HostPublicContext] = []
+        self._inner = DeterministicHostEntryModel()
+
+    async def generate(self, context: HostPublicContext) -> Mapping[str, object]:
+        self.calls += 1
+        self.contexts.append(context)
+        return await self._inner.generate(context)
+
+
+async def _room_views(
+    db: AsyncSession, room_number: int, player_count: int = 1
+) -> tuple[str, list[Player], list[PlayerView]]:
+    room, players, _ = await _start_room(
+        db,
+        room_number=room_number,
+        player_count=player_count,
+        prepare_checkpoint=False,
+    )
+    views = [
+        await ws_controller.session_view_application.current_player_view(
+            room_id=room.id,
+            player_id=player.id,
+        )
+        for player in players
+    ]
+    return str(room.id), players, views
+
+
+async def _enqueue_keeper(
+    db: AsyncSession,
+    *,
+    room_id: str,
+    player_id: str,
+    actor_id: str,
+    client_action_id: str,
+    utterance: str,
+):
+    item, created = await host_action_queue.enqueue(
+        db,
+        room_id=room_id,
+        player_id=player_id,
+        actor_id=actor_id,
+        client_action_id=client_action_id,
+        utterance=utterance,
+        recipient=_KEEPER,
+    )
+    return item, created
+
+
+async def _narration_events(db: AsyncSession, room_id: str) -> list[Event]:
+    rows = (
+        await db.scalars(
+            select(Event)
+            .where(Event.room_id == room_id, Event.event_type == "narration.push")
+            .order_by(Event.created_at, Event.id)
+        )
+    ).all()
+    return [event for event in rows if event.correlation_id != "game-opening"]
+
+
+def _install_router(monkeypatch: pytest.MonkeyPatch) -> _RecordingHostEntryModel:
+    model = _RecordingHostEntryModel()
+    router = HostEntryRouter(model)
+    monkeypatch.setattr(ws_controller, "_get_host_entry_router", lambda: router)
+    monkeypatch.setattr(ws_controller, "_host_entry_router", router)
+    action_lock_manager._locks.clear()
+    return model
+
+
+@pytest.mark.asyncio
+async def test_frozen_direct_response_retries_without_second_router_call(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """路线冻结后中途崩溃：恢复使用已保存文本，不得重新询问模型。"""
+
+    model = _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4641)
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[0].id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-crash",
+        utterance="跟邻居打个招呼",
+    )
+    original = ws_controller._run_direct_host_action
+    runs = {"n": 0}
+
+    async def flaky(db, item, view, websocket, **kwargs):  # noqa: ANN001
+        runs["n"] += 1
+        if runs["n"] == 1:
+            raise RuntimeError("simulated crash after freeze")
+        return await original(db, item, view, websocket, **kwargs)
+
+    monkeypatch.setattr(ws_controller, "_run_direct_host_action", flaky)
+    await ws_controller._drain_host_action_queue(room_id)
+    db_session.expire_all()
+
+    item = await host_action_queue.get_by_client_action(db_session, room_id, "greet-crash")
+    events = await _narration_events(db_session, room_id)
+    assert model.calls == 1
+    assert runs["n"] == 2
+    assert item is not None
+    assert item.status == "completed"
+    assert item.execution_route == "direct_response"
+    assert item.direct_response_text == "对方礼貌地点了点头。"
+    assert [event.correlation_id for event in events] == ["greet-crash"]
+    assert events[0].payload["text"] == "对方礼貌地点了点头。"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_failure_after_commit_keeps_completed_direct_response(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4642)
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[0].id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-broadcast",
+        utterance="跟邻居打个招呼",
+    )
+
+    async def boom_emit(*args, **kwargs):  # noqa: ANN002, ARG001
+        raise RuntimeError("broadcast failed after commit")
+
+    monkeypatch.setattr(ws_controller, "_emit_turn_narration", boom_emit)
+    await ws_controller._drain_host_action_queue(room_id)
+    db_session.expire_all()
+
+    item = await host_action_queue.get_by_client_action(db_session, room_id, "greet-broadcast")
+    events = await _narration_events(db_session, room_id)
+    assert item is not None
+    assert item.status == "completed"
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_client_action_id_does_not_rewrite_completed_direct_response(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4643)
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[0].id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-once",
+        utterance="跟邻居打个招呼",
+    )
+    await ws_controller._drain_host_action_queue(room_id)
+    player_id = players[0].id
+    actor_id = views[0].self_actor.id
+    db_session.expire_all()
+    _, created = await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=player_id,
+        actor_id=actor_id,
+        client_action_id="greet-once",
+        utterance="跟邻居打个招呼",
+    )
+    await ws_controller._drain_host_action_queue(room_id)
+    db_session.expire_all()
+
+    events = await _narration_events(db_session, room_id)
+    again = await host_action_queue.get_by_client_action(db_session, room_id, "greet-once")
+    assert created is False
+    assert again is not None
+    assert again.status == "completed"
+    assert model.calls == 1
+    assert [event.correlation_id for event in events] == ["greet-once"]
+
+
+@pytest.mark.asyncio
+async def test_existing_event_only_completes_queue_on_recovery(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4644)
+    item, _ = await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[0].id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-replay",
+        utterance="跟邻居打个招呼",
+    )
+    await host_action_queue.save_execution_route(
+        db_session,
+        item,
+        route="direct_response",
+        text="对方礼貌地点了点头。",
+        provenance="model_direct",
+    )
+    event = Event(
+        room_id=room_id,
+        player_id=players[0].id,
+        event_type="narration.push",
+        correlation_id="greet-replay",
+        visibility="public",
+        actor_id=views[0].self_actor.id,
+        scene_id=views[0].scene.id,
+        view_revision=views[0].revision,
+        payload={"messageId": "greet-replay", "text": "对方礼貌地点了点头。"},
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await ws_controller._drain_host_action_queue(room_id)
+    db_session.expire_all()
+
+    recovered = await host_action_queue.get_by_client_action(db_session, room_id, "greet-replay")
+    count = await db_session.scalar(
+        select(func.count())
+        .select_from(Event)
+        .where(
+            Event.room_id == room_id,
+            Event.event_type == "narration.push",
+            Event.correlation_id == "greet-replay",
+        )
+    )
+    assert recovered is not None
+    assert recovered.status == "completed"
+    assert model.calls == 0
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_fifo_direct_response_then_legacy_does_not_cut_in_line(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4645, player_count=2)
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[0].id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-first",
+        utterance="跟邻居打个招呼",
+    )
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[1].id,
+        actor_id=views[1].self_actor.id,
+        client_action_id="search-second",
+        utterance="搜索书桌里的暗格",
+    )
+    order: list[str] = []
+    original_direct = ws_controller._run_direct_host_action
+
+    async def record_direct(db, item, view, websocket, **kwargs):  # noqa: ANN001
+        order.append(item.client_action_id)
+        return await original_direct(db, item, view, websocket, **kwargs)
+
+    async def record_start(**kwargs):  # noqa: ANN003
+        order.append(kwargs["client_action_id"])
+        return SimpleNamespace(waiting_for_player=False)
+
+    async def skip_send(*args, **kwargs):  # noqa: ANN002, ARG001
+        return True
+
+    monkeypatch.setattr(ws_controller, "_run_direct_host_action", record_direct)
+    monkeypatch.setattr(ws_controller.action_plan_turn_application, "start", record_start)
+    monkeypatch.setattr(ws_controller, "_send_action_plan_result", skip_send)
+    await ws_controller._drain_host_action_queue(room_id)
+    db_session.expire_all()
+
+    first = await host_action_queue.get_by_client_action(db_session, room_id, "greet-first")
+    second = await host_action_queue.get_by_client_action(db_session, room_id, "search-second")
+    events = await _narration_events(db_session, room_id)
+    assert order == ["greet-first", "search-second"]
+    assert model.calls == 2
+    assert first is not None and first.status == "completed"
+    assert first.execution_route == "direct_response"
+    assert second is not None and second.status == "completed"
+    assert second.execution_route == "delegate_to_legacy"
+    assert [event.correlation_id for event in events] == ["greet-first"]
+
+
+@pytest.mark.asyncio
+async def test_failed_direct_response_unblocks_following_queue_item(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4646, player_count=2)
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[0].id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-poison",
+        utterance="跟邻居打个招呼",
+    )
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[1].id,
+        actor_id=views[1].self_actor.id,
+        client_action_id="greet-next",
+        utterance="跟邻居打个招呼",
+    )
+    original = ws_controller._run_direct_host_action
+
+    async def poison_first(db, item, view, websocket, **kwargs):  # noqa: ANN001
+        if item.client_action_id == "greet-poison":
+            raise RuntimeError("poisoned head")
+        return await original(db, item, view, websocket, **kwargs)
+
+    monkeypatch.setattr(ws_controller, "_run_direct_host_action", poison_first)
+    await ws_controller._drain_host_action_queue(room_id)
+    db_session.expire_all()
+
+    failed = await host_action_queue.get_by_client_action(db_session, room_id, "greet-poison")
+    nxt = await host_action_queue.get_by_client_action(db_session, room_id, "greet-next")
+    events = await _narration_events(db_session, room_id)
+    assert failed is not None
+    assert failed.status == "failed"
+    assert failed.attempt_count == 2
+    assert nxt is not None and nxt.status == "completed"
+    assert [event.correlation_id for event in events] == ["greet-next"]
+    assert await host_action_queue.peek_next(db_session, room_id) is None
+
+
+@pytest.mark.asyncio
+async def test_later_direct_response_sees_previous_public_narration(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _install_router(monkeypatch)
+    room_id, players, views = await _room_views(db_session, 4647, player_count=2)
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[0].id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="greet-a",
+        utterance="跟邻居打个招呼",
+    )
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[1].id,
+        actor_id=views[1].self_actor.id,
+        client_action_id="greet-b",
+        utterance="跟邻居打个招呼",
+    )
+    await ws_controller._drain_host_action_queue(room_id)
+    db_session.expire_all()
+
+    assert model.calls == 2
+    second_history = model.contexts[1].recent_history
+    assert any(
+        entry.text == "对方礼貌地点了点头。" and entry.source == "keeper_narration"
+        for entry in second_history
+    )
+
+
+@pytest.mark.asyncio
+async def test_keeper_processing_lease_blocks_later_queue_item(
+    db_session: AsyncSession,
+) -> None:
+    room_id, players, views = await _room_views(db_session, 4648, player_count=2)
+    first, _ = await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[0].id,
+        actor_id=views[0].self_actor.id,
+        client_action_id="keeper-first",
+        utterance="跟邻居打个招呼",
+    )
+    await _enqueue_keeper(
+        db_session,
+        room_id=room_id,
+        player_id=players[1].id,
+        actor_id=views[1].self_actor.id,
+        client_action_id="keeper-second",
+        utterance="跟邻居打个招呼",
+    )
+    claimed = await host_action_queue.claim(
+        db_session, first, recipient_kind="keeper", lease_seconds=180
+    )
+    assert claimed is not None
+    assert await host_action_queue.peek_next(db_session, room_id) is None
+    schedule = dict(await host_action_queue.recovery_schedule(db_session))
+    assert 170 <= schedule[room_id] <= 180
+
+    claimed.lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    await db_session.commit()
+    recovered = await host_action_queue.peek_next(db_session, room_id)
+    assert recovered is not None
+    assert recovered.client_action_id == "keeper-first"


### PR DESCRIPTION
Closes #464

主持入口与 #360 FIFO 在失败、重试和重启时不再把已冻结行动丢掉，单次失败也不会让后续队列永久卡住。这是 #421-E 在 A 完成后可并行交付的那一截：直接回应、旧链委托，以及房间 FIFO。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `app/controller/ws.py` | 出队失败不再直接 discard。已完成的 direct_response 只记广播失败；processing 先重试一次，再 `failed` 并放行后续项 |
| `app/service/host_action_queue.py` | `claim` 不再在 Python 侧评估 lease/退避时间，避免 SQLite naive/aware 比较把合法领取打成内部错误 |
| `tests/test_host_entry_recovery.py` | 覆盖冻结后崩溃、广播失败、重复 client_action_id、FIFO 直答+旧链、失败不堵下一项、后一条能读到前一条公开叙事 |
| `tests/test_host_action_queue.py` | 补 SQLite 重载后二次领取 retryable_failure |

## 关键决策

**为什么失败不直接 discard：**
discard 后同一 `client_action_id` 无法再入队。路线已经冻结时，丢掉等于丢失这次行动。processing 最多再领一次；第二次仍失败才 `failed`，房间继续处理后面的队列。

**为什么广播失败要保持 completed：**
direct_response 是先写事件、再完成队列、最后广播。广播挂了，权威结果已经在库里，重连应重放，不能当没发生。

**为什么 claim 关掉 synchronize_session：**
SQLite 把带时区列读成 naive UTC。SQLAlchemy 在 Python 里比较 `lease_expires_at <= now` 会 TypeError，SQL 其实已经领成功。过期本地行再重载，和 SQL 结果一致。

**为什么这个 Issue 现在可以关：**
#464 只跟踪 E 里可与 B 并行的前置部分。B/C/D 的恢复仍由对应 Issue 和 #421 后续整合负责，不堵在本 Issue 上。

## 验证

- 后端：`630 passed, 23 skipped`
- `uv run ruff check .`、`ruff format --check .`、`ty check` 通过
- 修之前能复现：冻结后中途崩溃会 discard；SQLite 重载后二次 `claim` 因时间比较 TypeError

## 已知限制

- 只覆盖 `direct_response` 和现有 `delegate_to_legacy` / ActionPlan 等待
- 身份失效等不可恢复错误仍结束当前项，不把房间卡在 processing

## 不在本 PR 范围

- #459 / #421-B 的规则请求本身，以及它的冻结/恢复窗口
- #421-C 多步后果、#421-D 追问纠正、#421-F 全量切换
- 前端进度文案（#454 已合并）
