### PR TITLE
fix(narrator): 修复死物环境描写误触发姿态校验 (#425)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/application/persistent_results.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/persistent_results.py
@@ -108,8 +108,8 @@ def unsupported_persistent_claim(
                 + 1
             )
             sentence = asserted_text[sentence_start : match.end()]
-            mentioned_ids = {
-                entity.id
+            mentioned_entities = tuple(
+                entity
                 for entity in entities
                 if any(
                     name and name in sentence
@@ -118,14 +118,62 @@ def unsupported_persistent_claim(
                         *getattr(entity, "aliases", ()),
                     )
                 )
-            }
-            has_evidence = any(
-                result.state_key == key
-                and result.state_value == value
-                and (not mentioned_ids or result.target_id in mentioned_ids)
-                for result in committed_results
             )
-            if not has_evidence and player_view is not None:
+            mentioned_ids = {entity.id for entity in mentioned_entities}
+            if key == "posture":
+                character_ids = {
+                    entity.id
+                    for entity in mentioned_entities
+                    if getattr(entity, "kind", "npc") == "npc"
+                }
+                if mentioned_entities and not character_ids:
+                    # “钥匙躺在桌上”描述的是物件位置，不是角色姿态。
+                    continue
+                if character_ids:
+                    mentioned_ids = character_ids
+                elif (
+                    player_view is not None
+                    and entities
+                    and not any(
+                        getattr(entity, "kind", "npc") == "npc" for entity in entities
+                    )
+                ):
+                    # 没有点名实体且场景只有物件时，属于环境描写而非角色姿态。
+                    continue
+            if key == "posture" and player_view is not None and entities and not mentioned_ids:
+                # 无名称指代仍需绑定唯一可见 NPC，不能用任意一条姿态证据背书。
+                candidate_ids = {
+                    entity.id
+                    for entity in entities
+                    if getattr(entity, "kind", "npc") == "npc"
+                }
+                evidence_target_ids = {
+                    result.target_id
+                    for result in committed_results
+                    if result.state_key == key and result.state_value == value
+                }
+                evidence_target_ids.update(
+                    entity.id
+                    for entity in entities
+                    if any(
+                        state.key == key and state.value == value
+                        for state in entity.observable_state
+                    )
+                )
+                has_evidence = (
+                    len(candidate_ids) == 1
+                    and candidate_ids.issubset(evidence_target_ids)
+                )
+            else:
+                has_evidence = any(
+                    result.state_key == key
+                    and result.state_value == value
+                    and (not mentioned_ids or result.target_id in mentioned_ids)
+                    for result in committed_results
+                )
+            if not has_evidence and player_view is not None and not (
+                key == "posture" and entities and not mentioned_ids
+            ):
                 has_evidence = any(
                     state.key == key
                     and state.value == value

--- a/agent-collaboration-framework/tests/test_narrator_policy.py
+++ b/agent-collaboration-framework/tests/test_narrator_policy.py
@@ -456,6 +456,96 @@ class PersistentNarrationPolicyTests(unittest.IsolatedAsyncioTestCase):
                     self._context()
                 )
 
+    async def test_allows_object_prone_environment_description(self):
+        """死物使用“躺在/躺着”描述位置时，不应触发角色姿态校验。"""
+        context = self._context()
+        context.player_view.scene.visible_entities = (
+            SimpleNamespace(
+                id="key",
+                name="一把钥匙",
+                aliases=(),
+                kind="object",
+                observable_state=(),
+            ),
+        )
+
+        output = await ActionPlanNarrator(
+            _PersistentNarrationModel("一把钥匙躺在桌上。")
+        ).narrate(context)
+
+        self.assertEqual(output.text, "一把钥匙躺在桌上。")
+
+    async def test_allows_unbound_object_description_without_visible_npc(self):
+        """纯物件场景中未点名实体的环境描写也不应被误判为角色姿态。"""
+        context = self._context()
+        context.player_view.scene.visible_entities = (
+            SimpleNamespace(
+                id="notebook",
+                name="一本笔记",
+                aliases=(),
+                kind="object",
+                observable_state=(),
+            ),
+        )
+
+        output = await ActionPlanNarrator(
+            _PersistentNarrationModel("桌上躺着一本笔记。")
+        ).narrate(context)
+
+        self.assertEqual(output.text, "桌上躺着一本笔记。")
+
+    async def test_rejects_named_npc_prone_without_evidence(self):
+        """点名 NPC 的躺倒描述仍必须有权威姿态证据。"""
+        context = self._context()
+        context.player_view.scene.visible_entities = (
+            SimpleNamespace(
+                id="butler",
+                name="守墓人",
+                aliases=(),
+                kind="npc",
+                observable_state=(),
+            ),
+        )
+
+        with self.assertRaises(ActionPlanNarrationValidationError) as raised:
+            await ActionPlanNarrator(
+                _PersistentNarrationModel("守墓人躺在墓园草地上。")
+            ).narrate(context)
+
+        self.assertEqual(
+            raised.exception.reason,
+            "persistent_claim_without_evidence:posture",
+        )
+
+    async def test_allows_named_npc_prone_with_evidence(self):
+        """点名 NPC 且当前回合已提交姿态结果时允许叙述。"""
+        context = self._context(
+            results=(
+                CommittedResult(
+                    kind="character_state",
+                    target_id="butler",
+                    state_key="posture",
+                    state_value="prone",
+                    event_ref="event-1",
+                ),
+            )
+        )
+        context.player_view.scene.visible_entities = (
+            SimpleNamespace(
+                id="butler",
+                name="守墓人",
+                aliases=(),
+                kind="npc",
+                observable_state=(),
+            ),
+        )
+
+        output = await ActionPlanNarrator(
+            _PersistentNarrationModel("守墓人躺在墓园草地上。")
+        ).narrate(context)
+
+        self.assertEqual(output.text, "守墓人躺在墓园草地上。")
+
     async def test_allows_unprojected_companion_active_presence(self):
         """未进入标准场景投影的随行人物不能被全局在场校验误伤。"""
         output = await ActionPlanNarrator(

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -299,8 +299,8 @@ needs_clarification，才用自然的角色内措辞提出一次最小澄清。c
 确定性记录 required ref。不得以未经证据确认的关键发现替代这些结果。
 text 只能包含自然的角色内叙事，不得把 claimed_evidence_refs、suggested_actions 或其他
 JSON/schema 字段和值重复写入正文。
-如果输入中提供 narration_retry_hint，说明上一版叙事漏报了一个已提交结果；本次必须
-在自然叙事中明确写出该结果，并准确 claim 对应 ref，然后再返回完整 JSON。
+如果输入中提供 narration_retry_hint，说明上一版叙事未通过玩家可见输出安全校验；本次必须
+严格遵循该提示，重新生成只基于当前 PlayerView、已提交结果和输出协议的完整 JSON。
 
 如果当前回合同时需要 NPC 接话，把守秘人的权威结果写进 text，把 NPC 台词写进
 npc_replies。npc_replies 最多 3 条；speaker_id 只能逐字复制当前场景里已可见 NPC

--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -1800,6 +1800,27 @@ class ActionPlanTurnApplication:
                             )
                         }
                     )
+                elif attempt == 0 and exc.reason.startswith("persistent_claim_without_evidence:"):
+                    # 持久状态校验失败时，明确要求模型删除无证据断言，避免原地重试。
+                    context = context.model_copy(
+                        update={
+                            "narration_retry_hint": (
+                                "上一版叙事包含没有权威证据确认的持久状态或物品变化。"
+                                "请删除该断言，只描述当前 PlayerView 和已提交结果能够证明的内容。"
+                            )
+                        }
+                    )
+                elif attempt == 0:
+                    # 其他安全校验失败也必须改变下一次模型输入，而不是重复原请求。
+                    context = context.model_copy(
+                        update={
+                            "narration_retry_hint": (
+                                "上一版叙事未通过玩家可见输出安全校验。请重新生成符合当前"
+                                " PlayerView、已提交结果和输出协议的自然叙事，不得输出内部字段、"
+                                "未经证据确认的事实或不匹配的叙事类型。"
+                            )
+                        }
+                    )
                 if attempt == 1:
                     if (
                         exc.reason == "required_evidence_missing"

--- a/trpg-backend/tests/test_action_plan_turn_recovery.py
+++ b/trpg-backend/tests/test_action_plan_turn_recovery.py
@@ -97,6 +97,7 @@ class _NarrationContextStub:
         self.player_input = SimpleNamespace(
             client_action_id="action-narration-test",
             utterance="",
+            interlocutor_id=None,
         )
         self.player_view = SimpleNamespace(
             scene=SimpleNamespace(visible_entities=()),
@@ -341,6 +342,78 @@ async def test_narration_retries_atmosphere_repeat_with_hint() -> None:
     assert "不得再用午后阳光、夜色、窗景等环境开场重铺" in retry_context.narration_retry_hint
     assert narration.kind == "narration"
     assert "这次行动已经按当前可确认的结果完成" in narration.text
+
+
+@pytest.mark.asyncio
+async def test_narration_retries_persistent_claim_with_actionable_hint() -> None:
+    """持久状态校验失败后，第二次模型调用必须收到删除断言的提示。"""
+    application = object.__new__(ActionPlanTurnApplication)
+    success = SimpleNamespace(kind="narration", text="环境恢复正常。", npc_replies=())
+    narrate = AsyncMock(
+        side_effect=[
+            ActionPlanNarrationValidationError("persistent_claim_without_evidence:posture"),
+            success,
+        ]
+    )
+    application._narrator = SimpleNamespace(narrate=narrate)
+    context = cast(
+        ActionPlanNarrationContext,
+        _NarrationContextStub(
+            NarrationEvidence(
+                ref="evt-1",
+                kind="entity_discovered",
+                subject_id="x",
+                subject_name="公开结果",
+                description="环境恢复正常。",
+                required_in_narration=False,
+            ),
+            "resolved",
+        ),
+    )
+
+    narration = await application._narrate(context)
+
+    assert narration is success
+    assert narrate.await_count == 2
+    retry_hint = narrate.await_args_list[1].args[0].narration_retry_hint
+    assert "没有权威证据确认" in retry_hint
+    assert "只描述当前 PlayerView" in retry_hint
+
+
+@pytest.mark.asyncio
+async def test_narration_retries_unknown_validation_with_generic_hint() -> None:
+    """未单独分类的安全拒绝也不能原样重复第一次模型输入。"""
+    application = object.__new__(ActionPlanTurnApplication)
+    success = SimpleNamespace(kind="narration", text="已按当前结果处理。", npc_replies=())
+    narrate = AsyncMock(
+        side_effect=[
+            ActionPlanNarrationValidationError("evidence_scope"),
+            success,
+        ]
+    )
+    application._narrator = SimpleNamespace(narrate=narrate)
+    context = cast(
+        ActionPlanNarrationContext,
+        _NarrationContextStub(
+            NarrationEvidence(
+                ref="evt-1",
+                kind="entity_discovered",
+                subject_id="x",
+                subject_name="公开结果",
+                description="已按当前结果处理。",
+                required_in_narration=False,
+            ),
+            "resolved",
+        ),
+    )
+
+    narration = await application._narrate(context)
+
+    assert narration is success
+    assert narrate.await_count == 2
+    retry_hint = narrate.await_args_list[1].args[0].narration_retry_hint
+    assert "未通过玩家可见输出安全校验" in retry_hint
+    assert "输出协议" in retry_hint
 
 
 def test_required_evidence_fallback_omits_second_person_description_in_named_actor() -> None:

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -151,6 +151,11 @@ def test_action_plan_narration_forbids_repeating_previous_atmosphere() -> None:
     assert "不要再写一整段地点简介" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
 
 
+def test_action_plan_narration_retry_hint_covers_all_safety_rejections() -> None:
+    assert "未通过玩家可见输出安全校验" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
+    assert "只基于当前 PlayerView、已提交结果和输出协议" in _ACTION_PLAN_NARRATION_INSTRUCTIONS
+
+
 def load_paper_chase() -> ModuleContentV3:
     examples = (
         ROOT


### PR DESCRIPTION
## 关联 Issue

Closes #425

## 主要改动

- 在 `unsupported_persistent_claim` 中按可见实体类型区分角色姿态与死物环境描写。
- “一把钥匙躺在桌上”“桌上躺着一本笔记”等 object 描写不再触发 `posture` 持久声明拒绝。
- 点名 NPC 的“躺倒”仍要求本回合或当前 `PlayerView` 存在精确姿态证据；无名称指代仍保留唯一可见 NPC 的保守校验。
- 为 `persistent_claim_without_evidence:*` 和其他 Narrator 安全校验补充可操作的二次生成提示，避免原地重试。
- 更新 Narrator Prompt，明确 `narration_retry_hint` 适用于所有玩家可见输出安全校验失败。
- 增加死物描述、NPC 无证据姿态、NPC 有证据姿态和重试提示回归测试。

## 采用该方案的原因

问题根因在共享叙事安全校验的目标绑定，而不是某个模组文本或提示词单独配置。修复在校验入口按实体类型处理 `posture`，可以同时覆盖《银之锁》及其他模组的环境描写，并继续保留角色状态的证据门禁。

本 PR 只调整 `posture` 和 Narrator 重试上下文，不恢复 `standing` 规则，不修改其他持久状态类别，不新增协议、数据库字段或模组专用分支。没有 `PlayerView` 的旧调用方继续保留保守拒绝行为。

## 测试与验证

- [x] Framework 定向测试：`30 passed`
- [x] Backend 定向测试：`82 passed`
- [x] Framework 完整测试：`429 passed`
- [x] Backend 完整测试：`627 passed, 23 skipped`
- [x] 本次改动文件 Ruff 检查通过
- [x] 本次改动文件格式检查通过
- [x] `git diff --check` 通过
- [ ] 真实模型 smoke test：未启用 API Key，未运行

截至本次更新，GitHub CI 的 E2E、PostgreSQL migration、codegen drift 和 PR changes 检查已通过；Backend CI 主测试仍在运行。

完整 Framework Ruff 检查仍报告 upstream `main` 已存在的基线问题，本 PR 未修改无关文件。

## 风险与回滚

- 主要行为变化是：纯 object 环境中的“躺在/躺着”不再被当作角色姿态；未确认的 NPC 姿态仍会被拦截。
- Narrator 首次安全校验失败后会收到额外重试提示；第二次仍失败时沿用现有确定性兜底。
- 不涉及数据库迁移或数据格式变化。
- 如需回滚，回滚提交 `3ed350b` 即可恢复原有行为。

## UI 证据

不适用。本 PR 未修改前端页面或用户界面协议。

## AI 使用情况

本 PR 使用 AI 辅助完成代码检索、根因分析、实现和测试编写。实现边界依据 #425 明确确认：不恢复 `standing`，不修改模组内容，不新增协议或数据库迁移；已完成自动化测试、静态检查和代码 diff 复核，尚未完成人工 Reviewer 审核。

## 自检

- [x] 改动范围符合 #425
- [x] 不包含 #426、#451、#459 等其他 Issue 的实现
- [x] 已包含必要的回归测试和 Prompt 同步
- [x] 未包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查和自动化 diff 检查
- [ ] 已完成人工 Review，等待 Reviewer 审核