### PR TITLE
fix(rule-engine): 为缺少状态位的自由行动增加安全降级 (#424)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/contracts/validation.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/validation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Literal, TypeAlias
 
 from pydantic import Field, model_validator
+from pydantic.json_schema import SkipJsonSchema
 
 from .common import ContractError, ContractModel
 
@@ -66,6 +67,8 @@ class ValidationResult(ContractModel):
     fault: ValidationFault | None = None
     player_safe_reason: str = Field(min_length=1, max_length=512)
     affected_effects: tuple[EffectValidationDetail, ...] = ()
+    # 仅供 Host 语义修复使用，不进入任何公开 JSON schema。
+    generic_fallback_allowed: SkipJsonSchema[bool] = False
     evidence_refs: tuple[str, ...] = ()
     classification_coverage: ClassificationCoverage = "complete"
     internal_reason: str | None = Field(default=None, max_length=1024)
@@ -107,6 +110,7 @@ class ValidationResult(ContractModel):
                 )
                 for item in self.affected_effects
             ),
+            generic_fallback_allowed=self.generic_fallback_allowed,
         )
 
 
@@ -119,6 +123,8 @@ class ValidationFeedback(ContractModel):
     fault: ValidationFault | None = None
     player_safe_reason: str = Field(min_length=1, max_length=512)
     affected_effects: tuple[SafeEffectRef, ...] = ()
+    # Engine 已确认目标没有可写状态时，Host 才能收窄为普通行动。
+    generic_fallback_allowed: SkipJsonSchema[bool] = False
 
 
 class AdjudicationValidationError(ContractError):

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -216,18 +216,38 @@ def _target_persistent_capability(
     也不替模型决定最终效果。运行时临时实体没有预声明状态键，视为不可写。
     """
 
-    for entity in runtime.module_content.entities:
-        if entity.id == target_id:
-            return entity.kind, frozenset(entity.state)
+    item = runtime.game_state.item_instances.get(target_id)
+    module_entity = next(
+        (
+            entity
+            for entity in runtime.module_content.entities
+            if entity.id == target_id
+            or (item is not None and entity.id == item.definition_id)
+        ),
+        None,
+    )
+    if item is not None:
+        # 物品实例的 state.values 是运行时权威状态；必须与模块初始声明合并，
+        # 否则已被打开/锁定/损坏的物品会被误判为没有状态位而错误降级。
+        state_keys = set(item.state.values)
+        state_keys.update(
+            runtime.game_state.public_entity_state_keys.get(target_id, ())
+        )
+        if module_entity is not None:
+            state_keys.update(module_entity.state)
+        return "object", frozenset(state_keys)
+    if module_entity is not None:
+        return module_entity.kind, frozenset(module_entity.state)
     if target_id in runtime.game_state.runtime_entities:
         payload = runtime.game_state.runtime_entities[target_id]
         kind = payload.get("kind")
         return (kind if kind in {"npc", "object"} else "object"), frozenset()
-    if target_id in runtime.game_state.item_instances:
-        return "object", frozenset()
     if target_id in runtime.game_state.actors:
         return "actor", frozenset(runtime.game_state.actors[target_id].state)
-    if target_id in runtime.canon_location_ids or target_id in runtime.game_state.runtime_locations:
+    if (
+        target_id in runtime.canon_location_ids
+        or target_id in runtime.game_state.runtime_locations
+    ):
         return "location", None
     if target_id in runtime.canon_information_ids:
         return "information", None

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -206,6 +206,34 @@ def _target_kinds_matching(
     return frozenset(kind for kind, hit in matches.items() if hit)
 
 
+def _target_persistent_capability(
+    runtime: EngineRuntimeSnapshot,
+    target_id: str,
+) -> tuple[str | None, frozenset[str] | None]:
+    """返回目标的真实类型及模组声明的可写状态键。
+
+    该能力快照只在 Host 处理持久结果拒绝时使用；不把隐藏状态投影给模型，
+    也不替模型决定最终效果。运行时临时实体没有预声明状态键，视为不可写。
+    """
+
+    for entity in runtime.module_content.entities:
+        if entity.id == target_id:
+            return entity.kind, frozenset(entity.state)
+    if target_id in runtime.game_state.runtime_entities:
+        payload = runtime.game_state.runtime_entities[target_id]
+        kind = payload.get("kind")
+        return (kind if kind in {"npc", "object"} else "object"), frozenset()
+    if target_id in runtime.game_state.item_instances:
+        return "object", frozenset()
+    if target_id in runtime.game_state.actors:
+        return "actor", frozenset(runtime.game_state.actors[target_id].state)
+    if target_id in runtime.canon_location_ids or target_id in runtime.game_state.runtime_locations:
+        return "location", None
+    if target_id in runtime.canon_information_ids:
+        return "information", None
+    return None, None
+
+
 def _normalize_target_kind(
     runtime: EngineRuntimeSnapshot,
     adjudication: ActionAdjudication,
@@ -259,6 +287,7 @@ class AdjudicationEngineService:
         player_safe_reason: str,
         internal_reason: str | None = None,
         classification_coverage: ClassificationCoverage = "partial_validation_failure",
+        generic_fallback_allowed: bool = False,
     ) -> NoReturn:
         raise AdjudicationValidationError(
             ValidationResult(
@@ -267,6 +296,7 @@ class AdjudicationEngineService:
                 repairability=repairability,
                 fault=fault,
                 player_safe_reason=player_safe_reason,
+                generic_fallback_allowed=generic_fallback_allowed,
                 classification_coverage=classification_coverage,
                 internal_reason=internal_reason,
             )
@@ -1463,13 +1493,32 @@ class AdjudicationEngineService:
         else:
             # 自由行动的完整性必须在创建待检定、掷骰或写入事件之前完成；规则路径
             # 的效果由模组拥有，因此仍允许模型 success_effects 为空。
-            persistent_problem = validate_persistent_effects(adjudication)
+            target_kind, target_state_keys = _target_persistent_capability(
+                runtime,
+                adjudication.target.id,
+            )
+            persistent_problem = validate_persistent_effects(
+                adjudication,
+                target_kind=target_kind,
+                target_state_keys=target_state_keys,
+            )
             if persistent_problem is not None:
+                if persistent_problem.allow_generic_fallback:
+                    # 只记录可降级候选；原始裁决仍然拒绝，最终是否收窄由 Host
+                    # 的语义保持检查决定，Engine 不替模型改写意图。
+                    logger.info(
+                        "persistent_effect_generic_fallback_candidate",
+                        extra={
+                            "target_kind": target_kind,
+                            "persistence_intent": adjudication.persistence_intent,
+                        },
+                    )
                 self._reject_validation(
                     persistent_problem.code,
                     repairability="auto_repairable",
                     fault="agent",
                     player_safe_reason=persistent_problem.player_safe_reason,
+                    generic_fallback_allowed=persistent_problem.allow_generic_fallback,
                 )
         self._validate_effect_sequence(
             runtime,

--- a/agent-collaboration-framework/collaboration_framework/engine/persistent_results.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/persistent_results.py
@@ -8,6 +8,7 @@ COC7 战斗算法；模型必须通过受控的 ``method.family`` 和 ``persiste
 from __future__ import annotations
 
 import logging
+from collections.abc import Collection
 from dataclasses import dataclass
 from typing import Literal
 
@@ -53,6 +54,8 @@ class PersistentEffectProblem:
 
     code: Literal["PERSISTENT_EFFECT_REQUIRED", "PERSISTENT_EFFECT_MISMATCH"]
     player_safe_reason: str
+    # 仅供 Host 的一次性语义修复使用；不改变 Engine 对原始裁决的拒绝。
+    allow_generic_fallback: bool = False
 
 
 @dataclass(frozen=True)
@@ -98,8 +101,16 @@ def effective_persistence_intent(adjudication: ActionAdjudication) -> Persistenc
 
 def validate_persistent_effects(
     adjudication: ActionAdjudication,
+    *,
+    target_kind: str | None = None,
+    target_state_keys: Collection[str] | None = None,
 ) -> PersistentEffectProblem | None:
-    """检查自由裁决成功分支是否完整表达声明的持久结果。"""
+    """检查自由裁决成功分支是否完整表达声明的持久结果。
+
+    ``target_kind`` 和 ``target_state_keys`` 是 Engine 内部提供的能力快照，
+    用来识别“模型声明了持久意图，但目标根本没有对应状态位”的可降级场景。
+    它们不进入玩家或模型可见协议，也不会让 Engine 自动改写裁决。
+    """
 
     intent = effective_persistence_intent(adjudication)
     family = adjudication.method.family.strip().lower()
@@ -130,6 +141,12 @@ def validate_persistent_effects(
         return PersistentEffectProblem(
             "PERSISTENT_EFFECT_REQUIRED",
             "该行动需要可提交的持久结果，请补充对应效果",
+            allow_generic_fallback=_generic_fallback_allowed(
+                adjudication,
+                policy=policy,
+                target_kind=target_kind,
+                target_state_keys=target_state_keys,
+            ),
         )
 
     if policy is not None and policy.intent != adjudication.persistence_intent:
@@ -143,6 +160,30 @@ def validate_persistent_effects(
         "PERSISTENT_EFFECT_MISMATCH",
         "持久结果的效果类型、目标或状态值与行动意图不一致",
     )
+
+
+def _generic_fallback_allowed(
+    adjudication: ActionAdjudication,
+    *,
+    policy: _FamilyPolicy | None,
+    target_kind: str | None,
+    target_state_keys: Collection[str] | None,
+) -> bool:
+    """判断是否可以把无效果裁决交给 Host 收窄为普通检定。"""
+
+    if adjudication.persistence_intent not in {"character_state", "object_state"}:
+        return False
+    if adjudication.persistence_intent == "character_state":
+        # 角色状态即使暂时没有公开值，也必须由 NPC/角色的状态能力承载；只有
+        # 把角色动作错误地指向物体（如只有 cut 键的绳索）时才允许收窄。
+        return target_kind is not None and target_kind not in {"npc", "actor"}
+    if target_kind is not None and (
+        adjudication.persistence_intent == "object_state" and target_kind != "object"
+    ):
+        return True
+    if policy is None or policy.state_key is None or target_state_keys is None:
+        return policy is None and target_kind in {"object", "location", "information"}
+    return policy.state_key not in set(target_state_keys)
 
 
 def _has_matching_effect(

--- a/agent-collaboration-framework/collaboration_framework/host/application/semantic_preservation.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/semantic_preservation.py
@@ -76,6 +76,23 @@ def compare_repair_semantics(
     if target_result.status == "requires_clarification":
         return target_result
 
+    persistent_downgrade = False
+    if (
+        original.persistence_intent != repaired.persistence_intent
+        and repaired.persistence_intent == "none"
+        and original.persistence_intent in {"character_state", "object_state"}
+    ):
+        # 只有 Engine 确认目标没有相应状态能力、且两条分支都没有领域效果时，
+        # 才允许把持久意图收窄为普通检定；NPC 状态不能走这条路径绕过校验。
+        persistent_downgrade = _is_safe_persistent_downgrade(
+            original,
+            repaired,
+            validation_feedback,
+            player_view,
+        )
+        if not persistent_downgrade:
+            return _clarification("PERSISTENCE_INTENT_CHANGED")
+
     old_target_id = original.target.id
     new_target_id = repaired.target.id
     success = _compare_effect_branch(
@@ -110,6 +127,12 @@ def compare_repair_semantics(
             status="narrowed",
             reason_code="INVALID_EFFECT_REMOVED",
             safe_reason="已移除校验器明确拒绝的无效效果",
+        )
+    if persistent_downgrade:
+        return SemanticPreservationResult(
+            status="narrowed",
+            reason_code="PERSISTENCE_INTENT_NARROWED",
+            safe_reason="目标没有可写持久状态，已保留行动与检定并收窄为普通裁决",
         )
     if target_result.reason_code != "UNCHANGED":
         return target_result
@@ -241,7 +264,7 @@ def _check_explicit_constraints(
     step: ActionPlanStep,
     repaired: ActionAdjudication,
 ) -> SemanticPreservationResult | None:
-    text = _normalize_text(" ".join((player_input.utterance, plan_goal, step.semantic_goal)))
+    text = _normalize_text(f"{player_input.utterance} {plan_goal} {step.semantic_goal}")
     family = _normalize_text(repaired.method.family)
     effects = {effect.type for effect in (*repaired.success_effects, *repaired.failure_effects)}
     if ("不伤害" in text or "不要伤害" in text) and family in {"combat", "attack", "threaten"}:
@@ -349,6 +372,47 @@ def _is_persistent_effect_repair(
     meaningful_before = [item for item in before if item != {"type": "narrative_only"}]
     meaningful_after = [item for item in after if item != {"type": "narrative_only"}]
     return len(meaningful_before) <= 1 and len(meaningful_after) == 1
+
+
+def _is_safe_persistent_downgrade(
+    original: ActionAdjudication,
+    repaired: ActionAdjudication,
+    feedback: ValidationFeedback,
+    player_view: PlayerView,
+) -> bool:
+    """只允许 Engine 标记的无状态目标收窄为普通行动。"""
+
+    if feedback.code != "PERSISTENT_EFFECT_REQUIRED" or not feedback.generic_fallback_allowed:
+        return False
+    if any(
+        effect.type != "narrative_only"
+        for effect in (
+            *original.success_effects,
+            *original.failure_effects,
+            *repaired.success_effects,
+            *repaired.failure_effects,
+        )
+    ):
+        return False
+    target = next(
+        (
+            item
+            for item in player_view.scene.visible_entities
+            if item.id == original.target.id
+        ),
+        None,
+    )
+    if target is None or target.id != repaired.target.id:
+        return False
+    if original.persistence_intent == "character_state":
+        # 物体（例如只有 cut 状态的绳索）没有角色姿态/意识可供写入；NPC
+        # 则始终保留完整性闸门，不能降级掩盖漏报的角色状态。
+        return target.kind == "object"
+    if original.persistence_intent == "object_state":
+        object_state_keys = {"open", "locked", "broken"}
+        visible_keys = {item.key for item in target.observable_state}
+        return target.kind == "object" and not (visible_keys & object_state_keys)
+    return False
 
 
 def _inventory_portability_repair_status(

--- a/agent-collaboration-framework/collaboration_framework/host/prompts/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/prompts/action_plan.py
@@ -2,7 +2,7 @@
 
 from collaboration_framework.contracts import ActionPlanPolicy
 
-PROMPT_VERSION = "trpg-host-intent-v6"
+PROMPT_VERSION = "trpg-host-intent-v7"
 TURN_PLANNER_PROMPT_VERSION = "trpg-turn-planner-v2"
 
 
@@ -221,4 +221,9 @@ move_entity(holder_actor_id=...) 只能引用 scene.loose_items、inventory，�
 题（最常见的是 target.kind 与 target.id 不配套，或引用了 PlayerView 里并不存在的对
 象），然后给出一份改正后的完整裁决，不要原样重复上一份，也不要因此改写这一步的语义
 目标。
+
+如果拒绝码为 PERSISTENT_EFFECT_REQUIRED，且当前目标没有能够承载该持久结果的权威状态位，
+不要伪造状态键或效果；保持 target、method 和 check 不变，将 persistence_intent 收窄为
+none，并让 success_effects / failure_effects 只保留空值或 narrative_only。只要原行动仍需要
+检定，就必须保留原检定，不能因为没有持久效果而把行动改成澄清。
 """.strip()

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -17,8 +17,8 @@ from collaboration_framework.contracts import (
     AdjudicationValidationError,
     AdvanceWorldTimeEffect,
     CancelActionPlanRequest,
-    CheckDecisionRequest,
     ChangeEntityStateEffect,
+    CheckDecisionRequest,
     ContractError,
     EnterLocationEffect,
     GetAdjudicationStatusRequest,
@@ -478,6 +478,41 @@ class PersistentEmptyAdjudicator(PersistentRepairAdjudicator):
             method=ActionMethod(family="knock_out", description="用撬棍砸晕他"),
             persistence_intent="character_state",
             check=NoAdjudicationCheck(),
+        )
+
+
+class PersistentFallbackAdjudicator(RecordingAdjudicator):
+    """首次声明物体不存在角色状态，重试时收窄为保留检定的普通行动。"""
+
+    async def adjudicate(self, context):
+        self.contexts.append(context)
+        check = RequiredAdjudicationCheck(
+            candidates=(
+                SkillCheckCandidate(
+                    candidate_id=SKILL,
+                    skill_id=SKILL,
+                    difficulty="regular",
+                    method_summary="挣脱束缚",
+                    player_safe_reason="检验能否凭力量挣脱",
+                ),
+            )
+        )
+        return ActionAdjudication(
+            request_id="untrusted",
+            source_revision="untrusted",
+            actor_id="untrusted",
+            summary="使劲挣脱束缚",
+            target=ActionTarget(kind="entity", id="study_window"),
+            method=ActionMethod(
+                family="restrain" if context.previous_rejection is None else "action",
+                description="使劲挣脱束缚",
+            ),
+            persistence_intent=(
+                "character_state" if context.previous_rejection is None else "none"
+            ),
+            check=check,
+            success_effects=(NarrativeOnlyEffect(),),
+            failure_effects=(NarrativeOnlyEffect(),),
         )
 
 
@@ -1290,6 +1325,30 @@ async def test_engine_rejection_is_repaired_once_instead_of_stopping_the_plan() 
     # The repair reuses the frozen step identity; nothing is committed twice.
     assert len({context.step_request_id for context in step_two}) == 1
     assert len(engine_store.inspect_domain_events("room_01")) == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_persistent_state_falls_back_while_preserving_check() -> None:
+    """没有角色状态的物体目标应继续进入原有技能检定，而不是澄清。"""
+
+    service, adjudicator, _, _, _ = orchestrator(
+        adjudicator=PersistentFallbackAdjudicator("world"),
+        start="kimball_study",
+    )
+    result = await service.start_or_resume(
+        player_input(utterance="使劲挣脱束缚"),
+        plan=ActionPlan(
+            goal="使劲挣脱束缚",
+            steps=(ActionPlanStep(kind="action", semantic_goal="使劲挣脱束缚"),),
+        ),
+    )
+
+    assert result.run.status == "waiting_for_player"
+    assert len(adjudicator.contexts) == 2
+    assert result.run.steps[0].repair_attempts == 1
+    assert result.run.steps[0].last_validation_code == "PERSISTENT_EFFECT_REQUIRED"
+    assert result.run.steps[0].adjudication is not None
+    assert result.run.steps[0].adjudication.persistence_intent == "none"
 
 
 @pytest.mark.asyncio

--- a/agent-collaboration-framework/tests/test_architecture.py
+++ b/agent-collaboration-framework/tests/test_architecture.py
@@ -138,13 +138,15 @@ class ArchitectureTests(unittest.TestCase):
         )
         self.assertTrue(HostAgentContext.model_fields)
         self.assertTrue(Intent.model_fields)
-        self.assertEqual(PROMPT_VERSION, "trpg-host-intent-v6")
+        self.assertEqual(PROMPT_VERSION, "trpg-host-intent-v7")
         self.assertEqual(TURN_PLANNER_PROMPT_VERSION, "trpg-turn-planner-v2")
         planning = turn_planning_instructions(ActionPlanPolicy())
         self.assertIn("公开地点、人物、物件名称或别名", planning)
         self.assertIn("泛化成“眼前的人”", planning)
         self.assertTrue(host_turn_decision_instructions(ActionPlanPolicy()))
-        self.assertTrue(current_step_adjudication_instructions())
+        adjudication_prompt = current_step_adjudication_instructions()
+        self.assertIn("PERSISTENT_EFFECT_REQUIRED", adjudication_prompt)
+        self.assertIn("persistence_intent 收窄为", adjudication_prompt)
 
     def test_engine_does_not_import_host(self) -> None:
         for path in (PACKAGE / "engine").rglob("*.py"):

--- a/agent-collaboration-framework/tests/test_persistent_results.py
+++ b/agent-collaboration-framework/tests/test_persistent_results.py
@@ -9,6 +9,7 @@ from collaboration_framework.contracts import (
     ActionAdjudication,
     ActionMethod,
     ActionTarget,
+    ChangeEntityStateEffect,
     NoAdjudicationCheck,
 )
 from collaboration_framework.engine.persistent_results import (
@@ -35,3 +36,79 @@ def test_unknown_family_is_observable_without_changing_validation(caplog) -> Non
     record = next(item for item in caplog.records if item.message == "persistent_family_policy_missing")
     assert record.family == "观察"
     assert record.persistence_intent == "none"
+
+
+def _persistent_action(*, intent: str, family: str, target: str = "target") -> ActionAdjudication:
+    """构造最小自由裁决，专门验证持久意图的降级标记。"""
+
+    return ActionAdjudication(
+        request_id="persistent-test",
+        source_revision="revision-1",
+        actor_id="actor-1",
+        summary="尝试改变目标状态",
+        target=ActionTarget(kind="entity", id=target),
+        method=ActionMethod(family=family, description="尝试改变目标状态"),
+        persistence_intent=intent,
+        check=NoAdjudicationCheck(),
+    )
+
+
+def test_missing_state_capability_can_fallback_to_generic_check() -> None:
+    result = validate_persistent_effects(
+        _persistent_action(intent="character_state", family="restrain"),
+        target_kind="object",
+        target_state_keys={"cut"},
+    )
+
+    assert result is not None
+    assert result.code == "PERSISTENT_EFFECT_REQUIRED"
+    assert result.allow_generic_fallback is True
+
+
+def test_npc_character_state_still_requires_effect() -> None:
+    result = validate_persistent_effects(
+        _persistent_action(intent="character_state", family="knock_out"),
+        target_kind="npc",
+        target_state_keys={"consciousness"},
+    )
+
+    assert result is not None
+    assert result.code == "PERSISTENT_EFFECT_REQUIRED"
+    assert result.allow_generic_fallback is False
+
+
+def test_object_state_with_matching_capability_still_requires_effect() -> None:
+    result = validate_persistent_effects(
+        _persistent_action(intent="object_state", family="open"),
+        target_kind="object",
+        target_state_keys={"open"},
+    )
+
+    assert result is not None
+    assert result.code == "PERSISTENT_EFFECT_REQUIRED"
+    assert result.allow_generic_fallback is False
+
+
+def test_persistent_effect_mismatch_never_marks_generic_fallback() -> None:
+    action = _persistent_action(intent="character_state", family="knock_out")
+    action = action.model_copy(
+        update={
+            "success_effects": (
+                ChangeEntityStateEffect(
+                    entity_id="target",
+                    key="posture",
+                    value="prone",
+                ),
+            )
+        },
+        deep=True,
+    )
+    result = validate_persistent_effects(
+        action,
+        target_kind="npc",
+        target_state_keys={"consciousness", "posture"},
+    )
+
+    assert result is not None
+    assert result.code == "PERSISTENT_EFFECT_MISMATCH"
+    assert result.allow_generic_fallback is False

--- a/agent-collaboration-framework/tests/test_persistent_results.py
+++ b/agent-collaboration-framework/tests/test_persistent_results.py
@@ -4,6 +4,7 @@
 """
 
 import logging
+from types import SimpleNamespace
 
 from collaboration_framework.contracts import (
     ActionAdjudication,
@@ -12,6 +13,7 @@ from collaboration_framework.contracts import (
     ChangeEntityStateEffect,
     NoAdjudicationCheck,
 )
+from collaboration_framework.engine.adjudication import _target_persistent_capability
 from collaboration_framework.engine.persistent_results import (
     validate_persistent_effects,
 )
@@ -112,3 +114,34 @@ def test_persistent_effect_mismatch_never_marks_generic_fallback() -> None:
     assert result is not None
     assert result.code == "PERSISTENT_EFFECT_MISMATCH"
     assert result.allow_generic_fallback is False
+
+
+def test_item_instance_live_state_is_included_in_capability_snapshot() -> None:
+    """物品实例已写入状态后，后续缺效果裁决仍必须走持久结果闸门。"""
+
+    runtime = SimpleNamespace(
+        module_content=SimpleNamespace(
+            entities=(
+                SimpleNamespace(id="drawer", kind="object", state={"open": False}),
+            )
+        ),
+        game_state=SimpleNamespace(
+            item_instances={
+                "drawer": SimpleNamespace(
+                    definition_id="drawer",
+                    state=SimpleNamespace(values={"open": True}),
+                )
+            },
+            public_entity_state_keys={"drawer": ("open",)},
+            runtime_entities={},
+            actors={},
+            runtime_locations={},
+        ),
+        canon_location_ids=set(),
+        canon_information_ids=set(),
+    )
+
+    kind, state_keys = _target_persistent_capability(runtime, "drawer")
+
+    assert kind == "object"
+    assert "open" in state_keys

--- a/agent-collaboration-framework/tests/test_semantic_preservation.py
+++ b/agent-collaboration-framework/tests/test_semantic_preservation.py
@@ -10,8 +10,8 @@ from collaboration_framework.contracts import (
     ActionTarget,
     ChangeEntityStateEffect,
     ConsumeEntityEffect,
-    EnterLocationEffect,
     EnsureRuntimeEntityEffect,
+    EnterLocationEffect,
     ModuleContentV3,
     MoveEntityEffect,
     NarrativeOnlyEffect,
@@ -21,6 +21,7 @@ from collaboration_framework.contracts import (
     RuleDecisionRef,
     SkillCheckCandidate,
     ValidationFeedback,
+    VisibleEntity,
 )
 from collaboration_framework.engine import (
     ActorState,
@@ -130,6 +131,100 @@ def test_visible_target_id_correction_is_preserved() -> None:
 
     assert result.status == "preserved"
     assert result.reason_code == "TARGET_ID_CORRECTED"
+
+
+def test_missing_object_state_can_narrow_to_generic_check() -> None:
+    """只有没有角色状态能力的物体目标才可收窄为普通行动。"""
+
+    _, _, projector = runtime()
+    view = asyncio.run(projector.project(player_input(utterance="观察")))
+    rope = VisibleEntity(
+        id="restraint_rope",
+        kind="object",
+        name="细绳",
+        description="捆住双手的细绳",
+    )
+    view = view.model_copy(
+        update={
+            "scene": view.scene.model_copy(
+                update={"visible_entities": (*view.scene.visible_entities, rope)}
+            )
+        },
+        deep=True,
+    )
+    original = ActionAdjudication(
+        request_id="persistent-repair",
+        source_revision="0",
+        actor_id="pc_1",
+        summary="使劲挣脱束缚",
+        target=ActionTarget(kind="entity", id="restraint_rope"),
+        method=ActionMethod(family="restrain", description="使劲挣脱束缚"),
+        persistence_intent="character_state",
+        check=NoAdjudicationCheck(),
+    )
+    repaired = original.model_copy(
+        update={
+            "method": ActionMethod(family="action", description="使劲挣脱束缚"),
+            "persistence_intent": "none",
+        },
+        deep=True,
+    )
+    result = compare_repair_semantics(
+        player_input=player_input(utterance="使劲挣脱束缚"),
+        plan_goal="使劲挣脱束缚",
+        step=ActionPlanStep(kind="action", semantic_goal="使劲挣脱束缚"),
+        original=original,
+        repaired=repaired,
+        validation_feedback=ValidationFeedback(
+            status="rejected",
+            code="PERSISTENT_EFFECT_REQUIRED",
+            repairability="auto_repairable",
+            fault="agent",
+            player_safe_reason="当前候选需要机械修正",
+            generic_fallback_allowed=True,
+        ),
+        player_view=view,
+    )
+
+    assert result.status == "narrowed"
+    assert result.reason_code == "PERSISTENCE_INTENT_NARROWED"
+
+
+def test_npc_persistent_intent_cannot_be_downgraded() -> None:
+    """NPC 的角色状态行动不能借收窄路径绕过持久结果完整性。"""
+
+    _, _, projector = runtime()
+    view = asyncio.run(projector.project(player_input(utterance=f"查看{TARGET_LABEL}")))
+    original = _action(target_id=TARGET, family="knock_out").model_copy(
+        update={"persistence_intent": "character_state"},
+        deep=True,
+    )
+    repaired = original.model_copy(
+        update={
+            "method": ActionMethod(family="action", description=f"查看{TARGET_LABEL}"),
+            "persistence_intent": "none",
+        },
+        deep=True,
+    )
+    result = compare_repair_semantics(
+        player_input=player_input(utterance=f"击晕{TARGET_LABEL}"),
+        plan_goal=f"击晕{TARGET_LABEL}",
+        step=ActionPlanStep(kind="action", semantic_goal=f"击晕{TARGET_LABEL}"),
+        original=original,
+        repaired=repaired,
+        validation_feedback=ValidationFeedback(
+            status="rejected",
+            code="PERSISTENT_EFFECT_REQUIRED",
+            repairability="auto_repairable",
+            fault="agent",
+            player_safe_reason="当前候选需要机械修正",
+            generic_fallback_allowed=False,
+        ),
+        player_view=view,
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "PERSISTENCE_INTENT_CHANGED"
 
 
 def test_target_id_correction_can_update_matching_effect_reference() -> None:

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -73,7 +73,11 @@ persistence_intent，但 success_effects/failure_effects 按规则所有权要�
 上述 open/close/lock 等物体动作族只适用于一个已存在的物理实体确实改变
 对应状态的情况。自然语言中同一动词的服务请求、惯用语或抽象含义，不得映射成
 物体 open；若没有单独建模的权威状态，使用 method.family=action、
-persistence_intent=none 和 narrative_only，不要伪造 object_state 效果。
+persistence_intent=none 和 narrative_only，不要伪造 object_state 效果。如果规则引擎返回
+PERSISTENT_EFFECT_REQUIRED，且 PlayerView 中的目标没有能够承载该结果的权威状态位，保持原
+target、method、check 不变，将 persistence_intent 收窄为 none，success_effects 和
+failure_effects 只保留空值或 narrative_only；不得凭空添加状态键，也不得因此丢弃原本应执行
+的力量或技能检定。
 
 **明确旅行地点决策表（高优先级）**：当玩家直接指定了目的地类型时，只能选择：
 

--- a/trpg-backend/tests/test_rule_match_adjudication.py
+++ b/trpg-backend/tests/test_rule_match_adjudication.py
@@ -206,6 +206,15 @@ def test_prompt_treats_action_families_as_advisory() -> None:
     assert "不能仅因动作族词汇不同就放弃" in instructions
 
 
+def test_prompt_allows_generic_check_when_no_persistent_state_exists() -> None:
+    """无可写状态时，提示词必须要求保留检定并收窄持久意图。"""
+
+    instructions = current_step_adjudication_instructions()
+    assert "PERSISTENT_EFFECT_REQUIRED" in instructions
+    assert "persistence_intent 收窄为" in instructions
+    assert "不能因为没有持久效果而把行动改成澄清" in instructions
+
+
 def test_offline_match_recognizes_surveillance_wording() -> None:
     """离线兜底至少覆盖 #453 的自然中文观察说法。"""
 


### PR DESCRIPTION
Closes #424

## 现象与根因

当玩家执行合理的自由行动，但目标实体没有模组声明的可写持久状态位时，模型可能提交 `character_state` 或 `object_state` 持久意图却没有效果，Engine 原本会直接拒绝。典型表现是“使劲挣脱束缚”丢失原有力量检定，无法进入正常结果流程。

## 主要改动

- Engine 读取运行时目标类型和已声明的可写状态能力，仅把“目标没有相应状态承载能力”的 `PERSISTENT_EFFECT_REQUIRED` 标记为 Host 可降级候选，原始裁决仍然拒绝并重新校验。
- Host 语义保持允许一次受控的 `persistence_intent=none` 收窄；目标、动作、方法、检定和语义必须保持不变，成功/失败分支只能为空或 `narrative_only`。
- 具备角色或物体状态能力的目标仍然要求真实持久效果，`PERSISTENT_EFFECT_MISMATCH`、模组规则路径和其他持久结果保护不变。
- 更新主持提示词，明确无状态位时保持行动和检定、不伪造状态；Narrator 只能依据检定与玩家可见事实叙述。
- 增加框架与后端回归测试，覆盖自由行动降级、NPC/物体安全边界、语义修复和提示词约束。

## 为什么保留持久结果校验

这是一次受控降级，不是删除完整性闸门。击晕 NPC、打开或损坏物体等真实持久行动仍必须提交匹配效果；只有目标根本没有可写状态能力且没有真实领域效果时，才允许保留检定并收窄为普通行动，避免伪造世界状态。

## 测试结果

- `agent-collaboration-framework`: `441 passed`
- `trpg-backend`: `639 passed, 23 skipped`
- 变更相关后端 Ruff 格式检查通过，`git diff --check` 通过
- 框架全量 Ruff 仍报告主线已有的 `SIM114` 基线问题，本 PR 未修改该无关代码

## 兼容性、风险与回滚

不新增公开 API、Schema 字段、数据库迁移或模组状态键。放宽范围仅覆盖此前因缺少状态承载能力而失败的自由行动；真实持久结果仍 fail-closed。若发现回归，可回滚提交 `79d08ac`，不影响已有存档结构。

## AI 使用与人工 Review

本 PR 使用 AI 辅助代码阅读、实现和测试生成；行为边界、测试结果与最终 diff 由提交者审阅确认。合并前需要人工 Review，不绕过分支保护。

## 自检清单

- [x] 未修改《追书人》或《银之锁》模组内容
- [x] 未新增数据库字段或公开协议字段
- [x] 保留 NPC/物体真实持久结果校验
- [x] 保留原有检定参数和结果叙述约束
- [x] 已运行两个子项目完整测试集
- [x] 未直接合并，等待人工 Review
