### PR TITLE
fix(character): 选择预设卡后立即水合技能点

### DIFF
--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -751,7 +751,11 @@ describe('CharacterPage', () => {
       residence: '阿卡姆',
       birthplace: '波士顿',
       occupation: '会计师',
-      attributes: Object.fromEntries(mockRuleset.attributes.map(attribute => [attribute.key, 50])),
+      attributes: Object.fromEntries(
+        mockRuleset.attributes
+          .filter(attribute => attribute.key !== 'LUCK')
+          .map(attribute => [attribute.key, 50]),
+      ),
       derivedStats: { HP: 10, SAN: 50, MP: 10 },
       skills: { accounting: 1, stealth: 1 },
       equipment: [],

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Ruleset } from 'trpg-sdk'
@@ -525,7 +525,11 @@ describe('CharacterPage', () => {
       residence: '阿卡姆',
       birthplace: '波士顿',
       occupation: '记者',
-      attributes: Object.fromEntries(mockRuleset.attributes.map(attribute => [attribute.key, 50])),
+      attributes: Object.fromEntries(
+        mockRuleset.attributes
+          .filter(attribute => attribute.key !== 'LUCK')
+          .map(attribute => [attribute.key, 50]),
+      ),
       derivedStats: { HP: 10, SAN: 50, MP: 10 },
       skills: { charm: 40, climb: 30 },
       occupationChoiceSkillIds: null,
@@ -737,5 +741,38 @@ describe('CharacterPage', () => {
 
     expect(await screen.findByLabelText('思想与信念')).toHaveValue('真相总会留下痕迹')
     expect(screen.getByLabelText('其他')).toHaveValue('来自旧报社')
+  })
+
+  it('hydrates the room draft when a library selection sets the character id', async () => {
+    mockCharacterApi.fetchCharacter.mockResolvedValue({
+      name: '卡库调查员',
+      age: 30,
+      gender: '女',
+      residence: '阿卡姆',
+      birthplace: '波士顿',
+      occupation: '会计师',
+      attributes: Object.fromEntries(mockRuleset.attributes.map(attribute => [attribute.key, 50])),
+      derivedStats: { HP: 10, SAN: 50, MP: 10 },
+      skills: { accounting: 1, stealth: 1 },
+      equipment: [],
+      background: '',
+      notes: '',
+    })
+
+    renderPage()
+    expect(mockCharacterApi.fetchCharacter).not.toHaveBeenCalled()
+
+    act(() => useRoomStore.getState().setCharacterId('library-draft'))
+
+    await waitFor(() => {
+      expect(mockCharacterApi.fetchCharacter).toHaveBeenCalledWith('room-1', 'library-draft')
+      expect(screen.getByPlaceholderText('请输入角色姓名')).toHaveValue('卡库调查员')
+    })
+    expect(mockPreviewCharacter).toHaveBeenCalledWith(expect.objectContaining({
+      attributes: expect.objectContaining({ LUCK: 50 }),
+      occupationId: 1,
+      skills: { accounting: 1, stealth: 1 },
+    }))
+    expect(screen.getByText('待掷')).toBeInTheDocument()
   })
 })

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -223,6 +223,9 @@ export default function CharacterPage() {
     (location.state as { fromCharacterReady?: boolean } | null)?.fromCharacterReady
   )
   const characterPageRef = useRef<HTMLDivElement>(null)
+  const roomId = useRoomStore((s) => s.roomId)
+  const characterId = useRoomStore((s) => s.characterId)
+  const setCharacterId = useRoomStore((s) => s.setCharacterId)
 
   // 建卡规则目录（职业/技能/属性）改从后端 GET /systems/{systemId}/ruleset
   // 拿（issue #84 S3），职业网格/技能列表在数据到达前先显示 loading。
@@ -284,8 +287,6 @@ export default function CharacterPage() {
   // 有 characterId 就以后端那份为准覆盖表单，清掉浏览器缓存也照样能继续编辑。
   useEffect(() => {
     if (!ruleset) return
-    const roomId = useRoomStore.getState().roomId
-    const characterId = useRoomStore.getState().characterId
     // 卡库宿主没有房间，也没有 characterId；读的是那张卡库卡，摊平成向导已经
     // 会读的形状后走同一条水合路径（属性 → 权威 preview 反推技能点 → 填表单）。
     const load = templateHostId
@@ -324,7 +325,10 @@ export default function CharacterPage() {
         // 就会把技能点清空覆盖回后端。所以改成先算后填：失败就整体不水合，
         // 退回本地缓存/空白表单，跟"压根没读回来"是同一种一致状态。
         const view = await previewCharacter({
-          attributes: savedAttrs,
+          // 卡库播种会清除上一局的幸运值，但技能点预算和技能基础值都不依赖
+          // LUCK。仅为这次反推提供合法占位值；表单仍使用 savedAttrs，要求玩家
+          // 在本局重新投掷幸运。
+          attributes: { LUCK: 50, ...savedAttrs },
           occupationId: matched?.id ?? null,
           skills: saved.skills ?? {},
           occupationChoiceSkillIds: saved.occupationChoiceSkillIds ?? null,
@@ -402,7 +406,7 @@ export default function CharacterPage() {
         // 读不回来（比如还没建过草稿）就沿用本地缓存/空白表单，不打断建卡。
       })
     return () => { cancelled = true }
-  }, [ruleset, templateHostId])
+  }, [ruleset, templateHostId, roomId, characterId])
 
   // ruleset 到达后，把缺失的属性补上默认值。
   //
@@ -728,8 +732,6 @@ export default function CharacterPage() {
 
   const derived = useMemo(() => normalizeDerivedStats(preview?.derivedStats), [preview])
 
-  const roomId = useRoomStore((s) => s.roomId)
-  const setCharacterId = useRoomStore((s) => s.setCharacterId)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState('')
   const [validationAttempted, setValidationAttempted] = useState(false)
@@ -1251,8 +1253,6 @@ export default function CharacterPage() {
       const characterId = await createCharacterDraft(roomId, templateId)
       setCharacterId(characterId)
       setLibraryOpen(false)
-      // 房间副本的幸运值已由服务端清除，必须回到向导让玩家手动掷本局幸运骰。
-      navigate(0)
     } catch (err) {
       setLibraryError(
         err instanceof ApiError && err.status === 409


### PR DESCRIPTION
## 概要

- 响应式订阅房间 `characterId`，选择卡库预设并创建草稿后立即触发权威数据水合
- 移除依赖 `navigate(0)` 的强制刷新同步
- 水合技能时为已清除旧局幸运值的预设卡提供仅用于预览的合法占位值，表单仍要求本局重新投掷幸运
- 增加挂载后设置角色 ID 的回归测试，覆盖技能、职业与待掷幸运状态

## 验证

- `cd trpg-frontend && npm test -- --run src/routes/games/trpg/CharacterPage.test.tsx`
- `cd trpg-frontend && npm run lint`
- `cd trpg-frontend && npm run build`
- 浏览器手动回放：选择预设卡后无需退出重进，技能值和预算立即恢复，幸运保持待掷

Closes #458