### PR TITLE
fix(module): 追书人搬石板需已发现且未搬开

### DIFF
--- a/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json
+++ b/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json
@@ -1,7 +1,7 @@
 {
   "content_schema_version": 3,
   "module_id": "paper-chase-zh-coc7",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "world_ref": "coc-7e",
   "background": "时代与地点为美国禁酒令时期的密歇根州阿诺兹堡。调查员受托马斯·金博尔委托，从五本失窃的旧书和叔叔道格拉斯一年前的失踪案入手，走访旧宅、图书馆与公共墓地。叙事应保持安静、克制而带哥特气息，以夜色、旧书、墓园和孤独感作为反复意象；面对异常时不要急于渲染纯粹敌意，应为同情、选择与淡淡哀伤保留空间。任何尚未由线索确认的真相都不得提前告知玩家。",
   "information": [
@@ -2764,6 +2764,29 @@
           ],
           "target_ids": [
             "crypt_entrance"
+          ]
+        },
+        "when": {
+          "op": "all",
+          "items": [
+            {
+              "op": "predicate",
+              "predicate": "entity_state_is",
+              "args": {
+                "entity_id": "crypt_entrance",
+                "key": "discovered",
+                "value": true
+              }
+            },
+            {
+              "op": "predicate",
+              "predicate": "entity_state_is",
+              "args": {
+                "entity_id": "crypt_entrance",
+                "key": "slab_moved",
+                "value": false
+              }
+            }
           ]
         },
         "question": {

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -1795,11 +1795,11 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
     async def test_rule_option_publishes_whether_it_rolls_dice(self) -> None:
         """Agent 必须能分辨哪条分支要掷骰，否则只能编一个技能 id 出来。"""
 
-        async def candidates(scene_id: str):
+        async def candidates(scene_id: str, **overrides):
             store = InMemoryEngineStore()
             store.register_room(
                 module_content=self.content,
-                initial_state=game_state(self.content, scene_id=scene_id),
+                initial_state=game_state(self.content, scene_id=scene_id, **overrides),
             )
             view = await RuleEngineService(store).read_keeper_capabilities(
                 PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
@@ -1811,9 +1811,173 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(in_crypt["enter_crypt"].options[0].requires_check)
 
         # 搬石板要掷 STR，而它属于墓地——石板在墓地，不在地穴里。
-        at_cemetery = await candidates("cemetery")
+        at_cemetery = await candidates(
+            "cemetery",
+            entities={"crypt_entrance": {"discovered": True, "slab_moved": False}},
+        )
         self.assertTrue(at_cemetery["move_crypt_slab"].options[0].requires_check)
         self.assertNotIn("move_crypt_slab", in_crypt)
+
+    async def test_move_crypt_slab_requires_discovered_unmoved_entrance(self) -> None:
+        """#474：猜到「石板」不能绕过发现门禁；搬开后不能再发同一规则。"""
+
+        str_check = RequiredAdjudicationCheck(
+            candidates=(
+                SkillCheckCandidate(
+                    candidate_id="STR",
+                    skill_id="STR",
+                    difficulty="regular",
+                    method_summary="用力搬开石板",
+                    player_safe_reason="这是当前可用的做法",
+                ),
+            )
+        )
+
+        async def published(**entities) -> set[str]:
+            store = InMemoryEngineStore()
+            store.register_room(
+                module_content=self.content,
+                initial_state=game_state(
+                    self.content, scene_id="cemetery", entities=entities
+                ),
+            )
+            view = await RuleEngineService(store).read_keeper_capabilities(
+                PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+            )
+            return {item.rule_id for item in view.rule_candidates}
+
+        async def submit_move(*, request_id: str, **entities):
+            store = InMemoryEngineStore()
+            store.register_room(
+                module_content=self.content,
+                initial_state=game_state(
+                    self.content, scene_id="cemetery", entities=entities
+                ),
+            )
+            engine = AdjudicationEngineService(
+                store, dice=DiceRoller(SequenceDiceSource([5]))
+            )
+            rules = RuleEngineService(store)
+            snapshot = await rules.read(
+                PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+            )
+            try:
+                execution = await engine.submit(
+                    SubmitAdjudicationRequest(
+                        room_id=ROOM,
+                        player_id=PLAYER,
+                        adjudication=ActionAdjudication(
+                            request_id=request_id,
+                            source_revision=snapshot.revision,
+                            actor_id=ACTOR,
+                            summary="搬开石板",
+                            target=ActionTarget(kind="entity", id="crypt_entrance"),
+                            method=ActionMethod(family="move", description="搬开石板"),
+                            rule_decision=RuleDecisionRef(
+                                rule_id="move_crypt_slab", option_id="STR"
+                            ),
+                            check=str_check,
+                            success_effects=(),
+                            failure_effects=(),
+                        ),
+                    )
+                )
+            except AdjudicationValidationError as exc:
+                return store, exc
+            return store, execution
+
+        hidden = {"crypt_entrance": {"discovered": False, "slab_moved": False}}
+        ready = {"crypt_entrance": {"discovered": True, "slab_moved": False}}
+        moved = {"crypt_entrance": {"discovered": True, "slab_moved": True}}
+
+        self.assertNotIn("move_crypt_slab", await published(**hidden))
+        self.assertIn("move_crypt_slab", await published(**ready))
+        self.assertNotIn("move_crypt_slab", await published(**moved))
+
+        hidden_store, rejected = await submit_move(request_id="slab-hidden", **hidden)
+        self.assertIsInstance(rejected, AdjudicationValidationError)
+        self.assertEqual(rejected.result.code, "RULE_OUT_OF_SCOPE")
+        self.assertEqual(rejected.result.player_safe_reason, "当前行动不能使用该规则选项")
+        self.assertEqual(len(hidden_store.inspect_domain_events(ROOM)), 0)
+        self.assertIs(
+            hidden_store.inspect_state(ROOM).entities["crypt_entrance"].get("slab_moved"),
+            False,
+        )
+
+        store, admitted = await submit_move(request_id="slab-ready", **ready)
+        self.assertNotIsInstance(admitted, AdjudicationValidationError)
+        pending = admitted.pending_decision
+        assert pending is not None
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([5]))
+        )
+        resolved = await engine.decide(
+            CheckDecisionRequest(
+                request_id="slab-ready:select",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=admitted.view_revision,
+                decision_id=pending.decision_id,
+                decision_version=pending.decision_version,
+                choice=SelectCheckChoice(candidate_id="STR"),
+            )
+        )
+        check_run = resolved.check_run
+        assert check_run is not None
+        await engine.decide_post_roll(
+            PostRollDecisionRequest(
+                request_id="slab-ready:accept",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=resolved.view_revision,
+                check_id=check_run.check_id,
+                check_version=check_run.version,
+                option_id="accept-current",
+            )
+        )
+        self.assertIs(
+            store.inspect_state(ROOM).entities["crypt_entrance"]["slab_moved"], True
+        )
+        events_after_success = len(store.inspect_domain_events(ROOM))
+
+        snapshot = await RuleEngineService(store).read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        with self.assertRaises(AdjudicationValidationError) as rejected_again:
+            await AdjudicationEngineService(store).submit(
+                SubmitAdjudicationRequest(
+                    room_id=ROOM,
+                    player_id=PLAYER,
+                    adjudication=ActionAdjudication(
+                        request_id="slab-again",
+                        source_revision=snapshot.revision,
+                        actor_id=ACTOR,
+                        summary="再搬一次石板",
+                        target=ActionTarget(kind="entity", id="crypt_entrance"),
+                        method=ActionMethod(family="move", description="搬开石板"),
+                        rule_decision=RuleDecisionRef(
+                            rule_id="move_crypt_slab", option_id="STR"
+                        ),
+                        check=str_check,
+                        success_effects=(),
+                        failure_effects=(),
+                    ),
+                )
+            )
+        self.assertEqual(rejected_again.exception.result.code, "RULE_OUT_OF_SCOPE")
+        self.assertEqual(len(store.inspect_domain_events(ROOM)), events_after_success)
+        self.assertIs(
+            store.inspect_state(ROOM).entities["crypt_entrance"]["slab_moved"], True
+        )
+
+        moved_store, again = await submit_move(request_id="slab-already-moved", **moved)
+        self.assertIsInstance(again, AdjudicationValidationError)
+        self.assertEqual(again.result.code, "RULE_OUT_OF_SCOPE")
+        self.assertEqual(len(moved_store.inspect_domain_events(ROOM)), 0)
+        self.assertIs(
+            moved_store.inspect_state(ROOM).entities["crypt_entrance"]["slab_moved"],
+            True,
+        )
 
     async def test_rule_decision_from_another_location_is_refused(self) -> None:
         """候选按场景发布，提交也必须按场景复查。

--- a/e2e/tests/content-catalog.e2e.ts
+++ b/e2e/tests/content-catalog.e2e.ts
@@ -19,7 +19,7 @@ test('世界标签、追书人 v3 发布元数据和玩家安全开局简介正�
   assert.ok(paperChase)
   assert.equal(paperChase.title, '追书人')
   assert.equal(paperChase.nameEn, 'Paper Chase')
-  assert.equal(paperChase.version, '3.0.8')
+  assert.equal(paperChase.version, '3.0.9')
   assert.equal(paperChase.playersMin, 1)
   assert.equal(paperChase.playersMax, 4)
   assert.equal(paperChase.estimatedDuration, '1-2 小时')

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -38,7 +38,7 @@ import asyncio
 import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from functools import partial
 from typing import Literal, cast
@@ -601,7 +601,8 @@ async def _enqueue_host_action(
         for event in events:
             audience = tuple(str(value) for value in event.payload.get("audiencePlayerIds", ()))
             await _broadcast_dialogue_event(db, event, audience)
-    await _broadcast_room_action_state(db, room_id)
+    await anyio.sleep(0)
+    await _broadcast_room_action_state_fresh(room_id)
 
 
 async def _npc_dialogue_audience(
@@ -1409,7 +1410,10 @@ async def _short_db_session() -> AsyncIterator[AsyncSession]:
         yield session
     finally:
         with anyio.CancelScope(shield=True):
-            await session.close()
+            # Cancelled TestClient/WS tasks can leave aiosqlite already
+            # terminated; closing then raises "no active connection".
+            with suppress(SQLAlchemyError):
+                await session.close()
 
 
 def _connection_is_gone(websocket: WebSocket, exc: Exception) -> bool:

--- a/trpg-backend/app/service/builtin_module_loader.py
+++ b/trpg-backend/app/service/builtin_module_loader.py
@@ -44,7 +44,7 @@ class BuiltinModuleSpec:
 PAPER_CHASE_SPEC = BuiltinModuleSpec(
     scenario_id="00000000-0000-0000-0000-000000000003",
     module_id="paper-chase-zh-coc7",
-    version="3.0.8",
+    version="3.0.9",
     world_ref="coc-7e",
     source_path=MODULE_FIXTURE_ROOT / "追书人" / "module-content-v3.json",
     display_name="追书人",

--- a/trpg-backend/tests/test_chat_ws.py
+++ b/trpg-backend/tests/test_chat_ws.py
@@ -31,6 +31,7 @@ from tests.test_ws import (
     complete_character,
     create_room,
     join_as,
+    receive_replayed_opening,
     receive_until,
     register_and_login,
     start_game,
@@ -42,7 +43,7 @@ def sync_client() -> Iterator[TestClient]:
     yield TestClient(app)
 
 
-def _join_ws(ws, player: dict) -> None:
+def _join_ws(ws, player: dict, *, started: bool = False) -> None:
     ws.send_json(
         {
             "type": "room.join",
@@ -51,6 +52,9 @@ def _join_ws(ws, player: dict) -> None:
         }
     )
     assert ws.receive_json()["type"] == "session.bound"
+    if started:
+        ws.receive_json()
+        receive_replayed_opening(ws)
 
 
 def _send_chat(ws, player: dict, text: str, client_message_id: str) -> None:
@@ -176,7 +180,7 @@ def test_multiplayer_action_chat_is_roleplay_and_not_host_event(
     start_game(sync_client, room, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
-        _join_ws(ws, room)
+        _join_ws(ws, room, started=True)
         ws.send_json(
             {
                 "type": "action.chat.send",
@@ -215,7 +219,7 @@ def test_chat_idempotency_keeps_original_channel_and_actor_shape(
     start_game(sync_client, room, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
-        _join_ws(ws, room)
+        _join_ws(ws, room, started=True)
         _send_chat(ws, room, "首次落成讨论消息", "shared-id-1")
         first = receive_until(ws, lambda item: item.get("type") == "chat.message")[0]
         ws.send_json(
@@ -243,7 +247,7 @@ def test_single_player_action_chat_is_rejected(sync_client: TestClient) -> None:
     start_game(sync_client, room, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
-        _join_ws(ws, room)
+        _join_ws(ws, room, started=True)
         ws.send_json(
             {
                 "type": "action.chat.send",
@@ -266,7 +270,7 @@ def test_npc_recipient_bypasses_keeper_processing(sync_client: TestClient) -> No
     start_game(sync_client, room, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
-        _join_ws(ws, room)
+        _join_ws(ws, room, started=True)
         ws.send_json(
             {
                 "type": "action.plan.submit",
@@ -297,7 +301,7 @@ def test_single_player_accepts_implicit_keeper_recipient(sync_client: TestClient
     start_game(sync_client, room, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
-        _join_ws(ws, room)
+        _join_ws(ws, room, started=True)
         ws.send_json(
             {
                 "type": "action.plan.submit",
@@ -324,7 +328,7 @@ def test_multiplayer_rejects_implicit_keeper_recipient(sync_client: TestClient) 
     start_game(sync_client, room, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
-        _join_ws(ws, room)
+        _join_ws(ws, room, started=True)
         ws.send_json(
             {
                 "type": "action.plan.submit",
@@ -356,7 +360,7 @@ def test_action_submit_broadcasts_utterance_then_narration(sync_client: TestClie
     start_game(sync_client, room, token)
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
-        _join_ws(ws, room)
+        _join_ws(ws, room, started=True)
         _submit_action(ws, room, "我推开吱呀作响的木门")
         echo, _ = receive_until(ws, lambda message: message.get("type") == "action.broadcast")
         narration, _ = receive_until(ws, lambda message: message.get("type") == "narration.push")
@@ -394,7 +398,7 @@ def test_clarification_narration_is_visible_to_other_players(
     action_id = "clarify-public-397"
 
     with sync_client.websocket_connect(f"/ws/{room['roomId']}?token={token}") as ws:
-        _join_ws(ws, room)
+        _join_ws(ws, room, started=True)
         ws.send_json(
             {
                 "type": "action.plan.submit",

--- a/trpg-backend/tests/test_paper_chase_loader.py
+++ b/trpg-backend/tests/test_paper_chase_loader.py
@@ -23,7 +23,7 @@ async def test_loader_is_idempotent_and_reports_real_content(
 
     assert result.outcome == "unchanged"
     assert result.module_id == BUILTIN_MODULE_ID
-    assert result.version == "3.0.8"
+    assert result.version == "3.0.9"
     assert result.world_ref == "coc-7e"
     assert result.location_count == 12
     assert result.entity_count == 14
@@ -48,7 +48,7 @@ async def test_paper_chase_models_caretaker_bottle_as_discoverable_state() -> No
     """
 
     payload = json.loads(loader.PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8"))
-    assert payload["version"] == "3.0.8"
+    assert payload["version"] == "3.0.9"
     entities = {entity["id"]: entity for entity in payload["entities"]}
     information = {item["id"]: item for item in payload["information"]}
     rules = {rule["id"]: rule for rule in payload["rules"]}
@@ -68,6 +68,17 @@ async def test_paper_chase_models_caretaker_bottle_as_discoverable_state() -> No
     assert "小酒瓶" in bottle_clue["keeper_content"]
 
 
+def test_paper_chase_move_crypt_slab_requires_discovery_gate() -> None:
+    """#474：搬石板必须先发现入口，且不能对已搬开的石板再发同一规则。"""
+
+    payload = json.loads(loader.PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8"))
+    rules = {rule["id"]: rule for rule in payload["rules"]}
+    when = rules["move_crypt_slab"]["trigger"]["when"]
+    assert when["op"] == "all"
+    items = {(item["args"]["key"], item["args"]["value"]) for item in when["items"]}
+    assert items == {("discovered", True), ("slab_moved", False)}
+
+
 def test_paper_chase_keeps_previous_v2_snapshots() -> None:
     """切到 v3 不删旧快照——它们是这次迁移的出处记录。
 
@@ -77,7 +88,7 @@ def test_paper_chase_keeps_previous_v2_snapshots() -> None:
     """
 
     current = json.loads(loader.PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8"))
-    assert current["version"] == "3.0.8"
+    assert current["version"] == "3.0.9"
     assert current["content_schema_version"] == 3
 
     for name, version in (
@@ -223,7 +234,7 @@ async def test_loader_preserves_rooms_pinned_older_version(
 
     result = await loader.load_paper_chase(db_session)
 
-    assert result.version == "3.0.8"
+    assert result.version == "3.0.9"
     pinned = await db_session.get(ModuleVersion, (BUILTIN_MODULE_ID, "3.0.5"))
     assert pinned is not None
     assert pinned.content_json == pinned_content


### PR DESCRIPTION
Closes #474

《追书人》`move_crypt_slab` 增加与候选发布同源的状态门禁：只有地穴入口已被发现、且石板尚未搬开时，规则才可发布和提交。玩家猜到「石板」不能绕过发现条件。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `追书人/module-content-v3.json` | `move_crypt_slab.trigger.when`：`discovered==true` 且 `slab_moved==false`；版本升到 3.0.9 |
| `app/service/builtin_module_loader.py` | Loader 固定版本改为 3.0.9 |
| `tests/test_projection_v3.py` | 未发现不发布/提交被拒、发现后走 STR、搬开后不能再交；墓地候选测试补上已发现状态 |
| `tests/test_paper_chase_loader.py` | 钉住 3.0.9 与 `when` 条件 |
| `e2e/tests/content-catalog.e2e.ts` | 目录版本断言改为 3.0.9 |

## 关键决策

**为什么只改模组 `when`，不改引擎：**
`call_to_figure` 已经用 `trigger.when` 做状态门禁。候选发布和提交校验都走 `agent_match_admits`，同一条件两边求值。不需要新机制。

**为什么版本升到 3.0.9 而不是改 3.0.8：**
ModuleVersion 不可变。同 `(module_id, version)` 内容不同会直接拒绝加载。已开局房间继续钉在 3.0.8；新房间才吃到门禁。

**为什么不靠 Prompt 或删掉玩家说法：**
issue 明确禁止用隐藏语义、禁止猜测来代替确定性门禁。未发现时即使 Agent 提交 `move_crypt_slab / STR`，也以玩家安全的 `RULE_OUT_OF_SCOPE` 拒绝，不发起检定、不写 `slab_moved`。

**为什么不修 `check=none`：**
那是 #462。本 PR 只处理进入检定之前这条规则有没有资格成为候选并被提交。

## 验证

- 框架：`tests.test_projection_v3` + `tests.test_paper_chase_v3_fixture` 共 66 passed（含新的三态回归和地穴终局）
- 后端：`tests/test_paper_chase_loader.py` + `tests/test_builtin_module_loader.py` + `tests/test_module_content_cache.py` 共 24 passed
- 确定性覆盖：`discovered=false` 不在候选且提交 `RULE_OUT_OF_SCOPE`；`discovered=true && slab_moved=false` 发起 STR；成功后 `slab_moved=true` 且再提交不产生新状态事件

## 已知限制

- 已存在的 3.0.8 房间不会自动获得该门禁
- 真实模型不一定每次都点名 `move_crypt_slab`；产品验收不能只看「没弹出 STR」

## 不在本 PR 范围

- #462 `check=none` 静默成功
- #319 地穴进入、腐臭昏迷、SAN、对话与结局链
- #316 完整实体认知 / 跨地点感知
