### PR TITLE
fix: 修复守秘人与 NPC 的身份及回复顺序 (#479)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
@@ -91,9 +91,6 @@ class ActionPlanNarrator:
             raise ActionPlanNarrationValidationError(rejection)
         if output.npc_replies and _EMBEDDED_DIALOGUE_RE.search(output.text):
             raise ActionPlanNarrationValidationError("npc_dialogue_embedded_in_text")
-        if context.recipient_kind == "keeper" and output.npc_replies:
-            # 守秘人输出不能伪装成 NPC；NPC 台词必须走 dialogue.npc 事件。
-            raise ActionPlanNarrationValidationError("keeper_cannot_speak_as_npc")
         subject_rejection = narration_subject_rejection_reason(
             output.text,
             addressing_mode=getattr(context, "addressing_mode", "second_person"),

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_narrator.py
@@ -91,6 +91,9 @@ class ActionPlanNarrator:
             raise ActionPlanNarrationValidationError(rejection)
         if output.npc_replies and _EMBEDDED_DIALOGUE_RE.search(output.text):
             raise ActionPlanNarrationValidationError("npc_dialogue_embedded_in_text")
+        if context.recipient_kind == "keeper" and output.npc_replies:
+            # 守秘人输出不能伪装成 NPC；NPC 台词必须走 dialogue.npc 事件。
+            raise ActionPlanNarrationValidationError("keeper_cannot_speak_as_npc")
         subject_rejection = narration_subject_rejection_reason(
             output.text,
             addressing_mode=getattr(context, "addressing_mode", "second_person"),

--- a/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
+++ b/agent-collaboration-framework/collaboration_framework/host/schemas/action_plan.py
@@ -460,6 +460,9 @@ class ActionPlanNarrationContext(ContractModel):
     player_view: PlayerView
     addressing_mode: Literal["second_person", "named_actor"] = "second_person"
     acting_character_name: str = ""
+    # 执行身份用于区分守秘人叙事和 NPC 对话；默认值保持旧调用方兼容。
+    recipient_kind: Literal["keeper", "npc"] = "keeper"
+    execution_mode: Literal["dialogue_only", "rule_action"] = "rule_action"
     # 记忆是只读的玩家安全上下文；它不能替代当前 PlayerView 或提交事实。
     memories: tuple[MemoryEntry, ...] = ()
     conversation_summary: ConversationSummary | None = None

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -873,6 +873,24 @@ async def _run_queued_host_action(
             audience_actor_ids=audience_actor_ids,
             output=output,
         )
+        # 保持 SDK 对 submitPlannedAction 的完成通知兼容；真正可见的回复仍只来自 dialogue.npc。
+        connections = manager.player_connections(item.room_id, item.player_id)
+        websocket = connections[0] if connections else None
+        await _send_to_player(
+            websocket,
+            {
+                "protocol_version": "1",
+                "message_type": "turn.completed",
+                "correlation_id": item.client_action_id,
+                "payload": {
+                    "room_id": item.room_id,
+                    "player_id": item.player_id,
+                    "actor_id": item.actor_id,
+                    "narration": {"kind": "narration", "text": "NPC 对话已完成"},
+                    "player_view": view.to_json_dict(),
+                },
+            },
+        )
         for event_id in item.result_event_ids:
             event = await db.get(Event, event_id)
             if event is not None:

--- a/trpg-backend/app/controller/ws.py
+++ b/trpg-backend/app/controller/ws.py
@@ -818,7 +818,7 @@ async def _run_queued_host_action(
     item,
     view: PlayerView,
 ) -> None:
-    """队列项统一走 Host 主链；NPC 只是在输入里多了一个结构化说话对象。"""
+    """执行 NPC 直接对话；普通对话不得经过 Keeper Narrator 或 ActionPlan。"""
 
     claimed = await host_action_queue_service.claim_npc(
         db,
@@ -830,7 +830,7 @@ async def _run_queued_host_action(
     item = claimed
     try:
         require_dialogue_npc(view, item.recipient_entity_id or "")
-        audience_player_ids, _ = await _npc_dialogue_audience(
+        audience_player_ids, audience_actor_ids = await _npc_dialogue_audience(
             db,
             room_id=item.room_id,
             scene_id=view.scene.id,
@@ -842,31 +842,41 @@ async def _run_queued_host_action(
             return
         if await db.get(Player, item.player_id) is None:
             raise ValueError("玩家已不在房间中")
-        interlocutor_id = item.recipient_entity_id or None
-        interlocutor_name = None
-        if interlocutor_id is not None:
-            interlocutor_name = require_dialogue_npc(view, interlocutor_id).name
-        result = await action_plan_turn_application.start(
-            room_id=item.room_id,
-            player_id=item.player_id,
-            client_action_id=item.client_action_id,
-            utterance=item.utterance,
-            interlocutor_id=interlocutor_id,
-            interlocutor_name=interlocutor_name,
-            on_progress=None,
-            on_phase=None,
-            on_input_accepted=partial(_broadcast_action_utterance, db),
-        )
-        await host_action_queue_service.mark_started(db, item)
-        connections = manager.player_connections(item.room_id, item.player_id)
-        websocket = connections[0] if connections else None
-        await _send_action_plan_result(
+        player = await room_service.get_player(db, item.player_id)
+        player_event = await npc_dialogue_service.persist_player_event(
             db,
-            websocket,
-            item.room_id,
-            item.player_id,
-            result,
+            item=item,
+            view=view,
+            audience_player_ids=audience_player_ids,
+            nickname=player.nickname if player is not None else "玩家",
         )
+        await _broadcast_dialogue_event(db, player_event, audience_player_ids)
+        output = await npc_dialogue_service.generate_replies(
+            view=view,
+            player_id=item.player_id,
+            actor_id=item.actor_id,
+            interlocutor_id=item.recipient_entity_id or "",
+            utterance=item.utterance,
+        )
+        # 服务端再次确认 speaker，避免模型把场景外 NPC 注入公开事件。
+        allowed_ids = {npc.id for npc in visible_dialogue_npcs(view)}
+        if output.npc_messages[0].speaker_id != item.recipient_entity_id or any(
+            message.speaker_id not in allowed_ids for message in output.npc_messages
+        ):
+            raise ValueError("NPC 模型返回了无效说话者")
+        await npc_dialogue_service.persist_replies(
+            db,
+            item=item,
+            view=view,
+            player_event=player_event,
+            audience_player_ids=audience_player_ids,
+            audience_actor_ids=audience_actor_ids,
+            output=output,
+        )
+        for event_id in item.result_event_ids:
+            event = await db.get(Event, event_id)
+            if event is not None:
+                await _broadcast_dialogue_event(db, event, audience_player_ids)
     except ValueError as exc:
         await host_action_queue_service.mark_npc_failed(db, item)
         for target_socket in manager.player_connections(item.room_id, item.player_id):

--- a/trpg-backend/app/service/npc_dialogue.py
+++ b/trpg-backend/app/service/npc_dialogue.py
@@ -11,12 +11,18 @@ from pydantic import BaseModel, Field, ValidationError, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.adapters import (
+    DeepSeekChatCompletionsJsonClient,
+    OpenAIResponsesJsonClient,
+    QwenChatCompletionsJsonClient,
+)
 from app.adapters.openai_models import StructuredJsonClient
 from app.adapters.structured_http import StructuredOutputError
 from app.core.config import (
     Settings,
     get_settings,
     model_client_retry_policy,
+    secret_value,
 )
 from app.dto.ws import DialogueNpcPayload, DialoguePlayerPayload
 from app.models.content import ModuleAsset
@@ -178,6 +184,88 @@ class NpcDialogueService:
 
     def __init__(self, *, lease_seconds: int = 180) -> None:
         self.lease_seconds = max(180, lease_seconds)
+
+    async def generate_replies(
+        self,
+        *,
+        view: PlayerView,
+        player_id: str,
+        actor_id: str,
+        interlocutor_id: str,
+        utterance: str,
+        recent_dialogue: tuple[RecentDialogueItem, ...] = (),
+    ) -> NpcDialogueOutput:
+        """构造严格的玩家安全上下文并生成 NPC 回复；不暴露 Engine 或 Keeper 数据。"""
+
+        actor = view.self_actor
+        responders = tuple(
+            NpcPublicSnapshot(
+                id=npc.id,
+                name=npc.name,
+                aliases=tuple(getattr(npc, "aliases", ()) or ()),
+                description=npc.description or "",
+                observable_state=tuple(
+                    {"key": state.key, "value": state.value} for state in npc.observable_state
+                ),
+            )
+            for npc in visible_dialogue_npcs(view)
+        )
+        context = NpcDialogueContext(
+            room_id=view.room_id,
+            player_id=player_id,
+            actor_id=actor_id,
+            actor_name=actor.name,
+            scene_id=view.scene.id,
+            scene_name=view.scene.name,
+            scene_description=view.scene.description,
+            interlocutor_id=interlocutor_id,
+            allowed_responders=responders,
+            recent_dialogue=recent_dialogue,
+            utterance=utterance,
+        )
+        return await self._model().generate(context)
+
+    def _model(self) -> FakeNpcDialogueModel | PromptNpcDialogueModel:
+        """按统一 Host 配置选择 Fake 或真实结构化模型。"""
+
+        settings = get_settings()
+        if settings.host_model_provider == "fake":
+            return FakeNpcDialogueModel()
+        if settings.host_model_provider == "deepseek":
+            api_key, base_url, model, timeout = (
+                settings.deepseek_api_key,
+                settings.deepseek_base_url,
+                settings.deepseek_model,
+                settings.deepseek_timeout_seconds,
+            )
+            client_type = DeepSeekChatCompletionsJsonClient
+        elif settings.host_model_provider == "qwen":
+            api_key, base_url, model, timeout = (
+                settings.qwen_api_key,
+                settings.qwen_base_url,
+                settings.qwen_model,
+                settings.qwen_timeout_seconds,
+            )
+            client_type = QwenChatCompletionsJsonClient
+        else:
+            api_key, base_url, model, timeout = (
+                settings.openai_api_key,
+                settings.openai_base_url,
+                settings.openai_model,
+                settings.openai_timeout_seconds,
+            )
+            client_type = OpenAIResponsesJsonClient
+        if api_key is None:
+            raise ValueError("NPC Host 模型缺少 API key")
+        return PromptNpcDialogueModel(
+            client_type(
+                api_key=secret_value(api_key),
+                base_url=base_url,
+                model=model,
+                timeout_seconds=timeout,
+                retry_policy=model_client_retry_policy(settings),
+            )
+        )
 
     async def portrait_url(
         self,


### PR DESCRIPTION
Closes #479

## 改动
- 普通 @NPC 直接走结构化 dialogue.player/dialogue.npc，不再调用 Keeper ActionPlan/Narrator。
- NPC 模型上下文复用现有 Host provider，并由服务端校验 speaker_id 与可见 NPC。
- Narrator 契约增加 recipient_kind/execution_mode，Keeper 返回 npc_replies 时拒绝，避免身份伪装。

## 验证
- trpg-backend: tests/test_npc_dialogue.py 7 passed
- trpg-backend: tests/test_ws.py 26 passed
- agent-collaboration-framework: tests/test_narrator_policy.py 30 passed

规则型 NPC 行为和混合输入仍需后续增量完善；本 PR 优先修复普通 NPC 对话身份与顺序。