### PR TITLE
feat(rule-engine): 建立 CoC7 适配层与 Actor 条件能力 (#485)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/engine/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/__init__.py
@@ -1,6 +1,6 @@
 """Deterministic game-rule execution boundary."""
 
-# ruff: noqa: F401 -- this module intentionally re-exports the public engine API.
+
 
 from .adapters import InMemoryEngineStore
 from .adjudication import AdjudicationEngineService
@@ -9,8 +9,39 @@ from .capabilities import (
     audit_runtime_capabilities,
     require_runtime_capabilities,
 )
+from .conditions import (
+    ConditionMutation,
+    active_conditions,
+    apply_condition,
+    consume_condition,
+    has_active_condition,
+    remove_condition,
+)
 from .dice import DiceRoller, SequenceDiceSource, SystemDiceSource
 from .initialization import create_initial_game_state
+from .models import (
+    ActorCondition,
+    ActorResources,
+    ActorState,
+    AgendaItem,
+    AgendaSource,
+    CheckRun,
+    CompletedAction,
+    CompletedAdjudicationCommand,
+    ConditionExpiry,
+    DomainEvent,
+    EngineExecutionResult,
+    EngineRuntimeSnapshot,
+    GameState,
+    LocationKnowledge,
+    PendingCheckDecision,
+    RuleAgenda,
+    RuntimeTimeTask,
+    StateModifiedEvent,
+    TimePointOccurrence,
+    WorldTimePoint,
+    WorldTimeState,
+)
 from .navigation import effective_location_knowledge, resolve_location_target
 from .persistent_results import (
     CHARACTER_STATE_VALUES,
@@ -19,42 +50,24 @@ from .persistent_results import (
     committed_results_from_events,
     validate_persistent_effects,
 )
-from .models import (
-    AgendaItem,
-    AgendaSource,
-    ActorResources,
-    ActorState,
-    LocationKnowledge,
-    CheckRun,
-    WorldTimePoint,
-    WorldTimeState,
-    CompletedAction,
-    CompletedAdjudicationCommand,
-    DomainEvent,
-    EngineExecutionResult,
-    EngineRuntimeSnapshot,
-    GameState,
-    PendingCheckDecision,
-    RuleAgenda,
-    RuntimeTimeTask,
-    StateModifiedEvent,
-    TimePointOccurrence,
-)
 from .ports import EngineStore, EngineTransaction, RevisionConflictError
 from .service import RuleEngineService
 
 __all__ = [
-    "AgendaItem",
-    "AgendaSource",
-    "CompletedAction",
-    "CompletedAdjudicationCommand",
+    "CHARACTER_STATE_VALUES",
+    "OBJECT_STATE_VALUES",
+    "PUBLIC_STATE_KEYS",
+    "ActorCondition",
     "ActorResources",
     "ActorState",
-    "LocationKnowledge",
     "AdjudicationEngineService",
-    "WorldTimePoint",
-    "WorldTimeState",
+    "AgendaItem",
+    "AgendaSource",
     "CheckRun",
+    "CompletedAction",
+    "CompletedAdjudicationCommand",
+    "ConditionExpiry",
+    "ConditionMutation",
     "DiceRoller",
     "DomainEvent",
     "EngineExecutionResult",
@@ -63,24 +76,29 @@ __all__ = [
     "EngineTransaction",
     "GameState",
     "InMemoryEngineStore",
+    "LocationKnowledge",
     "PendingCheckDecision",
-    "RuleAgenda",
-    "RuntimeTimeTask",
     "RevisionConflictError",
-    "RuntimeCapabilityIssue",
+    "RuleAgenda",
     "RuleEngineService",
+    "RuntimeCapabilityIssue",
+    "RuntimeTimeTask",
     "SequenceDiceSource",
     "StateModifiedEvent",
-    "TimePointOccurrence",
     "SystemDiceSource",
+    "TimePointOccurrence",
+    "WorldTimePoint",
+    "WorldTimeState",
+    "active_conditions",
+    "apply_condition",
     "audit_runtime_capabilities",
+    "committed_results_from_events",
+    "consume_condition",
     "create_initial_game_state",
     "effective_location_knowledge",
+    "has_active_condition",
+    "remove_condition",
     "require_runtime_capabilities",
     "resolve_location_target",
-    "CHARACTER_STATE_VALUES",
-    "OBJECT_STATE_VALUES",
-    "PUBLIC_STATE_KEYS",
-    "committed_results_from_events",
     "validate_persistent_effects",
 ]

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from typing import Literal, NoReturn
 from uuid import uuid4
 
-from pydantic import JsonValue
+from pydantic import JsonValue, TypeAdapter
 
 from collaboration_framework.contracts import (
     AcceptResultOption,
@@ -23,12 +23,15 @@ from collaboration_framework.contracts import (
     AdjudicationRecovery,
     AdjudicationStatusView,
     AdvanceWorldTimeEffect,
+    CancelTimeTaskStep,
     CheckDecisionRequest,
     CheckRunView,
     CheckStep,
     ContractError,
+    CreateTimeTaskStep,
     EnterLocationEffect,
     GetAdjudicationStatusRequest,
+    InvokeRulesetActionStep,
     NarrationEvidence,
     PendingCheckOption,
     PostRollDecisionRequest,
@@ -142,6 +145,32 @@ class _SettlementRunner:
             state,
             effect,
             room_id=self._room_id,
+            request_id=self._request_id,
+            actor_id=self._actor_id,
+            offset=offset,
+        )
+
+    def validate_ruleset_action(
+        self,
+        runtime: EngineRuntimeSnapshot,
+        step: InvokeRulesetActionStep,
+    ) -> None:
+        self._service._validate_ruleset_action(runtime, step)
+
+    def apply_ruleset_action(
+        self,
+        runtime: EngineRuntimeSnapshot,
+        state: GameState,
+        step: InvokeRulesetActionStep,
+        *,
+        rule_id: str,
+        offset: int,
+    ) -> tuple[GameState, tuple[DomainEvent, ...]]:
+        return self._service._apply_ruleset_action(
+            runtime,
+            state,
+            step,
+            rule_id=rule_id,
             request_id=self._request_id,
             actor_id=self._actor_id,
             offset=offset,
@@ -718,6 +747,7 @@ class AdjudicationEngineService:
                     passed=True,
                     player_id=request.player_id,
                     prefix_events=(),
+                    allow_party_time_advance=allow_party_time_advance,
                     allow_party_scene_transition=allow_party_scene_transition,
                 )
                 new_state, events = final.state, final.events
@@ -1814,7 +1844,7 @@ class AdjudicationEngineService:
         adjudication: ActionAdjudication,
         passed: bool,
         check_run: CheckRun | None,
-    ) -> tuple[ActionEffect, ...]:
+    ) -> tuple[object, ...]:
         """Whose effects commit: the rule's if one owns this action, else the Agent's.
 
         #226 §5 gives a named rule `effect_authority: rule` — the Agent chose the
@@ -1877,6 +1907,7 @@ class AdjudicationEngineService:
         player_id: str,
         prefix_events: tuple[DomainEvent, ...],
         check_run: CheckRun | None = None,
+        allow_party_time_advance: bool = False,
         allow_party_scene_transition: bool = False,
     ) -> ActionFinalization:
         """Commit this action's effects and settle the Rules they triggered.
@@ -1931,6 +1962,8 @@ class AdjudicationEngineService:
             adjudication=adjudication,
             player_id=player_id,
             result=None,
+            allow_party_time_advance=allow_party_time_advance,
+            allow_party_scene_transition=allow_party_scene_transition,
         )
 
     def _settle_check(
@@ -2074,6 +2107,8 @@ class AdjudicationEngineService:
         adjudication: ActionAdjudication,
         player_id: str,
         result: SettlementResult | None,
+        allow_party_time_advance: bool = False,
+        allow_party_scene_transition: bool = False,
     ) -> ActionFinalization:
         """跑完父动作还欠的那部分，再把 Agenda 封存。
 
@@ -2093,6 +2128,8 @@ class AdjudicationEngineService:
                 runtime=runtime,
                 request_id=request_id,
                 actor_id=actor_id,
+                allow_party_time_advance=allow_party_time_advance,
+                allow_party_scene_transition=allow_party_scene_transition,
             )
         if not result.blocked and not completion_emitted:
             state, result = self._complete_parent_action(
@@ -2366,12 +2403,14 @@ class AdjudicationEngineService:
         settlement: RuleSettlement,
         state: GameState,
         events: list[DomainEvent],
-        effects: tuple[ActionEffect, ...],
+        effects: tuple[object, ...],
         *,
         runtime: EngineRuntimeSnapshot,
         request_id: str,
         actor_id: str,
-    ) -> tuple[GameState, SettlementResult, tuple[ActionEffect, ...]]:
+        allow_party_time_advance: bool = False,
+        allow_party_scene_transition: bool = False,
+    ) -> tuple[GameState, SettlementResult, tuple[object, ...]]:
         """执行一个效果 → 提交它的事件 → 立即结算该事件的规则 → 再下一个。
 
         返回停下时的 state、最后一次结算结果，以及**还没执行**的效果。
@@ -2380,6 +2419,14 @@ class AdjudicationEngineService:
         是规则输入，它们的规则也必须在第一个效果之前就位。
         """
 
+        effects = tuple(self._coerce_rule_operation(item) for item in effects)
+        self._validate_mixed_rule_operations(
+            runtime,
+            effects,
+            actor_id=actor_id,
+            allow_party_time_advance=allow_party_time_advance,
+            allow_party_scene_transition=allow_party_scene_transition,
+        )
         result = settlement.advance(state, events)
         if result.blocked:
             return result.state, result, effects
@@ -2400,6 +2447,52 @@ class AdjudicationEngineService:
             if result.blocked:
                 return state, result, effects[index + 1 :]
         return state, result, ()
+
+    @staticmethod
+    def _coerce_rule_operation(item: object) -> object:
+        """Restore typed operations after an Agenda JSON round-trip."""
+
+        if not isinstance(item, dict):
+            return item
+        kind = item.get("kind")
+        if kind == "invoke_ruleset_action":
+            return InvokeRulesetActionStep.model_validate(item)
+        if kind == "create_time_task":
+            return CreateTimeTaskStep.model_validate(item)
+        if kind == "cancel_time_task":
+            return CancelTimeTaskStep.model_validate(item)
+        if "type" in item:
+            return TypeAdapter(ActionEffect).validate_python(item)
+        return item
+
+    def _validate_mixed_rule_operations(
+        self,
+        runtime: EngineRuntimeSnapshot,
+        effects: tuple[object, ...],
+        *,
+        actor_id: str,
+        allow_party_time_advance: bool = False,
+        allow_party_scene_transition: bool = False,
+    ) -> None:
+        """Preflight a mixed rule walk before its first state mutation."""
+
+        ordinary = tuple(
+            item
+            for item in effects
+            if not isinstance(item, (InvokeRulesetActionStep, CreateTimeTaskStep, CancelTimeTaskStep))
+        )
+        if ordinary:
+            self._validate_effect_sequence(
+                runtime,
+                ordinary,
+                allow_party_time_advance=allow_party_time_advance,
+                allow_party_scene_transition=allow_party_scene_transition,
+            )
+        for item in effects:
+            if isinstance(item, InvokeRulesetActionStep):
+                self._validate_ruleset_action(
+                    runtime, item, rule_id="rule_walk", actor_id=actor_id
+                )
 
     def _complete_parent_action(
         self,
@@ -2461,7 +2554,7 @@ class AdjudicationEngineService:
         self,
         state: GameState,
         events: list[DomainEvent],
-        effects: tuple[ActionEffect, ...],
+        effects: tuple[object, ...],
         *,
         runtime: EngineRuntimeSnapshot,
         request_id: str,
@@ -2513,7 +2606,7 @@ class AdjudicationEngineService:
         self,
         runtime: EngineRuntimeSnapshot,
         state: GameState,
-        effect: ActionEffect,
+        effect: ActionEffect | InvokeRulesetActionStep,
         *,
         room_id: str,
         request_id: str,
@@ -2529,6 +2622,16 @@ class AdjudicationEngineService:
         recording one.
         """
 
+        if isinstance(effect, InvokeRulesetActionStep):
+            return self._apply_ruleset_action(
+                runtime,
+                state,
+                effect,
+                rule_id="parent_action",
+                request_id=request_id,
+                actor_id=actor_id,
+                offset=offset,
+            )
         result = effect_registry.apply(
             effect,
             effect_registry.ApplyContext(
@@ -2571,6 +2674,116 @@ class AdjudicationEngineService:
                 )
             )
         return result.state, tuple(emitted)
+
+    @staticmethod
+    def _ruleset_operation_key(
+        runtime: EngineRuntimeSnapshot,
+        step: InvokeRulesetActionStep,
+        *,
+        rule_id: str,
+        actor_id: str,
+    ) -> str:
+        return f"{runtime.module_content.world_ref}:{rule_id}:{step.id}:{actor_id}"
+
+    def _validate_ruleset_action(
+        self,
+        runtime: EngineRuntimeSnapshot,
+        step: InvokeRulesetActionStep,
+        *,
+        rule_id: str = "validation",
+        actor_id: str | None = None,
+    ) -> None:
+        """Check a registered action and its parameters without committing it."""
+
+        action = ruleset_registry.world_action_for(
+            runtime.module_content.world_ref, step.action_id
+        )
+        if action is None or not callable(action):
+            self._reject_validation(
+                "RULESET_ACTION_NOT_REGISTERED",
+                repairability="hard_reject",
+                fault="engine",
+                player_safe_reason="规则引擎无法处理当前规则动作",
+                internal_reason=(
+                    f"{step.action_id!r} is not registered for "
+                    f"world_ref={runtime.module_content.world_ref!r}"
+                ),
+                classification_coverage="rule_effects_excluded",
+            )
+        bound_actor_id = actor_id or next(iter(runtime.game_state.actors), "")
+        context = ruleset_registry.RulesetActionContext(
+            state=runtime.game_state,
+            actor_id=bound_actor_id,
+            actor_binding=step.actor_binding,
+            parameters=step.parameters,
+            request_id="validation",
+            operation_key=self._ruleset_operation_key(
+                runtime, step, rule_id=rule_id, actor_id=bound_actor_id
+            ),
+        )
+        try:
+            action(context)
+        except ruleset_registry.RulesetActionError as exc:
+            self._reject_validation(
+                exc.code,
+                repairability="auto_repairable",
+                fault="engine",
+                player_safe_reason="规则动作参数或目标无效",
+                internal_reason=str(exc),
+                classification_coverage="rule_effects_excluded",
+            )
+        except (ValueError, TypeError) as exc:
+            self._reject_validation(
+                "RULESET_ACTION_INVALID_PARAMETERS",
+                repairability="auto_repairable",
+                fault="engine",
+                player_safe_reason="规则动作参数无效",
+                internal_reason=str(exc),
+                classification_coverage="rule_effects_excluded",
+            )
+
+    def _apply_ruleset_action(
+        self,
+        runtime: EngineRuntimeSnapshot,
+        state: GameState,
+        step: InvokeRulesetActionStep,
+        *,
+        rule_id: str,
+        request_id: str,
+        actor_id: str,
+        offset: int,
+    ) -> tuple[GameState, tuple[DomainEvent, ...]]:
+        self._validate_ruleset_action(
+            runtime, step, rule_id=rule_id, actor_id=actor_id
+        )
+        action = ruleset_registry.require_world_action(
+            runtime.module_content.world_ref, step.action_id
+        )
+        result = action(
+            ruleset_registry.RulesetActionContext(
+                state=state,
+                actor_id=actor_id,
+                actor_binding=step.actor_binding,
+                parameters=step.parameters,
+                request_id=request_id,
+                operation_key=self._ruleset_operation_key(
+                    runtime, step, rule_id=rule_id, actor_id=actor_id
+                ),
+            )
+        )
+        if result.event_type is None:
+            return result.state, ()
+        return result.state, (
+            self._event_from_state(
+                result.state,
+                room_id=runtime.game_state.room_id,
+                offset=offset,
+                request_id=request_id,
+                actor_id=actor_id,
+                event_type=result.event_type,
+                payload=result.payload,
+            ),
+        )
 
     @staticmethod
     def _run_view(check_run: CheckRun):

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -46,8 +46,8 @@ from collaboration_framework.contracts.validation import (
     Repairability,
     ValidationResult,
 )
-from collaboration_framework.registry import check_profiles as check_profile_registry
 from collaboration_framework.registry import effects as effect_registry
+from collaboration_framework.registry import rulesets as ruleset_registry
 
 from .agenda_execution import RuleSettlement, SettlementResult
 from .dice import DiceRoller, coc7_success_level, passes_difficulty
@@ -2274,7 +2274,12 @@ class AdjudicationEngineService:
             settlement.fail("rule_check_actor_binding_unsupported")
             return None
 
-        option = self._passive_check_option(state, adjudication.actor_id, step)
+        option = self._passive_check_option(
+            state,
+            adjudication.actor_id,
+            step,
+            world_ref=runtime.module_content.world_ref,
+        )
         if option is None:
             # 停在一个引擎读不出目标值的检定上。此前这类情况会静默挂着；现在
             # 它和其他「引擎做不到」一样显式失败并留痕（#398 §阶段一）。
@@ -2325,6 +2330,8 @@ class AdjudicationEngineService:
         state: GameState,
         actor_id: str,
         step: CheckStep,
+        *,
+        world_ref: str,
     ) -> PendingCheckOption | None:
         """规则自己指定技能，所以菜单只有一条。
 
@@ -2332,7 +2339,10 @@ class AdjudicationEngineService:
         此之前这两个字段除契约、测试与 build 脚本外零消费者。
         """
 
-        profile = check_profile_registry.registration_for(step.check.profile_id)
+        profile = ruleset_registry.check_profile_for(
+            world_ref,
+            step.check.profile_id,
+        )
         if profile is None:
             return None
         actor = state.actors.get(actor_id)

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -82,7 +82,12 @@ from .rules_v3 import (
     resolve_rule_option,
     walk_rule,
 )
-from .time_tasks import active_occurrences, settle_due_tasks
+from .time_tasks import (
+    active_occurrences,
+    cancel_time_task,
+    create_time_task,
+    settle_due_tasks,
+)
 from .timeline import advanced_to_next, next_point_after, time_advance_block_reason
 
 logger = logging.getLogger(__name__)
@@ -2474,25 +2479,96 @@ class AdjudicationEngineService:
         allow_party_time_advance: bool = False,
         allow_party_scene_transition: bool = False,
     ) -> None:
-        """Preflight a mixed rule walk before its first state mutation."""
+        """Preflight a mixed operation stream without losing author order.
 
-        ordinary = tuple(
-            item
-            for item in effects
-            if not isinstance(item, (InvokeRulesetActionStep, CreateTimeTaskStep, CancelTimeTaskStep))
-        )
-        if ordinary:
+        Time-task operations change the occurrence vocabulary used by a later
+        ``advance_world_time`` effect. Validate each contiguous ordinary batch
+        against a simulated state, then fold the operation's state write into
+        that simulation before looking at the next batch.
+        """
+
+        simulated_state = runtime.game_state.model_copy(deep=True)
+        ordinary: list[ActionEffect] = []
+
+        def flush_ordinary() -> None:
+            nonlocal simulated_state
+            if not ordinary:
+                return
+            batch_runtime = runtime.model_copy(
+                update={"game_state": simulated_state}, deep=True
+            )
             self._validate_effect_sequence(
-                runtime,
-                ordinary,
+                batch_runtime,
+                tuple(ordinary),
                 allow_party_time_advance=allow_party_time_advance,
                 allow_party_scene_transition=allow_party_scene_transition,
             )
-        for item in effects:
-            if isinstance(item, InvokeRulesetActionStep):
-                self._validate_ruleset_action(
-                    runtime, item, rule_id="rule_walk", actor_id=actor_id
+            for effect in ordinary:
+                result = effect_registry.apply(
+                    effect,
+                    effect_registry.ApplyContext(
+                        runtime=batch_runtime.model_copy(
+                            update={"game_state": simulated_state}, deep=True
+                        ),
+                        state=simulated_state,
+                        services=_EFFECT_SERVICES,
+                        room_id=simulated_state.room_id,
+                        request_id="validation",
+                        actor_id=actor_id,
+                        offset=1,
+                    ),
                 )
+                simulated_state = result.state
+            ordinary.clear()
+
+        for item in effects:
+            if isinstance(item, (CreateTimeTaskStep, CancelTimeTaskStep)):
+                flush_ordinary()
+                if isinstance(item, CreateTimeTaskStep):
+                    simulated_state, _, _ = create_time_task(
+                        runtime.module_content,
+                        simulated_state,
+                        item,
+                        rule_id="parent_action",
+                    )
+                else:
+                    simulated_state, _ = cancel_time_task(
+                        simulated_state,
+                        item,
+                        rule_id="parent_action",
+                    )
+                continue
+            if isinstance(item, InvokeRulesetActionStep):
+                flush_ordinary()
+                action_runtime = runtime.model_copy(
+                    update={"game_state": simulated_state}, deep=True
+                )
+                self._validate_ruleset_action(
+                    action_runtime, item, rule_id="parent_action", actor_id=actor_id
+                )
+                action = ruleset_registry.require_world_action(
+                    action_runtime.module_content.world_ref, item.action_id
+                )
+                simulated_state = action(
+                    ruleset_registry.RulesetActionContext(
+                        state=simulated_state,
+                        actor_id=actor_id,
+                        actor_binding=item.actor_binding,
+                        parameters=item.parameters,
+                        request_id="validation",
+                        operation_key=self._ruleset_operation_key(
+                            action_runtime,
+                            item,
+                            rule_id="parent_action",
+                            actor_id=actor_id,
+                        ),
+                    )
+                ).state
+                continue
+            # The remaining values are the discriminated ``ActionEffect``
+            # variants restored from the parent continuation.
+            ordinary.append(item)  # type: ignore[arg-type]
+        flush_ordinary()
 
     def _complete_parent_action(
         self,
@@ -2606,7 +2682,12 @@ class AdjudicationEngineService:
         self,
         runtime: EngineRuntimeSnapshot,
         state: GameState,
-        effect: ActionEffect | InvokeRulesetActionStep,
+        effect: (
+            ActionEffect
+            | InvokeRulesetActionStep
+            | CreateTimeTaskStep
+            | CancelTimeTaskStep
+        ),
         *,
         room_id: str,
         request_id: str,
@@ -2628,6 +2709,15 @@ class AdjudicationEngineService:
                 state,
                 effect,
                 rule_id="parent_action",
+                request_id=request_id,
+                actor_id=actor_id,
+                offset=offset,
+            )
+        if isinstance(effect, (CreateTimeTaskStep, CancelTimeTaskStep)):
+            return self._apply_time_task_step(
+                runtime,
+                state,
+                effect,
                 request_id=request_id,
                 actor_id=actor_id,
                 offset=offset,
@@ -2674,6 +2764,52 @@ class AdjudicationEngineService:
                 )
             )
         return result.state, tuple(emitted)
+
+    def _apply_time_task_step(
+        self,
+        runtime: EngineRuntimeSnapshot,
+        state: GameState,
+        step: CreateTimeTaskStep | CancelTimeTaskStep,
+        *,
+        request_id: str,
+        actor_id: str,
+        offset: int,
+    ) -> tuple[GameState, tuple[DomainEvent, ...]]:
+        """Execute a recovered time-task operation in the parent barrier."""
+
+        if isinstance(step, CreateTimeTaskStep):
+            state, task, occurrence = create_time_task(
+                runtime.module_content, state, step, rule_id="parent_action"
+            )
+            event_type = "time.task_scheduled"
+            payload = {
+                "task_id": task.task_id,
+                "task_key": task.task_key,
+                "rule_id": task.rule_id,
+                "occurrence_id": task.occurrence_id,
+                "created_occurrence": occurrence is not None,
+            }
+        else:
+            state, cancelled = cancel_time_task(state, step, rule_id="parent_action")
+            event_type = "time.task_cancelled"
+            payload = {
+                "task_key": step.task_key,
+                "rule_id": "parent_action",
+                "reason_code": step.reason_code,
+                "cancelled": cancelled is not None,
+            }
+        return state, (
+            self._event_from_state(
+                state,
+                room_id=runtime.game_state.room_id,
+                offset=offset,
+                request_id=request_id,
+                actor_id=actor_id,
+                event_type=event_type,
+                payload=payload,
+                visibility="hidden",
+            ),
+        )
 
     @staticmethod
     def _ruleset_operation_key(

--- a/agent-collaboration-framework/collaboration_framework/engine/agenda_execution.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/agenda_execution.py
@@ -27,9 +27,11 @@ from collaboration_framework.contracts import (
     ActionEffect,
     CancelTimeTaskStep,
     CreateTimeTaskStep,
+    InvokeRulesetActionStep,
     ModuleContentV3,
     RuleSpecV3,
 )
+from collaboration_framework.contracts.validation import AdjudicationValidationError
 
 from .models import (
     AgendaItem,
@@ -55,16 +57,16 @@ def _is_time_task_step(item: object) -> bool:
     return isinstance(item, CreateTimeTaskStep | CancelTimeTaskStep)
 
 
-def _ordered_chunks(effects: list[ActionEffect]) -> list[object]:
+def _ordered_chunks(effects: list[object]) -> list[object]:
     """把有序列表切成「连续效果批」与「单个任务步骤」交替的序列。
 
     保住作者顺序的同时，让每一批效果都对着它真正会被应用时的那个状态校验。
     """
 
     chunks: list[object] = []
-    run: list[ActionEffect] = []
+    run: list[object] = []
     for item in effects:
-        if _is_time_task_step(item):
+        if _is_time_task_step(item) or isinstance(item, InvokeRulesetActionStep):
             if run:
                 chunks.append(run)
                 run = []
@@ -121,6 +123,22 @@ class EffectRunner(Protocol):
         payload: dict,
         visibility: str,
     ) -> DomainEvent: ...
+
+    def validate_ruleset_action(
+        self,
+        runtime: EngineRuntimeSnapshot,
+        step: InvokeRulesetActionStep,
+    ) -> None: ...
+
+    def apply_ruleset_action(
+        self,
+        runtime: EngineRuntimeSnapshot,
+        state: GameState,
+        step: InvokeRulesetActionStep,
+        *,
+        rule_id: str,
+        offset: int,
+    ) -> tuple[GameState, tuple[DomainEvent, ...]]: ...
 
 
 @dataclass(frozen=True)
@@ -379,7 +397,29 @@ class RuleSettlement:
                 visibility="hidden",
             )
         )
-        state = self.commit_effects(state, walk.effects, events, rule_id=rule.id)
+        try:
+            state = self.commit_effects(state, walk.effects, events, rule_id=rule.id)
+        except AdjudicationValidationError as exc:
+            failed_step_id = next(
+                (
+                    item.id
+                    for item in walk.effects
+                    if isinstance(item, InvokeRulesetActionStep)
+                ),
+                walk.suspended_at,
+            )
+            self._set_item(item_index, "failed")
+            self.agenda = self.agenda.model_copy(
+                update={
+                    "status": "failed",
+                    "failure_code": exc.result.code,
+                    "current_rule_id": rule.id,
+                    "current_branch_id": self.queue[item_index].branch_id,
+                    "current_step_id": failed_step_id,
+                }
+            )
+            self.suspended = True
+            return state, False
 
         status = agenda_status_for_walk(rule, walk)
         if status == "stable":
@@ -435,7 +475,21 @@ class RuleSettlement:
             )
             return self._result(state)
         self.agenda = self.agenda.model_copy(update={"step_count": next_step_count})
-        state = self.commit_effects(state, walk.effects, events, rule_id=rule.id)
+        try:
+            state = self.commit_effects(state, walk.effects, events, rule_id=rule.id)
+        except AdjudicationValidationError as exc:
+            self._set_item(item_index, "failed")
+            self.agenda = self.agenda.model_copy(
+                update={
+                    "status": "failed",
+                    "failure_code": exc.result.code,
+                    "current_rule_id": rule.id,
+                    "current_branch_id": self.queue[item_index].branch_id,
+                    "current_step_id": resume_step_id,
+                }
+            )
+            self.suspended = True
+            return self._result(state)
 
         status = agenda_status_for_walk(rule, walk)
         if status == "stable":
@@ -499,7 +553,7 @@ class RuleSettlement:
     def commit_effects(
         self,
         state: GameState,
-        effects: list[ActionEffect],
+        effects: list[object],
         events: list[DomainEvent],
         *,
         rule_id: str,
@@ -514,9 +568,24 @@ class RuleSettlement:
         # 一段连续的效果仍然整批校验，因为校验会在效果之间累积 vocabulary
         # （比如连续两次 advance_world_time 要各自对着前一跳的时钟校验）。
         # 任务步骤是这些批次的分界。
+        # Validate every ruleset operation before the first ordinary effect is
+        # applied. An unknown action must not leave an earlier effect committed.
+        for item in effects:
+            if isinstance(item, InvokeRulesetActionStep):
+                self.runner.validate_ruleset_action(self.runtime, item)
         for chunk in _ordered_chunks(effects):
             if _is_time_task_step(chunk):
                 state = self._commit_time_task(state, chunk, events, rule_id=rule_id)
+                continue
+            if isinstance(chunk, InvokeRulesetActionStep):
+                state, emitted = self.runner.apply_ruleset_action(
+                    self.runtime,
+                    state,
+                    chunk,
+                    rule_id=rule_id,
+                    offset=len(events) + 1,
+                )
+                events.extend(emitted)
                 continue
             rule_runtime = self.runtime.model_copy(
                 update={"game_state": state}, deep=True

--- a/agent-collaboration-framework/collaboration_framework/engine/capabilities.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/capabilities.py
@@ -9,9 +9,11 @@ from collaboration_framework.contracts import (
     ContractModel,
     ModuleContentV3,
 )
+from collaboration_framework.registry import rulesets as ruleset_registry
+
+SUPPORTED_WORLD_REFS = ruleset_registry.DEFAULT_RULESET_REGISTRY.world_refs
 
 
-SUPPORTED_WORLD_REFS = frozenset({"coc-7e"})
 class RuntimeCapabilityIssue(ContractModel):
     owner: str = Field(min_length=1)
     capability: str = Field(min_length=1)
@@ -34,7 +36,7 @@ def audit_runtime_capabilities(
     check here at load time is the world ruleset.
     """
 
-    if module_content.world_ref in SUPPORTED_WORLD_REFS:
+    if ruleset_registry.is_registered(module_content.world_ref):
         return ()
     return (
         RuntimeCapabilityIssue(

--- a/agent-collaboration-framework/collaboration_framework/engine/conditions.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/conditions.py
@@ -1,0 +1,174 @@
+"""Pure Actor condition lifecycle operations (#485).
+
+Conditions are authoritative state, while ``ActorState.conditions`` remains a
+small player-safe projection for compatibility with existing rooms and views.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import ActorCondition, ConditionExpiry, GameState
+
+
+@dataclass(frozen=True)
+class ConditionMutation:
+    state: GameState
+    condition: ActorCondition | None
+    changed: bool
+
+
+def active_conditions(state: GameState, actor_id: str) -> tuple[ActorCondition, ...]:
+    actor = state.actors.get(actor_id)
+    if actor is None:
+        return ()
+    return tuple(item for item in actor.condition_states if item.status == "active")
+
+
+def has_active_condition(state: GameState, actor_id: str, condition_id: str) -> bool:
+    return any(item.condition_id == condition_id for item in active_conditions(state, actor_id))
+
+
+def apply_condition(
+    state: GameState,
+    *,
+    actor_id: str,
+    condition_id: str,
+    source: str,
+    application_reason: str,
+    application_key: str,
+    expiry: ConditionExpiry | None = None,
+    applied_event_id: str | None = None,
+) -> ConditionMutation:
+    """Apply once by stable key (and avoid duplicate active condition ids)."""
+
+    actor = state.actors.get(actor_id)
+    if actor is None:
+        raise ValueError(f"unknown actor: {actor_id}")
+    for existing in actor.condition_states:
+        if existing.application_key == application_key:
+            return ConditionMutation(state=state, condition=existing, changed=False)
+    for existing in actor.condition_states:
+        if existing.condition_id == condition_id and existing.status == "active":
+            return ConditionMutation(state=state, condition=existing, changed=False)
+    record = ActorCondition(
+        condition_id=condition_id,
+        source=source,
+        application_reason=application_reason,
+        application_key=application_key,
+        expiry=expiry,
+        applied_event_id=applied_event_id,
+    )
+    records = (*actor.condition_states, record)
+    actors = dict(state.actors)
+    actors[actor_id] = actor.model_copy(
+        update={
+            "condition_states": records,
+            "conditions": tuple(
+                dict.fromkeys(
+                    item.condition_id for item in records if item.status == "active"
+                )
+            ),
+        }
+    )
+    return ConditionMutation(
+        state=state.model_copy(update={"actors": actors}, deep=True),
+        condition=record,
+        changed=True,
+    )
+
+
+def _finish_condition(
+    state: GameState,
+    *,
+    actor_id: str,
+    condition_id: str,
+    status: str,
+    reason: str,
+    event_id: str | None,
+) -> ConditionMutation:
+    actor = state.actors.get(actor_id)
+    if actor is None:
+        raise ValueError(f"unknown actor: {actor_id}")
+    index = next(
+        (
+            index
+            for index, item in enumerate(actor.condition_states)
+            if item.condition_id == condition_id and item.status == "active"
+        ),
+        None,
+    )
+    if index is None:
+        return ConditionMutation(state=state, condition=None, changed=False)
+    existing = actor.condition_states[index]
+    record = existing.model_copy(
+        update={
+            "status": status,
+            "removal_reason": reason,
+            "removal_event_id": event_id,
+        }
+    )
+    records = list(actor.condition_states)
+    records[index] = record
+    actors = dict(state.actors)
+    actors[actor_id] = actor.model_copy(
+        update={
+            "condition_states": tuple(records),
+            "conditions": tuple(
+                dict.fromkeys(
+                    item.condition_id for item in records if item.status == "active"
+                )
+            ),
+        }
+    )
+    return ConditionMutation(
+        state=state.model_copy(update={"actors": actors}, deep=True),
+        condition=record,
+        changed=True,
+    )
+
+
+def remove_condition(
+    state: GameState,
+    *,
+    actor_id: str,
+    condition_id: str,
+    reason: str,
+    event_id: str | None = None,
+) -> ConditionMutation:
+    return _finish_condition(
+        state,
+        actor_id=actor_id,
+        condition_id=condition_id,
+        status="removed",
+        reason=reason,
+        event_id=event_id,
+    )
+
+
+def consume_condition(
+    state: GameState,
+    *,
+    actor_id: str,
+    condition_id: str,
+    reason: str,
+    event_id: str | None = None,
+) -> ConditionMutation:
+    return _finish_condition(
+        state,
+        actor_id=actor_id,
+        condition_id=condition_id,
+        status="consumed",
+        reason=reason,
+        event_id=event_id,
+    )
+
+
+__all__ = [
+    "ConditionMutation",
+    "active_conditions",
+    "apply_condition",
+    "consume_condition",
+    "has_active_condition",
+    "remove_condition",
+]

--- a/agent-collaboration-framework/collaboration_framework/engine/models.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/models.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Literal
 
-from pydantic import Field, JsonValue
+from pydantic import Field, JsonValue, model_validator
 
 from collaboration_framework.contracts import (
     ActionAdjudication,
-    ActionEffect,
     ActionRequest,
     ActionResult,
     AdjudicationExecution,
@@ -45,6 +44,31 @@ class ActorResources(ContractModel):
     mythos: int = Field(default=0, ge=0)
 
 
+class ConditionExpiry(ContractModel):
+    """Structured lifecycle target for an expiring Actor condition.
+
+    The reference points at an authored time point or a durable TimeTask; the
+    engine never infers expiry by parsing a condition id.
+    """
+
+    kind: Literal["time_point", "time_task"]
+    reference_id: str = Field(min_length=1)
+
+
+class ActorCondition(ContractModel):
+    """Auditable, authoritative lifecycle record for one applied condition."""
+
+    condition_id: str = Field(min_length=1)
+    source: str = Field(min_length=1)
+    application_reason: str = Field(min_length=1)
+    application_key: str = Field(min_length=1)
+    status: Literal["active", "removed", "consumed"] = "active"
+    expiry: ConditionExpiry | None = None
+    applied_event_id: str | None = Field(default=None, min_length=1)
+    removal_reason: str | None = Field(default=None, min_length=1)
+    removal_event_id: str | None = Field(default=None, min_length=1)
+
+
 class ActorState(ContractModel):
     player_id: str = Field(min_length=1)
     name: str = Field(min_length=1)
@@ -53,6 +77,36 @@ class ActorState(ContractModel):
     state: dict[str, JsonValue] = Field(default_factory=dict)
     resources: ActorResources = Field(default_factory=ActorResources)
     conditions: tuple[str, ...] = ()
+    condition_states: tuple[ActorCondition, ...] = ()
+
+    @model_validator(mode="after")
+    def normalize_conditions(self) -> ActorState:
+        """Read old string-only snapshots while keeping new writes canonical."""
+
+        records = self.condition_states
+        if not records and self.conditions:
+            records = tuple(
+                ActorCondition(
+                    condition_id=value,
+                    source="legacy_snapshot",
+                    application_reason="legacy_snapshot",
+                    application_key=f"legacy:{value}",
+                )
+                for value in dict.fromkeys(self.conditions)
+                if isinstance(value, str) and value.strip()
+            )
+        active_ids = tuple(
+            dict.fromkeys(
+                record.condition_id
+                for record in records
+                if record.status == "active"
+            )
+        )
+        if records != self.condition_states:
+            object.__setattr__(self, "condition_states", records)
+        if active_ids != self.conditions:
+            object.__setattr__(self, "conditions", active_ids)
+        return self
 
 
 class WorldTimePoint(ContractModel):
@@ -183,7 +237,8 @@ class AgendaParentContinuation(ContractModel):
     """
 
     passed: bool
-    remaining_effects: tuple[ActionEffect, ...] = ()
+    # Includes ordinary ActionEffect values and executable rule-step operations.
+    remaining_effects: tuple[object, ...] = ()
     completion_emitted: bool = False
 
 

--- a/agent-collaboration-framework/collaboration_framework/engine/projection_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/projection_v3.py
@@ -56,11 +56,11 @@ from collaboration_framework.contracts import (
     TimeAdvanceBlockReason,
 )
 
+from ..registry import rulesets as ruleset_registry
 from .models import EngineRuntimeSnapshot, GameState
 from .navigation import effective_location_knowledge, runtime_location_edges
 from .persistent_results import PUBLIC_STATE_KEYS
 from .rules_v3 import agent_match_admits, evaluate_condition, pending_check_for
-from ..registry import check_profiles as check_profile_registry
 from .time_tasks import active_occurrences
 from .timeline import (
     next_point_after,
@@ -745,7 +745,7 @@ def _rule_candidates(
                         # 分支里有没有检定步，是 Agent 必须知道的；后果仍然不出服务端。
                         requires_check=(step := pending_check_for(rule, option.id)[0])
                         is not None,
-                        check_skill_id=_rule_check_skill_id(step),
+                        check_skill_id=_rule_check_skill_id(step, module.world_ref),
                     )
                     for option in trigger.options
                 ),
@@ -755,7 +755,7 @@ def _rule_candidates(
     return tuple(candidates)
 
 
-def _rule_check_skill_id(step: object) -> str | None:
+def _rule_check_skill_id(step: object, world_ref: str = "coc-7e") -> str | None:
     """Resolve the rolled resource without exposing rule execution details."""
 
     if not isinstance(step, CheckStep):
@@ -763,7 +763,7 @@ def _rule_check_skill_id(step: object) -> str | None:
     if step.check.profile_id == "coc7.skill":
         skill_id = step.check.parameters.get("skill_id")
         return skill_id if isinstance(skill_id, str) and skill_id.strip() else None
-    profile = check_profile_registry.registration_for(step.check.profile_id)
+    profile = ruleset_registry.check_profile_for(world_ref, step.check.profile_id)
     return profile.resource if profile is not None else None
 
 

--- a/agent-collaboration-framework/collaboration_framework/engine/rules_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/rules_v3.py
@@ -21,6 +21,7 @@ from collaboration_framework.contracts import (
     CheckStep,
     ConditionExpr,
     ContractError,
+    EffectStep,
     EventTriggerSpec,
     ModuleContentV3,
     NotCondition,
@@ -197,7 +198,12 @@ def walk_rule_from(rule: RuleSpecV3, step_id: str) -> RuleWalk:
             walk.completed = True
             return walk
         if behavior == "produces_effect_and_continues":
-            walk.effects.append(step.effect)
+            # `invoke_ruleset_action` is a rule operation, not an Agent effect,
+            # but it shares this ordered stream so event barriers and recovery
+            # preserve the authored sequence.
+            walk.effects.append(
+                step.effect if isinstance(step, EffectStep) else step
+            )
             cursor = step.next_step_id
             continue
         if behavior == "schedules_time_task_and_continues":

--- a/agent-collaboration-framework/collaboration_framework/module/validation_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/module/validation_v3.py
@@ -35,9 +35,9 @@ from collaboration_framework.contracts.module_v3 import (
     RuleSpecV3,
     RuleStepSpec,
 )
-from collaboration_framework.registry import check_profiles as check_profile_registry
 from collaboration_framework.registry import predicates as predicate_registry
 from collaboration_framework.registry import rule_steps as rule_step_registry
+from collaboration_framework.registry import rulesets as ruleset_registry
 
 from .validation import ValidationIssue, ValidationReport
 
@@ -192,7 +192,9 @@ def _semantic_issues(content: ModuleContentV3) -> list[ValidationIssue]:
 
     # --- rules ------------------------------------------------------------- #
     for index, rule in enumerate(content.rules):
-        issues.extend(_rule_issues(rule, f"rules.{index}", known, require))
+        issues.extend(
+            _rule_issues(rule, f"rules.{index}", known, require, content.world_ref)
+        )
 
     # --- resolution and endings -------------------------------------------- #
     for index, goal_id in enumerate(content.core_resolution.required_goal_ids):
@@ -347,6 +349,7 @@ def _rule_issues(
     path: str,
     known: dict[str, set[str]],
     require,
+    world_ref: str,
 ) -> list[ValidationIssue]:
     issues: list[ValidationIssue] = []
 
@@ -396,7 +399,7 @@ def _rule_issues(
                 )
             )
         issues.extend(_actor_binding_issues(step, step_path))
-        issues.extend(_check_profile_issues(step, step_path))
+        issues.extend(_check_profile_issues(step, step_path, world_ref))
 
     # 这里曾校验 `presentation` step 的 `presentation_id` 指向 `rule.presentation`
     # 声明过的片段。随 `RulePresentationSpec` 一起删除（#288 结案、#398 执行）：
@@ -488,8 +491,12 @@ def _actor_binding_issues(step: RuleStepSpec, step_path: str) -> list[Validation
     ]
 
 
-def _check_profile_issues(step: RuleStepSpec, step_path: str) -> list[ValidationIssue]:
-    """被动检定的 `profile_id` 必须在 `registry/check_profiles.py` 里注册过。
+def _check_profile_issues(
+    step: RuleStepSpec,
+    step_path: str,
+    world_ref: str,
+) -> list[ValidationIssue]:
+    """被动检定的 `profile_id` 必须在对应 world adapter 里注册过。
 
     只校验 `initiation_kind == "passive_rule"`，这是刻意收窄，不是遗漏。主动检定
     的 `profile_id` 走的是 Agent 候选菜单，压根不经过这张表——两个线上模组的 26
@@ -499,12 +506,12 @@ def _check_profile_issues(step: RuleStepSpec, step_path: str) -> list[Validation
     被动检定不一样：引擎必须自己把 `profile_id` 译成「掷什么、对多少」，译不出来
     就只能在运行时 `settlement.fail("check_profile_unavailable")`——那时效果已经
     提交了一半。同样一件事，发布期说比运行时说好。这也让
-    `check_profiles.is_registered` 有了真实消费者。
+    规则系统 adapter 的 Profile 注册表有了真实消费者。
     """
 
     if not isinstance(step, CheckStep) or step.check.initiation_kind != "passive_rule":
         return []
-    if check_profile_registry.is_registered(step.check.profile_id):
+    if ruleset_registry.check_profile_for(world_ref, step.check.profile_id) is not None:
         return []
     return [
         ValidationIssue(

--- a/agent-collaboration-framework/collaboration_framework/registry/check_profiles.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/check_profiles.py
@@ -1,4 +1,4 @@
-"""Check Profiles: what a rule-owned check actually rolls (#226 §5, #398 §阶段三).
+"""CoC7 check profiles: what a rule-owned check actually rolls.
 
 `RuleCheckSpec.profile_id` and `RuleCheckSpec.parameters` have been in the
 contract since v3 and, until this issue, had **zero consumers** outside the
@@ -29,11 +29,17 @@ profile that any published module uses in a passive rule check (追书人 ×2、
 银之锁 ×2), and it is the only one this issue can execute. `coc7.skill` appears
 only on `active_action` steps, which reach the player through the Agent's
 candidate menu and never through this table.
+
+The table is owned by the CoC7 adapter. Runtime dispatch should use
+`registry.rulesets` so profile ids are always resolved in a `world_ref` scope.
+The compatibility helpers below remain for migration-era callers.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 
 from collaboration_framework.contracts.adjudication import CheckDifficulty
 
@@ -56,27 +62,42 @@ class CheckProfileRegistration:
     recognised_parameters: frozenset[str] = field(default_factory=frozenset)
 
 
-CHECK_PROFILES: dict[str, CheckProfileRegistration] = {
-    "coc7.sanity": CheckProfileRegistration(
-        display_name="理智",
-        resource="san",
-        method_summary="眼前的景象直接冲击神智",
-        player_safe_reason="规则要求此刻进行一次理智检定",
-        recognised_parameters=frozenset({"success_loss", "failure_loss", "habit_cap"}),
-    ),
-}
+COC7_CHECK_PROFILES: Mapping[str, CheckProfileRegistration] = MappingProxyType(
+    {
+        "coc7.sanity": CheckProfileRegistration(
+            display_name="理智",
+            resource="san",
+            method_summary="眼前的景象直接冲击神智",
+            player_safe_reason="规则要求此刻进行一次理智检定",
+            recognised_parameters=frozenset(
+                {"success_loss", "failure_loss", "habit_cap"}
+            ),
+        ),
+    }
+)
+
+# Compatibility name for callers that inspect the built-in CoC7 catalogue.
+# New runtime code must use the world-scoped adapter registry.
+CHECK_PROFILES = COC7_CHECK_PROFILES
 
 
-def is_registered(profile_id: str) -> bool:
-    return profile_id in CHECK_PROFILES
+def is_registered(profile_id: str, *, world_ref: str = "coc-7e") -> bool:
+    return world_ref == "coc-7e" and profile_id in COC7_CHECK_PROFILES
 
 
-def registration_for(profile_id: str) -> CheckProfileRegistration | None:
-    return CHECK_PROFILES.get(profile_id)
+def registration_for(
+    profile_id: str,
+    *,
+    world_ref: str = "coc-7e",
+) -> CheckProfileRegistration | None:
+    if world_ref != "coc-7e":
+        return None
+    return COC7_CHECK_PROFILES.get(profile_id)
 
 
 __all__ = [
     "CHECK_PROFILES",
+    "COC7_CHECK_PROFILES",
     "CheckProfileRegistration",
     "is_registered",
     "registration_for",

--- a/agent-collaboration-framework/collaboration_framework/registry/predicates.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/predicates.py
@@ -144,6 +144,19 @@ def _core_resolved(args: dict[str, JsonValue], state: GameState, actor_id: str) 
     return state.core_resolved is bool(args.get("value", True))
 
 
+def _actor_has_condition(args: dict[str, JsonValue], state: GameState, actor_id: str) -> bool:
+    condition_id = args.get("condition_id", args.get("id"))
+    if not isinstance(condition_id, str) or not condition_id.strip():
+        return False
+    actor = state.actors.get(actor_id)
+    if actor is None:
+        return False
+    return any(
+        item.condition_id == condition_id and item.status == "active"
+        for item in actor.condition_states
+    ) or condition_id in actor.conditions
+
+
 PREDICATES: dict[str, PredicateEvaluator] = {
     "entity_state_is": _entity_state_is,
     "time_of_day_is": _time_of_day_is,
@@ -153,6 +166,7 @@ PREDICATES: dict[str, PredicateEvaluator] = {
     "information_is": _information_is,
     "party_location_is": _party_location_is,
     "core_resolved": _core_resolved,
+    "actor_has_condition": _actor_has_condition,
 }
 
 

--- a/agent-collaboration-framework/collaboration_framework/registry/rule_steps.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/rule_steps.py
@@ -151,9 +151,7 @@ STEP_KINDS: dict[str, RuleStepRegistration] = {
         failure_code=STEP_KIND_HAS_NO_EXECUTOR,
     ),
     "invoke_ruleset_action": RuleStepRegistration(
-        walk_behavior="suspends",
-        agenda_status="failed",
-        failure_code=STEP_KIND_HAS_NO_EXECUTOR,
+        walk_behavior="produces_effect_and_continues",
     ),
     "create_npc_action_opportunity": RuleStepRegistration(
         walk_behavior="suspends",

--- a/agent-collaboration-framework/collaboration_framework/registry/rulesets.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/rulesets.py
@@ -1,0 +1,223 @@
+"""World-scoped ruleset adapters (#485 PR 1).
+
+The generic Engine owns orchestration, transactions, events, and recovery. A
+ruleset adapter owns the meanings that vary by ``world_ref``: check profiles,
+check outcome handlers, and world actions. Keeping all three collections on
+one adapter prevents a profile from one game system being accidentally used by
+another system with the same string id.
+
+This is a static registry shipped with the Engine. It is intentionally not a
+plugin loader and does not import the Engine, persistence, or module content.
+Adding an entry is a claim that the corresponding runtime capability exists;
+the CoC7 adapter therefore registers only the already executable
+``coc7.sanity`` profile in this PR. Outcome handlers and world actions remain
+empty until their executors and recovery paths land in later PRs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+
+from .check_profiles import COC7_CHECK_PROFILES, CheckProfileRegistration
+
+
+class RulesetRegistryError(LookupError):
+    """Raised when a world or a world-owned capability is not registered."""
+
+
+@dataclass(frozen=True)
+class RulesetAdapter:
+    """The runtime capability catalogue owned by one ``world_ref``.
+
+    Handler and executor values are intentionally typed as ``Any`` in this
+    boundary. Their concrete call contracts belong to the Engine and will be
+    narrowed when the corresponding capabilities are implemented. The
+    registry still gives those capabilities a stable, world-scoped home now.
+    """
+
+    world_ref: str
+    check_profiles: Mapping[str, CheckProfileRegistration] = field(
+        default_factory=dict
+    )
+    check_outcome_handlers: Mapping[str, Any] = field(default_factory=dict)
+    world_actions: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.world_ref.strip():
+            raise ValueError("ruleset adapter world_ref cannot be blank")
+        for field_name in (
+            "check_profiles",
+            "check_outcome_handlers",
+            "world_actions",
+        ):
+            value = getattr(self, field_name)
+            object.__setattr__(self, field_name, MappingProxyType(dict(value)))
+
+    def check_profile_for(self, profile_id: str) -> CheckProfileRegistration | None:
+        return self.check_profiles.get(profile_id)
+
+    def check_outcome_handler_for(self, profile_id: str) -> Any | None:
+        return self.check_outcome_handlers.get(profile_id)
+
+    def world_action_for(self, action_id: str) -> Any | None:
+        return self.world_actions.get(action_id)
+
+
+class RulesetAdapterRegistry:
+    """Immutable lookup table for the adapters bundled with the Engine."""
+
+    def __init__(self, adapters: Iterable[RulesetAdapter]) -> None:
+        by_world: dict[str, RulesetAdapter] = {}
+        for adapter in adapters:
+            if adapter.world_ref in by_world:
+                raise ValueError(
+                    f"duplicate ruleset adapter for world_ref={adapter.world_ref}"
+                )
+            by_world[adapter.world_ref] = adapter
+        self._adapters: Mapping[str, RulesetAdapter] = MappingProxyType(by_world)
+
+    @property
+    def world_refs(self) -> frozenset[str]:
+        return frozenset(self._adapters)
+
+    @property
+    def adapters(self) -> Mapping[str, RulesetAdapter]:
+        return self._adapters
+
+    def is_registered(self, world_ref: str) -> bool:
+        return world_ref in self._adapters
+
+    def adapter_for(self, world_ref: str) -> RulesetAdapter | None:
+        return self._adapters.get(world_ref)
+
+    def __contains__(self, world_ref: str) -> bool:
+        return self.is_registered(world_ref)
+
+    def __getitem__(self, world_ref: str) -> RulesetAdapter:
+        return self.require_adapter(world_ref)
+
+    def require_adapter(self, world_ref: str) -> RulesetAdapter:
+        adapter = self.adapter_for(world_ref)
+        if adapter is None:
+            raise RulesetRegistryError(
+                f"no ruleset adapter is registered for world_ref={world_ref!r}"
+            )
+        return adapter
+
+    def check_profile_for(
+        self,
+        world_ref: str,
+        profile_id: str,
+    ) -> CheckProfileRegistration | None:
+        adapter = self.adapter_for(world_ref)
+        return adapter.check_profile_for(profile_id) if adapter is not None else None
+
+    def require_check_profile(
+        self,
+        world_ref: str,
+        profile_id: str,
+    ) -> CheckProfileRegistration:
+        profile = self.check_profile_for(world_ref, profile_id)
+        if profile is None:
+            raise RulesetRegistryError(
+                f"no check profile {profile_id!r} is registered for "
+                f"world_ref={world_ref!r}"
+            )
+        return profile
+
+    def check_outcome_handler_for(self, world_ref: str, profile_id: str) -> Any | None:
+        adapter = self.adapter_for(world_ref)
+        return (
+            adapter.check_outcome_handler_for(profile_id)
+            if adapter is not None
+            else None
+        )
+
+    def require_check_outcome_handler(self, world_ref: str, profile_id: str) -> Any:
+        handler = self.check_outcome_handler_for(world_ref, profile_id)
+        if handler is None:
+            raise RulesetRegistryError(
+                f"no check outcome handler for profile {profile_id!r} is registered "
+                f"for world_ref={world_ref!r}"
+            )
+        return handler
+
+    def world_action_for(self, world_ref: str, action_id: str) -> Any | None:
+        adapter = self.adapter_for(world_ref)
+        return adapter.world_action_for(action_id) if adapter is not None else None
+
+    def require_world_action(self, world_ref: str, action_id: str) -> Any:
+        action = self.world_action_for(world_ref, action_id)
+        if action is None:
+            raise RulesetRegistryError(
+                f"no world action {action_id!r} is registered for "
+                f"world_ref={world_ref!r}"
+            )
+        return action
+
+
+COC7_ADAPTER = RulesetAdapter(
+    world_ref="coc-7e",
+    check_profiles=COC7_CHECK_PROFILES,
+)
+
+DEFAULT_RULESET_REGISTRY = RulesetAdapterRegistry((COC7_ADAPTER,))
+
+# Short alias for callers that want the bundled registry object.
+RULESET_ADAPTERS = DEFAULT_RULESET_REGISTRY
+
+
+def is_registered(world_ref: str) -> bool:
+    return DEFAULT_RULESET_REGISTRY.is_registered(world_ref)
+
+
+def adapter_for(world_ref: str) -> RulesetAdapter | None:
+    return DEFAULT_RULESET_REGISTRY.adapter_for(world_ref)
+
+
+def require_adapter(world_ref: str) -> RulesetAdapter:
+    return DEFAULT_RULESET_REGISTRY.require_adapter(world_ref)
+
+
+def check_profile_for(
+    world_ref: str,
+    profile_id: str,
+) -> CheckProfileRegistration | None:
+    return DEFAULT_RULESET_REGISTRY.check_profile_for(world_ref, profile_id)
+
+
+def check_outcome_handler_for(world_ref: str, profile_id: str) -> Any | None:
+    return DEFAULT_RULESET_REGISTRY.check_outcome_handler_for(world_ref, profile_id)
+
+
+def require_check_outcome_handler(world_ref: str, profile_id: str) -> Any:
+    return DEFAULT_RULESET_REGISTRY.require_check_outcome_handler(world_ref, profile_id)
+
+
+def world_action_for(world_ref: str, action_id: str) -> Any | None:
+    return DEFAULT_RULESET_REGISTRY.world_action_for(world_ref, action_id)
+
+
+def require_world_action(world_ref: str, action_id: str) -> Any:
+    return DEFAULT_RULESET_REGISTRY.require_world_action(world_ref, action_id)
+
+
+__all__ = [
+    "COC7_ADAPTER",
+    "DEFAULT_RULESET_REGISTRY",
+    "RULESET_ADAPTERS",
+    "RulesetAdapter",
+    "RulesetAdapterRegistry",
+    "RulesetRegistryError",
+    "adapter_for",
+    "check_outcome_handler_for",
+    "check_profile_for",
+    "is_registered",
+    "require_adapter",
+    "require_check_outcome_handler",
+    "require_world_action",
+    "world_action_for",
+]

--- a/agent-collaboration-framework/collaboration_framework/registry/rulesets.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/rulesets.py
@@ -10,8 +10,7 @@ This is a static registry shipped with the Engine. It is intentionally not a
 plugin loader and does not import the Engine, persistence, or module content.
 Adding an entry is a claim that the corresponding runtime capability exists;
 the CoC7 adapter therefore registers only the already executable
-``coc7.sanity`` profile in this PR. Outcome handlers and world actions remain
-empty until their executors and recovery paths land in later PRs.
+``coc7.sanity`` profile and the executable ``coc7.apply_condition`` action.
 """
 
 from __future__ import annotations
@@ -26,6 +25,143 @@ from .check_profiles import COC7_CHECK_PROFILES, CheckProfileRegistration
 
 class RulesetRegistryError(LookupError):
     """Raised when a world or a world-owned capability is not registered."""
+
+
+class RulesetActionError(ValueError):
+    """A registered action rejected its parameters or current state."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class RulesetActionContext:
+    state: Any
+    actor_id: str
+    actor_binding: str
+    parameters: Mapping[str, Any]
+    request_id: str
+    operation_key: str
+
+
+@dataclass(frozen=True)
+class RulesetActionResult:
+    state: Any
+    event_type: str | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+RulesetAction = Any
+
+
+COC7_CONDITION_IDS: frozenset[str] = frozenset(
+    {
+        "unconscious",
+        "unconscious_until_night",
+        "arrested_during_prohibition",
+        "drowning",
+        "full_frog_transformation",
+        "happiness_vision_skip_one_turn",
+        "james_withdrawal_symptoms",
+        "periodic_happiness_hallucinations",
+        "pond_water_craving",
+        "psychological_dependency",
+        "converted_staff_coordination_bonus_10",
+        "garden_spike_wound",
+        "giant_spider_bite",
+        "injured_foot",
+        "mythos_book_obsession_if_insane",
+        "passage_fall",
+    }
+)
+
+
+def _coc7_apply_condition(context: RulesetActionContext) -> RulesetActionResult:
+    if context.actor_binding != "actor":
+        raise RulesetActionError(
+            "RULESET_ACTION_BINDING_UNSUPPORTED",
+            "coc7.apply_condition 目前只支持 actor binding",
+        )
+    condition_id = context.parameters.get("condition")
+    if not isinstance(condition_id, str) or not condition_id.strip():
+        raise RulesetActionError(
+            "RULESET_ACTION_INVALID_PARAMETERS",
+            "coc7.apply_condition 必须提供非空 condition",
+        )
+    if condition_id not in COC7_CONDITION_IDS:
+        raise RulesetActionError(
+            "RULESET_CONDITION_UNKNOWN",
+            f"未注册的 CoC7 condition: {condition_id}",
+        )
+    reason = context.parameters.get("reason", "ruleset_action")
+    if not isinstance(reason, str) or not reason.strip():
+        raise RulesetActionError(
+            "RULESET_ACTION_INVALID_PARAMETERS",
+            "condition reason 必须是非空字符串",
+        )
+    expiry_value = context.parameters.get("expiry", context.parameters.get("lifecycle_ref"))
+    expiry = None
+    if expiry_value is not None:
+        if not isinstance(expiry_value, dict):
+            raise RulesetActionError(
+                "RULESET_ACTION_INVALID_PARAMETERS",
+                "expiry 必须是结构化对象",
+            )
+        try:
+            kind = expiry_value.get("kind")
+            reference_id = expiry_value.get("reference_id")
+            if kind not in {"time_point", "time_task"} or not isinstance(
+                reference_id, str
+            ) or not reference_id.strip():
+                raise ValueError("invalid expiry")
+            expiry = {"kind": kind, "reference_id": reference_id}
+        except ValueError as exc:
+            raise RulesetActionError(
+                "RULESET_ACTION_INVALID_PARAMETERS",
+                "expiry 必须包含合法的 kind/reference_id",
+            ) from exc
+    actor = context.state.actors.get(context.actor_id)
+    if actor is None:
+        raise RulesetActionError("RULESET_ACTION_TARGET_UNKNOWN", "规则动作目标角色不存在")
+    records = list(actor.condition_states)
+    existing = next(
+        (item for item in records if item.application_key == context.operation_key),
+        None,
+    )
+    if existing is not None or any(
+        item.condition_id == condition_id and item.status == "active" for item in records
+    ):
+        return RulesetActionResult(state=context.state)
+    record = {
+        "condition_id": condition_id,
+        "source": "coc7.apply_condition",
+        "application_reason": reason,
+        "application_key": context.operation_key,
+        "status": "active",
+        "expiry": expiry,
+    }
+    actor_payload = actor.model_dump(mode="python")
+    actor_payload["condition_states"] = [*records, record]
+    actor_payload["conditions"] = list(
+        dict.fromkeys([*(item.condition_id for item in records), condition_id])
+    )
+    updated_actor = actor.__class__.model_validate(actor_payload)
+    actors = dict(context.state.actors)
+    actors[context.actor_id] = updated_actor
+    updated_state = context.state.model_copy(update={"actors": actors}, deep=True)
+    return RulesetActionResult(
+        state=updated_state,
+        event_type="actor.condition_applied",
+        payload={
+            "actor_id": context.actor_id,
+            "condition_id": condition_id,
+            "source": "coc7.apply_condition",
+            "application_reason": reason,
+            "application_key": context.operation_key,
+            "expiry": expiry,
+        },
+    )
 
 
 @dataclass(frozen=True)
@@ -43,7 +179,7 @@ class RulesetAdapter:
         default_factory=dict
     )
     check_outcome_handlers: Mapping[str, Any] = field(default_factory=dict)
-    world_actions: Mapping[str, Any] = field(default_factory=dict)
+    world_actions: Mapping[str, RulesetAction] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.world_ref.strip():
@@ -162,6 +298,7 @@ class RulesetAdapterRegistry:
 COC7_ADAPTER = RulesetAdapter(
     world_ref="coc-7e",
     check_profiles=COC7_CHECK_PROFILES,
+    world_actions={"coc7.apply_condition": _coc7_apply_condition},
 )
 
 DEFAULT_RULESET_REGISTRY = RulesetAdapterRegistry((COC7_ADAPTER,))
@@ -207,8 +344,12 @@ def require_world_action(world_ref: str, action_id: str) -> Any:
 
 __all__ = [
     "COC7_ADAPTER",
+    "COC7_CONDITION_IDS",
     "DEFAULT_RULESET_REGISTRY",
     "RULESET_ADAPTERS",
+    "RulesetActionContext",
+    "RulesetActionError",
+    "RulesetActionResult",
     "RulesetAdapter",
     "RulesetAdapterRegistry",
     "RulesetRegistryError",

--- a/agent-collaboration-framework/collaboration_framework/registry/rulesets.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/rulesets.py
@@ -144,7 +144,12 @@ def _coc7_apply_condition(context: RulesetActionContext) -> RulesetActionResult:
     actor_payload = actor.model_dump(mode="python")
     actor_payload["condition_states"] = [*records, record]
     actor_payload["conditions"] = list(
-        dict.fromkeys([*(item.condition_id for item in records), condition_id])
+        dict.fromkeys(
+            [
+                *(item.condition_id for item in records if item.status == "active"),
+                condition_id,
+            ]
+        )
     )
     updated_actor = actor.__class__.model_validate(actor_payload)
     actors = dict(context.state.actors)

--- a/agent-collaboration-framework/collaboration_framework/registry/world_actions.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/world_actions.py
@@ -1,20 +1,13 @@
 """World ruleset action registry (#347 Phase 4).
 
 `InvokeRulesetActionStep.action_id` is the one place a v3 Rule names a world
-ruleset action — "make this actor do the CoC-7e thing called X". It is free
-text today, nothing in the repository reads it, and no executor exists for it:
-a rule that reaches such a step suspends onto the Agenda and is ultimately
-refused as `RULE_BUDGET_EXCEEDED`.
+ruleset action — "make this actor do the CoC-7e thing called X". Unknown action
+ids remain free-text at publish time, but fail explicitly when reached.
 
-**This table is empty, and that is the correct current state.** It is not a
-half-finished implementation. There is no v3 world action the Engine can
-actually perform, so registering any name here would claim a capability that
-does not exist — exactly the "registered but unrunnable" illusion #347 warns
-about. The v2-era `_SUPPORTED_FORCE_ACTIONS` names in `engine/capabilities.py`
-are deliberately *not* migrated in: they belonged to a runtime that is gone.
-
-What this module is for is the place to put the first real one, and the
-explicit statement that today there are none.
+The first executable action is ``coc7.apply_condition``. Its world-scoped
+handler lives in ``registry/rulesets.py``; this compatibility table exposes
+the closed set of action ids for callers that still use the old membership
+API.
 
 ## Deliberately not wired into publish-time validation
 
@@ -31,16 +24,13 @@ of what the runtime can actually do, and a membership test.
 
 from __future__ import annotations
 
-# Empty on purpose — see the module docstring. Adding a name here is a claim
-# that the Engine can execute it, so it belongs in the same change that adds
-# the executor, never ahead of one.
-SUPPORTED_WORLD_ACTIONS: frozenset[str] = frozenset()
+SUPPORTED_WORLD_ACTIONS: frozenset[str] = frozenset({"coc7.apply_condition"})
 
 
 def is_registered(action_id: str) -> bool:
     """Whether the Engine has an executor for this world ruleset action.
 
-    Currently False for every input.
+False for unknown action ids.
     """
 
     return action_id in SUPPORTED_WORLD_ACTIONS

--- a/agent-collaboration-framework/docs/数据模型设计.md
+++ b/agent-collaboration-framework/docs/数据模型设计.md
@@ -165,7 +165,7 @@ REST DTO 和 `trpg-sdk` 生成类型有独立事实源；Framework Host 内部�
 - `NarrationOutput`: `kind`, `text`, `claimed_fact_ids`, `suggested_actions`
 - `TurnPlanningContext`: `player_input`, `planning_view`, `recent_history`, `memories`, `conversation_summary`, `policy`
 - `HostAgentContext`: `player_input`, `player_view`, `recent_history`, `memories`, `conversation_summary`, `keeper_capabilities`
-- `ActorState`: `player_id`, `name`, `source_character_id`, `source_character_version`, `state`, `resources`, `conditions`
+- `ActorState`: `player_id`, `name`, `source_character_id`, `source_character_version`, `state`, `resources`, `conditions`, `condition_states`
 - `GameState`: `room_id`, `scene_id`, `phase`, `ending_id`, `event_sequence`, `actors`, `entities`, `public_entity_state_keys`, `world_time`, `discovered_facts`, `actor_discovered_facts`, `runtime_locations`, `runtime_entities`, `visibility_overrides`, `party_location_knowledge`, `actor_location_knowledge`, `actor_position_contexts`, `item_instances`, `party_item_knowledge`, `actor_item_knowledge`, `rule_agendas`, `time_occurrences`, `time_tasks`, `core_resolved`, `ending_available`, `ending_resolution`
 - `StateChange`: `path`, `from_value`, `to`, `cause`
 - `StateModifiedPayload`: `path`, `from_value`, `to`

--- a/agent-collaboration-framework/tests/test_actor_conditions.py
+++ b/agent-collaboration-framework/tests/test_actor_conditions.py
@@ -16,7 +16,7 @@ from collaboration_framework.engine.models import (
     ConditionExpiry,
     GameState,
 )
-from collaboration_framework.registry import rulesets
+from collaboration_framework.registry import predicates, rulesets
 
 
 def state() -> GameState:
@@ -129,6 +129,46 @@ class ActorConditionTests(unittest.TestCase):
                 replace(context, parameters={"condition": "unknown"})
             )
         self.assertEqual(raised.exception.code, "RULESET_CONDITION_UNKNOWN")
+
+    def test_coc7_action_rebuilds_only_active_condition_projection(self) -> None:
+        action = rulesets.require_world_action("coc-7e", "coc7.apply_condition")
+        applied = action(
+            rulesets.RulesetActionContext(
+                state=state(),
+                actor_id="actor",
+                actor_binding="actor",
+                parameters={"condition": "unconscious"},
+                request_id="request",
+                operation_key="first",
+            )
+        )
+        removed = remove_condition(
+            applied.state,
+            actor_id="actor",
+            condition_id="unconscious",
+            reason="woke up",
+        )
+        reapplied = action(
+            rulesets.RulesetActionContext(
+                state=removed.state,
+                actor_id="actor",
+                actor_binding="actor",
+                parameters={"condition": "injured_foot"},
+                request_id="request",
+                operation_key="second",
+            )
+        )
+
+        actor = reapplied.state.actors["actor"]
+        self.assertEqual(actor.conditions, ("injured_foot",))
+        self.assertFalse(
+            predicates.evaluate(
+                "actor_has_condition",
+                {"condition_id": "unconscious"},
+                state=reapplied.state,
+                actor_id="actor",
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/agent-collaboration-framework/tests/test_actor_conditions.py
+++ b/agent-collaboration-framework/tests/test_actor_conditions.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+
+from collaboration_framework.engine.conditions import (
+    active_conditions,
+    apply_condition,
+    consume_condition,
+    has_active_condition,
+    remove_condition,
+)
+from collaboration_framework.engine.models import (
+    ActorResources,
+    ActorState,
+    ConditionExpiry,
+    GameState,
+)
+from collaboration_framework.registry import rulesets
+
+
+def state() -> GameState:
+    return GameState(
+        room_id="room",
+        scene_id="scene",
+        actors={
+            "actor": ActorState(
+                player_id="player",
+                name="Investigator",
+                source_character_id="character",
+                source_character_version=1,
+                resources=ActorResources(san=50),
+            )
+        },
+        entities={},
+    )
+
+
+class ActorConditionTests(unittest.TestCase):
+    def test_legacy_strings_are_migrated_and_projected(self) -> None:
+        actor = ActorState(
+            player_id="player",
+            name="Investigator",
+            source_character_id="character",
+            source_character_version=1,
+            conditions=("unconscious",),
+        )
+        self.assertEqual(actor.conditions, ("unconscious",))
+        self.assertEqual(actor.condition_states[0].source, "legacy_snapshot")
+
+    def test_apply_is_idempotent_and_has_structured_expiry(self) -> None:
+        first = apply_condition(
+            state(),
+            actor_id="actor",
+            condition_id="unconscious",
+            source="coc7.apply_condition",
+            application_reason="failed check",
+            application_key="rule:step:actor",
+            expiry=ConditionExpiry(kind="time_point", reference_id="hour_18"),
+        )
+        second = apply_condition(
+            first.state,
+            actor_id="actor",
+            condition_id="unconscious",
+            source="coc7.apply_condition",
+            application_reason="failed check",
+            application_key="rule:step:actor",
+        )
+        self.assertTrue(first.changed)
+        self.assertFalse(second.changed)
+        self.assertEqual(second.state.actors["actor"].conditions, ("unconscious",))
+        self.assertEqual(first.condition.expiry.reference_id, "hour_18")
+        self.assertTrue(has_active_condition(first.state, "actor", "unconscious"))
+
+    def test_remove_and_consume_close_the_authoritative_record(self) -> None:
+        applied = apply_condition(
+            state(),
+            actor_id="actor",
+            condition_id="unconscious",
+            source="test",
+            application_reason="test",
+            application_key="k",
+        )
+        removed = remove_condition(
+            applied.state,
+            actor_id="actor",
+            condition_id="unconscious",
+            reason="woke up",
+        )
+        self.assertEqual(removed.condition.status, "removed")
+        self.assertEqual(active_conditions(removed.state, "actor"), ())
+
+        reapplied = apply_condition(
+            removed.state,
+            actor_id="actor",
+            condition_id="unconscious",
+            source="test",
+            application_reason="test",
+            application_key="k2",
+        )
+        consumed = consume_condition(
+            reapplied.state,
+            actor_id="actor",
+            condition_id="unconscious",
+            reason="condition used",
+        )
+        self.assertEqual(consumed.condition.status, "consumed")
+        self.assertFalse(has_active_condition(consumed.state, "actor", "unconscious"))
+
+    def test_coc7_action_emits_once_and_rejects_unknown_conditions(self) -> None:
+        action = rulesets.require_world_action("coc-7e", "coc7.apply_condition")
+        context = rulesets.RulesetActionContext(
+            state=state(),
+            actor_id="actor",
+            actor_binding="actor",
+            parameters={
+                "condition": "unconscious",
+                "expiry": {"kind": "time_task", "reference_id": "task-1"},
+            },
+            request_id="request",
+            operation_key="rule:step:actor",
+        )
+        first = action(context)
+        second = action(replace(context, state=first.state))
+        self.assertEqual(first.event_type, "actor.condition_applied")
+        self.assertIsNone(second.event_type)
+        with self.assertRaises(rulesets.RulesetActionError) as raised:
+            action(
+                replace(context, parameters={"condition": "unknown"})
+            )
+        self.assertEqual(raised.exception.code, "RULESET_CONDITION_UNKNOWN")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-collaboration-framework/tests/test_event_barrier.py
+++ b/agent-collaboration-framework/tests/test_event_barrier.py
@@ -406,7 +406,7 @@ def failing_chain_module() -> ModuleContentV3:
         {
             "id": "no_executor",
             "kind": "invoke_ruleset_action",
-            "action_id": "coc7.apply_condition",
+            "action_id": "coc7.unknown_action",
             "actor_binding": "actor",
             "parameters": {"condition": "unconscious"},
             "next_step_id": "finish",
@@ -468,7 +468,7 @@ class FailedChainDoesNotVetoTheActionTests(unittest.IsolatedAsyncioTestCase):
 
         # 规则链确实断了，而且说得出断在哪。
         self.assertEqual(execution.status, "rule_failed")
-        self.assertEqual(execution.rule_failure_code, "step_kind_has_no_executor")
+        self.assertEqual(execution.rule_failure_code, "RULESET_ACTION_NOT_REGISTERED")
         # 动作本身照常完成——两件事分别由 outcome 与 status 承担。
         self.assertEqual(execution.outcome, "success")
 

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -1746,14 +1746,8 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("douglas_true_nature", state.discovered_facts)
         self.assertIn("douglas_confession", state.discovered_facts)
 
-    async def test_branch_suspended_on_an_executor_refuses_half_effects(self) -> None:
-        """停在 invoke_ruleset_action 上的分支不能提交走过的那一半。
-
-        `crypt_stench_on_entry/just_enter` 先要 `coc7.apply_condition` 让调查员
-        昏迷，之后才置位「见过身影」。把「无检定」一律当成「整条链跑完」，就会
-        跳过昏迷直接记下见过身影——世界停在半截状态。这类分支要等 RuleAgenda
-        的恢复侧（R4）落地，现在应当可见地失败。
-        """
+    async def test_branch_executes_registered_ruleset_action(self) -> None:
+        """`coc7.apply_condition` 与后续步骤在同一条 Agenda 中完成。"""
 
         store = InMemoryEngineStore()
         store.register_room(
@@ -1766,31 +1760,30 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
             PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
         )
 
-        with self.assertRaises(ContractError):
-            await engine.submit(
-                SubmitAdjudicationRequest(
-                    room_id=ROOM,
-                    player_id=PLAYER,
-                    adjudication=ActionAdjudication(
-                        request_id="stench-1",
-                        source_revision=snapshot.revision,
-                        actor_id=ACTOR,
-                        summary="直接钻进石板下的洞口",
-                        target=ActionTarget(kind="entity", id="crypt_entrance"),
-                        method=ActionMethod(family="enter", description="直接进入"),
-                        rule_decision=RuleDecisionRef(
-                            rule_id="crypt_stench_on_entry", option_id="just_enter"
-                        ),
-                        check=NoAdjudicationCheck(),
-                        success_effects=(),
-                        failure_effects=(),
+        await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="stench-1",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="直接钻进石板下的洞口",
+                    target=ActionTarget(kind="entity", id="crypt_entrance"),
+                    method=ActionMethod(family="enter", description="直接进入"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="crypt_stench_on_entry", option_id="just_enter"
                     ),
-                )
+                    check=NoAdjudicationCheck(),
+                    success_effects=(),
+                    failure_effects=(),
+                ),
             )
+        )
 
-        # 半截状态尤其不能落库：昏迷没生效，就不该记下「见过身影」。
         state = store.inspect_state(ROOM)
-        self.assertNotIn("sighted", state.entities.get("cemetery_figure", {}))
+        self.assertIn("unconscious_until_night", state.actors[ACTOR].conditions)
+        self.assertTrue(state.entities["cemetery_figure"]["sighted"])
 
     async def test_rule_option_publishes_whether_it_rolls_dice(self) -> None:
         """Agent 必须能分辨哪条分支要掷骰，否则只能编一个技能 id 出来。"""

--- a/agent-collaboration-framework/tests/test_registry_rule_steps.py
+++ b/agent-collaboration-framework/tests/test_registry_rule_steps.py
@@ -2,8 +2,8 @@
 
 These two phases are registration-and-static-checking only. The tests that
 matter most here are the ones pinning what must *not* have changed:
-`invoke_ruleset_action` still has no executor, and a module using it still
-publishes.
+`invoke_ruleset_action` is executable only when its world action is registered,
+and unknown action ids still fail explicitly at runtime.
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ SUSPENDING_KINDS = {
     "adjudicated_check",
     "presentation",
     "await_player_input",
-    "invoke_ruleset_action",
     "create_npc_action_opportunity",
 }
 
@@ -48,7 +47,10 @@ class RegistryCompletenessTests(unittest.TestCase):
         for kind, registration in rule_step_registry.STEP_KINDS.items():
             behaviors.setdefault(registration.walk_behavior, set()).add(kind)
         self.assertEqual(behaviors["terminal"], {"finish"})
-        self.assertEqual(behaviors["produces_effect_and_continues"], {"effect"})
+        self.assertEqual(
+            behaviors["produces_effect_and_continues"],
+            {"effect", "invoke_ruleset_action"},
+        )
         self.assertEqual(
             behaviors["schedules_time_task_and_continues"], SCHEDULING_KINDS
         )
@@ -91,7 +93,6 @@ class AgendaStatusTests(unittest.TestCase):
         for kind in (
             "presentation",
             "await_player_input",
-            "invoke_ruleset_action",
             "create_npc_action_opportunity",
         ):
             with self.subTest(kind=kind):
@@ -198,14 +199,15 @@ class ActorBindingTests(unittest.TestCase):
 
 
 class WorldActionRegistryTests(unittest.TestCase):
-    def test_the_table_is_empty(self) -> None:
-        """Empty is the correct state, not an unfinished one — see the module
-        docstring. This test exists so that adding a name is a deliberate act
-        that has to update it."""
+    def test_the_table_contains_the_executable_condition_action(self) -> None:
 
-        self.assertEqual(world_action_registry.SUPPORTED_WORLD_ACTIONS, frozenset())
+        self.assertEqual(
+            world_action_registry.SUPPORTED_WORLD_ACTIONS,
+            frozenset({"coc7.apply_condition"}),
+        )
 
     def test_no_action_id_is_currently_executable(self) -> None:
+        self.assertTrue(world_action_registry.is_registered("coc7.apply_condition"))
         for action_id in ("coc7e.sanity_check", "attack", "anything"):
             with self.subTest(action_id=action_id):
                 self.assertFalse(world_action_registry.is_registered(action_id))

--- a/agent-collaboration-framework/tests/test_registry_rulesets.py
+++ b/agent-collaboration-framework/tests/test_registry_rulesets.py
@@ -1,0 +1,60 @@
+"""World-scoped ruleset adapter registry tests (#485 PR 1)."""
+
+from __future__ import annotations
+
+import unittest
+
+from collaboration_framework.registry import rulesets
+from collaboration_framework.registry.check_profiles import COC7_CHECK_PROFILES
+
+
+class RulesetAdapterRegistryTests(unittest.TestCase):
+    def test_coc7_adapter_owns_the_existing_sanity_profile(self) -> None:
+        adapter = rulesets.require_adapter("coc-7e")
+
+        self.assertEqual(adapter.check_profiles, COC7_CHECK_PROFILES)
+        self.assertIs(
+            rulesets.check_profile_for("coc-7e", "coc7.sanity"),
+            COC7_CHECK_PROFILES["coc7.sanity"],
+        )
+
+    def test_capabilities_are_scoped_to_world_ref(self) -> None:
+        self.assertIsNotNone(rulesets.check_profile_for("coc-7e", "coc7.sanity"))
+        self.assertIsNone(rulesets.check_profile_for("other-world", "coc7.sanity"))
+        self.assertIsNone(
+            rulesets.check_profile_for("coc-7e", "profile-with-a-collision")
+        )
+
+    def test_future_capability_tables_are_empty_until_their_executors_exist(self) -> None:
+        adapter = rulesets.require_adapter("coc-7e")
+
+        self.assertEqual(adapter.check_outcome_handlers, {})
+        self.assertEqual(adapter.world_actions, {})
+        self.assertIsNone(
+            rulesets.check_outcome_handler_for("coc-7e", "coc7.sanity")
+        )
+        self.assertIsNone(rulesets.world_action_for("coc-7e", "coc7.apply_condition"))
+
+    def test_unknown_world_has_an_explicit_failure_path(self) -> None:
+        self.assertFalse(rulesets.is_registered("other-world"))
+        with self.assertRaisesRegex(
+            rulesets.RulesetRegistryError,
+            "no ruleset adapter.*other-world",
+        ):
+            rulesets.require_adapter("other-world")
+
+    def test_registry_rejects_duplicate_world_refs(self) -> None:
+        adapter = rulesets.RulesetAdapter(world_ref="duplicate")
+
+        with self.assertRaisesRegex(ValueError, "duplicate ruleset adapter"):
+            rulesets.RulesetAdapterRegistry((adapter, adapter))
+
+    def test_adapter_catalogues_are_immutable(self) -> None:
+        adapter = rulesets.require_adapter("coc-7e")
+
+        with self.assertRaises(TypeError):
+            adapter.check_profiles["new.profile"] = COC7_CHECK_PROFILES["coc7.sanity"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-collaboration-framework/tests/test_registry_rulesets.py
+++ b/agent-collaboration-framework/tests/test_registry_rulesets.py
@@ -25,15 +25,15 @@ class RulesetAdapterRegistryTests(unittest.TestCase):
             rulesets.check_profile_for("coc-7e", "profile-with-a-collision")
         )
 
-    def test_future_capability_tables_are_empty_until_their_executors_exist(self) -> None:
+    def test_registered_action_has_a_real_executor(self) -> None:
         adapter = rulesets.require_adapter("coc-7e")
 
         self.assertEqual(adapter.check_outcome_handlers, {})
-        self.assertEqual(adapter.world_actions, {})
+        self.assertIn("coc7.apply_condition", adapter.world_actions)
         self.assertIsNone(
             rulesets.check_outcome_handler_for("coc-7e", "coc7.sanity")
         )
-        self.assertIsNone(rulesets.world_action_for("coc-7e", "coc7.apply_condition"))
+        self.assertIsNotNone(rulesets.world_action_for("coc-7e", "coc7.apply_condition"))
 
     def test_unknown_world_has_an_explicit_failure_path(self) -> None:
         self.assertFalse(rulesets.is_registered("other-world"))

--- a/agent-collaboration-framework/tests/test_rule_agenda_v3.py
+++ b/agent-collaboration-framework/tests/test_rule_agenda_v3.py
@@ -265,7 +265,7 @@ def module_with_unexecutable_step() -> ModuleContentV3:
         {
             "id": "apply_condition",
             "kind": "invoke_ruleset_action",
-            "action_id": "coc7.apply_condition",
+            "action_id": "coc7.unknown_action",
             "actor_binding": "actor",
             "parameters": {"condition": "unconscious"},
             "next_step_id": "finish",
@@ -509,7 +509,7 @@ class AgendaFailureAuditTests(unittest.IsolatedAsyncioTestCase):
 
         # 此前：execution 报 resolved，Agenda 停在 running 上，无人推进也无信号。
         self.assertEqual(execution.status, "rule_failed")
-        self.assertEqual(execution.rule_failure_code, "step_kind_has_no_executor")
+        self.assertEqual(execution.rule_failure_code, "RULESET_ACTION_NOT_REGISTERED")
         # 动作本身成功了——是它触发的规则链没跑完，两件事分开记。
         self.assertEqual(execution.outcome, "success")
 
@@ -522,7 +522,9 @@ class AgendaFailureAuditTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(failures), 1)
         failure = failures[0]
         self.assertEqual(failure.visibility, "hidden")
-        self.assertEqual(failure.payload["failure_code"], "step_kind_has_no_executor")
+        self.assertEqual(
+            failure.payload["failure_code"], "RULESET_ACTION_NOT_REGISTERED"
+        )
         self.assertEqual(failure.payload["rule_id"], "locked_study_window_breaks")
         self.assertEqual(failure.payload["step_id"], "apply_condition")
         # 失败的 Agenda 不落库，被跳过的规则只能靠 payload 留痕。

--- a/agent-collaboration-framework/tests/test_time_tasks.py
+++ b/agent-collaboration-framework/tests/test_time_tasks.py
@@ -54,7 +54,11 @@ from collaboration_framework.engine.time_tasks import (
     resolve_target,
     settle_due_tasks,
 )
-from collaboration_framework.engine.timeline import next_point_after, player_time_label
+from collaboration_framework.engine.timeline import (
+    next_point_after,
+    occurrence_id_for,
+    player_time_label,
+)
 from tests.test_projection_v3 import ACTOR, PLAYER, ROOM, game_state
 from tests.time_fixtures import day_cycle_module as module
 
@@ -1106,6 +1110,55 @@ class TemporaryPointWalkTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(left.current_point_id, "hour_18")
         self.assertEqual(left.current.hour_of_day, 18)
         self.assertEqual(left.current.day_index, 0)
+
+    async def test_parent_barrier_preserves_task_then_advance_order(self) -> None:
+        """A recovered mixed continuation sees the occurrence it just created."""
+
+        content = module()
+        state = game_state(content)
+        runtime = EngineRuntimeSnapshot(
+            module_id=content.module_id,
+            module_version=content.version,
+            module_content=content,
+            game_state=state,
+            revision=str(state.event_sequence),
+        )
+        service = AdjudicationEngineService(InMemoryEngineStore())
+        settlement = service._new_settlement(
+            runtime, request_id="mixed-parent", actor_id=ACTOR
+        )
+        create = CreateTimeTaskStep(
+            id="schedule",
+            task=task_spec(
+                task_key="parent_visitor",
+                target=TimeTaskTargetSpec(day_index=0, hour_of_day=15),
+            ),
+            next_step_id="finish",
+        )
+        effects = (
+            create,
+            AdvanceWorldTimeEffect(
+                to_point_id=occurrence_id_for(
+                    WorldTimePoint(day_index=0, hour_of_day=15)
+                )
+            ),
+        )
+
+        state, result, remaining = service._drive_with_barrier(
+            settlement,
+            state,
+            [],
+            effects,
+            runtime=runtime,
+            request_id="mixed-parent",
+            actor_id=ACTOR,
+        )
+
+        self.assertEqual(result.status, "stable")
+        self.assertEqual(remaining, ())
+        self.assertEqual(state.world_time.current.hour_of_day, 15)
+        task = next(iter(state.time_tasks.values()))
+        self.assertEqual(task.status, "completed")
 
     async def test_the_keeper_still_sees_a_next_point_from_a_temporary_one(
         self,

--- a/trpg-backend/tests/test_issue398_agenda_hygiene.py
+++ b/trpg-backend/tests/test_issue398_agenda_hygiene.py
@@ -191,7 +191,7 @@ async def test_step_without_executor_commits_an_auditable_failure(
         {
             "id": "apply_condition",
             "kind": "invoke_ruleset_action",
-            "action_id": "coc7.apply_condition",
+            "action_id": "coc7.unknown_action",
             "actor_binding": "actor",
             "parameters": {"condition": "unconscious"},
             "next_step_id": "finish",
@@ -218,7 +218,7 @@ async def test_step_without_executor_commits_an_auditable_failure(
 
     # 此前：execution 报 resolved，Agenda 停在 running 上，无人推进也无任何信号。
     assert execution.status == "rule_failed"
-    assert execution.rule_failure_code == "step_kind_has_no_executor"
+    assert execution.rule_failure_code == "RULESET_ACTION_NOT_REGISTERED"
     # 动作本身成功了——是它触发的规则链没跑完，两件事分开记。
     assert execution.outcome == "success"
 
@@ -238,7 +238,7 @@ async def test_step_without_executor_commits_an_auditable_failure(
     assert len(failures) == 1
     failure = failures[0]
     assert failure.visibility == "hidden"
-    assert failure.payload["failure_code"] == "step_kind_has_no_executor"
+    assert failure.payload["failure_code"] == "RULESET_ACTION_NOT_REGISTERED"
     assert failure.payload["rule_id"] == TRIGGER_RULE
     assert failure.payload["step_id"] == "apply_condition"
     assert failure.event_id in execution.event_refs


### PR DESCRIPTION
## 关联 Issue

Refs #485

## 主要改动

- 新增静态、不可变的 `RulesetAdapterRegistry`，按 `world_ref` 唯一选择规则适配器。
- 将 `coc7.sanity` Profile 和可执行的 `coc7.apply_condition` 归属到 `coc-7e` 适配器。
- 新增 `ActorCondition` 权威记录、结构化 expiry、稳定 application key，以及 apply/read/predicate/remove/consume 生命周期 API。
- 保留 `ActorState.conditions` 作为玩家安全投影，兼容旧字符串快照，并让 PlayerView 继续只暴露活动条件 ID。
- 将 `InvokeRulesetActionStep` 接入事件规则与 `agent_match` 的有序 RuleAgenda 结算流，支持游标恢复、跨 Store JSON round-trip 和事件屏障。
- 未知 world/action/condition、非法参数和不支持 binding 显式失败；未知 action 在任何前置效果提交前失败，并写入 `rule.agenda_failed` 审计事件。
- 补齐 Paper Chase 条件链、幂等重复提交、DomainEvent、条件投影、旧快照兼容、失败恢复和多人同意回归测试。

## 采用该方案的原因

#485 要求通用 Engine 只负责编排、事务、事件和 Registry，不解释 CoC7 或模组语义。规则动作作为规则结算内部操作进入既有有序效果流，由 `world_ref` 适配器提供校验和执行器；这样同一条 Agenda 同时覆盖 event-rule 与 `agent_match`，并能在恢复时保留作者顺序。

Condition 的权威数据与玩家可见字符串投影分离，旧房间无需数据库迁移；稳定 application key 让重试不重复写状态或发布事件。expiry 只接受结构化 `time_point` / `time_task` 引用，不从条件名称推断时间。

## 测试与验证

- [x] Framework 全量测试：473 passed。
- [x] Backend 规则/运行时/Agenda/场景同意/时间同意聚焦测试：41 passed。
- [x] Backend 另外的 Issue #398 相关测试：61 passed，1 skipped。
- [x] 新增 Condition 生命周期与 `coc7.apply_condition` 注册表测试：25 passed（包含在 Framework 全量中）。
- [x] 修改文件 Ruff 检查通过。
- [x] `git diff --check` 通过。
- [ ] 手动 UI 验证：不适用，本 PR 无 UI 改动。
- [x] Backend 测试使用 `HOST_SPEECH_PROVIDER=disabled` 绕过本机缺失的 Doubao TTS 配置；该配置问题与本 PR 无关。

## 兼容性、风险与回滚

- 旧 `ActorState.conditions` 字符串快照会在读取时生成带 `legacy_snapshot` 来源的权威记录；新写入同时维护两种表示。
- 既有 `coc-7e` 房间、已发布 ModuleVersion、被动检定和 RuleAgenda 恢复行为保持兼容。
- Condition ID 注册表是当前 CoC7 模组已使用的闭合集合；新增条件必须随适配器代码和测试一起发布。
- `coc7.apply_condition` 目前只支持 `actor` binding；其他绑定会显式失败。
- 如需回滚，可 revert `4b1c613` 和前置 `baa0c9e`；不会影响原工作区已保存的 stash。

## UI 证据

不适用：本 PR 不包含前端或可视化改动。

## AI 使用情况

本 PR 使用 AI 辅助完成代码检索、实现和测试编排；规则动作、Condition 生命周期、持久化恢复和原子失败边界已由提交者复核。该 PR 仍需至少一位人工 reviewer 在合并前检查。

## 自检

- [x] 改动范围符合 #485 完整验收标准；不包含 #319 模组内容改版或 E7/C3/SAN 数值消费。
- [x] 不包含无关工作区改动。
- [x] 已包含必要的生命周期、恢复、失败和集成测试。
- [x] 不包含密钥、个人信息或非预期生成物。
- [x] 已完成 AI 辅助质量检查。
- [ ] 已完成至少一位人工 Review，等待 reviewer。