### PR TITLE
fix(rule-engine): 规则分支的掷骰需求与裁决检定必须一致 (#462)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -1479,7 +1479,7 @@ class AdjudicationEngineService:
         if adjudication.rule_decision is not None:
             # Refuses an id the module never declared, so a model cannot invent
             # a rule or reach a branch its option does not select.
-            rule, _ = resolve_rule_option(
+            rule, branch_id = resolve_rule_option(
                 runtime.module_content,
                 rule_id=adjudication.rule_decision.rule_id,
                 option_id=adjudication.rule_decision.option_id,
@@ -1508,6 +1508,44 @@ class AdjudicationEngineService:
                     internal_reason=(
                         "RuleDecision 超出当前可用范围: "
                         f"{adjudication.rule_decision.rule_id}"
+                    ),
+                )
+            # 分支声明的掷骰需求，和这次裁决实际带的检定，必须一致（#462）。
+            #
+            # `requires_check` 不是模组字段，投影发布候选时现算的就是下面这个
+            # `pending_check_for`（projection_v3.py），所以 Agent 手里的标注与
+            # 这里的判断同源、不可能不一致——不一致只可能是 Agent 自己写错了。
+            #
+            # 两个方向都必须拦：漏写 check，规则会被静默吞掉（不掷骰、不提交效果，
+            # 却照报 success）；多写 check，掷骰结果会被完全忽略（分支效果无条件
+            # 提交，失败也照样生效）。两种都比可见的失败更糟，因为它们不留痕迹。
+            #
+            # 与 RULE_OUT_OF_SCOPE 一样是 fault="agent" 且可自动修复：补上或去掉
+            # check 就能重新提交，没有理由让玩家的回合死在这里。区别在于此处
+            # agent_match_admits 已经通过、规则确实适用，所以放弃 rule_decision
+            # 不算可自动接受的修复（见 semantic_preservation 的 _rule_decision_dropped）。
+            check_step, _ = pending_check_for(rule, branch_id)
+            declares_check = adjudication.check.mode != "none"
+            if check_step is not None and not declares_check:
+                self._reject_validation(
+                    "RULE_REQUIRES_CHECK",
+                    repairability="auto_repairable",
+                    fault="agent",
+                    player_safe_reason="这次行动需要先进行一次检定",
+                    internal_reason=(
+                        f"Rule {rule.id} 的分支 {branch_id} 在 {check_step.id} 处要求掷骰，"
+                        "裁决却声明 check.mode=none"
+                    ),
+                )
+            if check_step is None and declares_check:
+                self._reject_validation(
+                    "RULE_FORBIDS_CHECK",
+                    repairability="auto_repairable",
+                    fault="agent",
+                    player_safe_reason="这次行动的结果不取决于检定",
+                    internal_reason=(
+                        f"Rule {rule.id} 的分支 {branch_id} 不含检定步，"
+                        f"裁决却声明 check.mode={adjudication.check.mode}"
                     ),
                 )
         else:
@@ -1837,10 +1875,37 @@ class AdjudicationEngineService:
         step, _ = pending_check_for(rule, branch_id)
         if step is not None:
             if check_run is None:
-                # 分支要求掷骰，裁决却没带检定：拒绝提交后果，而不是当作成功。
-                return ()
+                # 兜底：`_validate_adjudication` 已在提交期拦下这种裁决（#462），
+                # 走到这里说明有别的路径绕过了校验。过去这里 `return ()`，效果
+                # 确实没提交，但行动仍被判成功——规则对上层和玩家等价于不存在。
+                AdjudicationEngineService._reject_validation(
+                    "RULE_REQUIRES_CHECK",
+                    repairability="auto_repairable",
+                    fault="agent",
+                    player_safe_reason="这次行动需要先进行一次检定",
+                    internal_reason=(
+                        f"Rule {rule.id} 的分支 {branch_id} 要求掷骰，"
+                        "结算时却没有 CheckRun"
+                    ),
+                    classification_coverage="rule_effects_excluded",
+                )
             degree = (check_run.final_result or check_run.roll).degree
             return tuple(effects_after_degree(rule, step.id, degree))
+
+        if check_run is not None:
+            # 镜像面兜底（#462）：分支不掷骰，却带着掷骰结果走到了结算。下面那条
+            # 「整条链就是它的后果」的路径不看 degree，会把失败的掷骰照成功提交。
+            AdjudicationEngineService._reject_validation(
+                "RULE_FORBIDS_CHECK",
+                repairability="auto_repairable",
+                fault="agent",
+                player_safe_reason="这次行动的结果不取决于检定",
+                internal_reason=(
+                    f"Rule {rule.id} 的分支 {branch_id} 不含检定步，"
+                    "结算时却带着 CheckRun"
+                ),
+                classification_coverage="rule_effects_excluded",
+            )
 
         walk = walk_rule(rule, branch_id=branch_id)
         if walk.completed:

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -82,6 +82,20 @@ _REPAIR_HINTS: dict[str, str] = {
         "target_kinds、target_ids 为空即表示该维度不设限，非空才要求本次裁决落在"
         "其中。确认硬约束不匹配后，才去掉 rule_decision，按普通裁决重新给出这一步。"
     ),
+    "RULE_REQUIRES_CHECK": (
+        "所选 rule_decision 的分支需要掷骰（该候选的 requires_check=true），"
+        "但这一版把 check 写成了 mode=none。保留 summary、method、target 与"
+        " rule_decision 原样不动，只把 check 换成 RequiredAdjudicationCheck，"
+        "技能取该候选的 check_skill_id（没有就选玩家最贴合本次方法的技能）。"
+        "不要为了绕开这个错误去掉 rule_decision——规则此时此地确实适用，去掉它"
+        "会把一个由掷骰决定的模组分支变成自由叙事，这一步会因此停下来问玩家。"
+    ),
+    "RULE_FORBIDS_CHECK": (
+        "所选 rule_decision 的分支不掷骰（该候选的 requires_check=false），"
+        "结果是确定的，但这一版多带了一个 check。保留 summary、method、target 与"
+        " rule_decision 原样不动，只把 check 换成 NoAdjudicationCheck()。"
+        "不要为了凑格式编一个技能出来，也不要去掉 rule_decision。"
+    ),
     "INVENTORY_TARGET_NOT_PORTABLE": (
         "holder_actor_id 只接受 player_view.scene.loose_items、player_view.inventory，"
         "或同一 effects 序列先用 ensure_runtime_entity(entity_kind=object) 创建的物品。"

--- a/agent-collaboration-framework/collaboration_framework/host/application/semantic_preservation.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/semantic_preservation.py
@@ -53,7 +53,7 @@ def compare_repair_semantics(
     rule_dropped = _rule_decision_dropped(original, repaired, validation_feedback)
     if not rule_dropped and original.rule_decision != repaired.rule_decision:
         return _clarification("RULE_DECISION_CHANGED")
-    if not _check_is_mechanical(original, repaired):
+    if not _check_is_mechanical(original, repaired, validation_feedback):
         return _clarification("CHECK_CHANGED")
     constraint_result = _check_explicit_constraints(
         player_input,
@@ -236,13 +236,39 @@ def _compare_target(
     return _clarification("TARGET_CHANGED")
 
 
+def _check_realigns_with_rule(
+    original: ActionAdjudication,
+    repaired: ActionAdjudication,
+    feedback: ValidationFeedback,
+) -> bool:
+    """把 check 调整到与规则分支一致，是唯一可自动接受的 mode 变化（#462）。
+
+    引擎拒绝时已经点明了差在哪一边，修复只能朝那一边走：分支要掷骰就补上检定，
+    分支不掷骰就去掉检定。反方向、以及任何别的错误码下的 mode 变化，仍然是
+    `CHECK_CHANGED`——那等于修复把玩家这一步换成了另一件事。
+
+    这里只放行 mode 本身；候选技能、难度是否可用由引擎重新整体校验一遍
+    （`_validated_options`），Host 不替模型认领这部分判断。
+    """
+
+    before, after = original.check, repaired.check
+    if feedback.code == "RULE_REQUIRES_CHECK":
+        return before.mode == "none" and after.mode != "none"
+    if feedback.code == "RULE_FORBIDS_CHECK":
+        return before.mode != "none" and after.mode == "none"
+    return False
+
+
 def _check_is_mechanical(
     original: ActionAdjudication,
     repaired: ActionAdjudication,
+    feedback: ValidationFeedback,
 ) -> bool:
     before = original.check
     after = repaired.check
-    if before.mode != after.mode or len(before.candidates) != len(after.candidates):
+    if before.mode != after.mode:
+        return _check_realigns_with_rule(original, repaired, feedback)
+    if len(before.candidates) != len(after.candidates):
         return False
     for old, new in zip(before.candidates, after.candidates, strict=True):
         if (

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -31,6 +31,7 @@ from collaboration_framework.contracts import (
     PushAdjudication,
     Repairability,
     RequiredAdjudicationCheck,
+    RuleDecisionRef,
     SelectCheckChoice,
     SingleActionDecision,
     SkillCheckCandidate,
@@ -2587,3 +2588,116 @@ async def test_narrator_rejects_first_person_subject_in_prose() -> None:
         await ActionPlanNarrator(FirstPersonNarrationModel()).narrate(context)
 
     assert raised.value.reason == "subject_ownership"
+
+
+# --------------------------------------------------------------------------- #
+# #462：漏写 check 的那一版必须能沿着修复回路走回掷骰，而不是静默成功。
+# --------------------------------------------------------------------------- #
+
+NEIGHBOUR_SKILL = "fast-talk"
+
+
+def neighbourhood_runtime():
+    """站在邻里、手上有 fast-talk 的房间：`question_neighbors` 在这里可用。"""
+
+    module = ModuleContentV3.model_validate_json(V3_FIXTURE.read_text(encoding="utf-8"))
+    state = GameState(
+        room_id="room_01",
+        scene_id="neighborhood",
+        actors={
+            "pc_1": ActorState(
+                player_id="player_01",
+                name="陈探员",
+                source_character_id="character_v3",
+                source_character_version=1,
+                state={
+                    "skills": {SKILL: 60, NEIGHBOUR_SKILL: 55},
+                    "skill_labels": {SKILL: "侦查", NEIGHBOUR_SKILL: "话术"},
+                },
+            )
+        },
+        entities={},
+    )
+    engine_store = InMemoryEngineStore()
+    engine_store.register_room(module_content=module, initial_state=state)
+    return module, engine_store, PlayerViewProjector(RuleEngineService(engine_store))
+
+
+class MissingCheckAdjudicator:
+    """先犯真实模型犯过的那个错，再照着指引改。
+
+    实测两次都是这样：规则和选项都选对，`check` 却写成 `{"mode":"none"}`。
+    """
+
+    def __init__(self) -> None:
+        self.contexts = []
+
+    async def adjudicate(self, context):
+        self.contexts.append(context)
+        repairing = context.previous_rejection is not None
+        check = (
+            RequiredAdjudicationCheck(
+                candidates=(
+                    SkillCheckCandidate(
+                        candidate_id=NEIGHBOUR_SKILL,
+                        skill_id=NEIGHBOUR_SKILL,
+                        difficulty="regular",
+                        method_summary="搭话套近乎",
+                        player_safe_reason="使用话术",
+                    ),
+                )
+            )
+            if repairing
+            else NoAdjudicationCheck()
+        )
+        return ActionAdjudication(
+            request_id="untrusted",
+            source_revision="untrusted",
+            actor_id="untrusted",
+            summary="跟邻居打听消息",
+            target=ActionTarget(kind="entity", id="lyla"),
+            method=ActionMethod(family="social", description="跟邻居打听消息"),
+            rule_decision=RuleDecisionRef(
+                rule_id="question_neighbors", option_id="fast-talk"
+            ),
+            check=check,
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_rule_check_is_repaired_back_into_a_roll() -> None:
+    """#462 全链路：拒绝 → 带指引重试 → 语义保持放行 → 真的走到掷骰。
+
+    这条把四处改动串起来测：引擎的 RULE_REQUIRES_CHECK、`to_feedback` 不改写这个
+    码（改写了指引就查不到）、`_REPAIR_HINTS` 的指引跟着拒绝理由回到模型、
+    `_check_is_mechanical` 放行 none → required。少任何一环，这一步都会停成
+    needs_clarification，而不是停在玩家面前的那次检定上。
+    """
+
+    _, engine_store, projector = neighbourhood_runtime()
+    adjudicator = MissingCheckAdjudicator()
+    engine = AdjudicationEngineService(
+        engine_store,
+        dice=DiceRoller(SequenceDiceSource([10])),
+    )
+    service = ActionPlanOrchestrator(
+        store=InMemoryActionPlanRunStore(),
+        adjudicator=adjudicator,
+        executor=engine,
+        player_view_projector=projector,
+    )
+    original = player_input("issue462-parent", "跟邻居打听消息")
+
+    result = await service.start_or_resume(original, plan=plan(1))
+
+    # 修复过一次，而且第二次拿到的是这条错误码和它的指引。
+    assert len(adjudicator.contexts) == 2
+    rejection = adjudicator.contexts[1].previous_rejection
+    assert rejection is not None
+    assert rejection.startswith("RULE_REQUIRES_CHECK: ")
+    assert _REPAIR_HINTS["RULE_REQUIRES_CHECK"] in rejection
+
+    # 停在检定上等玩家，而不是「成功了但什么都没发生」。
+    assert result.run.status == "waiting_for_player"
+    assert result.latest_execution is not None
+    assert result.latest_execution.pending_decision is not None

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -2591,7 +2591,24 @@ async def test_narrator_rejects_first_person_subject_in_prose() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# #462：漏写 check 的那一版必须能沿着修复回路走回掷骰，而不是静默成功。
+# #462：`RULE_REQUIRES_CHECK` 被拒之后，Agent 那一次重新生成的端到端走向
+#
+# 语义保持闸门本身的逐行判定在 tests/test_semantic_preservation.py 的 #462 一节
+# （A–E 五行）。这里钉的是它下游真正发生了什么——因为「判 requires_clarification」
+# 和「玩家这一回合真的停下来被问」之间还隔着 orchestrator 的一整段分流：
+#
+# - A 规则不动 + 补 check
+#     → waiting_for_player，停在这条分支本来就该有的检定上（唯一自动通过的路）
+# - B 丢规则 + 不掷骰
+#     → needs_clarification，safe_failure_code = SEMANTIC_REPAIR_REQUIRES_CLARIFICATION
+# - E 原样返回没改
+#     → needs_clarification，safe_failure_code = REPAIR_BUDGET_EXHAUSTED
+#
+# C/D 与 B 走同一条 orchestrator 分支（都是 RULE_DECISION_CHANGED），差别只在语义
+# 保持那一层，不重复铺端到端。
+#
+# 三行都必须满足同一条底线：世界没有被写过，玩家的回合没有白白消耗成一次“成功但
+# 什么都没发生”。
 # --------------------------------------------------------------------------- #
 
 NEIGHBOUR_SKILL = "fast-talk"
@@ -2664,6 +2681,42 @@ class MissingCheckAdjudicator:
         )
 
 
+class RuleDroppingAdjudicator(MissingCheckAdjudicator):
+    """B 行：被拒之后不补 check，而是把规则整个丢掉，退回纯叙事。"""
+
+    async def adjudicate(self, context):
+        proposal = await super().adjudicate(context)
+        if context.previous_rejection is None:
+            return proposal
+        return proposal.model_copy(
+            update={"rule_decision": None, "check": NoAdjudicationCheck()},
+            deep=True,
+        )
+
+
+class StubbornAdjudicator(MissingCheckAdjudicator):
+    """E 行：原样返回，什么都不改。"""
+
+    async def adjudicate(self, context):
+        proposal = await super().adjudicate(context)
+        return proposal.model_copy(update={"check": NoAdjudicationCheck()}, deep=True)
+
+
+def issue462_service(adjudicator):
+    _, engine_store, projector = neighbourhood_runtime()
+    engine = AdjudicationEngineService(
+        engine_store,
+        dice=DiceRoller(SequenceDiceSource([10])),
+    )
+    service = ActionPlanOrchestrator(
+        store=InMemoryActionPlanRunStore(),
+        adjudicator=adjudicator,
+        executor=engine,
+        player_view_projector=projector,
+    )
+    return engine_store, service
+
+
 @pytest.mark.asyncio
 async def test_missing_rule_check_is_repaired_back_into_a_roll() -> None:
     """#462 全链路：拒绝 → 带指引重试 → 语义保持放行 → 真的走到掷骰。
@@ -2701,3 +2754,45 @@ async def test_missing_rule_check_is_repaired_back_into_a_roll() -> None:
     assert result.run.status == "waiting_for_player"
     assert result.latest_execution is not None
     assert result.latest_execution.pending_decision is not None
+
+
+@pytest.mark.asyncio
+async def test_dropping_the_rule_stops_the_plan_to_ask_the_player() -> None:
+    """B 行端到端：放弃规则不被禁止，但这一步要停下来问玩家。
+
+    与 `RULE_OUT_OF_SCOPE` 的分岔就在这里 —— 那边丢规则是静默放行的收窄
+    （`RULE_DECISION_DROPPED`），这边规则确实适用，丢掉它会把一个掷骰门控的模组
+    分支交给自由叙事，所以降级成「要玩家确认」。回合不死，是停下来问。
+    """
+
+    engine_store, service = issue462_service(RuleDroppingAdjudicator())
+    original = player_input("issue462-drop-parent", "跟邻居打听消息")
+
+    result = await service.start_or_resume(original, plan=plan(1))
+
+    assert result.run.status == "needs_clarification"
+    assert result.run.steps[0].status == "stopped"
+    assert result.run.steps[0].safe_failure_code == (
+        "SEMANTIC_REPAIR_REQUIRES_CLARIFICATION"
+    )
+    # 停下来问，不是「成功但什么都没发生」：世界一个字都没写过。
+    assert len(engine_store.inspect_domain_events(original.room_id)) == 0
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_repair_exhausts_the_budget_instead_of_committing() -> None:
+    """E 行端到端：空转修复撞回同一个拒绝，预算耗尽后停下问玩家。
+
+    语义保持那层判它 preserved（确实什么都没换），所以拦住它的必须是引擎——重新
+    提交会再次撞上 RULE_REQUIRES_CHECK。这条钉住「拒绝是稳定的」：同样的裁决第二
+    次提交不会因为走了修复回路就被放行。
+    """
+
+    engine_store, service = issue462_service(StubbornAdjudicator())
+    original = player_input("issue462-stubborn-parent", "跟邻居打听消息")
+
+    result = await service.start_or_resume(original, plan=plan(1))
+
+    assert result.run.status == "needs_clarification"
+    assert result.run.steps[0].safe_failure_code == "REPAIR_BUDGET_EXHAUSTED"
+    assert len(engine_store.inspect_domain_events(original.room_id)) == 0

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -60,7 +60,11 @@ from collaboration_framework.engine import (
 from collaboration_framework.engine.initialization import create_initial_game_state
 from collaboration_framework.engine.navigation import resolve_location_target
 from collaboration_framework.engine.projection_v3 import location_breadcrumbs
-from collaboration_framework.engine.rules_v3 import evaluate_condition, walk_rule
+from collaboration_framework.engine.rules_v3 import (
+    evaluate_condition,
+    pending_check_for,
+    walk_rule,
+)
 from tests.time_fixtures import day_cycle_module
 
 FIXTURE = (
@@ -862,9 +866,25 @@ class AdjudicationAgainstV3Tests(unittest.IsolatedAsyncioTestCase):
         菜单是按「玩家站在哪」发布的，所以 `question_neighbors` 会出现在候选里；
         `target=lyla` 仍需在提交时复查，但模型把打招呼归成 `social` 不再导致
         `RULE_OUT_OF_SCOPE`。
+
+        `fast-talk` 分支是要掷骰的，所以这里带上与它一致的 check：这条断言盯的是
+        动作族差异不阻断规则，不该顺带依赖「漏写 check 也能返回 success」那个
+        静默吞规则的老行为（#462）。
         """
 
-        store, engine, rules = self.build(scene_id="neighborhood")
+        store, engine, rules = self.build(
+            scene_id="neighborhood",
+            actors={
+                ACTOR: ActorState(
+                    player_id=PLAYER,
+                    name="陈探员",
+                    source_character_id="character_v3",
+                    source_character_version=1,
+                    state={"skills": {"spot-hidden": 60, "fast-talk": 55}},
+                    resources=ActorResources(san=55, luck=50),
+                )
+            },
+        )
         snapshot = await rules.read(
             PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
         )
@@ -881,7 +901,17 @@ class AdjudicationAgainstV3Tests(unittest.IsolatedAsyncioTestCase):
             summary="跟邻居打个招呼",
             target=ActionTarget(kind="entity", id="lyla"),
             method=ActionMethod(family="social", description="打招呼"),
-            check=NoAdjudicationCheck(),
+            check=RequiredAdjudicationCheck(
+                candidates=(
+                    SkillCheckCandidate(
+                        candidate_id="fast-talk",
+                        skill_id="fast-talk",
+                        difficulty="regular",
+                        method_summary="搭话套近乎",
+                        player_safe_reason="使用话术",
+                    ),
+                )
+            ),
             rule_decision=RuleDecisionRef(
                 rule_id="question_neighbors", option_id="fast-talk"
             ),
@@ -891,7 +921,9 @@ class AdjudicationAgainstV3Tests(unittest.IsolatedAsyncioTestCase):
                 room_id=ROOM, player_id=PLAYER, adjudication=greeting
             )
         )
-        self.assertEqual(execution.status, "resolved")
+        # 没被 RULE_OUT_OF_SCOPE 挡下，而是走到了这条分支本来就该有的检定上。
+        self.assertEqual(execution.status, "awaiting_skill_choice")
+        self.assertIsNotNone(execution.pending_decision)
         self.assertGreater(self.store_events(store), 0)
 
     @staticmethod
@@ -2126,6 +2158,245 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
                     ),
                 )
             )
+
+
+class RuleCheckAlignmentTests(unittest.IsolatedAsyncioTestCase):
+    """分支要不要掷骰，和裁决带不带检定，必须一致（#462）。
+
+    不一致的两个方向过去都是静默的：漏写 check 时规则整个被吞掉（不掷骰、不提交
+    效果，却照报 `outcome=success`），多写 check 时掷骰结果被完全忽略（分支效果
+    无条件提交，失败也照样生效）。两种都不留痕迹，对上层和玩家等价于「这条规则
+    不存在」/「这次掷骰不算数」，比可见的失败更糟。
+    """
+
+    def setUp(self) -> None:
+        self.content = module()
+
+    def build(self, **overrides):
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=self.content,
+            initial_state=game_state(self.content, **overrides),
+        )
+        return store, AdjudicationEngineService(store), RuleEngineService(store)
+
+    def night_watch_room(self):
+        return self.build(
+            scene_id="kimball_grounds",
+            world_time=WorldTimeState(
+                current_point_id="hour_18",
+                current=WorldTimePoint(day_index=0, hour_of_day=18),
+                current_time_segment="evening",
+            ),
+            entities={
+                "case_tracker": {"night_watch_checked": False},
+                "cemetery_figure": {
+                    "visit_observed": False,
+                    "left_forever": False,
+                    "sighted": False,
+                },
+            },
+        )
+
+    def crypt_room(self):
+        return self.build(
+            scene_id="crypt",
+            entities={
+                "cemetery_figure": {
+                    "visit_observed": True,
+                    "sighted": True,
+                    "confronted": True,
+                    "left_forever": False,
+                }
+            },
+        )
+
+    @staticmethod
+    def night_watch_adjudication(revision, check):
+        return ActionAdjudication(
+            request_id="night-watch-alignment",
+            source_revision=revision,
+            actor_id=ACTOR,
+            summary="监视周围环境",
+            target=ActionTarget(kind="location", id="kimball_grounds"),
+            method=ActionMethod(family="surveil", description="监视"),
+            rule_decision=RuleDecisionRef(rule_id="keep_night_watch", option_id="luck"),
+            check=check,
+            success_effects=(),
+            failure_effects=(),
+        )
+
+    @staticmethod
+    def let_leave_adjudication(revision, check):
+        return ActionAdjudication(
+            request_id="let-leave-alignment",
+            source_revision=revision,
+            actor_id=ACTOR,
+            summary="让道格拉斯离开",
+            target=ActionTarget(kind="entity", id="cemetery_figure"),
+            method=ActionMethod(family="let_leave", description="放他走"),
+            rule_decision=RuleDecisionRef(
+                rule_id="let_douglas_leave", option_id="proceed"
+            ),
+            check=check,
+            success_effects=(),
+            failure_effects=(),
+        )
+
+    async def revision(self, rules) -> int:
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        return snapshot.revision
+
+    def assert_requires_check(
+        self, rule_id: str, option_id: str, expected: bool
+    ) -> None:
+        """把断言钉在投影发布给 Agent 的那个 `requires_check` 上。
+
+        引擎判断和候选标注同源（都是 `pending_check_for`），所以这两条前置断言
+        既固定了模组事实，也保证下面测的正是 Agent 看得见的那个契约。
+        """
+
+        rule = next(item for item in self.content.rules if item.id == rule_id)
+        self.assertEqual(pending_check_for(rule, option_id)[0] is not None, expected)
+
+    async def test_branch_requiring_a_roll_refuses_a_check_free_adjudication(
+        self,
+    ) -> None:
+        """#462 主体：《追书人》守夜的幸运检定不能被静默吞掉。
+
+        真实模型下两次都复现：`rule_decision` 选对了 `keep_night_watch/luck`，
+        `check` 却写成 `{"mode":"none"}`。此前引擎照报 `action.succeeded`，而
+        `cemetery_figure.sighted` 始终是 false —— 规则从未执行。
+        """
+
+        self.assert_requires_check("keep_night_watch", "luck", True)
+        store, engine, rules = self.night_watch_room()
+        revision = await self.revision(rules)
+
+        with self.assertRaises(AdjudicationValidationError) as rejected:
+            await engine.submit(
+                SubmitAdjudicationRequest(
+                    room_id=ROOM,
+                    player_id=PLAYER,
+                    adjudication=self.night_watch_adjudication(
+                        revision, NoAdjudicationCheck()
+                    ),
+                )
+            )
+
+        result = rejected.exception.result
+        self.assertEqual(result.code, "RULE_REQUIRES_CHECK")
+        # 与 RULE_OUT_OF_SCOPE 同级：Agent 的失误，补上 check 就能重来，
+        # 没有理由让玩家的回合死在这里。
+        self.assertEqual(result.repairability, "auto_repairable")
+        self.assertEqual(result.fault, "agent")
+        # 拒绝必须是干净的：既不推进世界，也不发 action.succeeded。
+        self.assertEqual(len(store.inspect_domain_events(ROOM)), 0)
+        figure = store.inspect_state(ROOM).entities.get("cemetery_figure", {})
+        self.assertIs(figure.get("sighted"), False)
+
+    async def test_branch_without_a_roll_refuses_an_adjudication_carrying_a_check(
+        self,
+    ) -> None:
+        """#462 镜像面：不掷骰的分支多带一个 check，掷骰结果会被完全丢弃。
+
+        `let_douglas_leave/proceed` 是纯效果分支。此前提交一个
+        `RequiredAdjudicationCheck` 会真的掷骰、掷失败、报 `action.failed`，
+        而 `cemetery_figure.left_forever` 照样被翻成 true —— 世界按成功推进了。
+        """
+
+        self.assert_requires_check("let_douglas_leave", "proceed", False)
+        store, engine, rules = self.crypt_room()
+        revision = await self.revision(rules)
+
+        with self.assertRaises(AdjudicationValidationError) as rejected:
+            await engine.submit(
+                SubmitAdjudicationRequest(
+                    room_id=ROOM,
+                    player_id=PLAYER,
+                    adjudication=self.let_leave_adjudication(
+                        revision,
+                        RequiredAdjudicationCheck(
+                            candidates=(
+                                SkillCheckCandidate(
+                                    candidate_id="spot-hidden",
+                                    skill_id="spot-hidden",
+                                    difficulty="regular",
+                                    method_summary="盯住他",
+                                    player_safe_reason="使用侦查",
+                                ),
+                            )
+                        ),
+                    ),
+                )
+            )
+
+        result = rejected.exception.result
+        self.assertEqual(result.code, "RULE_FORBIDS_CHECK")
+        self.assertEqual(result.repairability, "auto_repairable")
+        self.assertEqual(result.fault, "agent")
+        self.assertEqual(len(store.inspect_domain_events(ROOM)), 0)
+        figure = store.inspect_state(ROOM).entities.get("cemetery_figure", {})
+        self.assertIs(figure.get("left_forever"), False)
+
+    async def test_aligned_check_reaches_the_roll(self) -> None:
+        """对齐之后就是主路径：补上 check 的那一版必须能正常走到掷骰。
+
+        这条钉住修复出口 —— 拒绝只有在「补 check 能重新提交」时才算可修复。
+        """
+
+        _, engine, rules = self.night_watch_room()
+        revision = await self.revision(rules)
+
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=self.night_watch_adjudication(
+                    revision,
+                    RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="luck",
+                                skill_id="luck",
+                                difficulty="regular",
+                                method_summary="留守观察",
+                                player_safe_reason="规则要求进行幸运检定",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+
+        self.assertEqual(execution.status, "awaiting_skill_choice")
+        self.assertIsNotNone(execution.pending_decision)
+
+    async def test_check_free_branch_still_commits_without_a_check(self) -> None:
+        """反向出口：32 条 `requires_check=false` 的分支合法地「有规则、无检定」。
+
+        新的不变量挂在分支的 `requires_check` 上，不是挂在「有没有
+        `rule_decision`」上，所以纯效果分支必须照常整条提交。
+        """
+
+        store, engine, rules = self.crypt_room()
+        revision = await self.revision(rules)
+
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=self.let_leave_adjudication(
+                    revision, NoAdjudicationCheck()
+                ),
+            )
+        )
+
+        self.assertEqual(execution.outcome, "success")
+        figure = store.inspect_state(ROOM).entities.get("cemetery_figure", {})
+        self.assertIs(figure.get("left_forever"), True)
 
 
 if __name__ == "__main__":

--- a/agent-collaboration-framework/tests/test_semantic_preservation.py
+++ b/agent-collaboration-framework/tests/test_semantic_preservation.py
@@ -521,7 +521,25 @@ def test_same_length_effect_replacement_requires_clarification() -> None:
     assert result.reason_code == "NEW_OR_CHANGED_EFFECT"
 
 
-def _greeting(*, rule: RuleDecisionRef | None) -> ActionAdjudication:
+def _fast_talk_check() -> RequiredAdjudicationCheck:
+    return RequiredAdjudicationCheck(
+        candidates=(
+            SkillCheckCandidate(
+                candidate_id="fast-talk",
+                skill_id="fast-talk",
+                difficulty="regular",
+                method_summary="搭话套近乎",
+                player_safe_reason="使用话术",
+            ),
+        )
+    )
+
+
+def _greeting(
+    *,
+    rule: RuleDecisionRef | None,
+    check=None,
+) -> ActionAdjudication:
     return ActionAdjudication(
         request_id="request",
         source_revision="0",
@@ -529,7 +547,7 @@ def _greeting(*, rule: RuleDecisionRef | None) -> ActionAdjudication:
         summary="跟邻居打个招呼",
         target=ActionTarget(kind="entity", id=TARGET),
         method=ActionMethod(family="social", description="打招呼"),
-        check=NoAdjudicationCheck(),
+        check=check or NoAdjudicationCheck(),
         rule_decision=rule,
     )
 
@@ -678,3 +696,87 @@ def test_nonportable_pickup_can_be_narrowed_to_zero_write_obstruction() -> None:
     )
 
     assert result.status == "narrowed"
+
+
+# --------------------------------------------------------------------------- #
+# #462：引擎拒绝「分支要不要掷骰」与「裁决带不带检定」不一致之后，唯一可自动
+# 接受的修复是把 check 调到与分支一致。放弃 rule_decision 不被禁止，但要问玩家。
+# --------------------------------------------------------------------------- #
+
+_NEIGHBOURS = RuleDecisionRef(rule_id="question_neighbors", option_id="fast-talk")
+
+
+def test_adding_the_required_check_is_a_mechanical_repair() -> None:
+    """#462：补上分支要求的那次检定，是这条错误码下走得通的修复。
+
+    今天任何 `check.mode` 变化都判 CHECK_CHANGED，修复会被卡死在语义保持这一关：
+    模型照着提示补了 `RequiredAdjudicationCheck`，这一步照样停下来问玩家。
+    """
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS),
+        _greeting(rule=_NEIGHBOURS, check=_fast_talk_check()),
+        "RULE_REQUIRES_CHECK",
+    )
+
+    assert result.status == "preserved"
+    assert result.reason_code == "MECHANICAL_REPAIR"
+
+
+def test_dropping_a_superfluous_check_is_a_mechanical_repair() -> None:
+    """#462 镜像面：不掷骰的分支，去掉多写的 check 同样是机械修复。"""
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS, check=_fast_talk_check()),
+        _greeting(rule=_NEIGHBOURS),
+        "RULE_FORBIDS_CHECK",
+    )
+
+    assert result.status == "preserved"
+    assert result.reason_code == "MECHANICAL_REPAIR"
+
+
+def test_realignment_only_goes_the_direction_the_engine_named() -> None:
+    """引擎说缺检定，修复却把检定去掉了——那不是对齐，是换了件事做。"""
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS, check=_fast_talk_check()),
+        _greeting(rule=_NEIGHBOURS),
+        "RULE_REQUIRES_CHECK",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "CHECK_CHANGED"
+
+
+def test_check_mode_may_not_change_under_an_unrelated_rejection() -> None:
+    """目标不存在跟掷不掷骰无关，这时改 check.mode 是模型在夹带。"""
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS),
+        _greeting(rule=_NEIGHBOURS, check=_fast_talk_check()),
+        "TARGET_UNAVAILABLE",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "CHECK_CHANGED"
+
+
+def test_dropping_the_rule_instead_of_adding_the_check_asks_the_player() -> None:
+    """#462 验收：这里的 `agent_match_admits` 已经通过，规则确实适用。
+
+    与 RULE_OUT_OF_SCOPE 不同——那边规则本就不适用，降级成叙事裁决不多拿任何东西；
+    这边降级会把一个掷骰门控的模组分支交给自由叙事，而 KeeperInformationCapability
+    已经把未发现情报的全文交给了 Agent，叙事侧还没有正向闸门（#446）。所以
+    `_rule_decision_dropped` 保持只认 RULE_OUT_OF_SCOPE，这一步落到
+    RULE_DECISION_CHANGED 上：回合不死，是停下来问玩家。
+    """
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS),
+        _greeting(rule=None, check=_fast_talk_check()),
+        "RULE_REQUIRES_CHECK",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "RULE_DECISION_CHANGED"

--- a/agent-collaboration-framework/tests/test_semantic_preservation.py
+++ b/agent-collaboration-framework/tests/test_semantic_preservation.py
@@ -699,14 +699,42 @@ def test_nonportable_pickup_can_be_narrowed_to_zero_write_obstruction() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# #462：引擎拒绝「分支要不要掷骰」与「裁决带不带检定」不一致之后，唯一可自动
-# 接受的修复是把 check 调到与分支一致。放弃 rule_decision 不被禁止，但要问玩家。
+# #462：`RULE_REQUIRES_CHECK` 被拒之后，Agent 那一次重新生成的每条出路
+#
+# 被拒的那版是 `rule_decision=R` + `check=none`。修复预算只有一次
+# （`ActionPlanPolicy.max_repair_attempts` 默认 1），所以下面这张表就是玩家这一
+# 回合的全部可能走向。每一行都由本节的一条测试钉住：
+#
+# | 行 | 重新生成的版本      | 闸门判定               | 最终走向            |
+# |----|--------------------|-----------------------|--------------------|
+# | A  | 规则不动 + 补 check | MECHANICAL_REPAIR     | 重新提交 → 正常掷骰 |
+# | B  | 丢规则 + 不掷骰     | RULE_DECISION_CHANGED | 停下问玩家          |
+# | C  | 丢规则 + 改自由检定 | RULE_DECISION_CHANGED | 停下问玩家          |
+# | D  | 换另一条规则        | RULE_DECISION_CHANGED | 停下问玩家          |
+# | E  | 原样返回没改        | MECHANICAL_REPAIR     | 引擎再拒 → 预算耗尽 |
+#
+# A/E 判 `preserved`，B/C/D 判 `requires_clarification`。E 之所以也是 preserved，
+# 是因为语义保持只回答「这次修复有没有换掉玩家原本要做的事」——什么都没换当然没换，
+# 拦住这种空转的是引擎第二次拒绝，不是这一层。
+#
+# B/C/D 三行都死在 `rule_decision` 的比较上——它排在 `check` 前面，所以这三种修复
+# 连 `_check_is_mechanical` 都走不到。这是有意的：`_rule_decision_dropped` 只认
+# `RULE_OUT_OF_SCOPE`（那边规则本就不适用，丢掉它等于回到本来就该走的普通叙事
+# 裁决），而这里 `agent_match_admits` 已经通过、规则确实适用，丢掉它等于把一个
+# 掷骰门控的模组分支交给自由叙事——而 `KeeperInformationCapability.content` 已经
+# 把未发现情报的全文交给了 Agent，叙事侧还没有正向闸门（#446）。
+#
+# 关键是「不被禁止」≠「可以自动走」：引擎没禁止 Agent 放弃规则，拦它的是这一层，
+# 而且拦法是降级成「要玩家确认」而不是「拒绝」。回合不死，是停下来问。
+#
+# A 行与 B 行的端到端走向（plan 真的掷骰 / 真的停成 needs_clarification）另见
+# tests/test_action_plan_orchestrator.py 的 #462 一节。
 # --------------------------------------------------------------------------- #
 
 _NEIGHBOURS = RuleDecisionRef(rule_id="question_neighbors", option_id="fast-talk")
 
 
-def test_adding_the_required_check_is_a_mechanical_repair() -> None:
+def test_row_a_adding_the_required_check_is_a_mechanical_repair() -> None:
     """#462：补上分支要求的那次检定，是这条错误码下走得通的修复。
 
     今天任何 `check.mode` 变化都判 CHECK_CHANGED，修复会被卡死在语义保持这一关：
@@ -762,7 +790,7 @@ def test_check_mode_may_not_change_under_an_unrelated_rejection() -> None:
     assert result.reason_code == "CHECK_CHANGED"
 
 
-def test_dropping_the_rule_instead_of_adding_the_check_asks_the_player() -> None:
+def test_row_c_dropping_the_rule_for_a_free_check_asks_the_player() -> None:
     """#462 验收：这里的 `agent_match_admits` 已经通过，规则确实适用。
 
     与 RULE_OUT_OF_SCOPE 不同——那边规则本就不适用，降级成叙事裁决不多拿任何东西；
@@ -780,3 +808,61 @@ def test_dropping_the_rule_instead_of_adding_the_check_asks_the_player() -> None
 
     assert result.status == "requires_clarification"
     assert result.reason_code == "RULE_DECISION_CHANGED"
+
+
+def test_row_b_dropping_the_rule_for_pure_narration_asks_the_player() -> None:
+    """B 行：丢掉规则、也不掷骰，退回纯叙事——同样要问玩家。
+
+    这是 Agent 最省力的一条出路，也是最危险的一条：规则此时此地确实适用，成功链
+    上挂着掷骰门控的 `reveal_information`，而模型手里就有那条情报的全文。放行它
+    等于让模型自由讲一个本该掷骰才揭晓的节拍，所以这里必须停下来问人。
+    """
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS),
+        _greeting(rule=None),
+        "RULE_REQUIRES_CHECK",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "RULE_DECISION_CHANGED"
+
+
+def test_row_d_swapping_to_another_rule_asks_the_player() -> None:
+    """D 行：换一条规则等于让模型自己挑模组后果，那是 #226 留在服务端的决定。
+
+    `RULE_OUT_OF_SCOPE` 下已有同形状的断言；这里钉的是新错误码下同样不放行——
+    `_rule_decision_dropped` 只认「有 -> 无」，换一条连那个方向都不是。
+    """
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS),
+        _greeting(
+            rule=RuleDecisionRef(
+                rule_id="impress_caretaker", option_id="credit-rating"
+            ),
+            check=_fast_talk_check(),
+        ),
+        "RULE_REQUIRES_CHECK",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "RULE_DECISION_CHANGED"
+
+
+def test_row_e_an_unchanged_reproposal_is_semantically_preserved() -> None:
+    """E 行：原样返回在这一层是「语义没变」，不是错误。
+
+    语义保持只回答「这次修复有没有换掉玩家原本要做的事」，没换就是 preserved。
+    拦住这种空转修复的是引擎——重新提交会再次撞上 RULE_REQUIRES_CHECK，然后修复
+    预算耗尽。端到端那半截见 orchestrator 的 E 行测试。
+    """
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS),
+        _greeting(rule=_NEIGHBOURS),
+        "RULE_REQUIRES_CHECK",
+    )
+
+    assert result.status == "preserved"
+    assert result.reason_code == "MECHANICAL_REPAIR"

--- a/e2e/tests/rule-engine-real-model.e2e.ts
+++ b/e2e/tests/rule-engine-real-model.e2e.ts
@@ -465,15 +465,27 @@ async function settleChecksFor(
   }
 }
 
-// 这条用例此前被 #462 堵住：真实模型两次都把规则与选项选对（`keep_night_watch` /
-// `luck`），却把 `check` 声明成 `{"mode":"none"}`，而候选上的 `requires_check` 明明
-// 是 true。引擎拿到"分支要掷骰、裁决没带检定"时 `return ()`——不提交任何效果，却
-// 照样报 `action.succeeded`，于是规则静默不触发、叙事写"什么都没发生"、无处报错。
-// #462 之后引擎改成拒 `RULE_REQUIRES_CHECK`（auto_repairable / fault=agent），模型
-// 拿着 `_REPAIR_HINTS` 的指引补上 check 再提交，所以这条链路重新走得通了。
+// 这条用例的**第一个**阻塞是 #462：真实模型两次都把规则与选项选对
+// （`keep_night_watch` / `luck`），却把 `check` 声明成 `{"mode":"none"}`。引擎拿到
+// "分支要掷骰、裁决没带检定"时 `return ()`——不提交任何效果，却照样报
+// `action.succeeded`。#462 已修：改成拒 `RULE_REQUIRES_CHECK`（auto_repairable /
+// fault=agent），模型拿着 `_REPAIR_HINTS` 的指引补上 check 就能重新提交。
+//
+// 但换到**第二个**阻塞上了，实测 3/3（模组 3.0.9 @ e5ef4c7）：模型不再点名任何
+// 规则，`rule_decision` 直接不出，改为即兴掷一次侦察（`可取消: true`、目标值 60，
+// 而不是规则的幸运 99），于是 `sighted` 始终是 false。候选本身发布得好好的——
+// `keep_night_watch` 在场、`requires_check=True`、`check_skill_id=luck`，
+// semantic_hints 里就有「监视」，而玩家这句正是「监视周围环境」。
+//
+// 「没有规则时不该掷骰」归 #480（即兴检定只验技能归属，不验背后有无规则/后果），
+// 不属于 #462 的范围（#462 明确不含「Agent 侧为何会漏写/不写」）。待 #480 落地后
+// 再解开这条 skip。
+const NPC_SIGHTING_BLOCKED =
+  '阻塞：真实模型不出 rule_decision，改为即兴侦察检定，规则从不进入链路（#480）'
+
 test(
   '#451 真实模型：守夜幸运成功后人影现身，且喊得出道格拉斯',
-  { timeout: TEST_TIMEOUT_MS, skip: REAL_MODEL ? false : '需要 E2E_REAL_MODEL=1' },
+  { timeout: TEST_TIMEOUT_MS, skip: NPC_SIGHTING_BLOCKED },
   async () => {
     const room = await openRoom('issue451-real-watch')
     try {

--- a/e2e/tests/rule-engine-real-model.e2e.ts
+++ b/e2e/tests/rule-engine-real-model.e2e.ts
@@ -465,17 +465,15 @@ async function settleChecksFor(
   }
 }
 
-// 已知阻塞：真实模型两次都把规则与选项选对（`keep_night_watch` / `luck`），却把
-// `check` 声明成 `{"mode":"none"}`，而候选上的 `requires_check` 明明是 true。引擎
-// 拿到"分支要掷骰、裁决没带检定"时 `return ()`——不提交任何效果，却照样报
-// `action.succeeded`。于是规则静默不触发、叙事写"什么都没发生"、无处报错。
-// 这是模组之外的第三个成因，不属于 #451；待引擎侧改成可修复的显式拒绝后解开 skip。
-const NPC_SIGHTING_BLOCKED =
-  '阻塞：Agent 声明 check=none 时引擎静默吞掉规则，既不掷骰也不提交效果'
-
+// 这条用例此前被 #462 堵住：真实模型两次都把规则与选项选对（`keep_night_watch` /
+// `luck`），却把 `check` 声明成 `{"mode":"none"}`，而候选上的 `requires_check` 明明
+// 是 true。引擎拿到"分支要掷骰、裁决没带检定"时 `return ()`——不提交任何效果，却
+// 照样报 `action.succeeded`，于是规则静默不触发、叙事写"什么都没发生"、无处报错。
+// #462 之后引擎改成拒 `RULE_REQUIRES_CHECK`（auto_repairable / fault=agent），模型
+// 拿着 `_REPAIR_HINTS` 的指引补上 check 再提交，所以这条链路重新走得通了。
 test(
   '#451 真实模型：守夜幸运成功后人影现身，且喊得出道格拉斯',
-  { timeout: TEST_TIMEOUT_MS, skip: NPC_SIGHTING_BLOCKED },
+  { timeout: TEST_TIMEOUT_MS, skip: REAL_MODEL ? false : '需要 E2E_REAL_MODEL=1' },
   async () => {
     const room = await openRoom('issue451-real-watch')
     try {


### PR DESCRIPTION
Closes #462

## 问题

Agent 把规则和选项都选对，却把 `check` 声明成 `NoAdjudicationCheck`（`mode="none"`）时，引擎既不发起检定、也不提交任何效果，但仍然返回 `outcome="success"` 并发出 `action.succeeded`。规则被静默吞掉：世界推进了、玩家回合被消耗、叙事写「什么都没发生」、日志干净、错误码为空。

`E2E_REAL_MODEL=1` 下用 DeepSeek 连跑两次《追书人》守夜场景，两次都复现——模型都把 `rule_decision` 选对（`keep_night_watch` / `luck`），都把 `check` 写成 `{"mode":"none"}`。

镜像面同样是洞（issue 正文「补充信息 · 镜像面」）：分支不掷骰、裁决却带了检定时，`_owned_effects` 走 `walk.completed` 直接返回整条链的效果，`check_run` 的 degree 被完全丢弃——玩家掷了骰、失败了、系统报 `action.failed`，世界却按成功推进了。

## 改动

在 `_validate_adjudication` 里加双向不变量，不一致时**可见地**拒绝：

```
requires_check == true   ⇒  check.mode != "none"
requires_check == false  ⇒  check.mode == "none"
```

不变量挂在分支的 `requires_check` 上，**不是**挂在「有没有 `rule_decision`」上：实测 4 个模组 63 条分支中 32 条 `requires_check=false`，它们合法地「有规则、无检定」。

| 文件 | 改动 |
|---|---|
| `engine/adjudication.py` `_validate_adjudication` | 拒 `RULE_REQUIRES_CHECK` / `RULE_FORBIDS_CHECK`（`auto_repairable` / `fault="agent"`，与既有 `RULE_OUT_OF_SCOPE` 同级）。拒绝发生在 commit 之前，不产生事件也不提交效果 |
| `engine/adjudication.py` `_owned_effects` | `return ()` 与镜像面换成同样的拒绝作为兜底 |
| `host/application/semantic_preservation.py` | `_check_is_mechanical` 仅在这两个错误码下放行**对应方向**的 `check.mode` 变化；`_rule_decision_dropped` **不动** |
| `host/application/action_plan_orchestrator.py` | 为两个错误码补 `_REPAIR_HINTS`，引导模型对齐 check 而不是丢 `rule_decision` |
| `e2e/tests/rule-engine-real-model.e2e.ts` | #451 守夜场景的阻塞理由从 #462 更新为 #480（见下「未达成的验收标准」） |

### 为什么 `_rule_decision_dropped` 不扩展

这里 `agent_match_admits` **已经通过**、规则确实适用，与 `RULE_OUT_OF_SCOPE`（规则本就不适用，降级为叙事裁决不多拿任何东西）不同。此处降级会把一个掷骰门控的模组分支交给自由叙事，而 `KeeperInformationCapability.content` 已把未发现情报全文交给 Agent、叙事侧尚无正向闸门（#446）。所以放弃 `rule_decision` 落到默认的 `RULE_DECISION_CHANGED` 上：回合不死，是停下来问玩家。

### 被拒之后：Agent 那一次重新生成的每条出路

引擎的拒绝只是起点。真正决定「玩家这一回合会怎样」的是 Agent 修复成什么样，而修复预算只有一次（`ActionPlanPolicy.max_repair_attempts` 默认 1），所以下面这张表就是这一回合的**全部**可能走向：

| 行 | 重新生成的版本 | 语义保持闸门 | 端到端结果 |
|---|---|---|---|
| **A** | 规则不动 + 补 check | `preserved` / `MECHANICAL_REPAIR` | 重新提交 → `waiting_for_player`，停在这条分支本来就该有的检定上 ✅ **唯一自动通过的路** |
| **B** | 丢规则 + 不掷骰（纯叙事） | `requires_clarification` / `RULE_DECISION_CHANGED` | `needs_clarification` + `SEMANTIC_REPAIR_REQUIRES_CLARIFICATION` |
| **C** | 丢规则 + 改自由检定 | 同上 | 同上 |
| **D** | 换另一条规则 | 同上 | 同上 |
| **E** | 原样返回没改 | `preserved`（语义确实没变） | 重新提交 → 引擎再拒 → `needs_clarification` + `REPAIR_BUDGET_EXHAUSTED` |

B/C/D 都死在 `rule_decision` 的比较上 —— 它排在 `check` 前面，这三种修复连 `_check_is_mechanical` 都走不到：

```python
rule_dropped = _rule_decision_dropped(original, repaired, validation_feedback)  # 只认 RULE_OUT_OF_SCOPE → False
if not rule_dropped and original.rule_decision != repaired.rule_decision:
    return _clarification("RULE_DECISION_CHANGED")        # ← B/C/D 死在这里
if not _check_is_mechanical(original, repaired, validation_feedback):
    return _clarification("CHECK_CHANGED")
```

E 之所以也判 `preserved`，是因为语义保持只回答「这次修复有没有换掉玩家原本要做的事」——什么都没换当然没换。拦住这种空转的是引擎第二次拒绝，不是这一层。

**关键是「不被禁止」≠「可以自动走」**：引擎没有禁止 Agent 放弃规则，拦它的是 Host 的语义保持闸门，而且拦法是降级成「要玩家确认」而不是「拒绝」。回合不死，是停下来问。

五行全部有测试钉住（A/C 原有，B/D/E 本次补齐），A/B/E 三行另有端到端覆盖。其中 **B 行的端到端最能说明问题**：修复前它是 `awaiting_narration` —— 规则被吞掉、plan 一路跑到叙事；修复后才会停下来问玩家。三条端到端都断言世界一个字都没写过。

### 一处既有测试的修正

`test_greeting_a_neighbour_is_repairable_not_a_dead_turn` 此前依赖的正是被吞掉的那条路径（`question_neighbors/fast-talk` 要掷骰，却提交 `check=none`，靠「漏写 check 也返回 success」通过）。改为带上对齐的 check，断言仍盯 #313 的「动作族差异不阻断规则」，只是出口从 `resolved` 变成这条分支本来就该有的 `awaiting_skill_choice`。

## 验证

issue 正文的复现脚本，修复后：

```text
REJECTED: RULE_REQUIRES_CHECK | auto_repairable | agent
  internal_reason: Rule keep_night_watch 的分支 luck 在 check_luck 处要求掷骰，裁决却声明 check.mode=none
cemetery_figure: {'sighted': False, 'visit_observed': False}
事件: []
```

镜像面（`let_douglas_leave/proceed` + `RequiredAdjudicationCheck`）：

```text
REJECTED: RULE_FORBIDS_CHECK | auto_repairable | agent
  internal_reason: Rule let_douglas_leave 的分支 proceed 不含检定步，裁决却声明 check.mode=required
left_forever: False
事件: []
```

新增 15 条直接测试，还原到 `upstream/main` 的源码后确认其中 6 条会红（其余是钉住既有行为不被改动的守卫）：

- `tests/test_projection_v3.py::RuleCheckAlignmentTests` —— 两个方向的拒绝（含「无事件、状态未变」）、对齐后能走到掷骰、`requires_check=false` 的分支照常整条提交；
- `tests/test_semantic_preservation.py` —— 两个方向的机械修复放行、反方向不放行、无关错误码下改 `check.mode` 仍要问玩家，以及上表 A–E 五行逐行判定；
- `tests/test_action_plan_orchestrator.py` —— A/B/E 三行的端到端走向：拒绝 → 带指引重试 → 分别落到「真的掷骰」「停下问玩家」「预算耗尽」。

### 未达成的验收标准：解除 e2e skip

issue 的验收标准里有一条「解除 `rule-engine-real-model.e2e.ts` 中 #451 守夜场景的 skip，并在真实模型下验证通过」。**这条没能达成**，原因不在本 PR 的范围内。

解除 skip 后用 DeepSeek 实测 3 次，3/3 失败，但失败原因已经不是 #462：

```text
[#451 真实模型] 守夜幸运 检定: 侦察 | 可取消: true | 目标值: 60
[#451 真实模型] 守夜幸运 掷出: {"value":1,"degree":"critical_success","passed":true}
[#451 真实模型] 守夜后人影: {"sighted":false,"discovered":false,"out_tonight":"none"}
```

模型**不再点名任何规则**——`rule_decision` 直接不出，改为即兴掷一次侦察（目标值 60，而不是规则的幸运 99；`可取消: true`，规则拥有的检定不可取消），于是引擎侧的 `RULE_REQUIRES_CHECK` 路径从未被触及。日志里 `keep_night_watch` 与 `rule_decision` 出现 0 次。

候选本身发布得好好的，用 e2e 同一份状态查投影：

```text
候选: keep_night_watch | hints: ('守夜', '盯着金博尔宅', '在暗处观察周围', '看看夜里有没有人出现', '监视')
     luck requires_check= True check_skill_id= luck
```

hints 里就有「监视」，而玩家这句正是「监视周围环境」。所以这不是投影或范围问题，是「没有规则时不该掷骰」那条通用闸门缺失 —— issue 17 主链路表第 2 行，归 **#480**；#462 的「不包含」里也明确写了不含「Agent 侧为何会漏写 `check`」。

对比 #462 立项时的实测（模组 3.0.8 @ `e4da4e8`，2/2 都选对了规则、只是 `check` 写成 `none`），上游这几十个提交之间 A 侧的规则匹配行为发生了变化。

因此这条用例**保留 skip**，阻塞理由更新为真实情况，待 #480 落地后再解开——不向仓库里塞一条已知会红的用例。

自动化检查：

- `agent-collaboration-framework`：476 passed
- `trpg-backend`：672 passed, 23 skipped
- `e2e`（确定性）：42 passed, 0 failed, 3 skipped（三条真实模型用例按 `E2E_REAL_MODEL=1` 门控）
- `e2e` typecheck 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
