### PR TITLE
fix(module): 呼喊人影后理智检定不再立刻送走道格拉斯

### DIFF
--- a/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json
+++ b/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json
@@ -1,7 +1,7 @@
 {
   "content_schema_version": 3,
   "module_id": "paper-chase-zh-coc7",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "world_ref": "coc-7e",
   "background": "时代与地点为美国禁酒令时期的密歇根州阿诺兹堡。调查员受托马斯·金博尔委托，从五本失窃的旧书和叔叔道格拉斯一年前的失踪案入手，走访旧宅、图书馆与公共墓地。叙事应保持安静、克制而带哥特气息，以夜色、旧书、墓园和孤独感作为反复意象；面对异常时不要急于渲染纯粹敌意，应为同情、选择与淡淡哀伤保留空间。任何尚未由线索确认的真相都不得提前告知玩家。",
   "information": [
@@ -2629,27 +2629,6 @@
               "key": "true_form_seen",
               "value": true
             },
-            "next_step_id": "succeed_2"
-          },
-          {
-            "id": "succeed_2",
-            "kind": "effect",
-            "effect": {
-              "type": "move_entity",
-              "entity_id": "cemetery_figure",
-              "location_id": "crypt"
-            },
-            "next_step_id": "succeed_3"
-          },
-          {
-            "id": "succeed_3",
-            "kind": "effect",
-            "effect": {
-              "type": "change_entity_state",
-              "entity_id": "cemetery_figure",
-              "key": "out_tonight",
-              "value": "none"
-            },
             "next_step_id": "finish"
           }
         ]
@@ -2956,6 +2935,7 @@
             "talk"
           ],
           "location_ids": [
+            "kimball_grounds",
             "crypt"
           ],
           "target_kinds": [
@@ -2964,6 +2944,15 @@
           "target_ids": [
             "cemetery_figure"
           ]
+        },
+        "when": {
+          "op": "predicate",
+          "predicate": "entity_state_is",
+          "args": {
+            "entity_id": "cemetery_figure",
+            "key": "willing_to_talk",
+            "value": true
+          }
         },
         "question": {
           "kind": "method",

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -1613,7 +1613,10 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
                 self.content,
                 scene_id="cemetery",
                 # 石板已被发现，剩下的就是搬开它。
-                entities={"crypt_entrance": {"discovered": True}},
+                entities={
+                    "crypt_entrance": {"discovered": True},
+                    "cemetery_figure": {"willing_to_talk": True},
+                },
             ),
         )
         # STR 检定取 5，稳定成功。
@@ -1978,6 +1981,194 @@ class RuleOwnedCheckTests(unittest.IsolatedAsyncioTestCase):
             moved_store.inspect_state(ROOM).entities["crypt_entrance"]["slab_moved"],
             True,
         )
+
+    async def test_call_to_figure_keeps_douglas_after_sanity_check(self) -> None:
+        """#475：呼喊后的被动理智检定不得把人影立刻送回地穴。"""
+
+        encounter = {
+            "cemetery_figure": {
+                "discovered": True,
+                "true_form_seen": False,
+                "willing_to_talk": False,
+                "out_tonight": "observed",
+                "location_id": "kimball_grounds",
+            },
+            "case_tracker": {"first_ghoul_sight_resolved": False},
+        }
+
+        async def shout(*, request_id: str, rolls: list[int]):
+            store = InMemoryEngineStore()
+            store.register_room(
+                module_content=self.content,
+                initial_state=game_state(
+                    self.content,
+                    scene_id="kimball_grounds",
+                    entities=encounter,
+                    world_time=WorldTimeState(
+                        current=WorldTimePoint(day_index=0, hour_of_day=18),
+                        current_point_id="hour_18",
+                        current_time_segment="evening",
+                    ),
+                ),
+            )
+            engine = AdjudicationEngineService(
+                store, dice=DiceRoller(SequenceDiceSource(rolls))
+            )
+            rules = RuleEngineService(store)
+            snapshot = await rules.read(
+                PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+            )
+            published = {
+                item.rule_id
+                for item in (
+                    await rules.read_keeper_capabilities(
+                        PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+                    )
+                ).rule_candidates
+            }
+            execution = await engine.submit(
+                SubmitAdjudicationRequest(
+                    room_id=ROOM,
+                    player_id=PLAYER,
+                    adjudication=ActionAdjudication(
+                        request_id=request_id,
+                        source_revision=snapshot.revision,
+                        actor_id=ACTOR,
+                        summary="喂你是谁",
+                        target=ActionTarget(kind="entity", id="cemetery_figure"),
+                        method=ActionMethod(family="talk", description="喊住人影"),
+                        rule_decision=RuleDecisionRef(
+                            rule_id="call_to_figure", option_id="proceed"
+                        ),
+                        check=NoAdjudicationCheck(),
+                        success_effects=(),
+                        failure_effects=(),
+                    ),
+                )
+            )
+            return store, engine, rules, published, execution
+
+        async def finish_sanity(store, engine, execution, request_id: str):
+            self.assertEqual(execution.status, "awaiting_skill_choice")
+            pending = execution.pending_decision
+            assert pending is not None
+            self.assertEqual(pending.options[0].display_name, "理智")
+            self.assertFalse(pending.allow_cancel)
+            rolled = await engine.decide(
+                CheckDecisionRequest(
+                    request_id=f"{request_id}:select",
+                    room_id=ROOM,
+                    player_id=PLAYER,
+                    source_revision=execution.view_revision,
+                    decision_id=pending.decision_id,
+                    decision_version=pending.decision_version,
+                    choice=SelectCheckChoice(candidate_id=pending.options[0].candidate_id),
+                )
+            )
+            assert rolled.check_run is not None
+            return await engine.decide_post_roll(
+                PostRollDecisionRequest(
+                    request_id=f"{request_id}:accept",
+                    room_id=ROOM,
+                    player_id=PLAYER,
+                    source_revision=rolled.view_revision,
+                    check_id=rolled.check_run.check_id,
+                    check_version=rolled.check_run.version,
+                    option_id="accept-current",
+                )
+            )
+
+        def still_here(store) -> None:
+            state = store.inspect_state(ROOM)
+            figure = state.entities["cemetery_figure"]
+            self.assertIs(figure["willing_to_talk"], True)
+            self.assertIs(figure["true_form_seen"], True)
+            self.assertEqual(figure.get("out_tonight"), "observed")
+            self.assertNotEqual(figure.get("location_id"), "crypt")
+            self.assertEqual(state.scene_id, "kimball_grounds")
+            self.assertFalse(
+                any(
+                    event.type == "entity.moved"
+                    and event.payload.get("entity_id") == "cemetery_figure"
+                    and event.payload.get("location_id") == "crypt"
+                    for event in store.inspect_domain_events(ROOM)
+                )
+            )
+
+        for roll, expected_outcome in ((5, "success"), (81, "failure")):
+            store, engine, rules, published, execution = await shout(
+                request_id=f"call-figure-{roll}",
+                rolls=[roll],
+            )
+            self.assertIn("call_to_figure", published)
+            self.assertNotIn("talk_to_figure", published)
+            resolved = await finish_sanity(
+                store, engine, execution, f"call-figure-{roll}"
+            )
+            self.assertEqual(resolved.status, "resolved")
+            self.assertEqual(resolved.outcome, expected_outcome)
+            still_here(store)
+            after = {
+                item.rule_id
+                for item in (
+                    await rules.read_keeper_capabilities(
+                        PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+                    )
+                ).rule_candidates
+            }
+            self.assertIn("talk_to_figure", after)
+            snapshot = await rules.read(
+                PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+            )
+            await engine.submit(
+                SubmitAdjudicationRequest(
+                    room_id=ROOM,
+                    player_id=PLAYER,
+                    adjudication=ActionAdjudication(
+                        request_id=f"talk-figure-{roll}",
+                        source_revision=snapshot.revision,
+                        actor_id=ACTOR,
+                        summary="与身影交谈",
+                        target=ActionTarget(kind="entity", id="cemetery_figure"),
+                        method=ActionMethod(family="talk", description="与身影交谈"),
+                        rule_decision=RuleDecisionRef(
+                            rule_id="talk_to_figure", option_id="proceed"
+                        ),
+                        check=NoAdjudicationCheck(),
+                        success_effects=(),
+                        failure_effects=(),
+                    ),
+                )
+            )
+            self.assertTrue(store.inspect_state(ROOM).core_resolved)
+
+        store, engine, rules, _published, execution = await shout(
+            request_id="call-figure-then-dawn",
+            rolls=[5],
+        )
+        await finish_sanity(store, engine, execution, "call-figure-then-dawn")
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="wait-until-dawn",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="等到天亮",
+                    target=ActionTarget(kind="location", id="kimball_grounds"),
+                    method=ActionMethod(family="wait", description="等到天亮"),
+                    check=NoAdjudicationCheck(),
+                    success_effects=(AdvanceWorldTimeEffect(to_point_id="hour_06"),),
+                ),
+            )
+        )
+        figure = store.inspect_state(ROOM).entities["cemetery_figure"]
+        self.assertEqual(figure.get("location_id"), "crypt")
+        self.assertEqual(figure.get("out_tonight"), "none")
 
     async def test_rule_decision_from_another_location_is_refused(self) -> None:
         """候选按场景发布，提交也必须按场景复查。

--- a/e2e/tests/content-catalog.e2e.ts
+++ b/e2e/tests/content-catalog.e2e.ts
@@ -19,7 +19,7 @@ test('世界标签、追书人 v3 发布元数据和玩家安全开局简介正�
   assert.ok(paperChase)
   assert.equal(paperChase.title, '追书人')
   assert.equal(paperChase.nameEn, 'Paper Chase')
-  assert.equal(paperChase.version, '3.0.9')
+  assert.equal(paperChase.version, '3.0.10')
   assert.equal(paperChase.playersMin, 1)
   assert.equal(paperChase.playersMax, 4)
   assert.equal(paperChase.estimatedDuration, '1-2 小时')

--- a/trpg-backend/app/service/builtin_module_loader.py
+++ b/trpg-backend/app/service/builtin_module_loader.py
@@ -44,7 +44,7 @@ class BuiltinModuleSpec:
 PAPER_CHASE_SPEC = BuiltinModuleSpec(
     scenario_id="00000000-0000-0000-0000-000000000003",
     module_id="paper-chase-zh-coc7",
-    version="3.0.9",
+    version="3.0.10",
     world_ref="coc-7e",
     source_path=MODULE_FIXTURE_ROOT / "追书人" / "module-content-v3.json",
     display_name="追书人",

--- a/trpg-backend/tests/test_paper_chase_loader.py
+++ b/trpg-backend/tests/test_paper_chase_loader.py
@@ -23,7 +23,7 @@ async def test_loader_is_idempotent_and_reports_real_content(
 
     assert result.outcome == "unchanged"
     assert result.module_id == BUILTIN_MODULE_ID
-    assert result.version == "3.0.9"
+    assert result.version == "3.0.10"
     assert result.world_ref == "coc-7e"
     assert result.location_count == 12
     assert result.entity_count == 14
@@ -48,7 +48,7 @@ async def test_paper_chase_models_caretaker_bottle_as_discoverable_state() -> No
     """
 
     payload = json.loads(loader.PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8"))
-    assert payload["version"] == "3.0.9"
+    assert payload["version"] == "3.0.10"
     entities = {entity["id"]: entity for entity in payload["entities"]}
     information = {item["id"]: item for item in payload["information"]}
     rules = {rule["id"]: rule for rule in payload["rules"]}
@@ -79,6 +79,33 @@ def test_paper_chase_move_crypt_slab_requires_discovery_gate() -> None:
     assert items == {("discovered", True), ("slab_moved", False)}
 
 
+def test_paper_chase_call_to_figure_does_not_leave_after_san() -> None:
+    """#475：呼喊后只留下交谈，不把人影立刻送回地穴。"""
+
+    payload = json.loads(loader.PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8"))
+    rules = {rule["id"]: rule for rule in payload["rules"]}
+    call_steps = rules["call_to_figure"]["execution"]["steps"]
+    call_effects = [step.get("effect") or {} for step in call_steps if step["kind"] == "effect"]
+    assert not any(effect.get("type") == "move_entity" for effect in call_effects)
+    assert not any(
+        effect.get("key") == "out_tonight" and effect.get("value") == "none"
+        for effect in call_effects
+    )
+    talk = rules["talk_to_figure"]["trigger"]
+    assert "kimball_grounds" in talk["scope"]["location_ids"]
+    assert talk["when"]["args"] == {
+        "entity_id": "cemetery_figure",
+        "key": "willing_to_talk",
+        "value": True,
+    }
+    finish = rules["figure_finishes_night_visit"]["execution"]["steps"]
+    finish_effects = [step.get("effect") or {} for step in finish if step["kind"] == "effect"]
+    assert any(
+        effect.get("type") == "move_entity" and effect.get("location_id") == "crypt"
+        for effect in finish_effects
+    )
+
+
 def test_paper_chase_keeps_previous_v2_snapshots() -> None:
     """切到 v3 不删旧快照——它们是这次迁移的出处记录。
 
@@ -88,7 +115,7 @@ def test_paper_chase_keeps_previous_v2_snapshots() -> None:
     """
 
     current = json.loads(loader.PAPER_CHASE_SOURCE_PATH.read_text(encoding="utf-8"))
-    assert current["version"] == "3.0.9"
+    assert current["version"] == "3.0.10"
     assert current["content_schema_version"] == 3
 
     for name, version in (
@@ -234,7 +261,7 @@ async def test_loader_preserves_rooms_pinned_older_version(
 
     result = await loader.load_paper_chase(db_session)
 
-    assert result.version == "3.0.9"
+    assert result.version == "3.0.10"
     pinned = await db_session.get(ModuleVersion, (BUILTIN_MODULE_ID, "3.0.5"))
     assert pinned is not None
     assert pinned.content_json == pinned_content


### PR DESCRIPTION
Closes #475

《追书人》`call_to_figure` 在被动理智检定后不再无条件把道格拉斯移回地穴。人影留在相遇地点可继续交谈；夜间结束仍由既有时间规则送回。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `追书人/module-content-v3.json` | `call_to_figure` 去掉 succeed_2 `move_entity→crypt` 和 succeed_3 `out_tonight=none`；`talk_to_figure` 地点加上 `kimball_grounds`，并加 `willing_to_talk==true`；版本升到 3.0.10 |
| `app/service/builtin_module_loader.py` | Loader 固定版本改为 3.0.10 |
| `tests/test_projection_v3.py` | 理智成功/失败后仍在 `kimball_grounds` 且可 `talk_to_figure`；天亮后 `figure_finishes_night_visit` 送回地穴 |
| `tests/test_paper_chase_loader.py` | 钉住 3.0.10，并断言呼喊后不再立刻离场 |
| `e2e/tests/content-catalog.e2e.ts` | 目录版本断言改为 3.0.10 |

## 关键决策

**为什么不改 RuleAgenda：**
被动 SAN 后恢复父动作剩余效果是对的。bug 在父规则把 `move_entity→crypt` 和 `out_tonight=none` 写在检定之后，成功失败都会执行。

**为什么版本升到 3.0.10：**
ModuleVersion 不可变。3.0.9 是 #474 的搬石板门禁。已开局房间继续钉在旧版本；新房间才吃到这次效果。

**为什么 `talk_to_figure` 同时改地点和 `when`：**
相遇发生在 `kimball_grounds`，只允许 `crypt` 会让人影留下也无法继续对话。`willing_to_talk==true` 防止未呼喊成功时提前发布交谈。

**为什么不新写一条“对话结束再离开”：**
`figure_finishes_night_visit` 已在下一时间点、`out_tonight != none` 时把 NPC 送回地穴。本 PR 只删掉检定后的立即离场。

## 验证

- 框架：`tests.test_projection_v3` + `tests.test_paper_chase_v3_fixture` 共 67 passed
- 后端：`tests/test_paper_chase_loader.py` + `tests/test_builtin_module_loader.py` + `tests/test_module_content_cache.py` 共 25 passed
- 确定性覆盖：SAN 5 成功 / 81 失败后 `location_id` 仍为 `kimball_grounds`、`out_tonight=observed`、无 `entity.moved(..., crypt)`，随后 `talk_to_figure` 可提交；`AdvanceWorldTimeEffect(to_point_id="hour_06")` 后回到 `crypt`

## 已知限制

- 已存在的 3.0.9 及更早房间不会自动获得该效果
- 真实模型不一定每次都点名 `call_to_figure`；产品验收不能只看「没把人影送走」

## 不在本 PR 范围

- #401 SAN 数值扣减（`success_loss` / `failure_loss`）
- RuleAgenda 恢复父 continuation 的机制
- #316 完整实体认知 / 跨地点感知
- #319 地穴进入、腐臭昏迷与结局链
