### PR TITLE
fix(character): 幸运骰补齐角色草稿属性

### DIFF
--- a/trpg-backend/app/controller/v1/rooms.py
+++ b/trpg-backend/app/controller/v1/rooms.py
@@ -482,6 +482,7 @@ async def roll_luck(
         character_service.CharacterNotFoundError,
         room_service.RoomAuthenticationError,
         room_service.RoomAuthorizationError,
+        room_service.RulesetNotConfiguredError,
         room_service.RoomConflictError,
     ) as exc:
         _raise_service_error(exc)

--- a/trpg-backend/app/service/character.py
+++ b/trpg-backend/app/service/character.py
@@ -511,6 +511,7 @@ async def roll_luck(
     character = await _get_own_character(db, room_id, character_id, reconnect_token)
     room = await find_room_by_id(db, room_id)
     _require_character_editable(room)
+    ruleset = await _resolve_ruleset(db, room)
     current_luck = (character.attributes or {}).get("LUCK")
     if isinstance(current_luck, int) and 1 <= current_luck <= 99:
         raise RoomConflictError("幸运值已经掷出，不能重复掷骰")
@@ -518,6 +519,11 @@ async def roll_luck(
     dice = [random.randint(1, 6) for _ in range(3)]
     luck = sum(dice) * 5
     attributes = dict(character.attributes or {})
+    # 首次点击幸运骰可能直接创建空草稿；补齐缺失的可加点属性，但不覆盖已有值。
+    if ruleset.attribute_point_buy is not None:
+        for attribute in ruleset.attributes:
+            if attribute.point_buy:
+                attributes.setdefault(attribute.key, ruleset.attribute_point_buy.default_value)
     attributes["LUCK"] = luck
     # 用版本条件完成原子写入：两个并发请求最多一个成功，后到者不能覆盖先到结果。
     result = cast(

--- a/trpg-backend/tests/test_character_templates.py
+++ b/trpg-backend/tests/test_character_templates.py
@@ -302,9 +302,7 @@ async def test_roll_luck_repairs_missing_attributes_after_template_seeding(
     )
     attributes = read.json()["data"]["attributes"]
     assert attributes["STR"] == 85
-    assert set(attributes) == {
-        "STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"
-    }
+    assert set(attributes) == {"STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"}
 
 
 async def test_seeding_a_room_draft_copies_the_template_portrait(

--- a/trpg-backend/tests/test_character_templates.py
+++ b/trpg-backend/tests/test_character_templates.py
@@ -265,6 +265,48 @@ async def test_seeding_a_room_draft_copies_the_card_and_then_stands_alone(
     assert stored.based_on_template_id == template["templateId"]
 
 
+async def test_roll_luck_repairs_missing_attributes_after_template_seeding(
+    client: AsyncClient,
+) -> None:
+    """卡库缺少部分属性时，幸运骰仍会补齐规则要求的属性键。"""
+    token = await register(client)
+    template = await _create_template(client, token)
+    incomplete_data = {
+        **TEMPLATE_DATA,
+        "attributes": {"STR": 85},
+    }
+    updated = await client.patch(
+        f"{TEMPLATES_BASE}/{template['templateId']}",
+        json={"data": incomplete_data},
+        headers=bearer(token),
+    )
+    assert updated.status_code == 200, updated.text
+
+    room = await create_room(client, token=token)
+    headers = {"X-Reconnect-Token": room["reconnectToken"]}
+    draft = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters",
+        json={"basedOnTemplateId": template["templateId"]},
+        headers=headers,
+    )
+    assert draft.status_code == 201, draft.text
+    character_id = draft.json()["data"]["characterId"]
+
+    rolled = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-luck",
+        headers=headers,
+    )
+    assert rolled.status_code == 200, rolled.text
+    read = await client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}", headers=headers
+    )
+    attributes = read.json()["data"]["attributes"]
+    assert attributes["STR"] == 85
+    assert set(attributes) == {
+        "STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"
+    }
+
+
 async def test_seeding_a_room_draft_copies_the_template_portrait(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -372,13 +372,48 @@ async def test_roll_luck_persists_one_server_authoritative_result(client: AsyncC
     reread = await client.get(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}", headers=headers
     )
-    assert reread.json()["data"]["attributes"]["LUCK"] == result["luck"]
+    attributes = reread.json()["data"]["attributes"]
+    assert attributes["LUCK"] == result["luck"]
+    assert set(attributes) == {
+        "STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"
+    }
 
     duplicate = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-luck",
         headers=headers,
     )
     assert duplicate.status_code == 409
+
+
+async def test_roll_luck_preserves_existing_attributes_and_fills_missing(
+    client: AsyncClient,
+) -> None:
+    """幸运骰补齐空属性时保留草稿中已有的玩家修改。"""
+    room = await create_room(client)
+    headers = reconnect(room["reconnectToken"])
+    draft = await client.post(f"{ROOMS_BASE}/{room['roomId']}/characters", headers=headers)
+    character_id = draft.json()["data"]["characterId"]
+    payload = {**BUILT_CHARACTER, "attributes": {"STR": 85}}
+    saved = await client.patch(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}",
+        json=payload,
+        headers=headers,
+    )
+    assert saved.status_code == 200, saved.text
+
+    rolled = await client.post(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-luck",
+        headers=headers,
+    )
+    assert rolled.status_code == 200, rolled.text
+    reread = await client.get(
+        f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}", headers=headers
+    )
+    attributes = reread.json()["data"]["attributes"]
+    assert attributes["STR"] == 85
+    assert set(attributes) == {
+        "STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"
+    }
 
 
 async def test_complete_character_without_luck_roll_is_rejected(client: AsyncClient) -> None:

--- a/trpg-backend/tests/test_characters.py
+++ b/trpg-backend/tests/test_characters.py
@@ -374,9 +374,7 @@ async def test_roll_luck_persists_one_server_authoritative_result(client: AsyncC
     )
     attributes = reread.json()["data"]["attributes"]
     assert attributes["LUCK"] == result["luck"]
-    assert set(attributes) == {
-        "STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"
-    }
+    assert set(attributes) == {"STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"}
 
     duplicate = await client.post(
         f"{ROOMS_BASE}/{room['roomId']}/characters/{character_id}/roll-luck",
@@ -411,9 +409,7 @@ async def test_roll_luck_preserves_existing_attributes_and_fills_missing(
     )
     attributes = reread.json()["data"]["attributes"]
     assert attributes["STR"] == 85
-    assert set(attributes) == {
-        "STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"
-    }
+    assert set(attributes) == {"STR", "CON", "DEX", "APP", "POW", "SIZ", "INT", "EDU", "LUCK"}
 
 
 async def test_complete_character_without_luck_roll_is_rejected(client: AsyncClient) -> None:


### PR DESCRIPTION
## 关联 Issue

Closes #495

## 主要改动

- 幸运骰服务端写入前读取当前规则集。
- 新建空草稿或卡库播种数据缺少基础属性时，按规则集默认值补齐可加点属性。
- 使用 `setdefault` 保留已有属性，不改变幸运值 `3d6*5` 和重复掷骰并发保护。
- 为规则集配置异常补充明确的 API 错误映射。
- 增加空草稿、部分属性草稿、卡库播种三类回归测试。

## 采用该方案的原因

问题根因是 `roll-luck` 可能先创建空草稿，但只持久化 `LUCK`，导致后续后端权威校验看到不完整属性。修复放在服务端共享入口，保证本地、预览环境和不同前端状态都遵循同一数据契约；`setdefault` 确保玩家已编辑或卡库带来的属性不会被覆盖。不改变公开接口结构，也不需要数据库迁移。

## 测试与验证

- [x] `cd trpg-backend && ./.venv/bin/pytest -q tests/test_characters.py tests/test_character_templates.py`：49 passed
- [x] `cd trpg-backend && ./.venv/bin/ruff check app/service/character.py app/controller/v1/rooms.py tests/test_characters.py tests/test_character_templates.py`：通过
- [x] `cd trpg-frontend && npm run lint`：通过
- [x] `cd trpg-frontend && npm run build`：通过
- [ ] 全量后端测试：663 passed、23 skipped、1 failed；失败为既有 WebSocket 测试的 SQLite `database is locked` 并发问题，与本 PR 修改文件和角色接口无关
- [ ] 服务器预览环境手动验证：待 PR 部署后执行

## 兼容性、风险与回滚

- 不修改请求/响应结构，不新增数据库迁移。
- 已存在属性保持原值；只补齐缺失的可加点属性。
- 未配置点数购买规则时不强行生成默认属性，保持现有规则集行为。
- 回滚 commit `f99cdf6` 即可恢复原逻辑。

## UI 证据

本 PR 无前端代码改动，不涉及 UI 布局或交互变化。后端读回数据完整后，现有建卡页面即可继续使用。

## AI 使用情况

本 PR 使用 AI 辅助定位日志、追踪前后端调用链、编写实现与回归测试；作者已人工检查差异、异常处理和测试结果，理解并确认所有改动。

## 自检

- [x] 改动范围符合 Issue #495
- [x] 不包含无关改动
- [x] 已包含必要的回归测试
- [x] 未包含密钥、令牌或个人信息
- [x] 已完成 AI 辅助质量检查和人工 Review 前检查
- [ ] 已完成人工 Review
