### PR TITLE
feat(rule-engine): agent_match 检定消费规则声明的来源、技能、难度与权限 (#483)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -727,7 +727,7 @@ class AdjudicationEngineService:
                         player_safe_reason="房间成员已变化，需要重新确认场景切换",
                     )
                 allow_party_scene_transition = True
-            self._validate_adjudication(
+            rule_check_origin = self._validate_adjudication(
                 runtime,
                 request.adjudication,
                 allow_party_time_advance=allow_party_time_advance,
@@ -803,6 +803,9 @@ class AdjudicationEngineService:
                 status="awaiting_skill_choice",
                 adjudication=request.adjudication,
                 options=options,
+                # 出处让这次检定认得自己的规则，`_rule_check_spec` 因此能取到作者
+                # 声明的权限；游标留空，结算仍旧走父动作的 `_finalize_action`（#483）。
+                rule_origin=rule_check_origin,
             )
             event = self._event(
                 runtime,
@@ -1500,7 +1503,16 @@ class AdjudicationEngineService:
         *,
         allow_party_time_advance: bool = False,
         allow_party_scene_transition: bool = False,
-    ) -> None:
+    ) -> RuleCheckOrigin | None:
+        """校验这次裁决，并把「这次检定出自哪」交还给调用方（#483）。
+
+        返回值只在「规则分支确实要掷骰」时非空。出处必须是服务端事实：这里已经从
+        固定的 ModuleVersion 解析出了权威 `CheckStep`（#462 的双向不变量就是拿它
+        算的），所以由这里返回，而不是让提交路径再解析一遍——两次解析就是两个可能
+        分叉的事实源。
+        """
+
+        rule_check_origin: RuleCheckOrigin | None = None
         state = runtime.game_state
         target = adjudication.target
         if target.kind not in _target_kinds_matching(runtime, target.id):
@@ -1583,6 +1595,14 @@ class AdjudicationEngineService:
                         f"裁决却声明 check.mode={adjudication.check.mode}"
                     ),
                 )
+            if check_step is not None:
+                # 不信 Agent 自报的来源，也不按候选菜单反推：rule/branch/step 三个
+                # id 全部来自刚刚在服务端解析过的那条分支。
+                rule_check_origin = RuleCheckOrigin(
+                    rule_id=rule.id,
+                    branch_id=branch_id,
+                    step_id=check_step.id,
+                )
         else:
             # 自由行动的完整性必须在创建待检定、掷骰或写入事件之前完成；规则路径
             # 的效果由模组拥有，因此仍允许模型 success_effects 为空。
@@ -1627,6 +1647,7 @@ class AdjudicationEngineService:
         )
         if adjudication.check.mode != "none":
             self._validated_options(runtime, adjudication)
+        return rule_check_origin
 
     def _validate_effect_sequence(
         self,

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -2051,9 +2051,16 @@ class AdjudicationEngineService:
         玩家自己的行动检定：提交 Agent 裁决好的 success/failure 效果。
         规则拥有的被动检定：回到挂起的 Agenda，按 `result_routes` 走它的分支，
         Agent 不再参与后果裁决（#226 §5）。
+
+        判据是「要不要回 Agenda」，不是「有没有出处」（#483）。`agent_match` 提交
+        路径也有出处——它就是靠出处拿到规则声明的技能与难度的——但它没有 Agenda，
+        结算的是父动作。两者曾经共用 `rule_origin is not None` 这一个判断，于是
+        「让主动检定认得自己的规则」和「把主动检定错误地当成被动检定恢复」变成了
+        同一件事。
         """
 
-        if decision.rule_origin is not None:
+        origin = decision.rule_origin
+        if origin is not None and origin.resumes_agenda:
             return self._resume_rule_check(
                 runtime,
                 request_id=request_id,
@@ -2090,7 +2097,7 @@ class AdjudicationEngineService:
         """
 
         origin = decision.rule_origin
-        assert origin is not None
+        assert origin is not None and origin.agenda_id is not None
         state = runtime.game_state.model_copy(deep=True)
         events = [
             *prefix_events,

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -986,6 +986,7 @@ class AdjudicationEngineService:
                 post_roll_options=post_options,
                 final_result=None if post_options else roll,
                 adjudication=decision.adjudication,
+                rule_origin=decision.rule_origin,
             )
             rolled_event = self._event(
                 runtime,
@@ -1606,6 +1607,7 @@ class AdjudicationEngineService:
                     rule_id=rule.id,
                     branch_id=branch_id,
                     step_id=check_step.id,
+                    module_version=runtime.module_version,
                 )
                 # 作者规定了掷什么，就必须掷什么（#483）。
                 #
@@ -2494,6 +2496,7 @@ class AdjudicationEngineService:
             options=(option,),
             rule_origin=RuleCheckOrigin(
                 agenda_id=agenda.agenda_id,
+                module_version=runtime.module_version,
                 rule_id=rule.id,
                 branch_id=agenda.current_branch_id or "default",
                 step_id=step.id,

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -72,7 +72,7 @@ from .persistent_results import (
     validate_persistent_effects,
 )
 from .ports import EngineStore
-from .projection_v3 import project_v3
+from .projection_v3 import project_v3, rule_check_skill_id
 from .rules_v3 import (
     agent_match_admits,
     create_rule_agenda,
@@ -1607,6 +1607,32 @@ class AdjudicationEngineService:
                     branch_id=branch_id,
                     step_id=check_step.id,
                 )
+                # 作者规定了掷什么，就必须掷什么（#483）。
+                #
+                # 拒绝而不是静默改写：候选里的 method_summary / player_safe_reason
+                # 是玩家会看到的文字，Agent 是照着自己选的技能写的。把 skill_id 换
+                # 掉、把文案留下，菜单上会出现「使用图书馆使用」配着幸运的目标值。
+                # 拒绝让 Agent 自己把这一组重写一遍，与 #462 的处理一致。
+                declared_skill = rule_check_skill_id(
+                    check_step, runtime.module_content.world_ref
+                )
+                mismatched = [
+                    candidate.skill_id
+                    for candidate in adjudication.check.candidates
+                    if declared_skill is not None
+                    and candidate.skill_id != declared_skill
+                ]
+                if mismatched:
+                    self._reject_validation(
+                        "RULE_CHECK_SKILL_MISMATCH",
+                        repairability="auto_repairable",
+                        fault="agent",
+                        player_safe_reason="这次行动要用规则指定的能力来判定",
+                        internal_reason=(
+                            f"Rule {rule.id} 的分支 {branch_id} 规定掷 {declared_skill}，"
+                            f"裁决却报了 {sorted(set(mismatched))}"
+                        ),
+                    )
         else:
             # 自由行动的完整性必须在创建待检定、掷骰或写入事件之前完成；规则路径
             # 的效果由模组拥有，因此仍允许模型 success_effects 为空。

--- a/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/adjudication.py
@@ -792,7 +792,11 @@ class AdjudicationEngineService:
                     fault="player",
                     player_safe_reason="该行动已经存在待处理检定",
                 )
-            options = self._validated_options(runtime, request.adjudication)
+            options = self._validated_options(
+                runtime,
+                request.adjudication,
+                rule_check=self._rule_check_spec(runtime, rule_check_origin),
+            )
             decision = PendingCheckDecision(
                 decision_id=self._new_id("check_decision"),
                 room_id=request.room_id,
@@ -955,7 +959,7 @@ class AdjudicationEngineService:
                     player_safe_reason="所选检定方式不在当前可用列表中",
                 )
             roll = self._roll(option.target_value, option.difficulty)
-            rule_check = self._rule_check_spec(runtime, decision)
+            rule_check = self._rule_check_spec(runtime, decision.rule_origin)
             post_options = self._post_roll_options(
                 runtime,
                 actor_id=decision.actor_id,
@@ -1646,7 +1650,11 @@ class AdjudicationEngineService:
             allow_party_scene_transition=allow_party_scene_transition,
         )
         if adjudication.check.mode != "none":
-            self._validated_options(runtime, adjudication)
+            self._validated_options(
+                runtime,
+                adjudication,
+                rule_check=self._rule_check_spec(runtime, rule_check_origin),
+            )
         return rule_check_origin
 
     def _validate_effect_sequence(
@@ -1707,6 +1715,8 @@ class AdjudicationEngineService:
         self,
         runtime: EngineRuntimeSnapshot,
         adjudication: ActionAdjudication,
+        *,
+        rule_check: RuleCheckSpec | None = None,
     ) -> tuple[PendingCheckOption, ...]:
         actor = runtime.game_state.actors[adjudication.actor_id]
         skills = actor.state.get("skills")
@@ -1769,7 +1779,15 @@ class AdjudicationEngineService:
                         else candidate.skill_id
                     ),
                     target_value=value,
-                    difficulty=candidate.difficulty,
+                    # 规则声明的难度是权威的（#483）：作者写「困难」就按困难判，
+                    # 不能被 Agent 的候选降成普通。未声明（None）时沿用候选，
+                    # 与被动路径 `step.check.difficulty or profile.default_difficulty`
+                    # 同一条规矩。
+                    difficulty=(
+                        rule_check.difficulty
+                        if rule_check is not None and rule_check.difficulty is not None
+                        else candidate.difficulty
+                    ),
                     method_summary=candidate.method_summary,
                     player_safe_reason=candidate.player_safe_reason,
                 )
@@ -1861,16 +1879,18 @@ class AdjudicationEngineService:
     @staticmethod
     def _rule_check_spec(
         runtime: EngineRuntimeSnapshot,
-        decision: PendingCheckDecision,
+        origin: RuleCheckOrigin | None,
     ) -> RuleCheckSpec | None:
         """规则拥有的检定回它的 spec；玩家自己发起的检定回 None。
 
-        `rule_origin` 非空即「这是规则拥有的检定」，游标足够把 `CheckStep` 找回
-        来——`_resume_rule_check` 做的是同一件事。`PendingCheckOption` 只带得动
+        出处非空即「这是规则拥有的检定」，`rule_id` + `step_id` 足够把 `CheckStep`
+        找回来——`_resume_rule_check` 做的是同一件事。`PendingCheckOption` 只带得动
         技能与目标值，带不动出处，所以在调用点解析而不是塞进 option。
+
+        取出处而不是取 `PendingCheckDecision`（#483）：提交期要用它算难度时，决策
+        对象还没建出来。
         """
 
-        origin = decision.rule_origin
         if origin is None:
             return None
         rule = next(

--- a/agent-collaboration-framework/collaboration_framework/engine/models.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/models.py
@@ -387,6 +387,10 @@ class RuleCheckOrigin(ContractModel):
     rule_id: str = Field(min_length=1)
     branch_id: str = Field(min_length=1)
     step_id: str = Field(min_length=1)
+    # 出处是对某一版模组说的。房间的模组版本升级之后，同一个 rule/step id 可能已经
+    # 换了含义，所以把当时那一版一并记下（#483）。老行没有这个键，读回来是 None
+    # ——「不知道是哪一版」比谎称是当前版本诚实。
+    module_version: str | None = Field(default=None, min_length=1)
     agenda_id: str | None = Field(default=None, min_length=1)
     source_event_id: str | None = Field(default=None, min_length=1)
 
@@ -465,6 +469,10 @@ class CheckRun(ContractModel):
     resolution_kind: Literal["initial_roll", "accept_result", "spend_luck", "push"] = "initial_roll"
     luck_spent: int | None = Field(default=None, ge=1)
     adjudication: ActionAdjudication
+    # 这次掷骰出自哪条规则（#483）。此前要判断只能拿 decision_id 回头 load
+    # `PendingCheckDecision`——它会随结算被改写，而 CheckRun 是掷骰当时的事实。
+    # 玩家投影 `CheckRunView` 不带它：出处是服务端私有的。
+    rule_origin: RuleCheckOrigin | None = None
 
 
 WorkflowRequest = SubmitAdjudicationRequest | CheckDecisionRequest | PostRollDecisionRequest

--- a/agent-collaboration-framework/collaboration_framework/engine/models.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/models.py
@@ -364,22 +364,51 @@ class DomainEvent(ContractModel):
 
 
 class RuleCheckOrigin(ContractModel):
-    """把一次检定钉回它所属的 Agenda 游标（#398 §阶段三）。
+    """这次检定出自模组的哪条规则、哪个分支、哪一步（#398 §阶段三，#483）。
 
-    被动检定不是玩家发起的，是规则走到 `CheckStep` 时引擎替规则问的。结算之后
-    要恢复的也不是「这次行动的成功/失败效果」，而是**同一条规则的
-    `result_routes` 分支**——所以必须记住是哪个 Agenda、哪条规则、哪个分支、
-    哪一步、由哪个事件触发。
+    出处与恢复游标是两件事，这里的字段分成两半：
+
+    - `rule_id` / `branch_id` / `step_id` 是**出处**，两条入口都有。有了它就能把
+      作者写在 `CheckStep.check` 上的技能、难度、幸运与推动权限找回来，这也是
+      `_rule_check_spec` 唯一关心的部分。
+    - `agenda_id` / `source_event_id` 是**恢复游标**，只有被动检定有。被动检定不是
+      玩家发起的，是规则走到 `CheckStep` 时引擎替规则问的，结算之后要恢复的不是
+      「这次行动的成功/失败效果」，而是同一条规则的 `result_routes` 分支，所以必须
+      记住是哪个 Agenda、由哪个事件触发。
+
+    这两半原本是揉在一起的五个必填字段，于是「有出处」和「要回 Agenda」变成了同一
+    个判断。主动提交路径有出处但没有 Agenda，一旦补上出处就会被 `_settle_check`
+    误当成被动检定路由到 `_resume_rule_check`，按不存在的游标恢复——所以拆开。
 
     不另加恢复令牌：`PendingCheckDecision.decision_version` 已经承担版本与恢复
     职责，再加一个只会多出一个可能不同步的事实源。
     """
 
-    agenda_id: str = Field(min_length=1)
     rule_id: str = Field(min_length=1)
     branch_id: str = Field(min_length=1)
     step_id: str = Field(min_length=1)
-    source_event_id: str = Field(min_length=1)
+    agenda_id: str | None = Field(default=None, min_length=1)
+    source_event_id: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def validate_resume_cursor(self) -> RuleCheckOrigin:
+        # 游标要么齐、要么没有。只有一半的话，`_resume_rule_check` 会在半路上
+        # 拿到 None，那种失败离这里很远、很难查。
+        if (self.agenda_id is None) != (self.source_event_id is None):
+            raise ValueError(
+                "RuleCheckOrigin 的 agenda_id 与 source_event_id 必须同时存在或同时缺席"
+            )
+        return self
+
+    @property
+    def resumes_agenda(self) -> bool:
+        """结算之后要不要回到 Agenda 继续走规则的 `result_routes`。
+
+        被动检定为 True，`agent_match` 提交路径为 False——后者结算的是父动作，
+        走 `_finalize_action`。
+        """
+
+        return self.agenda_id is not None
 
 
 class PendingCheckDecision(ContractModel):

--- a/agent-collaboration-framework/collaboration_framework/engine/projection_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/engine/projection_v3.py
@@ -745,7 +745,7 @@ def _rule_candidates(
                         # 分支里有没有检定步，是 Agent 必须知道的；后果仍然不出服务端。
                         requires_check=(step := pending_check_for(rule, option.id)[0])
                         is not None,
-                        check_skill_id=_rule_check_skill_id(step, module.world_ref),
+                        check_skill_id=rule_check_skill_id(step, module.world_ref),
                     )
                     for option in trigger.options
                 ),
@@ -755,8 +755,13 @@ def _rule_candidates(
     return tuple(candidates)
 
 
-def _rule_check_skill_id(step: object, world_ref: str = "coc-7e") -> str | None:
-    """Resolve the rolled resource without exposing rule execution details."""
+def rule_check_skill_id(step: object, world_ref: str = "coc-7e") -> str | None:
+    """作者在这一步上规定要掷的技能/资源，没规定则 None。
+
+    投影用它把 `check_skill_id` 作为提示发给 Agent；提交期用同一个函数判断 Agent
+    报的候选对不对（#483）。两处必须同源，否则会出现「菜单上写着掷幸运、提交时却
+    按另一套标准判」。
+    """
 
     if not isinstance(step, CheckStep):
         return None

--- a/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/action_plan_orchestrator.py
@@ -96,6 +96,14 @@ _REPAIR_HINTS: dict[str, str] = {
         " rule_decision 原样不动，只把 check 换成 NoAdjudicationCheck()。"
         "不要为了凑格式编一个技能出来，也不要去掉 rule_decision。"
     ),
+    "RULE_CHECK_SKILL_MISMATCH": (
+        "所选 rule_decision 的分支规定了要掷哪一项能力，这一版报的候选技能不是它。"
+        "把 check.candidates 换成该候选的 check_skill_id（它就在 "
+        "keeper_capabilities.rule_candidates[].options[] 上），并把 method_summary 与 "
+        "player_safe_reason 一起改写成描述这项能力的说法，不要留着上一版按别的技能"
+        "写的文案。保留 summary、method、target 与 rule_decision 原样不动，也不要"
+        "去掉 rule_decision——规则确实适用，去掉它这一步会停下来问玩家。"
+    ),
     "INVENTORY_TARGET_NOT_PORTABLE": (
         "holder_actor_id 只接受 player_view.scene.loose_items、player_view.inventory，"
         "或同一 effects 序列先用 ensure_runtime_entity(entity_kind=object) 创建的物品。"

--- a/agent-collaboration-framework/collaboration_framework/host/application/semantic_preservation.py
+++ b/agent-collaboration-framework/collaboration_framework/host/application/semantic_preservation.py
@@ -268,6 +268,14 @@ def _check_is_mechanical(
     after = repaired.check
     if before.mode != after.mode:
         return _check_realigns_with_rule(original, repaired, feedback)
+    if feedback.code == "RULE_CHECK_SKILL_MISMATCH":
+        # 引擎说这次该掷的是规则指定的能力，那么整组候选本来就得重写：换掉技能，
+        # method_summary 与 player_safe_reason 也得跟着换，不然菜单上会出现「使用
+        # 图书馆使用」配着幸运的目标值。掷什么由规则说了算，改成什么由引擎重新整体
+        # 校验（`_validated_options` 会再拒一次不合规的技能），这一层只负责确认
+        # 玩家原本要做的事没被换掉——那由上面的 summary / method / rule_decision
+        # 三道比较保证（#483）。
+        return True
     if len(before.candidates) != len(after.candidates):
         return False
     for old, new in zip(before.candidates, after.candidates, strict=True):

--- a/agent-collaboration-framework/collaboration_framework/registry/check_profiles.py
+++ b/agent-collaboration-framework/collaboration_framework/registry/check_profiles.py
@@ -33,6 +33,15 @@ candidate menu and never through this table.
 The table is owned by the CoC7 adapter. Runtime dispatch should use
 `registry.rulesets` so profile ids are always resolved in a `world_ref` scope.
 The compatibility helpers below remain for migration-era callers.
+
+#483 让主动检定开始消费作者声明的技能、难度与权限，但**没有**因此登记
+`coc7.skill`。它没有固定的 `resource`——目标值来自 `actor.state["skills"][skill_id]`，
+不是 `ActorResources` 上某个字段——所以 `_passive_check_option` 依然执行不了它。
+登记它只会让发布期校验开始放行引擎跑不动的 `passive_rule` 步，把一个发布期就能拦住
+的错误推迟到运行时。主动路径的目标值走 `_validated_options`，从不经过这张表。
+
+同理，#483 只消费决定「掷什么、怎么掷」的 `skill_id`；`success_loss` /
+`failure_loss` / `habit_cap` 仍旧是 recognised-but-unspent，归 #486 / #487。
 """
 
 from __future__ import annotations

--- a/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
+++ b/agent-collaboration-framework/tests/test_action_plan_orchestrator.py
@@ -2796,3 +2796,59 @@ async def test_an_unchanged_repair_exhausts_the_budget_instead_of_committing() -
     assert result.run.status == "needs_clarification"
     assert result.run.steps[0].safe_failure_code == "REPAIR_BUDGET_EXHAUSTED"
     assert len(engine_store.inspect_domain_events(original.room_id)) == 0
+
+
+class WrongSkillAdjudicator(MissingCheckAdjudicator):
+    """先报一个规则没规定的技能，被拒之后改成声明的那个（#483）。
+
+    `question_neighbors/fast-talk` 的 CheckStep 上写着 `skill_id="fast-talk"`。
+    """
+
+    async def adjudicate(self, context):
+        proposal = await super().adjudicate(context)
+        skill = NEIGHBOUR_SKILL if context.previous_rejection is not None else SKILL
+        return proposal.model_copy(
+            update={
+                "check": RequiredAdjudicationCheck(
+                    candidates=(
+                        SkillCheckCandidate(
+                            candidate_id=skill,
+                            skill_id=skill,
+                            difficulty="regular",
+                            method_summary="搭话套近乎" if skill == NEIGHBOUR_SKILL else "留意神色",
+                            player_safe_reason="使用话术" if skill == NEIGHBOUR_SKILL else "使用侦查",
+                        ),
+                    )
+                )
+            },
+            deep=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_wrong_skill_is_repaired_to_the_rule_declared_one() -> None:
+    """#483 全链路：拒绝 → 带指引重试 → 语义保持放行 → 掷规则规定的那项能力。
+
+    少任何一环这一步都会停成 needs_clarification：引擎不拒就静默掷错技能；
+    `_REPAIR_HINTS` 没条目模型不知道该改什么；`_check_is_mechanical` 不放行整组候选
+    重写就会判 CHECK_CHANGED。
+    """
+
+    adjudicator = WrongSkillAdjudicator()
+    _, service = issue462_service(adjudicator)
+    original = player_input("issue483-skill-parent", "跟邻居打听消息")
+
+    result = await service.start_or_resume(original, plan=plan(1))
+
+    assert len(adjudicator.contexts) == 2
+    rejection = adjudicator.contexts[1].previous_rejection
+    assert rejection is not None
+    assert rejection.startswith("RULE_CHECK_SKILL_MISMATCH: ")
+    assert _REPAIR_HINTS["RULE_CHECK_SKILL_MISMATCH"] in rejection
+
+    # 停在检定上等玩家，掷的是规则规定的那项能力。
+    assert result.run.status == "waiting_for_player"
+    assert result.latest_execution is not None
+    pending = result.latest_execution.pending_decision
+    assert pending is not None
+    assert pending.options[0].skill_id == NEIGHBOUR_SKILL

--- a/agent-collaboration-framework/tests/test_event_barrier.py
+++ b/agent-collaboration-framework/tests/test_event_barrier.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import json
 import unittest
+
+from pydantic import ValidationError
 from pathlib import Path
 
 from collaboration_framework.contracts import (
@@ -43,7 +45,11 @@ from collaboration_framework.engine import (
     InMemoryEngineStore,
 )
 from collaboration_framework.engine.dice import DiceRoller, SequenceDiceSource
-from collaboration_framework.engine.models import WorldTimePoint, WorldTimeState
+from collaboration_framework.engine.models import (
+    RuleCheckOrigin,
+    WorldTimePoint,
+    WorldTimeState,
+)
 from tests.time_fixtures import NIGHT_LATCH_RULE, day_cycle_module
 
 FIXTURE = (
@@ -606,3 +612,44 @@ class RuleOwnedCheckAuthorityTests(unittest.IsolatedAsyncioTestCase):
             execution.rule_failure_code, "rule_check_actor_binding_unsupported"
         )
         self.assertEqual(store.inspect_state(ROOM).rule_agendas, {})
+
+
+class RuleCheckOriginTests(unittest.TestCase):
+    """出处与恢复游标是两件事（#483）。
+
+    这两半原本是揉在一起的五个必填字段，于是「有出处」和「要回 Agenda」变成了同一
+    个判断（`_settle_check` 的 `rule_origin is not None`）。`agent_match` 提交路径
+    有出处但没有 Agenda——它结算的是父动作——所以一旦给它补上出处，就会被当成被动
+    检定路由到 `_resume_rule_check`，按不存在的游标恢复。
+    """
+
+    def test_provenance_alone_does_not_resume_an_agenda(self) -> None:
+        """主动路径：记得住自己出自哪条规则，但结算不回 Agenda。"""
+
+        origin = RuleCheckOrigin(rule_id="r", branch_id="b", step_id="s")
+        self.assertFalse(origin.resumes_agenda)
+        self.assertIsNone(origin.agenda_id)
+
+    def test_a_passive_origin_still_carries_its_resume_cursor(self) -> None:
+        """被动路径行为不变：游标齐全，结算回 Agenda 走 result_routes。"""
+
+        origin = RuleCheckOrigin(
+            rule_id="r",
+            branch_id="b",
+            step_id="s",
+            agenda_id="agenda-1",
+            source_event_id="event-1",
+        )
+        self.assertTrue(origin.resumes_agenda)
+
+    def test_half_a_resume_cursor_is_refused(self) -> None:
+        """游标要么齐、要么没有。
+
+        只有一半的话 `_resume_rule_check` 会在半路上拿到 None，那种失败离构造点很
+        远、很难查——在这里当场拒绝。
+        """
+
+        for partial in ({"agenda_id": "agenda-1"}, {"source_event_id": "event-1"}):
+            with self.subTest(**partial):
+                with self.assertRaises(ValidationError):
+                    RuleCheckOrigin(rule_id="r", branch_id="b", step_id="s", **partial)

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -2741,6 +2741,127 @@ class RuleDeclaredCheckPermissionTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(forbidden, {"accept-current"})
 
+    async def test_declared_difficulty_wins_over_the_agent_candidate(self) -> None:
+        """作者写「困难」就按困难判，不能被 Agent 的候选降成普通（#483）。
+
+        难度不改变玩家看到的「掷什么」，所以这里覆盖而不是拒绝——两个模组里只有 2
+        条主动检定声明了非 regular 难度，为此多一轮修复的噪音大于收益。
+        """
+
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=self.module_with_active_check(difficulty="hard"),
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([50]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-difficulty",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="查阅旧报",
+                    target=ActionTarget(kind="entity", id="newspaper_archive"),
+                    method=ActionMethod(family="research", description="查阅旧报"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="research_library_archive", option_id="library-use"
+                    ),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="library-use",
+                                skill_id="library-use",
+                                # Agent 报的是普通难度，规则说困难。
+                                difficulty="regular",
+                                method_summary="按年份检索",
+                                player_safe_reason="使用图书馆使用",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        pending = execution.pending_decision
+        assert pending is not None
+        self.assertEqual(pending.options[0].difficulty, "hard")
+
+        # 而且要真的按困难判：图书馆使用 70，掷 50 在普通下是成功，困难要 ≤35。
+        rolled = await engine.decide(
+            CheckDecisionRequest(
+                request_id="e5-difficulty:select",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=execution.view_revision,
+                decision_id=pending.decision_id,
+                decision_version=pending.decision_version,
+                choice=SelectCheckChoice(candidate_id="library-use"),
+            )
+        )
+        assert rolled.check_run is not None
+        self.assertEqual(rolled.check_run.difficulty, "hard")
+        self.assertEqual(rolled.check_run.roll.value, 50)
+        self.assertFalse(rolled.check_run.roll.passed)
+
+    async def test_an_undeclared_difficulty_falls_back_to_the_candidate(self) -> None:
+        """规则没声明难度时沿用 Agent 候选。
+
+        线上 42 条主动检定步**全部**显式写了 `difficulty`，所以这条得把它打成 None
+        才测得到——留着它是因为 `difficulty` 在契约上可选（`module_v3.py:445`），
+        新模组完全可以不写，那时不该把候选难度吃掉。
+        """
+
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=self.module_with_active_check(difficulty=None),
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([50]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-difficulty-default",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="查阅旧报",
+                    target=ActionTarget(kind="entity", id="newspaper_archive"),
+                    method=ActionMethod(family="research", description="查阅旧报"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="research_library_archive", option_id="library-use"
+                    ),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="library-use",
+                                skill_id="library-use",
+                                difficulty="extreme",
+                                method_summary="按年份检索",
+                                player_safe_reason="使用图书馆使用",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        pending = execution.pending_decision
+        assert pending is not None
+        self.assertEqual(pending.options[0].difficulty, "extreme")
+
     async def test_a_free_check_keeps_both_permissions(self) -> None:
         """没有 rule_decision 的自由裁决完全不受影响。
 

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -7,6 +7,7 @@ placed by `located_in` — only exist at that scale.
 
 from __future__ import annotations
 
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -2581,6 +2582,229 @@ class RuleCheckAlignmentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(execution.outcome, "success")
         figure = store.inspect_state(ROOM).entities.get("cemetery_figure", {})
         self.assertIs(figure.get("left_forever"), True)
+
+
+class RuleDeclaredCheckPermissionTests(unittest.IsolatedAsyncioTestCase):
+    """主动检定也要听模组声明的推动/幸运权限（#483）。
+
+    `allow_luck` / `allow_push` 的读取点（`_post_roll_options`）一直都在，卡住它的
+    是上游：`_rule_check_spec` 靠 `decision.rule_origin` 判断「这是不是规则拥有的
+    检定」，而提交路径建 `PendingCheckDecision` 时不带出处，于是两个权限恒为 True。
+    补上出处之后，这两个字段顺着现有代码自动生效，不需要新管线。
+
+    线上四个模组还没有哪条主动检定步声明过 `allow_push=false`，所以这里给真实模组
+    打补丁造出来——这是能力补全，不是修一个正在发生的 bug。
+    """
+
+    @staticmethod
+    def module_with_active_check(**check_overrides) -> ModuleContentV3:
+        data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        rule = next(
+            item for item in data["rules"] if item["id"] == "research_library_archive"
+        )
+        step = next(
+            item
+            for item in rule["execution"]["steps"]
+            if item["id"] == "check_library-use"
+        )
+        step["check"].update(check_overrides)
+        return ModuleContentV3.model_validate(data)
+
+    async def post_roll_options(self, module_content: ModuleContentV3) -> set[str]:
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=module_content,
+            initial_state=game_state(module_content, scene_id="library"),
+        )
+        # 目标值 70，掷 90 必失败——推动与幸运菜单才有内容可看。
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([90]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-permissions",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="查阅旧报",
+                    target=ActionTarget(kind="entity", id="newspaper_archive"),
+                    method=ActionMethod(family="research", description="查阅旧报"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="research_library_archive", option_id="library-use"
+                    ),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="library-use",
+                                skill_id="library-use",
+                                difficulty="regular",
+                                method_summary="按年份检索",
+                                player_safe_reason="使用图书馆使用",
+                            ),
+                        )
+                    ),
+                    success_effects=(),
+                    failure_effects=(),
+                ),
+            )
+        )
+        pending = execution.pending_decision
+        assert pending is not None
+        rolled = await engine.decide(
+            CheckDecisionRequest(
+                request_id="e5-permissions:select",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=execution.view_revision,
+                decision_id=pending.decision_id,
+                decision_version=pending.decision_version,
+                choice=SelectCheckChoice(candidate_id="library-use"),
+            )
+        )
+        assert rolled.check_run is not None
+        self.assertFalse(rolled.check_run.roll.passed)
+        return {option.option_id for option in rolled.check_run.post_roll_options}
+
+    async def test_submitted_check_records_where_it_came_from(self) -> None:
+        """出处落在 PendingCheckDecision 上，但不带恢复游标。
+
+        带了游标就会被 `_settle_check` 当成被动检定，按不存在的 Agenda 恢复；
+        不带出处则拿不到作者声明的权限。两个都要对。
+        """
+
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=self.module_with_active_check(),
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([90]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-origin",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="查阅旧报",
+                    target=ActionTarget(kind="entity", id="newspaper_archive"),
+                    method=ActionMethod(family="research", description="查阅旧报"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="research_library_archive", option_id="library-use"
+                    ),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="library-use",
+                                skill_id="library-use",
+                                difficulty="regular",
+                                method_summary="按年份检索",
+                                player_safe_reason="使用图书馆使用",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        pending = execution.pending_decision
+        assert pending is not None
+        stored = store.inspect_pending_check(ROOM, pending.decision_id)
+        assert stored is not None and stored.rule_origin is not None
+        self.assertEqual(stored.rule_origin.rule_id, "research_library_archive")
+        self.assertEqual(stored.rule_origin.branch_id, "library-use")
+        self.assertEqual(stored.rule_origin.step_id, "check_library-use")
+        self.assertFalse(stored.rule_origin.resumes_agenda)
+        # 出处是服务端私有的，不进玩家视图。
+        self.assertNotIn("rule_origin", pending.model_dump())
+
+    async def test_a_rule_can_forbid_pushing_its_own_active_check(self) -> None:
+        """作者写 `allow_push: false`，玩家菜单里就不该有推动。"""
+
+        allowed = await self.post_roll_options(self.module_with_active_check())
+        # 默认（两个字段为 null）行为不变：线上全部主动检定都走这一条。
+        self.assertIn("push-once", allowed)
+
+        forbidden = await self.post_roll_options(
+            self.module_with_active_check(allow_push=False, allow_luck=False)
+        )
+        self.assertEqual(forbidden, {"accept-current"})
+
+    async def test_a_free_check_keeps_both_permissions(self) -> None:
+        """没有 rule_decision 的自由裁决完全不受影响。
+
+        E5 只收窄「规则拥有的检定」。自由检定没有出处，`_rule_check_spec` 仍旧返回
+        None，两个权限继续默认放开——否则这次改动会悄悄削掉玩家在普通行动里的推动权。
+        """
+
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=module(),
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([90]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-free-check",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="随便翻翻",
+                    target=ActionTarget(kind="location", id="library"),
+                    method=ActionMethod(family="observe", description="随便翻翻"),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="spot-hidden",
+                                skill_id="spot-hidden",
+                                difficulty="regular",
+                                method_summary="扫一眼",
+                                player_safe_reason="使用侦查",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        pending = execution.pending_decision
+        assert pending is not None
+        stored = store.inspect_pending_check(ROOM, pending.decision_id)
+        assert stored is not None
+        self.assertIsNone(stored.rule_origin)
+        rolled = await engine.decide(
+            CheckDecisionRequest(
+                request_id="e5-free-check:select",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=execution.view_revision,
+                decision_id=pending.decision_id,
+                decision_version=pending.decision_version,
+                choice=SelectCheckChoice(candidate_id="spot-hidden"),
+            )
+        )
+        assert rolled.check_run is not None
+        self.assertIn(
+            "push-once", {item.option_id for item in rolled.check_run.post_roll_options}
+        )
 
 
 if __name__ == "__main__":

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -2862,6 +2862,126 @@ class RuleDeclaredCheckPermissionTests(unittest.IsolatedAsyncioTestCase):
         assert pending is not None
         self.assertEqual(pending.options[0].difficulty, "extreme")
 
+    async def submit_with_skill(self, skill_id: str, *, request_id: str):
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=module(),
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([50]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        return store, await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id=request_id,
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="查阅旧报",
+                    target=ActionTarget(kind="entity", id="newspaper_archive"),
+                    method=ActionMethod(family="research", description="查阅旧报"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="research_library_archive", option_id="library-use"
+                    ),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id=skill_id,
+                                skill_id=skill_id,
+                                difficulty="regular",
+                                method_summary="翻找",
+                                player_safe_reason="使用该能力",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+
+    async def test_a_candidate_that_is_not_the_declared_skill_is_refused(self) -> None:
+        """作者写了掷什么，Agent 就不能改掷别的（#483）。
+
+        这是《追书人》守夜那个洞的一般形式：作者在 `keep_night_watch/luck` 上写
+        `parameters.skill_id="luck"`，引擎却照 Agent 报的掷侦察，目标值和难度全错，
+        而且不报错。42 条主动检定步全都声明了技能，此前一条都没生效过。
+        """
+
+        with self.assertRaises(AdjudicationValidationError) as rejected:
+            await self.submit_with_skill("spot-hidden", request_id="e5-skill-wrong")
+
+        result = rejected.exception.result
+        self.assertEqual(result.code, "RULE_CHECK_SKILL_MISMATCH")
+        # 与 RULE_OUT_OF_SCOPE / RULE_REQUIRES_CHECK 同级：Agent 的失误，改对就能重来。
+        self.assertEqual(result.repairability, "auto_repairable")
+        self.assertEqual(result.fault, "agent")
+        assert result.internal_reason is not None
+        self.assertIn("library-use", result.internal_reason)
+
+    async def test_the_declared_skill_passes(self) -> None:
+        """报对技能就正常走到掷骰——拒绝必须有出口。"""
+
+        store, execution = await self.submit_with_skill(
+            "library-use", request_id="e5-skill-right"
+        )
+        self.assertEqual(execution.status, "awaiting_skill_choice")
+        assert execution.pending_decision is not None
+        self.assertEqual(execution.pending_decision.options[0].skill_id, "library-use")
+
+    async def test_a_free_check_may_roll_any_skill_the_actor_has(self) -> None:
+        """没有 rule_decision 就没有作者声明，自由裁决照旧自己挑技能。
+
+        E5 收窄的是「规则拥有的检定」。若这条也被卡住，玩家做任何普通行动都得先
+        有一条模组规则才能掷骰——那是 #480 的范围，不是这里。
+        """
+
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=module(),
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([50]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-free-skill",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="随便看看",
+                    target=ActionTarget(kind="location", id="library"),
+                    method=ActionMethod(family="observe", description="随便看看"),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="spot-hidden",
+                                skill_id="spot-hidden",
+                                difficulty="regular",
+                                method_summary="扫一眼",
+                                player_safe_reason="使用侦查",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        assert execution.pending_decision is not None
+        self.assertEqual(
+            execution.pending_decision.options[0].skill_id, "spot-hidden"
+        )
+
     async def test_a_free_check_keeps_both_permissions(self) -> None:
         """没有 rule_decision 的自由裁决完全不受影响。
 

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -60,7 +60,11 @@ from collaboration_framework.engine import (
 )
 from collaboration_framework.engine.initialization import create_initial_game_state
 from collaboration_framework.engine.navigation import resolve_location_target
-from collaboration_framework.engine.projection_v3 import location_breadcrumbs
+from collaboration_framework.registry import check_profiles as check_profile_registry
+from collaboration_framework.engine.projection_v3 import (
+    location_breadcrumbs,
+    rule_check_skill_id,
+)
 from collaboration_framework.engine.rules_v3 import (
     evaluate_condition,
     pending_check_for,
@@ -2980,6 +2984,108 @@ class RuleDeclaredCheckPermissionTests(unittest.IsolatedAsyncioTestCase):
         assert execution.pending_decision is not None
         self.assertEqual(
             execution.pending_decision.options[0].skill_id, "spot-hidden"
+        )
+
+    async def test_only_skill_id_is_consumed_from_parameters(self) -> None:
+        """参数按所有者分层：E5 只消费「掷什么」，不碰 CoC7 的后果语义（#483）。
+
+        `success_loss` / `failure_loss` / `habit_cap` 是 `coc7.sanity` 的结果语义，
+        归 #486 / #487。它们出现在主动检定步上时，E5 原样保留、不解释，也不因为
+        「不认得」就报错——`recognised_parameters` 的注释写明了这条区分：「规则写错
+        了」该在发布期拒绝，「引擎还没做到」不该。
+
+        这条测的是：多写这些键不改变这次掷骰的任何东西。
+        """
+
+        module_content = self.module_with_active_check(
+            parameters={
+                "skill_id": "library-use",
+                "success_loss": "1",
+                "failure_loss": "1d6",
+                "habit_cap": "5",
+            }
+        )
+        step = next(
+            item
+            for item in next(
+                rule
+                for rule in module_content.rules
+                if rule.id == "research_library_archive"
+            ).execution.steps
+            if item.id == "check_library-use"
+        )
+        # 只认 skill_id，其余三个键连读都不读。
+        self.assertEqual(rule_check_skill_id(step), "library-use")
+
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=module_content,
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([50]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-parameter-ownership",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="查阅旧报",
+                    target=ActionTarget(kind="entity", id="newspaper_archive"),
+                    method=ActionMethod(family="research", description="查阅旧报"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="research_library_archive", option_id="library-use"
+                    ),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="library-use",
+                                skill_id="library-use",
+                                difficulty="regular",
+                                method_summary="按年份检索",
+                                player_safe_reason="使用图书馆使用",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        pending = execution.pending_decision
+        assert pending is not None
+        # 提交照常通过，掷的还是图书馆使用 70，SAN 一点没动。
+        self.assertEqual(pending.options[0].skill_id, "library-use")
+        self.assertEqual(pending.options[0].target_value, 70)
+        self.assertEqual(
+            store.inspect_state(ROOM).actors[ACTOR].resources.san, 55
+        )
+
+    def test_the_profile_table_stays_out_of_the_active_path(self) -> None:
+        """`coc7.skill` 故意不注册，本 Issue 也不给它注册。
+
+        这张表自己的规矩是「登记一个名字等于宣称引擎能执行它，必须和执行器同一次
+        改动落地」。`coc7.skill` 没有固定的 `resource`——目标值来自
+        `actor.state["skills"][skill_id]`，不是 `ActorResources` 上某个字段——所以
+        `_passive_check_option` 执行不了它。注册它会让发布期校验开始放行引擎跑不动
+        的 `passive_rule` 步，把一个发布期就能拦住的错误推迟到运行时。
+
+        主动检定的目标值走 `_validated_options`，从来不经过这张表。
+        """
+
+        self.assertFalse(check_profile_registry.is_registered("coc7.skill"))
+        self.assertFalse(check_profile_registry.is_registered("coc7.luck"))
+        sanity = check_profile_registry.registration_for("coc7.sanity")
+        assert sanity is not None
+        # 后果语义仍归 coc7.sanity，E5 不接手。
+        self.assertEqual(
+            sanity.recognised_parameters,
+            frozenset({"success_loss", "failure_loss", "habit_cap"}),
         )
 
     async def test_a_free_check_keeps_both_permissions(self) -> None:

--- a/agent-collaboration-framework/tests/test_projection_v3.py
+++ b/agent-collaboration-framework/tests/test_projection_v3.py
@@ -3088,6 +3088,137 @@ class RuleDeclaredCheckPermissionTests(unittest.IsolatedAsyncioTestCase):
             frozenset({"success_loss", "failure_loss", "habit_cap"}),
         )
 
+    async def test_the_roll_records_which_rule_it_came_from(self) -> None:
+        """CheckRun 也要追溯得到 Rule / Branch / CheckStep 与当时的模组版本（#483）。
+
+        此前要判断一次掷骰属不属于规则，只能拿 `decision_id` 回头 load
+        `PendingCheckDecision`——而它会随结算被改写，CheckRun 才是掷骰当时的事实。
+        """
+
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=module(),
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([50]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-traceable",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="查阅旧报",
+                    target=ActionTarget(kind="entity", id="newspaper_archive"),
+                    method=ActionMethod(family="research", description="查阅旧报"),
+                    rule_decision=RuleDecisionRef(
+                        rule_id="research_library_archive", option_id="library-use"
+                    ),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="library-use",
+                                skill_id="library-use",
+                                difficulty="regular",
+                                method_summary="按年份检索",
+                                player_safe_reason="使用图书馆使用",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        pending = execution.pending_decision
+        assert pending is not None
+        rolled = await engine.decide(
+            CheckDecisionRequest(
+                request_id="e5-traceable:select",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=execution.view_revision,
+                decision_id=pending.decision_id,
+                decision_version=pending.decision_version,
+                choice=SelectCheckChoice(candidate_id="library-use"),
+            )
+        )
+        assert rolled.check_run is not None
+        stored = store.inspect_check_run(ROOM, rolled.check_run.check_id)
+        origin = stored.rule_origin
+        assert origin is not None
+        self.assertEqual(origin.rule_id, "research_library_archive")
+        self.assertEqual(origin.branch_id, "library-use")
+        self.assertEqual(origin.step_id, "check_library-use")
+        self.assertEqual(origin.module_version, module().version)
+        # 主动检定不回 Agenda —— 结算走父动作。
+        self.assertFalse(origin.resumes_agenda)
+        # 出处是服务端私有的，玩家投影里没有它。
+        self.assertNotIn("rule_origin", rolled.check_run.model_dump())
+
+    async def test_a_free_roll_records_no_rule_origin(self) -> None:
+        """自由掷骰没有出处——不能凭空指认一条规则。"""
+
+        store = InMemoryEngineStore()
+        store.register_room(
+            module_content=module(),
+            initial_state=game_state(module(), scene_id="library"),
+        )
+        engine = AdjudicationEngineService(
+            store, dice=DiceRoller(SequenceDiceSource([50]))
+        )
+        rules = RuleEngineService(store)
+        snapshot = await rules.read(
+            PlayerViewScope(room_id=ROOM, player_id=PLAYER, actor_id=ACTOR)
+        )
+        execution = await engine.submit(
+            SubmitAdjudicationRequest(
+                room_id=ROOM,
+                player_id=PLAYER,
+                adjudication=ActionAdjudication(
+                    request_id="e5-free-trace",
+                    source_revision=snapshot.revision,
+                    actor_id=ACTOR,
+                    summary="随便看看",
+                    target=ActionTarget(kind="location", id="library"),
+                    method=ActionMethod(family="observe", description="随便看看"),
+                    check=RequiredAdjudicationCheck(
+                        candidates=(
+                            SkillCheckCandidate(
+                                candidate_id="spot-hidden",
+                                skill_id="spot-hidden",
+                                difficulty="regular",
+                                method_summary="扫一眼",
+                                player_safe_reason="使用侦查",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        )
+        pending = execution.pending_decision
+        assert pending is not None
+        rolled = await engine.decide(
+            CheckDecisionRequest(
+                request_id="e5-free-trace:select",
+                room_id=ROOM,
+                player_id=PLAYER,
+                source_revision=execution.view_revision,
+                decision_id=pending.decision_id,
+                decision_version=pending.decision_version,
+                choice=SelectCheckChoice(candidate_id="spot-hidden"),
+            )
+        )
+        assert rolled.check_run is not None
+        self.assertIsNone(
+            store.inspect_check_run(ROOM, rolled.check_run.check_id).rule_origin
+        )
+
     async def test_a_free_check_keeps_both_permissions(self) -> None:
         """没有 rule_decision 的自由裁决完全不受影响。
 

--- a/agent-collaboration-framework/tests/test_semantic_preservation.py
+++ b/agent-collaboration-framework/tests/test_semantic_preservation.py
@@ -866,3 +866,63 @@ def test_row_e_an_unchanged_reproposal_is_semantically_preserved() -> None:
 
     assert result.status == "preserved"
     assert result.reason_code == "MECHANICAL_REPAIR"
+
+
+def _luck_check() -> RequiredAdjudicationCheck:
+    """按另一项能力重写的整组候选——文案也跟着换，这才是真实的修复形状。"""
+
+    return RequiredAdjudicationCheck(
+        candidates=(
+            SkillCheckCandidate(
+                candidate_id="luck",
+                skill_id="luck",
+                difficulty="regular",
+                method_summary="全凭运气",
+                player_safe_reason="使用幸运",
+            ),
+        )
+    )
+
+
+def test_rewriting_the_candidate_to_the_declared_skill_is_mechanical() -> None:
+    """#483：引擎说该掷规则指定的能力，那么整组候选本来就得重写。
+
+    换掉 `skill_id` 之后 `method_summary` 与 `player_safe_reason` 也得跟着换，
+    否则菜单上会出现「使用话术」配着幸运的目标值。这一层只确认玩家原本要做的事没被
+    换掉；掷什么由规则说了算，改成什么由引擎重新整体校验。
+    """
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS, check=_fast_talk_check()),
+        _greeting(rule=_NEIGHBOURS, check=_luck_check()),
+        "RULE_CHECK_SKILL_MISMATCH",
+    )
+
+    assert result.status == "preserved"
+    assert result.reason_code == "MECHANICAL_REPAIR"
+
+
+def test_the_candidate_may_not_be_rewritten_under_an_unrelated_rejection() -> None:
+    """目标不存在跟掷哪项能力无关，这时换技能是模型在夹带。"""
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS, check=_fast_talk_check()),
+        _greeting(rule=_NEIGHBOURS, check=_luck_check()),
+        "TARGET_UNAVAILABLE",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "CHECK_CHANGED"
+
+
+def test_dropping_the_rule_instead_of_fixing_the_skill_asks_the_player() -> None:
+    """改技能是可自动接受的修复，丢规则不是——沿用 #462 的策略，不扩展。"""
+
+    result = _compare(
+        _greeting(rule=_NEIGHBOURS, check=_fast_talk_check()),
+        _greeting(rule=None, check=_luck_check()),
+        "RULE_CHECK_SKILL_MISMATCH",
+    )
+
+    assert result.status == "requires_clarification"
+    assert result.reason_code == "RULE_DECISION_CHANGED"

--- a/trpg-backend/app/adapters/sqlalchemy_engine_store.py
+++ b/trpg-backend/app/adapters/sqlalchemy_engine_store.py
@@ -52,8 +52,10 @@ from app.service.module_content_cache import load_module_content
 # 落库 JSON 的 schema 版本。#310 给 CheckRun / CheckRunView 各加了字段，老行没有
 # 这些键，直接 model_validate 会当场失败——正卡在 awaiting_post_roll_decision 的
 # 房间一提交奖惩骰决定就炸。读路径按版本升级，写路径一律写当前版本。
-_CHECK_RUN_SCHEMA_VERSION = 2
-_SUPPORTED_CHECK_RUN_VERSIONS = frozenset({1, _CHECK_RUN_SCHEMA_VERSION})
+# v3：#483 给 CheckRun 加了 rule_origin（这次掷骰出自哪条规则）。老行没有这个键，
+# 模型里它可空，所以读路径不需要升级；升版本同样是为了让回滚失败得干净。
+_CHECK_RUN_SCHEMA_VERSION = 3
+_SUPPORTED_CHECK_RUN_VERSIONS = frozenset({1, 2, _CHECK_RUN_SCHEMA_VERSION})
 # #483 把 RuleCheckOrigin 的恢复游标（agenda_id / source_event_id）改成可选，好让
 # agent_match 提交路径也能记住出处。老行五个字段齐全，新模型照样读得动，所以读路径
 # 不需要升级——升版本是为了让**回滚**失败得干净：回滚后的旧代码遇到主动路径写的行
@@ -529,11 +531,13 @@ class _SqlAlchemyEngineTransaction(EngineTransaction):
         if record.check_schema_version not in _SUPPORTED_CHECK_RUN_VERSIONS:
             raise ContractError("不支持的 CheckRun schema version")
         payload = deepcopy(record.check_json)
-        if record.check_schema_version < _CHECK_RUN_SCHEMA_VERSION:
+        if record.check_schema_version < 2:
             # v1 行没有 `selected_skill_name`（#310 新增）。老行里根本没存过显示名，
             # 唯一还原得出来的只有 skill_id——这不是「数据没到位就填个假值」，而是
             # 这条记录当年确实只有这一个可用名称。新写入一律带真实显示名。
             payload.setdefault("selected_skill_name", payload.get("selected_skill_id"))
+        # v2 → v3 不需要升级：#483 新增的 `rule_origin` 可空，老行读回来是 None，
+        # 也就是「这次掷骰不知道出自哪条规则」——那正是当时的事实。
         check_run = CheckRun.model_validate(payload)
         if (
             check_run.room_id != record.room_id

--- a/trpg-backend/app/adapters/sqlalchemy_engine_store.py
+++ b/trpg-backend/app/adapters/sqlalchemy_engine_store.py
@@ -54,6 +54,13 @@ from app.service.module_content_cache import load_module_content
 # 房间一提交奖惩骰决定就炸。读路径按版本升级，写路径一律写当前版本。
 _CHECK_RUN_SCHEMA_VERSION = 2
 _SUPPORTED_CHECK_RUN_VERSIONS = frozenset({1, _CHECK_RUN_SCHEMA_VERSION})
+# #483 把 RuleCheckOrigin 的恢复游标（agenda_id / source_event_id）改成可选，好让
+# agent_match 提交路径也能记住出处。老行五个字段齐全，新模型照样读得动，所以读路径
+# 不需要升级——升版本是为了让**回滚**失败得干净：回滚后的旧代码遇到主动路径写的行
+# （没有 agenda_id）会炸在 pydantic 里，报一句看不出所以然的校验错；写上版本号，它
+# 会先撞上下面这个版本检查，直接说「不支持的 schema version」。
+_PENDING_DECISION_SCHEMA_VERSION = 2
+_SUPPORTED_PENDING_DECISION_VERSIONS = frozenset({1, _PENDING_DECISION_SCHEMA_VERSION})
 _ADJUDICATION_RESULT_SCHEMA_VERSION = 3
 _SUPPORTED_ADJUDICATION_RESULT_VERSIONS = frozenset({1, 2, _ADJUDICATION_RESULT_SCHEMA_VERSION})
 
@@ -934,7 +941,7 @@ class _SqlAlchemyEngineTransaction(EngineTransaction):
     ) -> PendingCheckDecision | None:
         if record is None:
             return None
-        if record.decision_schema_version != 1:
+        if record.decision_schema_version not in _SUPPORTED_PENDING_DECISION_VERSIONS:
             raise ContractError("不支持的 PendingCheckDecision schema version")
         decision = PendingCheckDecision.model_validate(deepcopy(record.decision_json))
         if (
@@ -966,7 +973,7 @@ class _SqlAlchemyEngineTransaction(EngineTransaction):
                     actor_id=decision.actor_id,
                     status=decision.status,
                     decision_version=decision.decision_version,
-                    decision_schema_version=1,
+                    decision_schema_version=_PENDING_DECISION_SCHEMA_VERSION,
                     decision_json=decision.to_json_dict(),
                     created_at=now,
                     updated_at=now,
@@ -975,6 +982,7 @@ class _SqlAlchemyEngineTransaction(EngineTransaction):
             return
         record.status = decision.status
         record.decision_version = decision.decision_version
+        record.decision_schema_version = _PENDING_DECISION_SCHEMA_VERSION
         record.decision_json = decision.to_json_dict()
         record.updated_at = now
 

--- a/trpg-backend/tests/test_issue398_passive_check.py
+++ b/trpg-backend/tests/test_issue398_passive_check.py
@@ -23,7 +23,10 @@ from collaboration_framework.contracts import (
     CheckDecisionRequest,
     NoAdjudicationCheck,
     PostRollDecisionRequest,
+    RequiredAdjudicationCheck,
+    RuleDecisionRef,
     SelectCheckChoice,
+    SkillCheckCandidate,
     SubmitAdjudicationRequest,
 )
 from collaboration_framework.engine import (
@@ -437,15 +440,15 @@ async def test_decisions_written_before_the_origin_split_still_load(
             )
         )
     ).one()
-    # 被动路径写出来的 JSON 本来就是老格式（五个字段齐全），把版本号压回 1 就等价
-    # 于一条部署前的行。
+    # 把这一行降级成 #483 之前的样子：只留当时那五个字段，版本号压回 1。
     origin = dict(record.decision_json["rule_origin"])
-    assert set(origin) == {
-        "agenda_id",
-        "rule_id",
-        "branch_id",
-        "step_id",
-        "source_event_id",
+    legacy_origin = {
+        key: origin[key]
+        for key in ("agenda_id", "rule_id", "branch_id", "step_id", "source_event_id")
+    }
+    record.decision_json = {
+        **record.decision_json,
+        "rule_origin": legacy_origin,
     }
     record.decision_schema_version = 1
     await db_session.commit()
@@ -456,5 +459,121 @@ async def test_decisions_written_before_the_origin_split_still_load(
     assert reloaded.rule_origin is not None
     # 恢复游标还在 —— 被动检定结算后仍旧回 Agenda，不会走主动路径的 _finalize_action。
     assert reloaded.rule_origin.resumes_agenda is True
-    assert reloaded.rule_origin.agenda_id == origin["agenda_id"]
-    assert reloaded.rule_origin.source_event_id == origin["source_event_id"]
+    assert reloaded.rule_origin.agenda_id == legacy_origin["agenda_id"]
+    assert reloaded.rule_origin.source_event_id == legacy_origin["source_event_id"]
+    # 老行不知道自己出自哪一版模组，读回来就该是 None，而不是谎称是当前版本。
+    assert reloaded.rule_origin.module_version is None
+
+
+async def _stand_in_library(db: AsyncSession, room_id: str) -> str:
+    """把房间摆到图书馆，`research_library_archive` 在那里可用。"""
+
+    game_session = await db.get(GameSession, room_id)
+    assert game_session is not None
+    state = GameState.model_validate(game_session.state_json)
+    actor_id = next(iter(state.actors))
+    actor = state.actors[actor_id]
+    existing = actor.state.get("skills")
+    skills = {
+        **(existing if isinstance(existing, dict) else {}),
+        "library-use": 70,
+    }
+    game_session.state_json = state.model_copy(
+        update={
+            "scene_id": "library",
+            "actors": {
+                actor_id: actor.model_copy(
+                    update={"state": {**actor.state, "skills": skills}}, deep=True
+                )
+            },
+        },
+        deep=True,
+    ).to_json_dict()
+    await db.commit()
+    return actor_id
+
+
+async def test_an_active_rule_check_keeps_its_origin_across_a_store_restart(
+    db_session: AsyncSession,
+    engine_store_factory: Callable[..., SqlAlchemyEngineStore],
+) -> None:
+    """主动检定的出处必须真的落库，并且跨进程读回来不丢失、不漂移（#483）。
+
+    这是新形状的第一条 SQL 往返：只有 rule/branch/step + module_version，没有 Agenda
+    游标。掷骰在另一个 Store 实例里完成——等价于结算发生在重启之后——CheckRun 上记的
+    出处仍要指向同一条分支。
+    """
+
+    room, players, _ = await _start_room(db_session, room_number=98)
+    room_id, player_id = room.id, players[0].id
+    actor_id = await _stand_in_library(db_session, room_id)
+
+    store = engine_store_factory()
+    async with store.transaction(room_id) as transaction:
+        runtime = await transaction.load_runtime()
+    execution = await AdjudicationEngineService(store).submit(
+        SubmitAdjudicationRequest(
+            room_id=room_id,
+            player_id=player_id,
+            adjudication=ActionAdjudication(
+                request_id="issue483-archive",
+                source_revision=runtime.revision,
+                actor_id=actor_id,
+                summary="查阅旧报",
+                target=ActionTarget(kind="entity", id="newspaper_archive"),
+                method=ActionMethod(family="research", description="查阅旧报"),
+                rule_decision=RuleDecisionRef(
+                    rule_id="research_library_archive", option_id="library-use"
+                ),
+                check=RequiredAdjudicationCheck(
+                    candidates=(
+                        SkillCheckCandidate(
+                            candidate_id="library-use",
+                            skill_id="library-use",
+                            difficulty="regular",
+                            method_summary="按年份检索",
+                            player_safe_reason="使用图书馆使用",
+                        ),
+                    )
+                ),
+            ),
+        )
+    )
+    pending = execution.pending_decision
+    assert pending is not None
+
+    # 落库的决策带着出处，但不带恢复游标。
+    async with engine_store_factory().transaction(room_id) as transaction:
+        stored = await transaction.load_pending_check(pending.decision_id)
+    assert stored is not None and stored.rule_origin is not None
+    assert stored.rule_origin.rule_id == "research_library_archive"
+    assert stored.rule_origin.branch_id == "library-use"
+    assert stored.rule_origin.step_id == "check_library-use"
+    assert stored.rule_origin.module_version == runtime.module_version
+    assert stored.rule_origin.resumes_agenda is False
+
+    # 换一个全新的 Store 实例结算：等价于掷骰发生在重启之后。
+    rolled = await AdjudicationEngineService(
+        engine_store_factory(),
+        dice=DiceRoller(SequenceDiceSource([50])),
+    ).decide(
+        CheckDecisionRequest(
+            request_id="issue483-archive:select",
+            room_id=room_id,
+            player_id=player_id,
+            source_revision=execution.view_revision,
+            decision_id=pending.decision_id,
+            decision_version=pending.decision_version,
+            choice=SelectCheckChoice(candidate_id="library-use"),
+        )
+    )
+    assert rolled.check_run is not None
+
+    async with engine_store_factory().transaction(room_id) as transaction:
+        run = await transaction.load_check_run(rolled.check_run.check_id)
+    assert run is not None and run.rule_origin is not None
+    # 不漂移：跨实例读回来还是同一条分支的同一步。
+    assert run.rule_origin.rule_id == "research_library_archive"
+    assert run.rule_origin.branch_id == "library-use"
+    assert run.rule_origin.step_id == "check_library-use"
+    assert run.rule_origin.module_version == runtime.module_version

--- a/trpg-backend/tests/test_issue398_passive_check.py
+++ b/trpg-backend/tests/test_issue398_passive_check.py
@@ -401,3 +401,60 @@ async def test_two_open_decisions_never_coexist_on_one_action(
         found = await transaction.find_pending_check_by_action(action_id)
     assert found is not None
     assert found.decision_id == second.pending_decision.decision_id
+
+
+async def test_decisions_written_before_the_origin_split_still_load(
+    db_session: AsyncSession,
+    engine_store_factory: Callable[..., SqlAlchemyEngineStore],
+) -> None:
+    """#483 拆开 `RuleCheckOrigin` 之后，部署前落库的检定必须还能读回来。
+
+    出处（rule/branch/step）与恢复游标（agenda/source_event）拆开时，后两个字段
+    从必填变成可选。老行五个字段齐全，新模型照样读得动——这条把 schema version
+    压回 1 走一遍读路径，确认版本检查放行、`resumes_agenda` 仍然为真，也就是被动
+    检定结算后照旧回 Agenda 走 `result_routes`，而不是被当成主动检定。
+    """
+
+    room, players, _ = await _start_room(db_session, room_number=97)
+    room_id, player_id = room.id, players[0].id
+    actor_id = await _arm_first_sight(db_session, room_id)
+
+    store = engine_store_factory()
+    async with store.transaction(room_id) as transaction:
+        runtime = await transaction.load_runtime()
+    execution = await AdjudicationEngineService(store).submit(
+        _see_true_form(room_id, player_id, actor_id, runtime.revision)
+    )
+    pending = execution.pending_decision
+    assert pending is not None
+
+    db_session.expire_all()
+    record = (
+        await db_session.scalars(
+            select(PendingCheckDecisionRecord).where(
+                PendingCheckDecisionRecord.room_id == room_id,
+                PendingCheckDecisionRecord.decision_id == pending.decision_id,
+            )
+        )
+    ).one()
+    # 被动路径写出来的 JSON 本来就是老格式（五个字段齐全），把版本号压回 1 就等价
+    # 于一条部署前的行。
+    origin = dict(record.decision_json["rule_origin"])
+    assert set(origin) == {
+        "agenda_id",
+        "rule_id",
+        "branch_id",
+        "step_id",
+        "source_event_id",
+    }
+    record.decision_schema_version = 1
+    await db_session.commit()
+
+    async with engine_store_factory().transaction(room_id) as transaction:
+        reloaded = await transaction.load_pending_check(pending.decision_id)
+    assert reloaded is not None
+    assert reloaded.rule_origin is not None
+    # 恢复游标还在 —— 被动检定结算后仍旧回 Agenda，不会走主动路径的 _finalize_action。
+    assert reloaded.rule_origin.resumes_agenda is True
+    assert reloaded.rule_origin.agenda_id == origin["agenda_id"]
+    assert reloaded.rule_origin.source_event_id == origin["source_event_id"]

--- a/trpg-backend/tests/test_rule_match_adjudication.py
+++ b/trpg-backend/tests/test_rule_match_adjudication.py
@@ -48,7 +48,7 @@ from collaboration_framework.engine import (
 )
 from collaboration_framework.engine.initialization import create_initial_game_state
 from collaboration_framework.engine.models import ActorState
-from collaboration_framework.engine.projection_v3 import _rule_check_skill_id
+from collaboration_framework.engine.projection_v3 import rule_check_skill_id
 from collaboration_framework.host.application import PlayerViewProjector, TurnExecutionError
 from collaboration_framework.host.prompts.action_plan import (
     current_step_adjudication_instructions,
@@ -237,7 +237,7 @@ def test_rule_check_skill_id_reads_coc7_skill_profile_parameter() -> None:
             "fumble": "done",
         },
     )
-    assert _rule_check_skill_id(step) == "credit-rating"
+    assert rule_check_skill_id(step) == "credit-rating"
 
 
 async def test_rule_once_builder_rejects_unmapped_rule_check_branch() -> None:


### PR DESCRIPTION
Closes #483

> **基于 #493（#462）**，`fix/issue-462-rule-requires-check` 之上开发。#483 正文说的就是「同一 PR 链」。#493 合并后我会 rebase 到 `upstream/main`，届时本 PR 只剩下面这 6 个提交。

## 问题

模组作者在 `CheckStep.check`（`RuleCheckSpec`）上声明了 `parameters.skill_id` / `difficulty` / `allow_luck` / `allow_push`，但**只有被动检定路径消费它们**。玩家行动走的 `agent_match` 提交路径把整个 spec 忽略掉，改用 Agent 自报的 `SkillCheckCandidate`。

《追书人》守夜的实测（作者声明 `parameters.skill_id="luck"` / `difficulty="regular"`）：

| | 模组作者声明 | 引擎实际用的 |
|---|---|---|
| 技能 | `luck`（该角色幸运 99） | `spot-hidden`（侦察 60）|
| 难度 | `regular` | `hard` |
| 报错 | — | **无** |

不是孤例：三个模组共 **42 条 `active_action` 检定步全部声明了 `parameters.skill_id`，全部零消费**（幸福蛙蛙村 16 / 追书人 23 / 银之锁 3），其中 2 条还声明了 `difficulty=hard` 同样被忽略。

## 数据流与那个陷阱

**根因**：`_rule_check_spec` 靠 `decision.rule_origin` 判断「这是不是规则拥有的检定」，提交路径建 `PendingCheckDecision` 时不带它，被动路径带。

**但「补上 rule_origin」会跑错分支**——`_settle_check` 也用 `rule_origin is not None` 路由到 `_resume_rule_check` 按 Agenda 游标恢复。主动路径没有 Agenda，它的结算走 `_finalize_action` → `_owned_effects`。

`rule_origin` 实际背了两个正交职责：

| 职责 | 消费者 | 主动路径要不要 |
|---|---|---|
| **出处** —— 出自哪条规则的哪一步，用来取配置 | `_rule_check_spec` | 要 |
| **恢复游标** —— 结算完回哪个 Agenda，用来路由结算 | `_settle_check` → `_resume_rule_check` | **绝不能要** |

所以第一步不是补字段，是拆职责。

> 顺带订正 [issue 17 §6](https://github.com/Ximaohu-LMX/TRPG-master-LMX/issues/17) 的判断：「提交路径补上 `rule_origin`，三个字段会顺着现有代码自动生效，不需要新管线」低估了成本。`allow_luck`/`allow_push` 确实自动生效，但前提是先拆职责；`difficulty` 的唯一消费者在被动路径上，需要单独接。

## 六个提交

| # | 提交 | 内容 |
|---|---|---|
| 1 | `refactor` | 拆 `rule_origin` 两职责：出处（rule/branch/step）必填，游标（agenda/source_event）可选。`_settle_check` 改按 `resumes_agenda` 路由。游标半齐当场拒绝。decision schema → v2 |
| 2 | `feat` | 提交路径写入出处 → `allow_luck` / `allow_push` **自动生效** |
| 3 | `feat` | 消费规则声明的 `difficulty`（覆盖，不拒绝） |
| 4 | `feat` | 强制 `parameters.skill_id`（拒绝，不覆盖）+ `RULE_CHECK_SKILL_MISMATCH` + Host 修复回路 |
| 5 | `test` | 参数所有权边界；**不动注册表**，并写清为什么 |
| 6 | `feat` | `CheckRun` 记住出处 + `module_version`；CheckRun schema → v3 |

### 三个字段处理为什么不一样

- **`difficulty` 覆盖**：不改变玩家看到的「掷什么」，42 条里只有 2 条声明非 regular，为它多花一轮修复预算噪音大于收益。#483 正文原文也是「按声明难度判定」。
- **`skill_id` 拒绝**：候选里的 `method_summary` / `player_safe_reason` 是玩家会看到的文字，Agent 是照着自己选的技能写的。只换 `skill_id` 留下文案，菜单上会出现「使用图书馆使用」配着幸运的目标值。
- **`allow_*` 自动生效**：读取点一直都在，卡住的是上游。

### 为什么不登记 `coc7.skill`

方案原本要把 `coc7.skill` / `coc7.luck` 登记进 `CHECK_PROFILES`。查下来这是错的，这张表自己的规矩已写明：

> Adding a name here is a claim that the Engine can execute it, so it belongs in the same change that adds the executor, never ahead of one.

`coc7.skill` 没有固定的 `resource`（目标值来自 `actor.state["skills"][skill_id]`，不是 `ActorResources` 上某个字段），`_passive_check_option` 执行不了它。登记它会让发布期校验开始放行引擎跑不动的 `passive_rule` 步，把一个发布期就能拦住的错误推迟到运行时。`coc7.luck` 则是没有任何模组在用。

所以只钉边界不动表，并在表的文档里记下这次取舍。

## 验收标准

- [x] `PendingCheckDecision` 与最终 `CheckRun` 能追溯到 Rule / Branch / CheckStep 与固定 ModuleVersion
- [x] 规则声明 `difficulty=hard/extreme` 时按声明难度判定
- [x] `allow_luck=false` / `allow_push=false` 时对应 post-roll 选项不出现
- [x] `parameters.skill_id` 与 Agent 候选冲突时不静默继续
- [x] 被动检定现有行为与测试保持通过
- [x] 重连、服务恢复后 `rule_origin` 不丢失、不漂移
- [x] 不消费 `success_loss` / `failure_loss` / `habit_cap`，有测试钉住边界
- [x] 与 #462 双向不变量的组合测试通过

## 验证

- `agent-collaboration-framework`：**500 passed**
- `trpg-backend`：**674 passed, 23 skipped**
- `e2e`（确定性）：**42 passed, 0 failed, 3 skipped**（三条真实模型用例按 `E2E_REAL_MODEL=1` 门控）

新增测试逐条做了变红验证（`git checkout upstream/main -- collaboration_framework/` 后重跑），确认是真回归守卫而非自证。其中**没有一条现有测试因强制 `skill_id` 而变红**——它们本来报的就是声明技能，影响面比预估小。

三条反向守卫钉住不该被误伤的东西：无 `rule_decision` 的自由裁决保留两个权限、可以掷任意自有技能、CheckRun 上不凭空指认规则。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
