### PR TITLE
fix(character): 保留首次掷幸运时的建卡表单

### DIFF
--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -334,6 +334,27 @@ describe('CharacterPage', () => {
     await advanceToAttributesAfterOccupationPreview()
   })
 
+  it('preserves the current form when the first luck roll creates an empty draft', async () => {
+    renderPage()
+
+    fireEvent.change(screen.getByPlaceholderText('请输入角色姓名'), { target: { value: '当前调查员' } })
+    fireEvent.click(screen.getByText('会计师'))
+    await waitFor(() => {
+      expect(mockPreviewCharacter).toHaveBeenCalledWith(expect.objectContaining({ occupationId: 1 }))
+    })
+    fireEvent.click(screen.getByRole('button', { name: /下一步/ }))
+    await waitFor(() => expect(screen.getByText('属性分配')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: '掷幸运骰' }))
+    await waitFor(() => expect(mockCharacterApi.createCharacterDraft).toHaveBeenCalledWith('room-1'))
+    await waitFor(() => expect(mockCharacterApi.rollLuckCharacter).toHaveBeenCalledWith('room-1', 'draft-1'))
+
+    // 首次掷骰创建的草稿尚未保存姓名和职业，回读不能把向导中的内容清空。
+    fireEvent.click(screen.getByRole('tab', { name: '基础信息' }))
+    expect(screen.getByPlaceholderText('请输入角色姓名')).toHaveValue('当前调查员')
+    expect(screen.getByText('取消选择')).toBeInTheDocument()
+  })
+
   it('shows quick-create validation in a dialog without moving the trigger button', () => {
     renderPage()
 
@@ -777,6 +798,8 @@ describe('CharacterPage', () => {
       occupationId: 1,
       skills: { accounting: 1, stealth: 1 },
     }))
+    // 属性状态只在属性页展示，先切换页面再验证幸运值的待掷状态。
+    fireEvent.click(screen.getByRole('tab', { name: '属性' }))
     expect(screen.getByText('待掷')).toBeInTheDocument()
   })
 })

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -240,6 +240,11 @@ export default function CharacterPage() {
     .getState()
     .getForRoom(useRoomStore.getState().roomId ?? '')
 
+  // 首次掷幸运时会先创建一张空的服务端草稿。这个草稿随后只补齐属性，
+  // 还没有姓名、职业和技能，不能反过来覆盖用户正在填写的向导表单。
+  // 仅跳过这一次回读；刷新页面或重新进入时仍按服务端数据正常水合。
+  const skipNextCharacterHydrationRef = useRef<string | null>(null)
+
   const [generationMethod, setGenerationMethod] = useState<'pointbuy' | 'roll'>(
     existingCharacter?.generationMethod ?? 'pointbuy'
   )
@@ -287,6 +292,15 @@ export default function CharacterPage() {
   // 有 characterId 就以后端那份为准覆盖表单，清掉浏览器缓存也照样能继续编辑。
   useEffect(() => {
     if (!ruleset) return
+    if (
+      !templateHostId
+      && roomId
+      && characterId
+      && skipNextCharacterHydrationRef.current === characterId
+    ) {
+      skipNextCharacterHydrationRef.current = null
+      return
+    }
     // 卡库宿主没有房间，也没有 characterId；读的是那张卡库卡，摊平成向导已经
     // 会读的形状后走同一条水合路径（属性 → 权威 preview 反推技能点 → 填表单）。
     const load = templateHostId
@@ -933,6 +947,9 @@ export default function CharacterPage() {
       let characterId = useRoomStore.getState().characterId
       if (!characterId) {
         characterId = await createCharacterDraft(roomId)
+        // 这张草稿还没保存当前向导里的基础信息，避免下面的回读 effect
+        // 用服务端空字段覆盖用户已经填好的姓名和职业。
+        skipNextCharacterHydrationRef.current = characterId
         setCharacterId(characterId)
       }
       const result = await rollLuckCharacter(roomId, characterId)


### PR DESCRIPTION
## 关联 Issue

Closes #495

## 主要改动

- 修复首次掷幸运创建空角色草稿后，服务端水合覆盖当前建卡向导的问题。
- 仅跳过该新草稿触发的单次水合，刷新或重新进入页面仍按服务端角色数据正常恢复。
- 增加首次幸运掷骰保留姓名和职业的回归测试。
- 修正卡库水合测试，先切换到属性页再检查“待掷”状态。

## 采用该方案的原因

首次幸运掷骰必须先创建服务端草稿，但此时草稿尚未保存姓名、职业和技能等向导字段。通过一次性的 `ref` 标记跳过该次回读，可以保留用户当前输入，同时不改变后续正常进入页面时以后端为准的水合行为。该方案改动范围小，不需要修改接口或数据库结构。

## 测试与验证

- [x] `CI=1 npx vitest run src/routes/games/trpg/CharacterPage.test.tsx --pool=forks --maxWorkers=1 --reporter=dot`（22 passed）
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [ ] 手动验证已完成（待维护者 Review 环境验证）

## 风险与回滚

- 风险：仅在首次创建空草稿并设置同一 `characterId` 的 effect 执行时跳过一次水合；正常已有草稿、卡库选卡和刷新恢复路径不受影响。
- 回滚：回退提交 `61c5c0f` 即可恢复原行为。

## UI 证据

本次无视觉布局变化；回归测试覆盖建卡页面中首次掷幸运后姓名和职业仍保留的可见状态。

## AI 使用情况

使用 AI 辅助定位异步水合竞态、编写修复和回归测试；已人工检查改动范围、状态流转和测试结果。

## 自检

- [x] 改动范围符合 Issue
- [x] 不包含无关改动
- [x] 已包含必要的测试
- [x] 不包含密钥、个人信息或非预期生成物
- [x] 已完成 AI 辅助质量检查，等待人工 Review

请进行人工 Review，勿绕过仓库保护规则直接合并。