### PR TITLE
feat(npc): 支持追书人 NPC 专属豆包音色 (#502)

### DIFF
--- a/agent-collaboration-framework/collaboration_framework/contracts/__init__.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/__init__.py
@@ -159,6 +159,7 @@ from .module_v3 import (
     EndingAnchorSpec,
     EndingPolicySpec,
     EntityRelationSpec,
+    EntityVoiceProfile,
     EntitySpecV3,
     EventTriggerSpec,
     ExecutionBranchSpec,

--- a/agent-collaboration-framework/collaboration_framework/contracts/module_v3.py
+++ b/agent-collaboration-framework/collaboration_framework/contracts/module_v3.py
@@ -211,6 +211,14 @@ class InitialCustodySpec(ContractModel):
     kind: Literal["location", "starting_actor"]
 
 
+class EntityVoiceProfile(ContractModel):
+    """NPC 的模组级语音配置；只保存可发布的稳定音色标识。"""
+
+    provider: Literal["doubao"]
+    resource_id: str = Field(min_length=1, max_length=200)
+    voice_type: str = Field(min_length=1, max_length=200)
+
+
 class EntitySpecV3(ContractModel):
     """一个 Canon 人物或物体。
 
@@ -231,12 +239,22 @@ class EntitySpecV3(ContractModel):
     initial_custody: InitialCustodySpec | None = None
     state: dict[str, JsonValue] = Field(default_factory=dict)
     item_component: ItemComponent | None = None
+    # 音色是模组公开展示元数据，只允许 NPC 配置，运行时仍由服务端校验资源和白名单。
+    voice: EntityVoiceProfile | None = None
     visibility: Literal["public", "party", "actor", "keeper"] = "public"
     # 受众与发现是两个独立概念。即使实体是 public，在已注册的确定性谓词确认其
     # 被发现之前，也可以不出现在任何玩家投影中。
     visibility_conditions: tuple[ConditionExpr, ...] = ()
     plot_relevance: bool = True
     lifecycle: Literal["campaign", "session"] = "campaign"
+
+    @model_validator(mode="after")
+    def validate_voice_kind(self) -> "EntitySpecV3":
+        """阻止物品等非 NPC 实体携带 NPC 专属音色。"""
+
+        if self.voice is not None and self.kind != "npc":
+            raise ValueError("只有 NPC 实体可以配置 voice")
+        return self
 
 
 # --------------------------------------------------------------------------- #
@@ -1057,6 +1075,7 @@ __all__ = [
     "EndingPolicySpec",
     "EntityRelationKind",
     "EntityRelationSpec",
+    "EntityVoiceProfile",
     "EntitySpecV3",
     "EventTriggerSpec",
     "ExecutionBranchSpec",

--- a/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json
+++ b/agent-collaboration-framework/docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json
@@ -218,6 +218,11 @@
         "委托人"
       ],
       "description": "道格拉斯·金博尔的侄子，现住在叔叔的旧居。他希望找回五本失窃藏书，并确认叔叔的下落。",
+      "voice": {
+        "provider": "doubao",
+        "resource_id": "seed-tts-2.0",
+        "voice_type": "zh_male_dongfanghaoran_uranus_bigtts"
+      },
       "located_in": "thomas_office",
       "state": {
         "case_open": true,
@@ -236,6 +241,11 @@
         "夜行者"
       ],
       "description": "夜色中一条瘦削的人影，怀里似乎夹着一本书。",
+      "voice": {
+        "provider": "doubao",
+        "resource_id": "seed-tts-2.0",
+        "voice_type": "zh_male_xuanyijieshuo_uranus_bigtts"
+      },
       "located_in": "crypt",
       "state": {
         "alive": true,
@@ -306,6 +316,11 @@
         "邻居"
       ],
       "description": "道格拉斯旧居附近的一名邻居，记得他失踪前的一些生活习惯。",
+      "voice": {
+        "provider": "doubao",
+        "resource_id": "seed-tts-2.0",
+        "voice_type": "zh_female_vv_uranus_bigtts"
+      },
       "located_in": "neighborhood",
       "state": {
         "interviewed": false
@@ -325,6 +340,11 @@
         "看守"
       ],
       "description": "公共墓地的看守，穿着一件旧外套，看起来有些紧张。",
+      "voice": {
+        "provider": "doubao",
+        "resource_id": "seed-tts-2.0",
+        "voice_type": "zh_male_ruyayichen_saturn_bigtts"
+      },
       "located_in": "cemetery",
       "state": {
         "impressed": false,
@@ -344,6 +364,11 @@
         "失眠症邻居"
       ],
       "description": "一位已经搬去底特律的老妇人，曾向报社留下关于墓地的陈述。",
+      "voice": {
+        "provider": "doubao",
+        "resource_id": "seed-tts-2.0",
+        "voice_type": "zh_female_santongyongns_saturn_bigtts"
+      },
       "located_in": "newspaper_office",
       "state": {},
       "visibility": "public",

--- a/agent-collaboration-framework/schemas/module-content-v3.schema.json
+++ b/agent-collaboration-framework/schemas/module-content-v3.schema.json
@@ -1111,6 +1111,17 @@
           ],
           "default": null
         },
+        "voice": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EntityVoiceProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "visibility": {
           "default": "public",
           "enum": [
@@ -1173,6 +1184,36 @@
         "name"
       ],
       "title": "EntitySpecV3",
+      "type": "object"
+    },
+    "EntityVoiceProfile": {
+      "additionalProperties": false,
+      "description": "NPC 的模组级语音配置；只保存可发布的稳定音色标识。",
+      "properties": {
+        "provider": {
+          "const": "doubao",
+          "title": "Provider",
+          "type": "string"
+        },
+        "resource_id": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Resource Id",
+          "type": "string"
+        },
+        "voice_type": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Voice Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "resource_id",
+        "voice_type"
+      ],
+      "title": "EntityVoiceProfile",
       "type": "object"
     },
     "EventTriggerSpec": {

--- a/agent-collaboration-framework/tests/test_module_content_v3.py
+++ b/agent-collaboration-framework/tests/test_module_content_v3.py
@@ -223,6 +223,27 @@ def mutate(**changes: Any) -> dict[str, Any]:
 
 
 class ModuleContentV3ContractTests(unittest.TestCase):
+    def test_voice_profile_is_supported_for_npc(self) -> None:
+        payload = module_payload()
+        payload["entities"][0]["voice"] = {
+            "provider": "doubao",
+            "resource_id": "seed-tts-2.0",
+            "voice_type": "voice-a",
+        }
+        content = ModuleContentV3.model_validate(payload)
+        self.assertEqual(content.entities[0].voice.voice_type, "voice-a")
+
+    def test_voice_profile_is_rejected_for_object(self) -> None:
+        payload = module_payload()
+        payload["entities"][0]["kind"] = "object"
+        payload["entities"][0]["voice"] = {
+            "provider": "doubao",
+            "resource_id": "seed-tts-2.0",
+            "voice_type": "voice-a",
+        }
+        with self.assertRaises(ValidationError):
+            ModuleContentV3.model_validate(payload)
+
     def test_reference_module_validates(self) -> None:
         report = validate_module_v3(module_payload())
         self.assertEqual(report.status, "pass", report.errors)

--- a/agent-collaboration-framework/tests/test_module_content_v3.py
+++ b/agent-collaboration-framework/tests/test_module_content_v3.py
@@ -225,6 +225,7 @@ def mutate(**changes: Any) -> dict[str, Any]:
 class ModuleContentV3ContractTests(unittest.TestCase):
     def test_voice_profile_is_supported_for_npc(self) -> None:
         payload = module_payload()
+        payload["entities"][0]["kind"] = "npc"
         payload["entities"][0]["voice"] = {
             "provider": "doubao",
             "resource_id": "seed-tts-2.0",

--- a/trpg-backend/app/controller/v1/host_speech.py
+++ b/trpg-backend/app/controller/v1/host_speech.py
@@ -26,7 +26,9 @@ from app.service.host_speech import (
     HostSpeechRateLimitedError,
     HostSpeechService,
     HostSpeechUnavailableError,
+    find_visible_dialogue,
     find_visible_narration,
+    get_npc_voice,
     get_room_voice,
     require_account_room_member,
 )
@@ -186,6 +188,76 @@ async def get_host_speech_sentence(
         if sentence_index < 0 or sentence_index >= len(sentences):
             raise HostSpeechNotFoundError("主持人语音分句不存在")
         voice_type = await get_room_voice(db, room_id, service)
+        result = await service.synthesize(
+            room_id=room_id,
+            player_id=player.id,
+            text=sentences[sentence_index],
+            voice_type=voice_type,
+        )
+    except Exception as exc:
+        _raise_public_error(exc)
+    return Response(
+        content=result.audio,
+        media_type=result.content_type,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.get(
+    "/{room_id}/dialogues/{message_id}/speech",
+    response_model=ApiResponse[HostSpeechManifestRead],
+)
+async def get_npc_speech_manifest(
+    room_id: str,
+    message_id: str,
+    request: Request,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> ApiResponse[HostSpeechManifestRead]:
+    """读取有 audience 权限的 NPC 对话分句清单。"""
+
+    player = await _member(db, room_id, reconnect_token, user)
+    try:
+        event = await find_visible_dialogue(
+            db, room_id=room_id, message_id=message_id, player_id=player.id
+        )
+        sentences = _service(request).sentences(event.payload["text"])
+    except Exception as exc:
+        _raise_public_error(exc)
+    return ApiResponse.ok(
+        HostSpeechManifestRead(
+            message_id=message_id,
+            sentences=[
+                HostSpeechSentenceRead(index=index, text=text)
+                for index, text in enumerate(sentences)
+            ],
+        )
+    )
+
+
+@router.get("/{room_id}/dialogues/{message_id}/speech/sentences/{sentence_index}")
+async def get_npc_speech_sentence(
+    room_id: str,
+    message_id: str,
+    sentence_index: int,
+    request: Request,
+    reconnect_token: str | None = Header(default=None, alias="X-Reconnect-Token"),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> Response:
+    """按对话 speaker_id 解析专属音色并返回一条 MP3；失败不修改事件。"""
+
+    player = await _member(db, room_id, reconnect_token, user)
+    service = _service(request)
+    try:
+        event = await find_visible_dialogue(
+            db, room_id=room_id, message_id=message_id, player_id=player.id
+        )
+        sentences = service.sentences(event.payload["text"])
+        if sentence_index < 0 or sentence_index >= len(sentences):
+            raise HostSpeechNotFoundError("NPC 语音分句不存在")
+        voice_type = await get_npc_voice(db, room_id=room_id, event=event, service=service)
         result = await service.synthesize(
             room_id=room_id,
             player_id=player.id,

--- a/trpg-backend/app/service/host_speech.py
+++ b/trpg-backend/app/service/host_speech.py
@@ -350,26 +350,27 @@ async def get_npc_voice(
     module_version = await db.get(ModuleVersion, (scenario.module_id, version))
     # 事件规范使用 camelCase；兼容早期测试/历史行的 snake_case 载荷。
     speaker_id = event.payload.get("speakerId") or event.payload.get("speaker_id") or event.actor_id
+    if not isinstance(speaker_id, str) or not speaker_id.strip() or module_version is None:
+        raise HostSpeechNotFoundError("NPC 音色对应的实体不存在")
     try:
-        content = (
-            ModuleContentV3.model_validate(module_version.content_json) if module_version else None
-        )
-        entity = next(
-            item
-            for item in (content.entities if content else ())
-            if item.kind == "npc" and item.id == speaker_id
-        )
-        profile = entity.voice
-        if (
-            profile is not None
-            and profile.provider == service.provider.name
-            and profile.resource_id == service.resource_id
-            and profile.voice_type in service.allowed_voice_types
-        ):
-            return profile.voice_type
-    except (StopIteration, TypeError, ValueError):
-        # 内容缺失、旧版本或非法 profile 都只能回退，不影响文字对话。
-        pass
+        content = ModuleContentV3.model_validate(module_version.content_json)
+    except (TypeError, ValueError) as exc:
+        raise HostSpeechUnavailableError("模组音色配置无法读取") from exc
+    entity = next(
+        (item for item in content.entities if item.kind == "npc" and item.id == speaker_id),
+        None,
+    )
+    if entity is None:
+        raise HostSpeechNotFoundError("NPC 音色对应的实体不存在")
+    profile = entity.voice
+    if (
+        profile is not None
+        and profile.provider == service.provider.name
+        and profile.resource_id == service.resource_id
+        and profile.voice_type in service.allowed_voice_types
+    ):
+        return profile.voice_type
+    # 合法 NPC 但 profile 与当前部署不匹配时安全回退，不影响文字对话。
     if fallback is None or fallback not in service.allowed_voice_types:
         raise HostSpeechUnavailableError("NPC 音色不可用，但文字对话仍可继续")
     return fallback

--- a/trpg-backend/app/service/host_speech.py
+++ b/trpg-backend/app/service/host_speech.py
@@ -8,6 +8,7 @@ import time
 from collections import OrderedDict, defaultdict, deque
 from dataclasses import dataclass
 
+from collaboration_framework.contracts import ModuleContentV3
 from collaboration_framework.host.application import split_narration_chunks
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,7 +19,9 @@ from app.adapters.host_speech import (
     HostSpeechResult,
 )
 from app.core.config import HostSpeechVoiceConfig, Settings, secret_value
-from app.models.event import Event
+from app.models.content import Scenario
+from app.models.engine import ModuleVersion
+from app.models.event import Event, EventAudience
 from app.models.room import Player, Room
 
 
@@ -109,6 +112,7 @@ class HostSpeechService:
         player_requests_per_minute: int,
         room_misses_per_minute: int,
         max_concurrency: int,
+        resource_id: str = "",
     ) -> None:
         self.provider = provider
         self.voices = voices
@@ -125,6 +129,8 @@ class HostSpeechService:
         self._room_limiter = _WindowRateLimiter()
         self._player_limit = player_requests_per_minute
         self._room_limit = room_misses_per_minute
+        # 资源包属于部署配置；NPC profile 只有与此值一致时才允许使用。
+        self.resource_id = resource_id
 
     @property
     def available(self) -> bool:
@@ -142,7 +148,7 @@ class HostSpeechService:
 
     def _cache_key(self, text: str, voice_type: str) -> str:
         digest = hashlib.sha256(text.encode()).hexdigest()
-        return f"{self.provider.version}:mp3:{voice_type}:{digest}"
+        return f"{self.provider.version}:{self.resource_id}:mp3:{voice_type}:{digest}"
 
     def _evict_expired(self, now: float) -> None:
         expired = [key for key, entry in self._cache.items() if entry.expires_at <= now]
@@ -249,6 +255,7 @@ def build_host_speech_service(settings: Settings) -> HostSpeechService:
         player_requests_per_minute=settings.host_speech_player_requests_per_minute,
         room_misses_per_minute=settings.host_speech_room_misses_per_minute,
         max_concurrency=settings.host_speech_max_concurrency,
+        resource_id=settings.doubao_tts_resource_id,
     )
 
 
@@ -291,6 +298,81 @@ async def find_visible_narration(
     if not isinstance(event.payload.get("text"), str) or not event.payload["text"]:
         raise HostSpeechInvalidRequestError("主持人消息没有可朗读文本")
     return event
+
+
+async def find_visible_dialogue(
+    db: AsyncSession,
+    *,
+    room_id: str,
+    message_id: str,
+    player_id: str,
+) -> Event:
+    """按冻结 audience 查找 NPC 对话，避免后来进场的玩家读取历史语音。"""
+
+    event = await db.scalar(
+        select(Event)
+        .join(EventAudience, EventAudience.event_id == Event.id)
+        .where(
+            Event.room_id == room_id,
+            Event.event_type == "dialogue.npc",
+            or_(Event.id == message_id, Event.correlation_id == message_id),
+            EventAudience.player_id == player_id,
+        )
+    )
+    if event is None:
+        raise HostSpeechNotFoundError("NPC 对话不存在或当前玩家无权读取")
+    if not isinstance(event.payload.get("text"), str) or not event.payload["text"]:
+        raise HostSpeechInvalidRequestError("NPC 对话没有可朗读文本")
+    return event
+
+
+async def get_npc_voice(
+    db: AsyncSession,
+    *,
+    room_id: str,
+    event: Event,
+    service: HostSpeechService,
+) -> str:
+    """从不可变 ModuleContent 按 speaker_id 解析 NPC 音色；失败时安全回退。"""
+
+    fallback = service.default_voice_type
+    room = await db.get(Room, room_id)
+    if room is None or room.scenario_id is None:
+        if fallback is None:
+            raise HostSpeechUnavailableError("主持人语音服务未配置")
+        return fallback
+    scenario = await db.get(Scenario, room.scenario_id)
+    version = room.module_version or (scenario.version if scenario else None)
+    if scenario is None or version is None:
+        if fallback is None:
+            raise HostSpeechUnavailableError("主持人语音服务未配置")
+        return fallback
+    module_version = await db.get(ModuleVersion, (scenario.module_id, version))
+    # 事件规范使用 camelCase；兼容早期测试/历史行的 snake_case 载荷。
+    speaker_id = event.payload.get("speakerId") or event.payload.get("speaker_id") or event.actor_id
+    try:
+        content = (
+            ModuleContentV3.model_validate(module_version.content_json) if module_version else None
+        )
+        entity = next(
+            item
+            for item in (content.entities if content else ())
+            if item.kind == "npc" and item.id == speaker_id
+        )
+        profile = entity.voice
+        if (
+            profile is not None
+            and profile.provider == service.provider.name
+            and profile.resource_id == service.resource_id
+            and profile.voice_type in service.allowed_voice_types
+        ):
+            return profile.voice_type
+    except (StopIteration, TypeError, ValueError):
+        # 内容缺失、旧版本或非法 profile 都只能回退，不影响文字对话。
+        pass
+    if fallback is None or fallback not in service.allowed_voice_types:
+        raise HostSpeechUnavailableError("NPC 音色不可用，但文字对话仍可继续")
+    return fallback
 
 
 async def get_room_voice(db: AsyncSession, room_id: str, service: HostSpeechService) -> str:

--- a/trpg-backend/tests/test_host_speech.py
+++ b/trpg-backend/tests/test_host_speech.py
@@ -1,7 +1,9 @@
 """Issue #220：主持人语音授权、分句、缓存及离线 Provider 集成。"""
 
 import asyncio
+import json
 import struct
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
@@ -81,47 +83,14 @@ async def test_cache_and_single_flight_share_one_provider_call() -> None:
 async def test_npc_voice_resolves_profile_and_falls_back_on_resource_mismatch() -> None:
     service = _service(_CountingProvider())
     service.resource_id = "seed-tts-2.0"
-    module = SimpleNamespace(
-        content_json={
-            "module_id": "m",
-            "version": "1",
-            "world_ref": "coc-7e",
-            "background": "",
-            "information": [],
-            "knowledge_goals": [],
-            "entities": [
-                {
-                    "id": "thomas",
-                    "kind": "npc",
-                    "name": "托马斯",
-                    "voice": {
-                        "provider": "counting",
-                        "resource_id": "old-resource",
-                        "voice_type": "voice-a",
-                    },
-                }
-            ],
-            "locations": [],
-            "location_edges": [],
-            "rules": [],
-            "core_resolution": {"required_information_ids": []},
-            "ending_policy": {"mode": "open"},
-            "ending_anchors": [],
-            "presentation": {
-                "title": "测试",
-                "players_min": 1,
-                "players_max": 1,
-                "estimated_duration": "",
-                "difficulty": 1,
-                "authors": [],
-                "player_intro_pages": [],
-            },
-            "initial_state": {"actors": [], "entities": [], "locations": []},
-            "world_profile": {},
-        }
+    fixture = (
+        Path(__file__).resolve().parents[2]
+        / "agent-collaboration-framework"
+        / "docs/module-parser/examples/module-content-validation/追书人/module-content-v3.json"
     )
-    room = SimpleNamespace(scenario_id="scenario", module_version="1")
-    scenario = SimpleNamespace(module_id="m", version="1")
+    module = SimpleNamespace(content_json=json.loads(fixture.read_text(encoding="utf-8")))
+    room = SimpleNamespace(scenario_id="scenario", module_version="3.0.10")
+    scenario = SimpleNamespace(module_id="paper-chase-zh-coc7", version="3.0.10")
 
     class FakeDb:
         async def get(self, model, key):

--- a/trpg-backend/tests/test_host_speech.py
+++ b/trpg-backend/tests/test_host_speech.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import struct
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from httpx import AsyncClient
@@ -20,6 +22,7 @@ from app.models.event import Event
 from app.service.host_speech import (
     HostSpeechService,
     build_host_speech_service,
+    get_npc_voice,
     split_narration_for_speech,
 )
 from tests.helpers import bearer, create_room, join_room, register
@@ -73,6 +76,78 @@ async def test_cache_and_single_flight_share_one_provider_call() -> None:
     cached = await service.synthesize(**kwargs)
     assert first.audio == second.audio == cached.audio
     assert provider.calls == 1
+
+
+async def test_npc_voice_resolves_profile_and_falls_back_on_resource_mismatch() -> None:
+    service = _service(_CountingProvider())
+    service.resource_id = "seed-tts-2.0"
+    module = SimpleNamespace(
+        content_json={
+            "module_id": "m",
+            "version": "1",
+            "world_ref": "coc-7e",
+            "background": "",
+            "information": [],
+            "knowledge_goals": [],
+            "entities": [
+                {
+                    "id": "thomas",
+                    "kind": "npc",
+                    "name": "托马斯",
+                    "voice": {
+                        "provider": "counting",
+                        "resource_id": "old-resource",
+                        "voice_type": "voice-a",
+                    },
+                }
+            ],
+            "locations": [],
+            "location_edges": [],
+            "rules": [],
+            "core_resolution": {"required_information_ids": []},
+            "ending_policy": {"mode": "open"},
+            "ending_anchors": [],
+            "presentation": {
+                "title": "测试",
+                "players_min": 1,
+                "players_max": 1,
+                "estimated_duration": "",
+                "difficulty": 1,
+                "authors": [],
+                "player_intro_pages": [],
+            },
+            "initial_state": {"actors": [], "entities": [], "locations": []},
+            "world_profile": {},
+        }
+    )
+    room = SimpleNamespace(scenario_id="scenario", module_version="1")
+    scenario = SimpleNamespace(module_id="m", version="1")
+
+    class FakeDb:
+        async def get(self, model, key):
+            from app.models.content import Scenario
+            from app.models.engine import ModuleVersion
+            from app.models.room import Room
+
+            if model is Room:
+                return room
+            if model is Scenario:
+                return scenario
+            if model is ModuleVersion:
+                return module
+            return None
+
+    event = SimpleNamespace(payload={"speakerId": "thomas"}, actor_id="thomas")
+    # provider 不匹配时必须回退，而不是把模组中的音色直接交给 Provider。
+    assert (
+        await get_npc_voice(
+            cast(AsyncSession, FakeDb()),
+            room_id="room",
+            event=cast(Event, event),
+            service=service,
+        )
+        == "voice-a"
+    )
 
 
 def test_doubao_configuration_fails_fast_without_credentials() -> None:

--- a/trpg-frontend/src/hooks/useHostSpeech.ts
+++ b/trpg-frontend/src/hooks/useHostSpeech.ts
@@ -25,6 +25,9 @@ interface UseHostSpeechOptions {
   accountToken: string | null
 }
 
+type SpeechMessageKind = 'host' | 'npc'
+type SpeechQueueItem = { messageId: string; kind: SpeechMessageKind }
+
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value))
 
 function readSettings(): LocalSettings {
@@ -65,7 +68,7 @@ export function useHostSpeech({ roomId, reconnectToken, accountToken }: UseHostS
   const [error, setError] = useState('')
 
   const audioRef = useRef<HTMLAudioElement | null>(null)
-  const queueRef = useRef<string[]>([])
+  const queueRef = useRef<SpeechQueueItem[]>([])
   const seenRef = useRef(new Set<string>())
   const processingRef = useRef(false)
   const enabledRef = useRef(enabled)
@@ -116,11 +119,11 @@ export function useHostSpeech({ roomId, reconnectToken, accountToken }: UseHostS
     setStatus('idle')
   }, [clearCurrent])
 
-  const fetchSentence = useCallback(async (messageId: string, index: number, signal: AbortSignal) => {
+  const fetchSentence = useCallback(async (messageId: string, kind: SpeechMessageKind, index: number, signal: AbortSignal) => {
     if (!roomId || !accountToken || !reconnectToken) throw new Error('缺少房间语音身份凭证')
-    const blob = await sdk.rooms.getHostSpeechSentence(
-      roomId, messageId, index, accountToken, reconnectToken, signal,
-    )
+    const blob = kind === 'npc'
+      ? await sdk.rooms.getNpcSpeechSentence(roomId, messageId, index, accountToken, reconnectToken, signal)
+      : await sdk.rooms.getHostSpeechSentence(roomId, messageId, index, accountToken, reconnectToken, signal)
     // stop() 可能发生在 fetch 已完成、continuation 尚未恢复的间隙；此处再检查
     // 一次，防止取消后才创建的 Object URL 躲过 stop() 的集中回收。
     if (signal.aborted) throw new DOMException('主持人语音请求已取消', 'AbortError')
@@ -157,7 +160,8 @@ export function useHostSpeech({ roomId, reconnectToken, accountToken }: UseHostS
     const generation = generationRef.current
     try {
       while (queueRef.current.length > 0 && generation === generationRef.current) {
-        const messageId = queueRef.current.shift()!
+        const item = queueRef.current.shift()!
+        const messageId = item.messageId
         setQueueLength(queueRef.current.length)
         setCurrentMessageId(messageId)
         setStatus('synthesizing')
@@ -165,21 +169,21 @@ export function useHostSpeech({ roomId, reconnectToken, accountToken }: UseHostS
         const controller = new AbortController()
         abortRef.current = controller
         if (!roomId || !accountToken || !reconnectToken) throw new Error('缺少房间语音身份凭证')
-        const manifest = await sdk.rooms.getHostSpeechManifest(
-          roomId, messageId, accountToken, reconnectToken, controller.signal,
-        )
+        const manifest = item.kind === 'npc'
+          ? await sdk.rooms.getNpcSpeechManifest(roomId, messageId, accountToken, reconnectToken, controller.signal)
+          : await sdk.rooms.getHostSpeechManifest(roomId, messageId, accountToken, reconnectToken, controller.signal)
         setCurrentSentences(manifest.sentences)
         // 最多保留当前句和下一句：当前句开始播放前触发下一句请求，减少句间停顿，
         // 又不会把整段叙事提前合成、在用户停止或切换音色时浪费 Provider 费用。
         let nextUrl: Promise<string> | null = manifest.sentences.length
-          ? fetchSentence(messageId, 0, controller.signal)
+          ? fetchSentence(messageId, item.kind, 0, controller.signal)
           : null
         try {
           for (let index = 0; index < manifest.sentences.length; index += 1) {
             setCurrentSentenceIndex(index)
             const currentUrl = await nextUrl!
             nextUrl = index + 1 < manifest.sentences.length
-              ? fetchSentence(messageId, index + 1, controller.signal)
+              ? fetchSentence(messageId, item.kind, index + 1, controller.signal)
               : null
             await playUrl(currentUrl, generation)
             revokeUrl(currentUrl)
@@ -213,24 +217,26 @@ export function useHostSpeech({ roomId, reconnectToken, accountToken }: UseHostS
 
   processQueueRef.current = () => { void processQueue() }
 
-  const markSeen = useCallback((messageIds: readonly string[]) => {
-    for (const id of messageIds) if (id.trim()) seenRef.current.add(id.trim())
+  const markSeen = useCallback((messageIds: readonly string[], kind: SpeechMessageKind = 'host') => {
+    for (const id of messageIds) if (id.trim()) seenRef.current.add(`${kind}:${id.trim()}`)
   }, [])
 
-  const enqueue = useCallback((messageId: string | undefined) => {
-    if (!enabledRef.current || !messageId || seenRef.current.has(messageId)) return
-    seenRef.current.add(messageId)
+  const enqueue = useCallback((messageId: string | undefined, kind: SpeechMessageKind = 'host') => {
+    if (!enabledRef.current || !messageId) return
+    const seenKey = `${kind}:${messageId}`
+    if (seenRef.current.has(seenKey)) return
+    seenRef.current.add(seenKey)
     // 设置 GET 尚未返回时先保留权威 ID，避免进入页面后第一句因竞态被吞掉；
     // 已明确 disabled 时则保持纯文本，不积压一个永远无法消费的队列。
     if (!credentialsReady || settings?.available === false) return
-    queueRef.current.push(messageId)
+    queueRef.current.push({ messageId, kind })
     setQueueLength(queueRef.current.length)
     processQueueRef.current()
   }, [credentialsReady, settings?.available])
 
-  const replay = useCallback((messageId: string | undefined) => {
+  const replay = useCallback((messageId: string | undefined, kind: SpeechMessageKind = 'host') => {
     if (!available || !messageId) return
-    queueRef.current.push(messageId)
+    queueRef.current.push({ messageId, kind })
     setQueueLength(queueRef.current.length)
     processQueueRef.current()
   }, [available])
@@ -331,6 +337,7 @@ export function useHostSpeech({ roomId, reconnectToken, accountToken }: UseHostS
     error,
     markSeen,
     enqueue,
+    enqueueNpc: (messageId: string | undefined) => enqueue(messageId, 'npc'),
     replay,
     pause,
     resume,

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.tsx
@@ -1459,6 +1459,7 @@ export default function RoomPage() {
   }, [roomId, playerId, roomPlayers, portraitVersionOverride, clearPortraitVersion])
   const hostSpeech = useHostSpeech({ roomId, reconnectToken, accountToken: getAuthToken() })
   const enqueueHostSpeech = hostSpeech.enqueue
+  const enqueueNpcSpeech = hostSpeech.enqueueNpc
   const markHostSpeechSeen = hostSpeech.markSeen
   const handleHostSpeechSettingsUpdated = hostSpeech.handleSettingsUpdated
   const isHost = roomInfo?.players.find((p) => p.playerId === playerId)?.isHost ?? false
@@ -1768,6 +1769,14 @@ export default function RoomPage() {
           item.type === 'narr' && item.narrationId ? [item.narrationId] : [],
         ),
       )
+      markHostSpeechSeen(
+        restored.flatMap((item) =>
+          item.type === 'npc' && item.messageId
+            ? [item.messageId.replace(/^dialogue\.npc:/, '')]
+            : [],
+        ),
+        'npc',
+      )
       setMessages((current) => mergeHistoricalMessages(current, restored))
       if (
         restored.some(
@@ -1971,6 +1980,7 @@ export default function RoomPage() {
       } else if (envelope.type === 'dialogue.npc') {
         setTyping(false)
         clearBackendProgress()
+        enqueueNpcSpeech(envelope.payload.messageId)
         setMessages((prev) => appendLiveMessage(prev, {
           type: 'npc',
           channel: 'action',
@@ -2171,7 +2181,7 @@ export default function RoomPage() {
       setProgressLabel('守秘人正在生成开场叙事')
     }
     return off
-  }, [clearBackendProgress, clearSettledAction, enqueueHostSpeech, handleHostSpeechSettingsUpdated, openDiceForCheck, playerId, senderName, showBackendPhase])
+  }, [clearBackendProgress, clearSettledAction, enqueueHostSpeech, enqueueNpcSpeech, handleHostSpeechSettingsUpdated, openDiceForCheck, playerId, senderName, showBackendPhase])
 
   const submitPlayerAction = (action: {
     clientActionId: string
@@ -2581,13 +2591,16 @@ export default function RoomPage() {
                 </div>
                 <div className="room-play__message-meta">
                   <span>{msg.time}</span>
-                  {isNarr && (
+                  {(isNarr || isNpc) && (
                     <button
                       type="button"
                       aria-label="重新朗读"
                       title="重新朗读"
-                      disabled={!hostSpeech.available || !msg.narrationId}
-                      onClick={() => hostSpeech.replay(msg.narrationId)}
+                      disabled={!hostSpeech.available || (!msg.narrationId && !isNpc)}
+                      onClick={() => {
+                        if (isNarr) hostSpeech.replay(msg.narrationId)
+                        else hostSpeech.replay(msg.messageId?.replace(/^dialogue\.npc:/, ''), 'npc')
+                      }}
                     >
                       <RotateCcw aria-hidden="true" />
                       重播

--- a/trpg-sdk/src/resources/rooms.ts
+++ b/trpg-sdk/src/resources/rooms.ts
@@ -222,4 +222,33 @@ export class RoomsResource {
       { ...this.hostSpeechAuth(token, reconnectToken, signal), method: 'GET' }
     );
   }
+
+  /** 读取当前玩家有权看到的 NPC 对话语音分句清单。 */
+  getNpcSpeechManifest(
+    roomId: string,
+    messageId: string,
+    token: string,
+    reconnectToken: string,
+    signal?: AbortSignal
+  ): Promise<HostSpeechManifest> {
+    return this.client.get<HostSpeechManifest>(
+      `/rooms/${encodeURIComponent(roomId)}/dialogues/${encodeURIComponent(messageId)}/speech`,
+      this.hostSpeechAuth(token, reconnectToken, signal)
+    );
+  }
+
+  /** 下载 NPC 对话的一条音频分句；音色由服务端根据 speaker_id 解析。 */
+  getNpcSpeechSentence(
+    roomId: string,
+    messageId: string,
+    sentenceIndex: number,
+    token: string,
+    reconnectToken: string,
+    signal?: AbortSignal
+  ): Promise<Blob> {
+    return this.client.requestBlob(
+      `/rooms/${encodeURIComponent(roomId)}/dialogues/${encodeURIComponent(messageId)}/speech/sentences/${sentenceIndex}`,
+      { ...this.hostSpeechAuth(token, reconnectToken, signal), method: 'GET' }
+    );
+  }
 }


### PR DESCRIPTION
## 关联 Issue

Closes #502

## 主要改动

- 为 `EntitySpecV3` 增加仅 NPC 可用的 Doubao voice profile。
- 为《追书人》五个 NPC 配置音色；道格拉斯沿用当前 v3 内容中的稳定实体 ID `cemetery_figure`。
- 扩展 `HostSpeechService`，按 `scenario_id + speaker_id` 解析 NPC 音色，并校验 provider、resource ID 和服务端白名单。
- profile 不匹配时回退默认音色；默认音色不可用时返回文字对话，不修改事件。
- 新增受冻结 audience 权限保护的 NPC 对话语音 manifest 和 MP3 分句接口。
- SDK 增加 NPC 语音方法。
- 前端复用主持人语音开关、速度和音量，NPC 对话进入独立串行队列，刷新/重连不会重复自动播放。
- Event 只保存 `speaker_id` 和文本，不保存音色 URL、临时音频地址或音频内容。

## 采用该方案的原因

音色属于模组公开元数据，放入不可变 `ModuleContentV3` 可以随模组版本发布，并复用已有 NPC 实体和事件架构，不需要新增 NPC 音色表或改变 Engine、Memory、Summary。服务端根据事件身份解析音色，客户端不能提交任意音色，保证历史回放和实时消息一致。

缓存键加入 provider 版本、resource ID、voice type 和文本，避免不同 NPC 音色错误共享缓存。资源或账号不支持某个 profile 时只回退默认音色，不阻塞文字对话。

## 测试与验证

- [x] Framework：`test_module_content_v3.py`、`test_paper_chase_v3_fixture.py`
- [x] Backend：`test_host_speech.py`、`test_builtin_module_loader.py`、`test_npc_dialogue.py`
- [x] SDK：lint、typecheck、tests
- [x] Frontend：lint、production build
- [x] codegen drift、E2E、PostgreSQL migration
- [ ] 上游 Backend CI 完整 `test`（当前仍在运行）

本地当前豆包配置为 `seed-tts-2.0`，五个映射使用部署白名单中的 voice ID；运行时仍会对账号实际资源再次校验并安全回退。

## 兼容性、迁移与回滚

不新增数据库迁移，旧模组缺少 `voice` 字段时按空 profile 加载，主持人语音接口保持兼容。回滚本 PR 只需恢复服务端、SDK 和前端代码；历史 Event 不包含音频 URL，因此无需数据清理。

## UI 证据

NPC 对话继续使用现有独立姓名、头像和颜色气泡；本 PR 增加语音播放队列和“重新朗读”入口。前端构建和 E2E 已验证该展示链路，未提交临时截图或生成物。

## AI 使用情况

实现过程中使用 AI 辅助定位现有 TTS、NPC 对话和 ModuleContent 链路，并生成初步代码建议；已人工逐项检查契约、权限、缓存键、错误回退和测试结果，未将模型输出直接作为安全边界。需要人工 Review 音色 ID 在目标账号资源包中的实际可用性。

## 风险与回滚

主要风险是不同豆包账号或资源包不暴露相同 `voice_type`，服务端会回退默认音色，不影响文字游戏。Provider 合成失败只影响语音请求，不删除或修改对话事件。若发现兼容性问题，可关闭语音或回滚本 PR，原有主持人语音和 NPC 文字对话仍可运行。

## 自检

- [x] 改动范围符合 Issue #502
- [x] 未混入工作区原有未提交修改
- [x] 已包含契约、权限、回退和播放测试
- [x] 未包含密钥、个人信息或临时音频
- [x] 已完成 AI 辅助质量检查，等待上游人工 Review
