### PR TITLE
fix(host): 单意图统一走安全规划与规则匹配

### DIFF
--- a/trpg-backend/app/core/action_plan_turn.py
+++ b/trpg-backend/app/core/action_plan_turn.py
@@ -212,11 +212,13 @@ _SEMANTIC_UNCERTAIN_ACTION_MARKERS = (
 
 
 def semantic_planner_required(utterance: str) -> tuple[bool, str]:
-    """Select semantic planning only where a fast single-step producer is unsafe.
+    """Classify why an input may need semantic planning for route observability.
 
-    This is deliberately a conservative, player-input-only gate. It does not infer
-    targets, rules, checks, effects, or hidden facts. Those remain the responsibility
-    of the current-step adjudicator after the plan is created.
+    Production no longer uses this classification as a security boundary: every
+    input goes through the player-safe Turn Planner when it is configured.  The
+    classification is deliberately player-input-only and remains useful in logs;
+    targets, rules, checks, effects, and hidden facts are still resolved only by the
+    current-step adjudicator after the plan is created.
     """
 
     text = utterance.strip()
@@ -1103,7 +1105,14 @@ class ActionPlanTurnApplication:
         semantic_required, semantic_reason = semantic_planner_required(utterance)
         # 普通玩家输入统一走安全规划器；Keeper 能力只在后续当前步骤裁决时读取。
         # semantic_planner_required 仍保留用于多步语义判断和日志，不再是边界开关。
-        use_semantic_planner = self._semantic_planner is not None and semantic_required
+        # Presence of the safe Planner is the route boundary.  `semantic_required`
+        # only labels why an input was interesting; using it as a gate sent clear
+        # single intents back through the legacy fused Planner, where #469 had
+        # intentionally removed Keeper capabilities.  Those inputs then had no
+        # Rule Match candidates at all.  A one-step ActionPlan is cheap and lets the
+        # current-step adjudicator read the scoped capabilities without exposing
+        # them to the player-safe planning model.
+        use_semantic_planner = self._semantic_planner is not None
         keeper_capabilities = await self._keeper_capabilities(player_input, view)
         try:
             if use_semantic_planner:
@@ -2606,11 +2615,18 @@ def _log_step_adjudicator_path(
 ) -> None:
     """Record only route metadata, never semantic text or adjudication payloads."""
 
+    candidate_count = (
+        len(context.keeper_capabilities.rule_candidates)
+        if context.keeper_capabilities is not None
+        else 0
+    )
     logger.info(
         "action_plan_step_adjudicator_completed",
         action=context.player_input.client_action_id[:12],
         step_index=context.step_index,
         path=path,
+        candidate_count=candidate_count,
+        selected_rule=adjudication.rule_decision is not None,
         has_check=not isinstance(adjudication.check, NoAdjudicationCheck),
     )
 
@@ -2627,6 +2643,11 @@ def _log_deterministic_adjudication_miss(
         action=context.player_input.client_action_id[:12],
         step_index=context.step_index,
         step_kind=context.step.kind,
+        candidate_count=(
+            len(context.keeper_capabilities.rule_candidates)
+            if context.keeper_capabilities is not None
+            else 0
+        ),
         reason=reason,
     )
 
@@ -3354,7 +3375,7 @@ _ACTION_FAMILY_HINTS: dict[str, tuple[str, ...]] = {
     "search": ("搜索", "搜查", "查找", "找线索", "寻找"),
     "research": ("研究", "查阅", "检索", "翻阅", "查旧报"),
     "social": ("留下好印象", "博取信任", "说服"),
-    "intimidate": ("恐吓", "威吓"),
+    "intimidate": ("恐吓", "威吓", "威胁", "要挟"),
     "bribe": ("贿赂", "收买"),
 }
 

--- a/trpg-backend/tests/test_rule_match_adjudication.py
+++ b/trpg-backend/tests/test_rule_match_adjudication.py
@@ -1132,15 +1132,32 @@ async def test_semantic_malformed_plan_returns_clarification_without_run() -> No
     assert await application.get_plan("semantic-room", "semantic-invalid") is None
 
 
-async def test_clear_single_step_uses_legacy_fast_producer_when_semantic_is_enabled() -> None:
+async def test_clear_single_step_uses_safe_semantic_planner_when_available() -> None:
     application = await _semantic_application()
 
-    class InvalidSemanticClient:
-        async def generate(self, **kwargs):
-            del kwargs
-            raise AssertionError("clear single-step input must not enter semantic Planner")
+    class RecordingSemanticPlanner:
+        calls = 0
 
-    application._semantic_planner = PromptTurnPlanner(InvalidSemanticClient())
+        async def generate(self, context):
+            self.calls += 1
+            return ActionPlan(
+                goal=context.player_input.utterance,
+                steps=(
+                    ActionPlanStep(
+                        kind="action",
+                        semantic_goal=context.player_input.utterance,
+                    ),
+                ),
+            )
+
+    class ForbiddenLegacyPlanner:
+        async def generate(self, context):
+            del context
+            raise AssertionError("生产单步输入不得回退到融合 Planner")
+
+    semantic_planner = RecordingSemanticPlanner()
+    application._semantic_planner = semantic_planner
+    application._planner = ForbiddenLegacyPlanner()
 
     result = await application.start(
         room_id="semantic-room",
@@ -1153,6 +1170,80 @@ async def test_clear_single_step_uses_legacy_fast_producer_when_semantic_is_enab
     run = await application.get_plan("semantic-room", "semantic-fast-path")
     assert run is not None
     assert len(run.steps) == 1
+    assert semantic_planner.calls == 1
+
+
+async def test_npc_single_intent_reaches_rule_match_after_safe_planning() -> None:
+    """#507：NPC 单意图也必须在当前步拿到规则候选，且 Planner 不见 Keeper 数据。"""
+
+    content = _content()
+    state = create_initial_game_state(
+        content,
+        room_id="issue-507-room",
+        actors={
+            "issue-507-actor": ActorState(
+                player_id="issue-507-player",
+                name="调查员",
+                source_character_id="issue-507-character",
+                source_character_version=1,
+                state={"skills": {"intimidate": 60}},
+            )
+        },
+    ).model_copy(update={"scene_id": "cemetery"}, deep=True)
+    store = InMemoryEngineStore()
+    store.register_room(module_content=content, initial_state=state)
+
+    class RecordingClient:
+        def __init__(self) -> None:
+            self.schemas: list[str] = []
+
+        async def generate(self, *, schema_name, schema, instructions, input_payload):
+            del schema, instructions
+            self.schemas.append(schema_name)
+            if schema_name == "trpg_turn_plan":
+                assert input_payload["player_input"]["interlocutor_id"] == "melodias"
+                assert "keeper_capabilities" not in input_payload
+                assert "melodias_night_sighting" not in str(input_payload)
+                return {
+                    "kind": "action_plan",
+                    "goal": "威胁守墓人交代道格拉斯的去向",
+                    "steps": [
+                        {
+                            "kind": "dialogue",
+                            "semantic_goal": "威胁守墓人交代道格拉斯的去向",
+                        }
+                    ],
+                }
+            raise AssertionError(f"单意图不应调用 {schema_name}")
+
+    client = RecordingClient()
+    application = build_action_plan_turn_application(
+        store=store,
+        engine=RuleEngineService(store),
+        adjudication_engine=AdjudicationEngineService(store),
+        settings=Settings(host_model_provider="deepseek", deepseek_api_key="test-key"),
+        client=client,
+        planner_client=client,
+        memory_source=_EmptyMemorySource(),
+    )
+
+    result = await application.start(
+        room_id="issue-507-room",
+        player_id="issue-507-player",
+        client_action_id="issue-507-single-threat",
+        utterance="告诉我道格拉斯藏在哪里，否则我就告发你",
+        interlocutor_id="melodias",
+        interlocutor_name="梅洛迪亚斯·杰弗逊",
+    )
+
+    assert result.status == "waiting_for_player"
+    assert client.schemas == ["trpg_turn_plan"]
+    run = await application.get_plan("issue-507-room", "issue-507-single-threat")
+    assert run is not None
+    adjudication = run.steps[0].adjudication
+    assert adjudication is not None
+    assert adjudication.rule_decision is not None
+    assert adjudication.rule_decision.rule_id == "intimidate_caretaker"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 关联 Issue

Closes #507

## 主要改动

- `ActionPlanTurnApplication.start()` 的路由边界改为「安全 Planner 是否存在」，不再叠加 `semantic_required` 作为开关：只要配置了 player-safe Turn Planner，所有玩家输入统一走该路径。
- `semantic_planner_required()` 降级为纯日志分类函数，仅用于标注输入「为什么值得注意」，不再承担安全边界职责；docstring 同步改写以免后来者再把它当门禁。
- `action_plan_step_adjudicator_completed` 与 `action_plan_step_adjudicator_deterministic_miss` 增加 `candidate_count`、`selected_rule` 两个字段，使「无候选」「候选已发送但未选中」「选中后被 Engine 拒绝」在日志中可区分。
- `_ACTION_FAMILY_HINTS` 的 `intimidate` 族补充「威胁」「要挟」两个常见说法。
- `tests/test_rule_match_adjudication.py` 补充对应覆盖。

## 采用该方案的原因

回归的根因是 `use_semantic_planner = self._semantic_planner is not None and semantic_required` 这一行：清晰单意图被判为 `semantic_required=False` 后退回旧的融合 Planner，而 #469 已从该路径移除 Keeper 能力，导致这类输入拿到的 Rule Match 候选为空。

修复不恢复完整 `keeper_capabilities`，而是让所有输入都经过 player-safe Planner——一个单步 ActionPlan 成本很低，随后由当前步裁决器读取白名单化的规则候选。私密能力仍然只在裁决边界内可见，不进入玩家侧规划模型，#426 / #469 的信息隔离方向保持不变。

## 测试与验证

- [x] `uv run pytest tests/test_rule_match_adjudication.py -q`（46 passed, 1 skipped）
- [x] 全量后端测试（本地已执行）
- [x] 真实模型手动验证：DeepSeek `deepseek-chat`，《追书人》3.0.10，墓地场景守墓人 `melodias`

手动验证对应 Issue 的第一条验收标准，单意图输入「你是不是见过有人在墓地游荡？告诉我！不然我就告发你」无需拆成多意图即可命中规则：

```
turn_planner_route_selected    route=semantic  route_reason=fast_single_step
action_plan_step_adjudicator_completed  candidate_count=7  selected_rule=True  path=rule_first
【检定结果】 skill=恐吓 target=43 roll=45 passed=True
```

`route_reason=fast_single_step` 说明这正是修复前会走 `route=legacy` 的路径，现在 `route=semantic` 且拿到 7 个候选并确定性命中规则。作为对照，同场景的 `route_reason=semantic_uncertainty_marker` 输入（「仔细观察守墓人」）同样得到 `candidate_count=7`、`path=rule_first`，两条路径对同一场景的候选供给已经一致。

## 风险与回滚

- 风险：所有输入改走语义 Planner，原先命中 fast path 的清晰单意图会多一次 Planner 调用。实测该步骤耗时约 0.9–1.3s，单回合端到端 2.4–6.0s，在既有超时预算内。
- 该改动只放宽路由，不改变裁决边界与效果执行；规则 ID、选项与目标仍由服务端在提交时重新校验。
- 回滚：回退提交 `e7e6d00` 即可恢复原路由。

## UI 证据

无前端改动，也无视觉变化。可见行为差异体现为单意图输入现在会正常进入规则检定流程，已由上述日志与检定结果覆盖。

## AI 使用情况

使用 AI 辅助复现回归、阅读日志定位路由边界并撰写 PR 说明；改动范围、日志字段语义与测试结果已人工核对。

## 后续观察（不属于本 Issue 范围）

同场景下输入「把他的钥匙抢过来」时，确定性匹配正确地返回 `rule_candidate_unresolved`，降级到 `path=model` 后模型选择了 `intimidate_caretaker`，产生了一次语义不贴切的恐吓检定。原因是墓地现有 8 条 agent_match 规则不含「抢夺物品」动作族，且裁决 prompt 中「不能仅因动作族词汇不同就放弃地点/目标/when 均匹配的候选」与「对不上任何候选时不要硬套」两条指令在此情形下相互冲突。这属于规则覆盖与 prompt 消歧问题，不是本次路由修复的回归，建议另开 Issue 跟进。

## 自检

- [x] 改动范围符合 Issue
- [x] 不包含无关改动
