### PR TITLE
fix(adapters): 建连超时与生成预算分开，开场恢复传输层重试 (#510)

### DIFF
--- a/trpg-backend/app/adapters/deepseek_models.py
+++ b/trpg-backend/app/adapters/deepseek_models.py
@@ -20,6 +20,7 @@ from app.adapters.structured_http import (
     StructuredOutputError,
     decode_structured_json,
     log_structured_output_failure,
+    model_http_timeout,
     post_structured_json,
     read_structured_payload,
 )
@@ -94,7 +95,7 @@ class DeepSeekChatCompletionsJsonClient(StructuredJsonClient):
                 "Authorization": f"Bearer {self._api_key}",
                 "Content-Type": "application/json",
             },
-            timeout=self._timeout_seconds,
+            timeout=model_http_timeout(self._timeout_seconds),
             transport=self._transport,
         ) as client:
             transport_result = await post_structured_json(

--- a/trpg-backend/app/adapters/image_generation.py
+++ b/trpg-backend/app/adapters/image_generation.py
@@ -101,7 +101,10 @@ class DashScopeImageProvider:
         try:
             async with httpx.AsyncClient(
                 headers=headers,
-                timeout=min(self._timeout_seconds, 30.0),
+                # 保留单次请求 30 秒的上限：DashScope 是异步任务 + 轮询，
+                # `self._timeout_seconds` 是整轮预算（上面的 deadline 在管），不是
+                # 单次 HTTP 的预算。这里只把建连从这 30 秒里拆出来。
+                timeout=model_http_timeout(min(self._timeout_seconds, 30.0)),
                 transport=self._transport,
             ) as client:
                 response = await client.post(
@@ -139,7 +142,7 @@ class DashScopeImageProvider:
         """尽力取消仍处于等待态的 DashScope 任务；运行中任务可能拒绝取消。"""
         async with httpx.AsyncClient(
             headers={"Authorization": f"Bearer {self._api_key}"},
-            timeout=min(self._timeout_seconds, 30.0),
+            timeout=model_http_timeout(min(self._timeout_seconds, 30.0)),
             transport=self._transport,
         ) as client:
             response = await client.post(f"{self._base_url}/tasks/{task_id}/cancel")

--- a/trpg-backend/app/adapters/image_generation.py
+++ b/trpg-backend/app/adapters/image_generation.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 import httpx
 from PIL import Image, ImageDraw
 
+from app.adapters.structured_http import model_http_timeout
 from app.service.portrait_generation import (
     ImageGenerationControl,
     ImageGenerationOutput,
@@ -248,7 +249,7 @@ class SufyImageProvider:
         try:
             async with httpx.AsyncClient(
                 headers=headers,
-                timeout=self._timeout_seconds,
+                timeout=model_http_timeout(self._timeout_seconds),
                 transport=self._transport,
             ) as client:
                 response = await client.post(

--- a/trpg-backend/app/adapters/openai_models.py
+++ b/trpg-backend/app/adapters/openai_models.py
@@ -43,6 +43,7 @@ from app.adapters.structured_http import (
     decode_structured_json,
     is_transient_model_error,
     log_structured_output_failure,
+    model_http_timeout,
     post_structured_json,
     read_structured_payload,
 )
@@ -494,7 +495,7 @@ class OpenAIResponsesJsonClient:
                 "Authorization": f"Bearer {self._api_key}",
                 "Content-Type": "application/json",
             },
-            timeout=self._timeout_seconds,
+            timeout=model_http_timeout(self._timeout_seconds),
             transport=self._transport,
         ) as client:
             transport_result = await post_structured_json(

--- a/trpg-backend/app/adapters/qwen_models.py
+++ b/trpg-backend/app/adapters/qwen_models.py
@@ -27,6 +27,7 @@ from app.adapters.structured_http import (
     StructuredOutputError,
     decode_structured_json,
     log_structured_output_failure,
+    model_http_timeout,
     post_structured_json,
     read_structured_payload,
 )
@@ -92,7 +93,7 @@ class QwenChatCompletionsJsonClient(StructuredJsonClient):
                 "Authorization": f"Bearer {self._api_key}",
                 "Content-Type": "application/json",
             },
-            timeout=self._timeout_seconds,
+            timeout=model_http_timeout(self._timeout_seconds),
             transport=self._transport,
         ) as client:
             transport_result = await post_structured_json(

--- a/trpg-backend/app/adapters/structured_http.py
+++ b/trpg-backend/app/adapters/structured_http.py
@@ -36,6 +36,36 @@ class StructuredOutputError(ValueError):
     """
 
 
+# TCP + TLS 握手的上限。与"等模型生成"是两件事：能连上的调用实测 3–5 秒就回来了，
+# 一个 5 秒还没握手成功的连接，给它 30 秒也一样握不上。
+#
+# 这个值存在的理由是 httpx 的 `timeout=<float>` 会把同一个标量套到 connect / read /
+# write / pool 四个阶段上。预览环境实测因此出现过整份预算全部烧在建连上的情况：
+# `trpg_opening_narration` 的失败记录是 duration_ms=30215、transport_attempts=1、
+# error_type=ConnectTimeout——30 秒耗尽、请求根本没发出去、也没剩下时间重试。
+# 把建连单独收紧之后，连不上会快速失败，预算留给生成和重试。
+_CONNECT_TIMEOUT_SECONDS = 5.0
+# 写请求体和从连接池取连接都应该很快；慢在这两处同样说明链路有问题。
+_WRITE_TIMEOUT_SECONDS = 10.0
+_POOL_TIMEOUT_SECONDS = 5.0
+
+
+def model_http_timeout(timeout_seconds: float) -> httpx.Timeout:
+    """把"单次调用预算"翻译成分阶段超时。
+
+    `timeout_seconds` 是调用方为**等模型出结果**准备的预算，因此它只落在 read 上；
+    握手、写入、取连接各有自己更短的上限。传入值比建连上限还小时以传入值为准，
+    免得反而把调用方显式收紧的预算放宽。
+    """
+
+    return httpx.Timeout(
+        connect=min(_CONNECT_TIMEOUT_SECONDS, timeout_seconds),
+        read=timeout_seconds,
+        write=min(_WRITE_TIMEOUT_SECONDS, timeout_seconds),
+        pool=min(_POOL_TIMEOUT_SECONDS, timeout_seconds),
+    )
+
+
 @dataclass(frozen=True)
 class ModelClientRetryPolicy:
     """有限次数的指数退避。默认值保守：一次重试、0.5 秒退避。"""

--- a/trpg-backend/app/core/turn.py
+++ b/trpg-backend/app/core/turn.py
@@ -305,19 +305,22 @@ def _configured_opening_models(
             FakeOpeningNarrationModel(),
             HostModelMetadata(provider="fake", model="deterministic"),
         )
-    # 开场叙事显式不重试，与回合链的策略不同。
+    # 开场叙事按传输层错误重试一次。
     #
-    # 开场整段被 `anyio.fail_after(opening_narration_timeout_seconds)` 包住，那是
-    # 一个**总**预算（超时即退回确定性模板），而单次请求预算是
-    # `<provider>_timeout_seconds`。两者默认都是 30 秒，于是第一次请求耗尽预算的
-    # 同时外层 deadline 到期，退避与第二次尝试直接被取消——重试在这条路径上
-    # 从来不会发生，配了也是假的。
+    # 这里原来是 `max_attempts=1`，理由是"外层总预算与单次请求预算都是 30 秒，第一次
+    # 请求耗尽预算的同时外层 deadline 到期，第二次尝试必然被取消，配了也是假的"。
+    # 那个前提已经不成立，两处都变了：
     #
-    # 让总预算容纳两次尝试需要放宽到 60 秒以上（config 的上限也只有 60），玩家
-    # 开局要多等一分钟；压缩单次预算又会让每一次生成都更容易超时（#267 才因为
-    # 10 秒太紧把它提到 30 秒）。开场本来就有确定性模板兜底，失败代价远低于让
-    # 玩家干等，所以这里选择如实地不重试，而不是配一个永远不生效的策略。
-    retry_policy = ModelClientRetryPolicy(max_attempts=1)
+    # - 外层 `opening_narration_timeout_seconds` 现在是 45 秒（#505）。
+    # - 更关键的是失败根本不是"生成太慢"。预览环境实测到的是
+    #   error_type=ConnectTimeout、duration_ms=30215、transport_attempts=1——TCP/TLS
+    #   握手就没成功，请求没发出去，整份预算全烧在建连上。原因是 httpx 的
+    #   `timeout=<float>` 会把同一个标量套到 connect 上，于是建连也被允许等 30 秒。
+    #
+    # `model_http_timeout()` 把建连收紧到 5 秒之后，一次连不上的尝试只花 5 秒，
+    # 45 秒的总预算装得下"快速失败 + 退避 + 一次完整生成"。上游是间歇性连不上
+    # （同一 provider 同期有 3.8–5.2 秒成功的调用），这正是重试能救回来的形态。
+    retry_policy = ModelClientRetryPolicy(max_attempts=2, backoff_seconds=0.5)
     if settings.host_model_provider == "deepseek":
         if settings.deepseek_api_key is None:
             raise ValueError("DeepSeek Host 模型缺少 API key")

--- a/trpg-backend/app/service/portrait_image.py
+++ b/trpg-backend/app/service/portrait_image.py
@@ -16,6 +16,7 @@ from urllib.parse import urljoin, urlparse
 import httpx
 from PIL import Image, UnidentifiedImageError
 
+from app.adapters.structured_http import model_http_timeout
 from app.service.portrait_generation import (
     PortraitImageGenerationError,
     PortraitImageTimeoutError,
@@ -88,7 +89,8 @@ class PortraitImageMaterializer:
         current_url = value
         try:
             async with httpx.AsyncClient(
-                timeout=self._timeout_seconds,
+                # 下载同样要把建连拆出来：连不上时不该占满整份下载预算。
+                timeout=model_http_timeout(self._timeout_seconds),
                 transport=self._transport,
             ) as client:
                 for redirect_count in range(_MAX_REDIRECTS + 1):

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -56,6 +56,7 @@ from app.adapters.structured_http import (
     ModelClientRetryPolicy,
     StructuredOutputError,
     is_transient_model_error,
+    model_http_timeout,
 )
 from app.core.action_plan_turn import (
     build_action_plan_turn_application,
@@ -1104,13 +1105,21 @@ def test_configured_retry_policy_reaches_every_structured_client() -> None:
     assert _retry_policy_of(plan_application._planner) == expected
 
 
-def test_opening_narration_client_does_not_retry() -> None:
-    """开场路径显式不重试。
+def test_opening_narration_client_retries_transport_failures_once() -> None:
+    """开场路径按传输层错误重试一次。
 
-    开场整段被 `anyio.fail_after(opening_narration_timeout_seconds)` 包住，那是
-    总预算；单次请求预算是 `deepseek_timeout_seconds`。两者默认都是 30 秒，第一次
-    请求耗尽预算时外层 deadline 同时到期，退避与第二次尝试会被取消。与其配一个
-    永远不生效的策略，不如如实地不重试——开场有确定性模板兜底。
+    这条测试原来钉的是"显式不重试"，理由是外层总预算与单次请求预算都是 30 秒，
+    第一次请求耗尽预算时外层 deadline 同时到期，第二次尝试必然被取消。那个前提
+    已经不成立：
+
+    - 外层预算是 45 秒（#505）。
+    - 失败形态也不是"生成太慢"。预览环境实测到 error_type=ConnectTimeout、
+      duration_ms=30215、transport_attempts=1——握手就没成功，整份预算烧在建连上。
+      `model_http_timeout()` 把建连收紧到 5 秒后，一次连不上的尝试只花 5 秒，
+      45 秒装得下"快速失败 + 退避 + 一次完整生成"。
+
+    重试次数固定为 2，不跟随 `model_client_max_attempts`：开场的总预算是固定的，
+    让它被一个通用配置项放大，就会重新回到"重试永远来不及"的状态。
     """
 
     settings = Settings.model_validate(
@@ -1121,7 +1130,7 @@ def test_opening_narration_client_does_not_retry() -> None:
         }
     )
     model, _ = _configured_opening_models(settings)
-    assert _retry_policy_of(model).max_attempts == 1
+    assert _retry_policy_of(model).max_attempts == 2
 
 
 async def test_outer_deadline_equal_to_request_timeout_cancels_the_retry() -> None:
@@ -1437,3 +1446,32 @@ async def test_openai_non_json_http_body_is_classified() -> None:
     )
     with pytest.raises(StructuredOutputError):
         await _generate(client)
+
+
+def test_model_http_timeout_keeps_connect_short_while_read_holds_the_budget() -> None:
+    """建连和等生成是两件事，不能共用一个标量。
+
+    httpx 的 `timeout=<float>` 会把同一个值套到 connect / read / write / pool 四个
+    阶段上。预览环境因此出现过整份预算全烧在建连上的情况：开场叙事记录为
+    duration_ms=30215、transport_attempts=1、error_type=ConnectTimeout——30 秒耗尽、
+    请求根本没发出去、也没剩下时间重试。
+    """
+
+    timeout = model_http_timeout(30.0)
+
+    assert timeout.read == 30.0, "等模型出结果的预算应当原样落在 read 上"
+    # 建连必须单独收紧，否则连不上的调用会吃掉整份预算。
+    assert timeout.connect == 5.0
+    assert timeout.write == 10.0
+    assert timeout.pool == 5.0
+
+
+def test_model_http_timeout_never_widens_a_tighter_budget() -> None:
+    """调用方显式给了更短的预算时，分阶段上限不能反而把它放宽。"""
+
+    timeout = model_http_timeout(2.0)
+
+    assert timeout.read == 2.0
+    assert timeout.connect == 2.0
+    assert timeout.write == 2.0
+    assert timeout.pool == 2.0

--- a/trpg-backend/tests/test_openai_models.py
+++ b/trpg-backend/tests/test_openai_models.py
@@ -1475,3 +1475,35 @@ def test_model_http_timeout_never_widens_a_tighter_budget() -> None:
     assert timeout.connect == 2.0
     assert timeout.write == 2.0
     assert timeout.pool == 2.0
+
+
+def test_no_production_http_client_passes_a_scalar_timeout() -> None:
+    """所有生产 HTTP 客户端都必须用分阶段超时（issue #510）。
+
+    这条是防漏网的：#510 第一版只扫了 `timeout=self._timeout_seconds` 这一种写法，
+    漏掉了 DashScope 的 `min(self._timeout_seconds, 30.0)`（review 抓到）和
+    portrait_image 的下载客户端。标量 timeout 会被 httpx 同时套到 connect 上，
+    这正是本 issue 要消除的形态，所以用源码扫描把它钉住。
+    """
+
+    import re
+    from pathlib import Path
+
+    backend_root = Path(__file__).resolve().parents[1] / "app"
+    offenders: list[str] = []
+    for path in sorted(backend_root.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        for match in re.finditer(r"httpx\.AsyncClient\((.*?)\)", source, re.DOTALL):
+            block = match.group(1)
+            timeout_match = re.search(r"timeout=([^,\n]+)", block)
+            if timeout_match is None:
+                continue
+            expression = timeout_match.group(1).strip()
+            if not expression.startswith("model_http_timeout("):
+                line = source[: match.start()].count("\n") + 1
+                offenders.append(f"{path.relative_to(backend_root.parent)}:{line} -> {expression}")
+
+    assert not offenders, (
+        "这些 httpx 客户端还在用标量 timeout，连不上时会把整份预算耗在建连上：\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
Closes #510

把模型调用的建连超时从"等模型生成"的预算里拆出来，并恢复开场叙事的传输层重试。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `trpg-backend/app/adapters/structured_http.py` | 新增 `model_http_timeout()`：调用方给的预算只落在 `read` 上，connect 5s / write 10s / pool 5s 各自封顶；传入值更小时以传入值为准 |
| `trpg-backend/app/adapters/qwen_models.py` | 改用 `model_http_timeout()` |
| `trpg-backend/app/adapters/deepseek_models.py` | 同上 |
| `trpg-backend/app/adapters/openai_models.py` | 同上 |
| `trpg-backend/app/adapters/image_generation.py` | 同上 |
| `trpg-backend/app/core/turn.py` | 开场 `ModelClientRetryPolicy` 的 `max_attempts` 由 1 恢复为 2，并重写那段前提已失效的注释 |
| `trpg-backend/tests/test_openai_models.py` | 两条分阶段超时的测试；更新钉住旧决定的 `test_opening_narration_client_does_not_retry` |

## 关键决策

**为什么不是把超时调大**：失败发生在建连阶段，不是生成阶段。预览服务器上的记录是 `error_type=ConnectTimeout`、`duration_ms=30215`、`transport_attempts=1`——握手就没成功，请求根本没发出去。一个 5 秒握不上的连接，给它 60 秒也一样握不上，只会让玩家多等。

**为什么建连要单独收紧**：httpx 的 `timeout=<float>` 会把同一个标量套到 connect / read / write / pool 四个阶段。于是 `QWEN_TIMEOUT_SECONDS=30` 同时意味着"允许握手花 30 秒"，一次连不上就把整份预算烧光，既没时间生成也没时间重试。拆开之后，连不上快速失败，预算留给真正需要它的 read。

**为什么 5 秒**：同一时段同一 provider 的成功调用是 3.8 秒和 5.2 秒（`trpg_host_entry_decision`），说明能连上时握手很快。5 秒足够覆盖正常握手，又不会让失败拖住整份预算。

**为什么开场要恢复重试**：原来 `max_attempts=1` 的理由写在注释里——"外层总预算与单次请求预算都是 30 秒，第一次请求耗尽预算时外层 deadline 同时到期，第二次尝试必然被取消，配了也是假的"。这个前提已被 #505 改掉（外层预算现为 45 秒），当时没有连带调整这里，是那个 PR 的疏漏。建连收紧到 5 秒之后，45 秒装得下"快速失败 + 退避 + 一次完整生成"，重试才真的会发生。

**为什么重试次数固定为 2 而不跟随 `model_client_max_attempts`**：开场的外层总预算是固定的。让重试次数被一个通用配置项放大，就会重新回到"总预算装不下、重试永远来不及"的状态——也就是这条路径最初写成不重试的那个原因。

**为什么生图那处也一起改**：`image_generation.py` 是同一个标量 timeout 的写法，而它的值是 120 秒——连不上时要干等两分钟才失败，后果比模型调用更严重。见「已知限制」对这一处证据的说明。

## 验证

- 后端 `test_openai_models` / `test_opening_narration` / `test_opening_provider_smoke` / `test_portrait_generation`：**126 passed, 1 skipped**
- ruff / ruff format / ty：全过

**变异检验**：把 `model_http_timeout()` 里的 connect 改回直接使用整份预算，`test_model_http_timeout_keeps_connect_short_while_read_holds_the_budget` 立即报红；复原后 4/4 通过。

按仓库约定没有跑后端全量——本次改动集中在 HTTP 客户端构造与开场装配，上面四个文件覆盖了受影响的路径。

## 已知限制

**这不保证开场一定不再降级。** 上游是间歇性连不上（同期有成功调用，也有 ConnectTimeout），重试提高的是成功率，不是确定性。如果某段时间完全连不通，仍然会走确定性模板兜底——那是设计上正确的行为。真实效果需要在预览环境观察 `opening_narration_completed` 中 `result=model` 的比例，以及失败记录里的 `transport_attempts` 是否变成 2。

**生图那处的改动没有实测证据支撑。** 我手上只有模型调用（qwen / deepseek）的 ConnectTimeout 日志，没有抓到生图链路失败的记录。改它的依据是"完全相同的标量 timeout 写法 + 更大的超时值"，属于按同一 bug 形态一并修正，不是从观测出发。如果 review 认为应当收窄到只改三个模型 adapter，我可以拆掉这一处。

## 不在本 PR 范围

**上游连接本身的稳定性。** 日志中 deepseek 与 qwen 都出现过 `ConnectTimeout`，本 PR 只让客户端更快失败并重试，不处理上游服务或网络链路。

**叙事重试耗尽后暴露的硬编码兜底文案**（玩家会看到"这次行动已经按当前可确认的结果完成。"）。根因是叙事建立的世界比引擎里的多，与本 PR 无关，另行处理。
