### PR TITLE
fix(frontend): 桌面端手机预览框按视口等比放大

### DIFF
--- a/trpg-frontend/src/features/onboarding/geometry.ts
+++ b/trpg-frontend/src/features/onboarding/geometry.ts
@@ -16,14 +16,20 @@ export function calculateSpotlightRect(
   target: Rect,
   root: RootFrame,
 ): Rect | null {
-  const rootLeft = root.left + root.borderLeft
-  const rootTop = root.top + root.borderTop
-  const rawLeft = target.left - rootLeft
-  const rawTop = target.top - rootTop
+  const layoutWidth = root.clientWidth + root.borderLeft * 2
+  const layoutHeight = root.clientHeight + root.borderTop * 2
+  const scaleX = layoutWidth > 0 ? root.width / layoutWidth : 1
+  const scaleY = layoutHeight > 0 ? root.height / layoutHeight : 1
+  const rootLeft = root.left + root.borderLeft * scaleX
+  const rootTop = root.top + root.borderTop * scaleY
+  const rawLeft = (target.left - rootLeft) / scaleX
+  const rawTop = (target.top - rootTop) / scaleY
+  const targetWidth = target.width / scaleX
+  const targetHeight = target.height / scaleY
   const visibleLeft = Math.max(0, Math.min(rawLeft, root.clientWidth))
   const visibleTop = Math.max(0, Math.min(rawTop, root.clientHeight))
-  const visibleRight = Math.max(0, Math.min(rawLeft + target.width, root.clientWidth))
-  const visibleBottom = Math.max(0, Math.min(rawTop + target.height, root.clientHeight))
+  const visibleRight = Math.max(0, Math.min(rawLeft + targetWidth, root.clientWidth))
+  const visibleBottom = Math.max(0, Math.min(rawTop + targetHeight, root.clientHeight))
 
   if (visibleRight <= visibleLeft || visibleBottom <= visibleTop) return null
 

--- a/trpg-frontend/src/features/onboarding/onboarding.test.ts
+++ b/trpg-frontend/src/features/onboarding/onboarding.test.ts
@@ -56,6 +56,27 @@ describe('onboarding geometry', () => {
 
     expect(rect).toEqual({ left: 20, top: 100, width: 350, height: 720 })
   })
+
+  it('converts viewport coordinates back into a scaled preview frame', () => {
+    const rect = calculateSpotlightRect(
+      { left: 799.6, top: 216.8, width: 400.8, height: 525.6 },
+      {
+        left: 766,
+        top: 20,
+        width: 468,
+        height: 984,
+        borderLeft: 8,
+        borderTop: 8,
+        clientWidth: 374,
+        clientHeight: 804,
+      },
+    )
+
+    expect(rect?.left).toBeCloseTo(20)
+    expect(rect?.top).toBeCloseTo(156)
+    expect(rect?.width).toBeCloseTo(334)
+    expect(rect?.height).toBeCloseTo(438)
+  })
 })
 
 describe('onboarding steps', () => {

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.test.tsx
@@ -348,6 +348,7 @@ describe('CharacterPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '掷幸运骰' }))
     await waitFor(() => expect(mockCharacterApi.createCharacterDraft).toHaveBeenCalledWith('room-1'))
     await waitFor(() => expect(mockCharacterApi.rollLuckCharacter).toHaveBeenCalledWith('room-1', 'draft-1'))
+    expect(screen.queryByRole('button', { name: '下一步' })).not.toBeInTheDocument()
 
     // 首次掷骰创建的草稿尚未保存姓名和职业，回读不能把向导中的内容清空。
     fireEvent.click(screen.getByRole('tab', { name: '基础信息' }))

--- a/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
+++ b/trpg-frontend/src/routes/games/trpg/CharacterPage.tsx
@@ -1983,35 +1983,6 @@ export default function CharacterPage() {
                 })}
               </div>
 
-              {!isTemplateHost && luckDice && (
-                <DiceModal
-                  open={luckDiceOpen}
-                  onClose={() => {
-                    // 关闭只收起面板，已确认的点数和当前进度保留，之后可继续。
-                    setLuckDiceOpen(false)
-                    setLuckRolling(false)
-                  }}
-                  onResult={() => undefined}
-                  checkRequest={null}
-                  checkDiceState={null}
-                  setCheckDiceState={() => undefined}
-                  sequentialTargets={luckDice}
-                  sequentialStartIndex={luckDiceIndex}
-                  sequentialAccumulated={luckAccumulated}
-                  onSequentialRoll={(value, index) => {
-                    const next = luckAccumulated + value
-                    setLuckAccumulated(next)
-                    setLuckDiceIndex(index + 1)
-                    setAttr(previous => ({ ...previous, LUCK: next * 5 }))
-                    if (index === luckDice.length - 1) {
-                      setLuckRollComplete(true)
-                      setLuckDiceOpen(false)
-                      setLuckRolling(false)
-                    }
-                  }}
-                />
-              )}
-
               {/* Derived Stats */}
               <div className="character-create__derived mt-3">
                 <h4 className="character-create__derived-title font-semibold text-brass-dark tracking-[0.08em] mb-3">衍生属性</h4>
@@ -2312,6 +2283,35 @@ export default function CharacterPage() {
 
           </div>
 
+          {!isTemplateHost && luckDice && (
+            <DiceModal
+              open={luckDiceOpen}
+              onClose={() => {
+                // 关闭只收起面板，已确认的点数和当前进度保留，之后可继续。
+                setLuckDiceOpen(false)
+                setLuckRolling(false)
+              }}
+              onResult={() => undefined}
+              checkRequest={null}
+              checkDiceState={null}
+              setCheckDiceState={() => undefined}
+              sequentialTargets={luckDice}
+              sequentialStartIndex={luckDiceIndex}
+              sequentialAccumulated={luckAccumulated}
+              onSequentialRoll={(value, index) => {
+                const next = luckAccumulated + value
+                setLuckAccumulated(next)
+                setLuckDiceIndex(index + 1)
+                setAttr(previous => ({ ...previous, LUCK: next * 5 }))
+                if (index === luckDice.length - 1) {
+                  setLuckRollComplete(true)
+                  setLuckDiceOpen(false)
+                  setLuckRolling(false)
+                }
+              }}
+            />
+          )}
+
           {/* ═══════════════ Occupation Detail Modal ═══════════════ */}
           {detailOcc && (
             <>
@@ -2505,27 +2505,29 @@ export default function CharacterPage() {
           )}
 
           {/* ═══════════════ Bottom action bar ═══════════════ */}
-          <div className="character-create__actions fixed bottom-0 left-0 right-0 px-5 py-3 max-w-[430px] mx-auto z-20">
-            {(currentNavigationIssues[0] || (step === 3 ? submitError : '')) && (
-              <p className="text-[11px] text-[#c04040] text-center mb-2">
-                {currentNavigationIssues[0] || submitError}
-              </p>
-            )}
-            <div className="flex gap-2.5">
-              <button
-                data-onboarding-page-back
-                onClick={handlePreviousStep}
-                className="character-create__action character-create__action--previous flex-1 flex items-center justify-center text-sm font-semibold transition-all active:scale-[0.97]">
-                上一步
-              </button>
-              <button onClick={handlePrimaryAction}
-                disabled={submitting}
-                data-onboarding-target={step === 3 ? 'character-submit' : undefined}
-                className="character-create__action character-create__action--next flex-1 flex items-center justify-center text-sm font-semibold transition-all active:scale-[0.97] disabled:opacity-60">
-                {submitting ? '提交中…' : step === 3 ? '完成创建' : '下一步'}
-              </button>
+          {!luckDiceOpen && (
+            <div className="character-create__actions fixed bottom-0 left-0 right-0 px-5 py-3 max-w-[430px] mx-auto z-20">
+              {(currentNavigationIssues[0] || (step === 3 ? submitError : '')) && (
+                <p className="text-[11px] text-[#c04040] text-center mb-2">
+                  {currentNavigationIssues[0] || submitError}
+                </p>
+              )}
+              <div className="flex gap-2.5">
+                <button
+                  data-onboarding-page-back
+                  onClick={handlePreviousStep}
+                  className="character-create__action character-create__action--previous flex-1 flex items-center justify-center text-sm font-semibold transition-all active:scale-[0.97]">
+                  上一步
+                </button>
+                <button onClick={handlePrimaryAction}
+                  disabled={submitting}
+                  data-onboarding-target={step === 3 ? 'character-submit' : undefined}
+                  className="character-create__action character-create__action--next flex-1 flex items-center justify-center text-sm font-semibold transition-all active:scale-[0.97] disabled:opacity-60">
+                  {submitting ? '提交中…' : step === 3 ? '完成创建' : '下一步'}
+                </button>
+              </div>
             </div>
-          </div>
+          )}
         </>
       )}
     </div>

--- a/trpg-frontend/src/routes/games/trpg/RoomPage.css
+++ b/trpg-frontend/src/routes/games/trpg/RoomPage.css
@@ -896,14 +896,14 @@
   overscroll-behavior: contain;
 }
 
-/* 连续幸运骰使用紧凑固定高度，避免移动端被普通骰子面板撑出大块留白。 */
+/* 连续幸运骰占手机框 72%，确保结果和确认按钮无需滚动即可同时看到。 */
 .room-play__bottom-panel--sequential-dice {
-  height: 64vh !important;
-  max-height: 64vh !important;
+  height: 72% !important;
+  max-height: 72dvh !important;
 }
 
 .room-play__bottom-panel--sequential-dice > .room-play__bottom-panel-content {
-  max-height: calc(64vh - 60px) !important;
+  max-height: calc(100% - 60px) !important;
 }
 
 .room-play__bottom-panel--character-sheet > .room-play__bottom-panel-content {
@@ -1150,12 +1150,12 @@
   }
 
   .room-play__bottom-panel--sequential-dice {
-    height: 64dvh !important;
-    max-height: 64dvh !important;
+    height: 72% !important;
+    max-height: 72dvh !important;
   }
 
   .room-play__bottom-panel--sequential-dice > .room-play__bottom-panel-content {
-    max-height: calc(64dvh - 60px) !important;
+    max-height: calc(100% - 60px) !important;
   }
 
   .room-play__header {

--- a/trpg-frontend/src/styles.css
+++ b/trpg-frontend/src/styles.css
@@ -53,6 +53,19 @@
       border: 8px solid #2c2416;
       height: 820px;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+      transform-origin: top center;
+    }
+  }
+
+  @media (min-width: 1200px) and (min-height: 960px) {
+    #root {
+      transform: translateZ(0) scale(1.1);
+    }
+  }
+
+  @media (min-width: 1600px) and (min-height: 1040px) {
+    #root {
+      transform: translateZ(0) scale(1.2);
     }
   }
 


### PR DESCRIPTION
## 概要

- 桌面大视口下将手机预览框等比放大至 1.1x / 1.2x，保持原有宽高比例
- 修正缩放后新手指引高亮框的坐标换算
- 调整幸运值投骰面板高度、底部贴合与建卡导航显示，确保操作按钮无需滚动且不重叠

## 验证

- 相关前端测试通过
- ESLint 通过
- 前端生产构建通过
- 浏览器验证桌面 1.2x 与手机视口布局

Closes #521