### PR TITLE
docs: 更新 v1.0 产品 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/status-MS3_稳定测试版-c58b3b?style=flat-square" alt="MS3 稳定测试版" />
+  <img src="https://img.shields.io/badge/release-v1.0-c58b3b?style=flat-square" alt="v1.0" />
   <img src="https://img.shields.io/badge/frontend-React_19_|_Vite_7-61dafb?style=flat-square" alt="React 19 and Vite 7" />
   <img src="https://img.shields.io/badge/backend-FastAPI_|_Python_3.12+-teal?style=flat-square" alt="FastAPI and Python 3.12+" />
   <img src="https://img.shields.io/badge/realtime-WebSocket-7050a0?style=flat-square" alt="WebSocket" />
@@ -8,15 +8,15 @@
 <h1 align="center">TRPG-master</h1>
 
 <p align="center">
-  由 AI 担任守秘人的在线 TRPG 游戏。
+  由 AI 担任守秘人的在线多人 TRPG 游戏。
   <br />
-  创建房间、制作调查员，然后直接用自然语言开始冒险。
+  创建房间、邀请朋友，用自然语言共同推进一个会记住行动、遵守规则的故事世界。
 </p>
 
 <p align="center">
-  <a href="http://218.11.5.114:10005"><strong>立即体验</strong></a>
+  <a href="http://218.11.5.114:10005"><strong>打开试玩版</strong></a>
   ·
-  <a href="https://github.com/orgs/1024XEngineer/projects/28">开发进度</a>
+  <a href="https://github.com/orgs/1024XEngineer/projects/28">开发看板</a>
   ·
   <a href="https://github.com/1024XEngineer/TRPG-master/issues">问题反馈</a>
 </p>
@@ -25,60 +25,53 @@
   <img src="docs/screenshots/product-hero.webp" alt="TRPG-master 侦探猫调查桌主题插画" />
 </p>
 
-## 在线体验
+## 这是什么
 
-### [进入 CI Preview](http://218.11.5.114:10005)
+TRPG 是一种由玩家共同参与的故事游戏。玩家直接说出角色想做什么，守秘人负责描述世界、扮演 NPC、执行规则，并根据大家的行动继续故事。
 
-CI Preview 始终部署 `main` 分支的最新版本，团队成员和访客可以随时进入试玩。
+现实中的守秘人难找，几个人同时组局也不容易。TRPG-master 希望让玩家创建一个在线房间后，就能由 AI 接手主持工作，随时开始一场冒险。
 
-> 这是持续更新的预览环境，不是正式生产服务器。部署更新时数据可能重置，请勿保存重要资料。
+它不只是在聊天室里续写故事。我们的核心判断是：**会讲故事，不等于会主持游戏。** 因此，模型负责理解和表达，骰子、时间、位置、线索、物品与结局等事实由规则引擎统一处理。AI 不能自行改写已经发生的结果，也不能提前泄露玩家尚未发现的信息。
 
-## 关于 TRPG-master
+## 现在能做什么
 
-TRPG-master 希望让一场跑团更容易开始。玩家不必等待守秘人到场：AI 主持人负责理解行动、描述场景和组织回合，规则引擎负责检定、资源与游戏状态的权威结算。
+- 创建房间或用房间码加入，让多名玩家进入同一个游戏世界；
+- 选择模组，创建自己的调查员并查看角色卡；
+- 用自然语言调查、交谈、移动和采取行动；
+- 在多人房间中区分角色扮演聊天与提交给守秘人的行动；
+- 完成技能检定、幸运消耗和强推，结果写入共享状态；
+- 查看地图、线索、物品和游戏记录；
+- 刷新或短暂断线后重新回到当前房间；
+- 按需使用角色头像生成和主持人语音。
 
-目前可以体验完整的基础流程：
+当前版本为 `v1.0`。在线试玩环境会随版本持续更新，部署时数据可能重置，请勿保存重要资料。
 
-- 注册登录，创建或加入游戏房间；
-- 选择模组并创建 CoC 7th 调查员；
-- 使用自然语言调查、交谈、移动和采取行动；
-- 完成技能检定、幸运消耗与强推；
-- 查看角色卡、地图、线索、物品和游戏记录；
-- 在手机或桌面浏览器中继续同一局游戏。
+## 内置模组
 
-## 当前可玩内容
+| 模组 | 人数 | 预计时长 | 无剧透简介 |
+| --- | ---: | ---: | --- |
+| 《追书人》 | 1–4 人 | 1–2 小时 | 调查五本藏书失窃案，以及一位藏书家一年前的失踪。 |
+| 《银之锁》 | 1 人 | 1–2 小时 | 在昏暗的银色房间醒来后，解开束缚与谜题，寻找逃离的方法。 |
+| 《幸福蛙蛙村》 | 1–4 人 | 4–6 小时 | 受托寻找失踪青年，前往一座以“幸福”为名的林间度假村。 |
+| 《常暗之厢》 | 2–3 人 | 约 1 小时 | 在驶入黑暗的末班电车上醒来，沿车厢寻找线索与出路。 |
 
-### 《追书人》 / Paper Chase
+模组内容统一转换为可校验的结构化数据。场景、人物、线索、秘密、规则和结局会在加载前检查，只有通过校验的内容才能进入游戏。
 
-禁酒令时期的阿诺兹堡，调查员受托找回五本失窃藏书，并调查一位藏书家一年前的失踪。
-
-| 项目 | 内容 |
-| --- | --- |
-| 规则 | Call of Cthulhu 7th Edition |
-| 人数 | 1–4 人 |
-| 时长 | 约 1-2 小时 |
-| 内容版本 | `3.0.7` |
-| 内容协议 | `content_schema_version=3` |
-
-《追书人》当前由 `module-content-v3.json` 加载。仓库中的其他模组文件主要用于内容解析与 Schema 回归，不代表已经开放游玩。
-
-## 它如何工作
+## 一次行动怎样完成
 
 ```text
-玩家输入自然语言行动
+玩家用自然语言描述行动
         ↓
-AI 主持人基于安全 PlayerView 生成单动作或有限 ActionPlan
+AI 守秘人理解玩家想做什么，并组织本轮主持
         ↓
-每个当前步骤基于最新 PlayerView 生成裁决候选
+规则引擎判断是否需要检定，计算并写入结果
         ↓
-规则引擎校验目标、检定与效果并权威持久化
+AI 根据已经确定的事实继续叙述
         ↓
-ActionPlan Narrator 只根据已提交 evidence 继续叙事
-        ↓
-服务端发送既有 WebSocket `turn.completed`
+所有玩家看到同一个世界继续变化
 ```
 
-模型负责理解和叙事，不能直接修改游戏状态。目标、技能、场景与模组事实会在应用边界重新校验，最终结果只由规则引擎提交。
+简单说，AI 可以理解和表达，但不能自行决定事实。这让我们既能保留自然语言交互，又能避免模型编造骰子结果、忘记状态或前后矛盾。
 
 ## 技术架构
 
@@ -88,19 +81,19 @@ trpg-frontend (React)
 trpg-sdk (REST + WebSocket)
         ↓
 trpg-backend (FastAPI)
-        ├── Host / Narrator
+        ├── AI Host / Narrator
         ├── Rule Engine
         ├── ModuleContent
         └── SQL Store
 ```
 
-| 层 | 技术 |
+| 部分 | 主要技术 |
 | --- | --- |
 | 前端 | React 19、TypeScript、Vite 7、Tailwind CSS、Zustand |
 | SDK | TypeScript、Rollup、REST、WebSocket |
 | 后端 | Python 3.12+、FastAPI、Pydantic、SQLAlchemy |
-| AI | Fake、OpenAI、Qwen、DeepSeek 适配器 |
-| 质量 | pytest、Vitest、ruff、ty、GitHub Actions、E2E |
+| AI | OpenAI、Qwen、DeepSeek 兼容适配器，以及离线 Fake Provider |
+| 质量保障 | pytest、Vitest、ruff、ty、GitHub Actions、E2E、真人试玩 |
 
 ## 本地运行
 
@@ -121,12 +114,12 @@ npm run build
 cd ../trpg-backend
 uv sync --locked
 uv run alembic upgrade head
-uv run python scripts/load_paper_chase.py
-uv run uvicorn app.main:app --reload \
-  --reload-dir app --reload-dir ../agent-collaboration-framework/collaboration_framework
+uv run uvicorn app.main:app --reload --reload-dir app --reload-dir ../agent-collaboration-framework/collaboration_framework
 ```
 
-后端默认运行在 <http://127.0.0.1:8000>。模型、角色生图和主持人语音等配置以 [`trpg-backend/.env.example`](trpg-backend/.env.example) 为准；不配置远程模型时默认使用离线 Fake Provider。
+后端默认运行在 <http://127.0.0.1:8000>，启动时会自动加载仓库内置模组。
+
+模型、角色生图和主持人语音等配置以 [`trpg-backend/.env.example`](trpg-backend/.env.example) 为准。不配置远程模型时会使用离线 Fake Provider，便于开发和自动化测试；真人试玩需要配置实际模型服务。
 
 ### 3. 启动前端
 
@@ -166,13 +159,13 @@ cd ../trpg-sdk
 npm run codegen
 ```
 
-## 项目进展
+## 项目记录
 
-- [项目看板](https://github.com/orgs/1024XEngineer/projects/28)：当前开发安排与状态
-- [Issues](https://github.com/1024XEngineer/TRPG-master/issues)：缺陷、需求与设计讨论
-- [Pull Requests](https://github.com/1024XEngineer/TRPG-master/pulls)：正在评审的实现
+- [研发看板](https://github.com/orgs/1024XEngineer/projects/28)：当前安排和进度
+- [Issues](https://github.com/1024XEngineer/TRPG-master/issues)：需求、缺陷和设计讨论
+- [Pull Requests](https://github.com/1024XEngineer/TRPG-master/pulls)：实现、评审和验收记录
 
-欢迎通过 Issue 提交复现步骤、体验反馈和改进建议。代码变更通过 fork + Pull Request 提交，并使用 Conventional Commits。
+欢迎通过 Issue 提交复现步骤和体验反馈。代码变更通过 Fork + Pull Request 提交，并使用 Conventional Commits。
 
 ## 团队
 


### PR DESCRIPTION
## 改了什么

- 将仓库首页从 MS3 更新为 v1.0 产品说明
- 补充在线多人、自然语言行动、规则裁决和共享状态等现有能力
- 补全四个内置模组及无剧透简介
- 用产品语言说明 AI 守秘人与规则引擎的分工
- 修正本地启动说明，内置模组由后端启动时自动加载

## 为什么

原 README 仍停留在 MS3，只介绍《追书人》，已经不能反映 MS4 的产品形态和实际完成度。

## 验证

- `git diff --check -- README.md`
- README 引用的本地图片和 `.env.example` 均存在
- 仅修改文档，不影响运行代码