### PR TITLE
fix(backend): 完成单次行动的全部场景切换提案

### DIFF
--- a/trpg-backend/app/service/scene_transition.py
+++ b/trpg-backend/app/service/scene_transition.py
@@ -302,18 +302,18 @@ async def mark_narration_persisted(
     room_id: str,
     parent_action_id: str,
 ) -> None:
-    record = await db.scalar(
-        select(SceneTransitionProposalRecord)
-        .where(
-            SceneTransitionProposalRecord.room_id == room_id,
-            SceneTransitionProposalRecord.parent_action_id == parent_action_id,
-            SceneTransitionProposalRecord.narration_persisted.is_(False),
+    records = (
+        await db.scalars(
+            select(SceneTransitionProposalRecord).where(
+                SceneTransitionProposalRecord.room_id == room_id,
+                SceneTransitionProposalRecord.parent_action_id == parent_action_id,
+                SceneTransitionProposalRecord.narration_persisted.is_(False),
+            )
         )
-        .order_by(SceneTransitionProposalRecord.created_at.desc())
-        .limit(1)
-    )
-    if record is not None:
-        record.narration_persisted = True
+    ).all()
+    if records:
+        for record in records:
+            record.narration_persisted = True
         await db.commit()
 
 

--- a/trpg-backend/tests/test_scene_transition_consent.py
+++ b/trpg-backend/tests/test_scene_transition_consent.py
@@ -323,6 +323,76 @@ async def _proposal(db: AsyncSession, room_id: str) -> SceneTransitionProposalRe
 
 
 @pytest.mark.asyncio
+async def test_narration_completion_marks_every_scene_proposal_for_parent_action(
+    db_session: AsyncSession,
+) -> None:
+    room, players, _ = await _start_room(
+        db_session,
+        room_number=5240,
+        player_count=2,
+        prepare_checkpoint=True,
+    )
+    session = await db_session.get(GameSession, room.id)
+    assert session is not None
+
+    async def create_approved(
+        action_id: str,
+        parent_action_id: str,
+    ) -> SceneTransitionProposalRecord:
+        await scene_transition.create_from_adjudication(
+            db_session,
+            _request(
+                room_id=room.id,
+                player_id=players[0].id,
+                revision=session.state_version,
+                action_id=action_id,
+            ),
+        )
+        record = await db_session.scalar(
+            select(SceneTransitionProposalRecord).where(
+                SceneTransitionProposalRecord.room_id == room.id,
+                SceneTransitionProposalRecord.action_request_id == action_id,
+            )
+        )
+        assert record is not None
+        await scene_transition.bind_parent_action(
+            db_session,
+            room_id=room.id,
+            proposal_id=record.proposal_id,
+            player_id=players[0].id,
+            parent_action_id=parent_action_id,
+        )
+        record.status = "approved"
+        await db_session.commit()
+        return record
+
+    first = await create_approved("scene-step-1-524", "scene-parent-524")
+    second = await create_approved("scene-step-2-524", "scene-parent-524")
+    unrelated = await create_approved("scene-other-524", "scene-other-parent-524")
+
+    await scene_transition.mark_narration_persisted(
+        db_session,
+        room_id=room.id,
+        parent_action_id="scene-parent-524",
+    )
+    await db_session.refresh(first)
+    await db_session.refresh(second)
+    await db_session.refresh(unrelated)
+    assert first.narration_persisted is True
+    assert second.narration_persisted is True
+    assert unrelated.narration_persisted is False
+
+    # 收尾可能在断线恢复中重放；重复调用必须保持幂等。
+    await scene_transition.mark_narration_persisted(
+        db_session,
+        room_id=room.id,
+        parent_action_id="scene-parent-524",
+    )
+    assert first.narration_persisted is True
+    assert second.narration_persisted is True
+
+
+@pytest.mark.asyncio
 async def test_engine_commit_before_proposal_commit_is_reconciled_as_approved(
     db_session: AsyncSession,
     engine_store_factory,


### PR DESCRIPTION
## 变更说明

- 父行动叙事落库时，完成该行动下全部尚未标记的场景切换提案
- 避免较早的 `approved + narration_persisted=false` 记录让房间永久停留在 `processing`
- 保持操作幂等，并且不影响其他父行动的提案
- 增加一次行动包含多条场景提案的回归测试

## 验证

- `uv run pytest tests/test_scene_transition_consent.py -q`：18 passed
- `uv run pytest tests/test_scene_transition_consent.py tests/test_action_plan_turn_recovery.py tests/test_action_plan_persistence.py -q`：53 passed
- `uv run ruff check app/service/scene_transition.py tests/test_scene_transition_consent.py`：通过
- 本地多人流程人工验证通过

Fixes #524
